### PR TITLE
Fix node capacity

### DIFF
--- a/src/app/cluster/node/node.component.html
+++ b/src/app/cluster/node/node.component.html
@@ -5,7 +5,7 @@
       {{node.metadata.name}}
     </div>
     <div fxFlex="20%">
-      <span *ngIf="!!node.status.allocatable"> {{node.status.allocatable.cpu}} CPU, {{getNodeCapacity()}}</span>
+      <span *ngIf="!!node.status.capacity"> {{node.status.capacity.cpu}} CPU, {{getFormattedNodeMemory()}}</span>
     </div>
     <div fxFlex="15%">
       <span *ngIf="!!node.status.nodeInfo">{{node.status.nodeInfo.kubeletVersion}}</span>

--- a/src/app/cluster/node/node.component.ts
+++ b/src/app/cluster/node/node.component.ts
@@ -98,9 +98,9 @@ export class NodeComponent implements OnInit {
 
   }
 
-  public getNodeCapacity(): string {
+  public getFormattedNodeMemory(): string {
     let memRE = /([0-9]+)([a-zA-Z])i/;
-    let nodeAllocatable = this.node.status.allocatable.memory;
+    let nodeAllocatable = this.node.status.capacity.memory;
     let resRE = nodeAllocatable.match(memRE);
     let nodeCapacity;
     let prefixes = ['Ki', 'Mi','Gi','Ti'];


### PR DESCRIPTION
capacity = Total resources
allocatable = The memory/cpu lefter after subtracting the already allocated resources (memory allocated by system processes, etc.)

We want to use the total values as allocateable looks confusing