### PR TITLE
add padding at the bottom, if there are no SSH keys

### DIFF
--- a/src/app/sshkey/ssh-key-list/ssh-key-list.component.html
+++ b/src/app/sshkey/ssh-key-list/ssh-key-list.component.html
@@ -1,5 +1,5 @@
 <ng-container [ngSwitch]="!!sshKeys && sshKeys.length > 0">
-    <mat-card *ngSwitchCase="false" style="margin-bottom: 20px;">
+    <mat-card *ngSwitchCase="false" class="km-card-list-no-keys" style="margin-bottom: 20px;">
       <mat-card-content>
         You have not added any SSH keys yet.
       </mat-card-content>

--- a/src/app/sshkey/ssh-key-list/ssh-key-list.component.scss
+++ b/src/app/sshkey/ssh-key-list/ssh-key-list.component.scss
@@ -24,3 +24,7 @@
   margin-top: 15px;
   margin-bottom: 50px;
 }
+
+.km-card-list-no-keys {
+  padding-bottom: 20px;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
SSH key view: add padding at the bottom, if no SSH keys are available

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #403 

**Special notes for your reviewer**:
/