### PR TITLE
download config btn is clickable everywhere

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/cluster/cluster-details/cluster-details.component.scss
@@ -175,10 +175,17 @@ kubermatic-cluster-health-status {
 }
 
 .download-kubeconfig-btn {
+  padding: 0;
+
   a {
+    display: flex;
+    align-items: center;
+    width: auto;
+    height: 100%;
     text-decoration: none;
     color: white;
     vertical-align: baseline !important;
+    padding: 0 16px;
   }
   a.disabled {
     color: rgba(0, 0, 0, 0.38);


### PR DESCRIPTION
**What this PR does / why we need it**:
Download config button wasn't triggered when clicking outside the a-tag. Fixed styling for this issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
too small for an issue

**Special notes for your reviewer**:
/