### PR TITLE
Always serve index.html even if files can't be found

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,4 +63,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.FileServer(dir).ServeHTTP(w, r)
 		return
 	}
+
+	// If we can't find the file, we still serve index.html
+	// to show dynamic pages or a 404 page
+	http.ServeFile(w, r, "./dist/index.html")
 }


### PR DESCRIPTION
When hitting `/clusters` we have not file named like that. We got a blank page, because I didn't return anything in that case.
We still want to return index.html if nothing can be found. If there really is no route, even in the angular router, then Angular shows a 404 page.