### PR TITLE
Cache node_modules in drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,7 +3,7 @@ workspace:
   path: src/github.com/kubermatic/dashboard-v2
 
 pipeline:
-  cache:
+  cache-restore:
     image: drillster/drone-volume-cache
     restore: true
     mount:


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment we download all npm modules with every pipeline.
As we have a package-lock.json committed we can easily cache the `node_modules/` folder too.

This will probably increase the build speed time significantly.
