### PR TITLE
add clustername to kubeconfig

### DIFF
--- a/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.html
+++ b/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.html
@@ -14,8 +14,8 @@
         </a>
       </button>
     </p>
-    <p>Configure kubectl command line by running the following command in Directory where the kubeconfig is located:</p>
-    <p class="code-block">$ export KUBECONFIG=$PWD/kubeconfig</p>
+    <p>Configure kubectl command line by running the following command in Directory where the kubeconfig-{{cluster.metadata.name}} is located:</p>
+    <p class="code-block">$ export KUBECONFIG=$PWD/kubeconfig-{{cluster.metadata.name}}</p>
     <p>Then start a proxy to connect to the Kubernetes control plane:</p>
     <p class="code-block">$ kubectl proxy</p>
     <p>Then open the Dashboard interface by navigating to the following location in your browser:</p>


### PR DESCRIPTION
**What this PR does / why we need it**:

Add cluster name to the `kubeconfig`, relates to https://github.com/kubermatic/kubermatic/pull/774