### PR TITLE
use v3 cluster upgrade endpoint

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -204,6 +204,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   public upgradeClusterDialog(): void {
     const modal = this.dialog.open(UpgradeClusterComponent);
     modal.componentInstance.cluster = this.cluster;
+    modal.componentInstance.datacenter = this.datacenter;
     modal.componentInstance.possibleVersions = this.upgradesList;
     const sub = modal.afterClosed().subscribe(() => {
       this.reloadCluster(this.cluster.metadata.name, this.datacenter.metadata.name);

--- a/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.spec.ts
+++ b/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.spec.ts
@@ -11,6 +11,7 @@ import { asyncData } from '../../../testing/services/api-mock.service';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { fakeDigitaloceanCluster } from '../../../testing/fake-data/cluster.fake';
 import Spy = jasmine.Spy;
+import { fakeDigitaloceanDatacenter } from '../../../testing/fake-data/datacenter.fake';
 
 const modules: any[] = [
   BrowserModule,
@@ -55,6 +56,7 @@ describe('UpgradeClusterComponent', () => {
   it('should call updateClusterUpgrade method from api', fakeAsync(() => {
     component.selectedVersion = 'new version';
     component.cluster = fakeDigitaloceanCluster;
+    component.datacenter = fakeDigitaloceanDatacenter;
     component.possibleVersions = ['1.9.5'];
 
     fixture.detectChanges();

--- a/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.ts
+++ b/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.ts
@@ -3,6 +3,7 @@ import { MatDialogRef } from '@angular/material';
 import { NotificationActions } from '../../../redux/actions/notification.actions';
 import { ClusterEntity } from '../../../shared/entity/ClusterEntity';
 import { ApiService } from '../../../core/services';
+import { DataCenterEntity } from '../../../shared/entity/DatacenterEntity';
 
 @Component({
   selector: 'kubermatic-upgrade-cluster',
@@ -11,6 +12,7 @@ import { ApiService } from '../../../core/services';
 })
 export class UpgradeClusterComponent implements OnInit {
   @Input() cluster: ClusterEntity;
+  @Input() datacenter: DataCenterEntity;
   possibleVersions: string[];
   selectedVersion: string;
 
@@ -25,7 +27,7 @@ export class UpgradeClusterComponent implements OnInit {
   }
 
   upgrade(): void {
-    this.api.updateClusterUpgrade(this.cluster.metadata.name, this.selectedVersion)
+    this.api.updateClusterUpgrade(this.cluster.metadata.name, this.datacenter.metadata.name, this.selectedVersion)
       .subscribe(result => NotificationActions.success('Success', `Cluster is being upgraded`));
 
     this.selectedVersion = null;

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -92,9 +92,9 @@ export class ApiService {
       });
   }
 
-  updateClusterUpgrade(cluster: string, upgradeVersion: string): Observable<ClusterEntity> {
+  updateClusterUpgrade(cluster: string, dc: string, upgradeVersion: string): Observable<ClusterEntity> {
     const body = { to: upgradeVersion };
-    const url = `${this.restRoot}/cluster/${cluster}/upgrade`;
+    const url = `${this.restRootV3}/dc/${dc}/cluster/${cluster}/upgrade`;
     return this.http.put<ClusterEntity>(url, body, { headers: this.headers });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the cluster upgrade dialog. We now use the v3 endpoin as the v1 upgrade endpoint got deprecated & removed.