### PR TITLE
fix grid of cluster detail page and reduce provider logo sizes 

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -54,9 +54,9 @@
   <mat-card class="km-card-list">
     <mat-card-header class="km-card-list-header providerinfo" >
       <mat-card-title fxLayout>
-        <div fxFlex="25%">Provider</div>
-        <div fxFlex="35%">Node Region</div>
-        <div fxFlex="40%">
+        <div fxFlex="45%">Provider</div>
+        <div fxFlex="30%">Node Region</div>
+        <div fxFlex="25%">
           SSH keys
           <span class="km-card-ssh-tooltip" matTooltip="You can only login into the nodes with the user ‘apiserver’.">
             <i class="fa fa-question-circle" aria-hidden="true"></i>
@@ -65,21 +65,21 @@
       </mat-card-title>
     </mat-card-header>
     <mat-card-content class="km-card-list-content" fxLayout>
-      <div fxFlex="25%">
+      <div fxFlex="45%" fxLayoutAlign="left center">
         <ng-container *ngIf="cluster.provider === 'bringyourown'">
-          <img src="/assets/images/clouds/{{cluster.provider}}.png" class="icon-seed-cluster" alt="Cluster Icon" height="30" />
+          <img src="/assets/images/clouds/{{cluster.provider}}.png" class="icon-seed-cluster" alt="Cluster Icon" />
         </ng-container>
         <ng-container *ngIf="cluster.provider !== 'bringyourown'">
-          <img src="/assets/images/clouds/{{nodeDc.spec.provider}}.png" class="icon-seed-cluster" alt="Cluster Icon" height="30" />
+          <img src="/assets/images/clouds/{{nodeDc.spec.provider}}.png" class="icon-seed-cluster" alt="Cluster Icon" />
         </ng-container>
       </div>
-      <div fxFlex="35%" class="km-provider-region" >
+      <div fxFlex="30%" class="km-provider-region" >
         <ng-container *ngIf="cluster.provider !== 'bringyourown'">
           <span class="{{'flag-icon flag-icon-' + nodeDc.spec.country.toLowerCase()}}"></span>
           <span class="location">{{nodeDc.spec.country}} / {{nodeDc.spec.location}}</span>
         </ng-container>
       </div>
-      <div fxFlex="40%">
+      <div fxFlex="25%">
         <ng-container [ngSwitch]="sshKeys.length > 0">
           <ul class="km-ssh-keys-list"  *ngSwitchCase="true">
             <li *ngFor="let key of sshKeys.slice(0, 3)">

--- a/src/app/cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/cluster/cluster-details/cluster-details.component.scss
@@ -46,6 +46,12 @@
   line-height: 16px;
   font-size: 14px;
   margin-bottom: 20px;
+
+  .icon-seed-cluster {
+    max-height: 30px;
+    max-width: 140px;
+
+  }
   &.seed  {
     .flag-icon {
       font-size: 24px;

--- a/src/app/cluster/cluster-list/cluster-item/cluster-item.component.html
+++ b/src/app/cluster/cluster-list/cluster-item/cluster-item.component.html
@@ -9,11 +9,11 @@
         <p fxHide.lt-md>{{this.cluster.spec.humanReadableName}}</p>
       </span>
     </div>
-    <div fxFlex="25%" fxFlex.sm="20.66%" fxFlex.xs="25%">
+    <div fxFlex="25%" fxFlex.sm="20.66%" fxFlex.xs="25%" fxLayoutAlign="left center">
       <ng-container [ngSwitch]="!!cluster.spec.cloud">
-        <span *ngSwitchCase="true">
-          <img [src]="getClusterImagePath()" class="icon-seed-cluster cluster-image" alt="Cluster Icon" height="30"/>
-        </span>
+        <ng-container *ngSwitchCase="true">
+          <img [src]="getClusterImagePath()" class="icon-seed-cluster cluster-image" alt="Cluster Icon"/>
+        </ng-container>
         <p *ngSwitchCase="false" class="text-muted">
           No provider
         </p>

--- a/src/app/cluster/cluster-list/cluster-item/cluster-item.component.scss
+++ b/src/app/cluster/cluster-list/cluster-item/cluster-item.component.scss
@@ -14,7 +14,10 @@
   > div {
     outline: none;
   }
+
   img {
+    max-height: 30px;
+    max-width: 140px;
     float: left;
   }
 
@@ -26,7 +29,7 @@
   }
 
   &.odd {
-    background-color: #F7FAFF;  
+    background-color: #F7FAFF;
   }
 
   &.statusRunning:hover {


### PR DESCRIPTION
**What this PR does / why we need it**:

- pixel pushing on the cluster list page and detail page to get a little bit more of a grid feeling
- the provider logos are a little bit more dynamic to fit better into the layout  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
