### PR TITLE
use v3 update-cluster endpoint instead of the dedicated upgrade endpoint

### DIFF
--- a/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.spec.ts
+++ b/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.spec.ts
@@ -23,11 +23,11 @@ const modules: any[] = [
 describe('UpgradeClusterComponent', () => {
   let fixture: ComponentFixture<UpgradeClusterComponent>;
   let component: UpgradeClusterComponent;
-  let updateClusterUpgradeSpy: Spy;
+  let editClusterSpy: Spy;
 
   beforeEach(async(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['updateClusterUpgrade']);
-    updateClusterUpgradeSpy = apiMock.updateClusterUpgrade.and.returnValue(asyncData(fakeDigitaloceanCluster));
+    const apiMock = jasmine.createSpyObj('ApiService', ['editCluster']);
+    editClusterSpy = apiMock.editCluster.and.returnValue(asyncData(fakeDigitaloceanCluster));
 
     TestBed.configureTestingModule({
       imports: [
@@ -53,7 +53,7 @@ describe('UpgradeClusterComponent', () => {
     expect(component).toBeTruthy();
   }));
 
-  it('should call updateClusterUpgrade method from api', fakeAsync(() => {
+  it('should call editCluster method from api', fakeAsync(() => {
     component.selectedVersion = 'new version';
     component.cluster = fakeDigitaloceanCluster;
     component.datacenter = fakeDigitaloceanDatacenter;
@@ -62,6 +62,6 @@ describe('UpgradeClusterComponent', () => {
     fixture.detectChanges();
     component.upgrade();
     tick();
-    expect(updateClusterUpgradeSpy.and.callThrough()).toHaveBeenCalledTimes(1);
+    expect(editClusterSpy.and.callThrough()).toHaveBeenCalledTimes(1);
   }));
 });

--- a/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.ts
+++ b/src/app/cluster/cluster-details/upgrade-cluster/upgrade-cluster.component.ts
@@ -27,8 +27,11 @@ export class UpgradeClusterComponent implements OnInit {
   }
 
   upgrade(): void {
-    this.api.updateClusterUpgrade(this.cluster.metadata.name, this.datacenter.metadata.name, this.selectedVersion)
-      .subscribe(result => NotificationActions.success('Success', `Cluster is being upgraded`));
+    this.cluster.spec.masterVersion = this.selectedVersion;
+
+    this.api.editCluster(this.cluster, this.datacenter.metadata.name).subscribe(result => {
+      NotificationActions.success('Success', `Cluster is being upgraded`);
+    });
 
     this.selectedVersion = null;
     this.dialogRef.close();


### PR DESCRIPTION
**What this PR does / why we need it**:
use v3 update-cluster endpoint instead of the dedicated upgrade endpoint

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #555 

**Special notes for your reviewer**:
