### PR TITLE
display info icon next to cluster name for aws

### DIFF
--- a/src/app/cluster/cluster-details/node-list/node-list.component.html
+++ b/src/app/cluster/cluster-details/node-list/node-list.component.html
@@ -35,8 +35,9 @@
             <div fxFlex="3%">{{i + 1}}</div>
             <div fxFlex="32%" style="word-break: normal ;" matTooltip="{{getTooltip(node)}}">
               {{node.metadata.displayName}}
+              <i class="fa fa-info-circle" matTooltip="{{getInfo(node)}}" *ngIf="showInfo(node)"></i>
             </div>
-            <div fxFlex="10%" fxLayoutAlign="left center">
+            <div fxFlex="10%">
               <img [src]="getOsImagePath(node)" class="os-image"/>
             </div>
             <div fxFlex="15%">

--- a/src/app/cluster/cluster-details/node-list/node-list.component.scss
+++ b/src/app/cluster/cluster-details/node-list/node-list.component.scss
@@ -78,3 +78,8 @@ button {
   max-height: 20px;
   max-width: 65px;
 }
+
+i.fa-info-circle {
+  color: #CCCCCC;
+  padding-left: 5px;
+}

--- a/src/app/cluster/cluster-details/node-list/node-list.component.ts
+++ b/src/app/cluster/cluster-details/node-list/node-list.component.ts
@@ -145,4 +145,16 @@ export class NodeListComponent implements OnChanges {
 
     return path;
   }
+
+  public showInfo(node: NodeEntity): boolean {
+    if (node.metadata.displayName !== node.metadata.name.replace('machine-', '') && node.metadata.name !== '') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  public getInfo(node: NodeEntity): string {
+    return node.metadata.name.replace('machine-', '');
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
using aws and ubuntu, cluster names are too long to display. in this case the name will be cut and an additional icon will appear, which - on hover - provides the 'missing' information. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #590 

**Special notes for your reviewer**:

**Release note**:
```release-note bugfix
Fixed the display of very long cluster names
```