### PR TITLE
adjust kubeconfig download name

### DIFF
--- a/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.ts
+++ b/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.ts
@@ -26,7 +26,7 @@ export class ClusterConnectComponent implements OnInit {
       const blob = new Blob([data], { type: 'text/plain' });
       const a = window.document.createElement('a');
       a.href = window.URL.createObjectURL(blob);
-      a.download = 'kubeconfig';
+      a.download = 'kubeconfig-' + this.cluster.metadata.name;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -228,7 +228,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
       const blob = new Blob([data], { type: 'text/plain' });
       const a = window.document.createElement('a');
       a.href = window.URL.createObjectURL(blob);
-      a.download = 'kubeconfig';
+      a.download = 'kubeconfig-' + this.cluster.metadata.name;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);


### PR DESCRIPTION
**What this PR does / why we need it**:
include cluster name in kubeconfig download name

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #598 

**Special notes for your reviewer**:

**Release note**:
```release-note
Downloaded kubeconfig will now contain the cluster's ID in its file name
```