### PR TITLE
show copy tooltip when hovering over Admin Token

### DIFF
--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.html
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.html
@@ -133,7 +133,7 @@
             <strong>Tokens</strong>
           </div>
           <div fxFlex="50%">
-            <div class="clickable inline" ngxClipboard [cbContent]="cluster.address['adminToken']">
+            <div class="clickable inline copy" ngxClipboard [cbContent]="cluster.address['adminToken']" matTooltip="click to copy">
               <span class="iconDocuments"></span>
               <strong>Admin</strong>
             </div>

--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.scss
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.scss
@@ -178,6 +178,10 @@ div.clickable {
     &.inline {
         display: inline-block;
     }
+
+    &.copy:active {
+        color: rgba(2, 136, 209, 0.7);
+    }
 }
 
 strong.inlineSeperator {


### PR DESCRIPTION
**What this PR does / why we need it**:
Show tooltip when hovering over Admin Token in 'Certificates and Keys' Box, to make copying more obvious. Also change the color of active link for a better 'click experience'.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #624 

**Special notes for your reviewer**:

**Release note**:
```release-note
Added a copy tooltip when hovering over an admin token
```