### PR TITLE
import titillium web within global.scss

### DIFF
--- a/src/assets/css/global.scss
+++ b/src/assets/css/global.scss
@@ -6,6 +6,7 @@
 //@import "bootstrap";
 
 @import "font-awesome/font-awesome";
+@import "titillium_web/titillium_web";
 //@import "ng2admin";
 
 @import "footer";

--- a/src/assets/css/titillium_web/titillium_web.scss
+++ b/src/assets/css/titillium_web/titillium_web.scss
@@ -3,7 +3,7 @@
     font-family: 'Titillium Web';
     font-style: normal;
     font-weight: 400;
-    src: local('Titillium Web Regular'), local('TitilliumWeb-Regular'), url('../../fonts/titillium_web/TitilliumWeb-Regular.ttf') format('ttf');
+    src: local('Titillium Web Regular'), local('TitilliumWeb-Regular'), url('../fonts/titillium_web/TitilliumWeb-Regular.ttf') format('truetype');
     unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
   }
   /* latin */
@@ -11,7 +11,7 @@
     font-family: 'Titillium Web';
     font-style: normal;
     font-weight: 400;
-    src: local('Titillium Web Regular'), local('TitilliumWeb-Regular'), url('../../fonts/titillium_web/TitilliumWeb-Regular.ttf') format('ttf');
+    src: local('Titillium Web Regular'), local('TitilliumWeb-Regular'), url('../fonts/titillium_web/TitilliumWeb-Regular.ttf') format('truetype');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
   }
    /* latin-ext */
@@ -19,7 +19,7 @@
     font-family: 'Titillium Web';
     font-style: normal;
     font-weight: 600;
-    src: local('Titillium Web Semi Bold'), local('TitilliumWeb-Bold'), url('../../fonts/titillium_web/TitilliumWeb-SemiBold.ttf') format('ttf');
+    src: local('Titillium Web Semi Bold'), local('TitilliumWeb-Bold'), url('../fonts/titillium_web/TitilliumWeb-SemiBold.ttf') format('truetype');
     unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
   }
   /* latin */
@@ -27,7 +27,7 @@
     font-family: 'Titillium Web';
     font-style: normal;
     font-weight: 600;
-    src: local('Titillium Web Semi Bold'), local('TitilliumWeb-Bold'), url('../../fonts/titillium_web/TitilliumWeb-SemiBold.ttf') format('ttf');
+    src: local('Titillium Web Semi Bold'), local('TitilliumWeb-Bold'), url('../fonts/titillium_web/TitilliumWeb-SemiBold.ttf') format('truetype');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
   }
 
@@ -36,7 +36,7 @@
   font-family: 'Titillium Web';
   font-style: normal;
   font-weight: 700;
-  src: local('Titillium Web Bold'), local('TitilliumWeb-Bold'), url('../../fonts/titillium_web/TitilliumWeb-Bold.ttf') format('ttf');
+  src: local('Titillium Web Bold'), local('TitilliumWeb-Bold'), url('../fonts/titillium_web/TitilliumWeb-Bold.ttf') format('truetype');
   unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -44,6 +44,6 @@
   font-family: 'Titillium Web';
   font-style: normal;
   font-weight: 700;
-  src: local('Titillium Web Bold'), local('TitilliumWeb-Bold'), url('../../fonts/titillium_web/TitilliumWeb-Bold.ttf') format('ttf');
+  src: local('Titillium Web Bold'), local('TitilliumWeb-Bold'), url('../fonts/titillium_web/TitilliumWeb-Bold.ttf') format('truetype');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="./assets/css/titillium_web/titillium_web.scss" rel="stylesheet">
   <link href="./assets/fonts/material_icons/material-icons.css" rel="stylesheet">  
   
   <!--script src="./env.js"></script-->


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove titillium web from `index.html` as it is not recommended to load scss files in browser. Added it to `global.scss` file, which will be executed in `angular-cli.json`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #626

**Special notes for your reviewer**:
/

**Release note**:
```release-note
NONE
```