### PR TITLE
enable download button even if pause is set

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -9,7 +9,7 @@
           <i class="fa fa-plus" style="margin-right: 5px;" aria-hidden="true"></i>
           Add Node
       </button>
-      <button class="connect-kubeconfig-btn" (click)="connectClusterDialog()" mat-button mat-raised-button color="primary" [disabled]="!isClusterRunning">
+      <button class="connect-kubeconfig-btn" (click)="connectClusterDialog()" mat-button mat-raised-button color="primary" [disabled]="this.clusterHealthClass !== 'statusRunning' && this.clusterHealthClass !== 'statusActionRequired'">
         Connect
       </button>
       <a class="download-kubeconfig-btn" mat-raised-button disabled="{{ !isClusterRunning }}" color="primary" href="{{ getDownloadURL() }}" target="_blank">Download config</a>


### PR DESCRIPTION
**What this PR does / why we need it**:
enable download button even if pause is set

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Kubeconfig can now be downloaded even for paused clusters
```