### PR TITLE
only show pause reason in cluster

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -9,7 +9,7 @@
           <i class="fa fa-plus" style="margin-right: 5px;" aria-hidden="true"></i>
           Add Node
       </button>
-      <button class="connect-kubeconfig-btn" (click)="connectClusterDialog()" mat-button mat-raised-button color="primary" [disabled]="this.clusterHealthClass !== 'statusRunning' && this.clusterHealthClass !== 'statusActionRequired'">
+      <button class="connect-kubeconfig-btn" (click)="connectClusterDialog()" mat-button mat-raised-button color="primary" [disabled]="this.clusterHealthClass !== 'statusRunning'">
         Connect
       </button>
       <a class="download-kubeconfig-btn" mat-raised-button disabled="{{ !isClusterRunning }}" color="primary" href="{{ getDownloadURL() }}" target="_blank">Download config</a>

--- a/src/app/cluster/cluster-health-status/cluster-health-status.component.ts
+++ b/src/app/cluster/cluster-health-status/cluster-health-status.component.ts
@@ -29,8 +29,6 @@ export class ClusterHealthStatusComponent implements OnChanges {
         return this.green;
       } else if (this.healthStatus === ClusterHealth.DELETING) {
         return this.red;
-      } else if (this.healthStatus === ClusterHealth.ACTIONREQUIRED) {
-        return this.redAction;
       } else {
         return this.orange;
       }
@@ -42,7 +40,7 @@ export class ClusterHealthStatusComponent implements OnChanges {
   public getHealthTooltipText(): string {
     if (this.healthStatus === ClusterHealth.DELETING) {
       return 'Deleting might take up to 15 minutes';
-    } else if (this.healthStatus === ClusterHealth.ACTIONREQUIRED) {
+    } else if (!!this.cluster.spec.pause) {
       return 'Manual action required';
     } else {
       return '';

--- a/src/app/core/services/cluster/cluster.service.ts
+++ b/src/app/core/services/cluster/cluster.service.ts
@@ -18,13 +18,7 @@ export class ClusterService {
       if (cluster.metadata.deletionTimestamp) {
         return ClusterHealth.DELETING;
       } else if (cluster.status.health.apiserver && cluster.status.health.scheduler && cluster.status.health.controller && cluster.status.health.machineController && cluster.status.health.etcd) {
-        if (cluster.spec.pause) {
-          return ClusterHealth.ACTIONREQUIRED;
-        } else {
-          return ClusterHealth.RUNNING;
-        }
-      } else if (cluster.spec.pause) {
-        return ClusterHealth.ACTIONREQUIRED;
+        return ClusterHealth.RUNNING;
       }
     }
     return ClusterHealth.WAITING;
@@ -34,13 +28,7 @@ export class ClusterService {
     if (cluster.metadata.deletionTimestamp) {
       return false;
     } else if (!!cluster.status.health && cluster.status.health.apiserver) {
-      if (cluster.spec.pause) {
-        return false;
-      } else {
-        return true;
-      }
-    } else if (cluster.spec.pause) {
-      return false;
+      return true;
     }
     return false;
   }

--- a/src/app/shared/model/ClusterHealthConstants.ts
+++ b/src/app/shared/model/ClusterHealthConstants.ts
@@ -2,5 +2,4 @@ export class ClusterHealth {
   public static readonly WAITING: string = 'statusWaiting';
   public static readonly RUNNING: string = 'statusRunning';
   public static readonly DELETING: string = 'statusDeleting';
-  public static readonly ACTIONREQUIRED: string = 'statusActionRequired';
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Only show pause reason in cluster. Also removed ClusterHealth.ACTIONREQUIRED as it isn't needed anymore,

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
/

**Special notes for your reviewer**:
/

**Release note**:
```release-note
NONE
```