### PR TITLE
don't expand node list when clicking on ip

### DIFF
--- a/src/app/cluster/cluster-details/node-list/node-list.component.ts
+++ b/src/app/cluster/cluster-details/node-list/node-list.component.ts
@@ -180,7 +180,6 @@ export class NodeListComponent implements OnChanges {
   public toggleNode(nodeName: string): void {
     const element = event.target as HTMLElement;
     const className = element.className;
-    
     if (!this.clickedDeleteNode[nodeName] && !this.clickedDuplicateNode[nodeName] && className !== 'copy') {
       if (this.isShowNodeDetails[nodeName]) {
         this.isShowNodeDetails[nodeName] = false;


### PR DESCRIPTION
**What this PR does / why we need it**:
don't expand node list when clicking on ip

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #674 

**Special notes for your reviewer**:
/

**Release note**:
```release-note bugfix
The node list will no longer be expanded when clicking on an IP
```