### PR TITLE
Remove Simple/Extended tab group for OpenStack Provider

### DIFF
--- a/src/app/cluster/cluster-details/add-node-modal/add-node-modal.component.html
+++ b/src/app/cluster/cluster-details/add-node-modal/add-node-modal.component.html
@@ -5,7 +5,7 @@
       <i class="fa fa-times" aria-hidden="true"></i>
     </button>
   </mat-toolbar>
-  <mat-tab-group (selectedTabChange)="changeView($event)" *ngIf="!cluster.spec.cloud.hetzner && !cluster.spec.cloud.bringyourown">
+  <mat-tab-group (selectedTabChange)="changeView($event)" *ngIf="!cluster.spec.cloud.hetzner && !cluster.spec.cloud.bringyourown && !cluster.spec.cloud.openstack">
     <mat-tab label="Simple"></mat-tab>
     <mat-tab label="Extended"></mat-tab>
   </mat-tab-group>


### PR DESCRIPTION
**What this PR does / why we need it**: Remove Simple/Extended tab group for OpenStack Provider since there are no hidden fields,

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #693 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```