### PR TITLE
Show chosen OpenStack image in create cluster summary step

### DIFF
--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -284,6 +284,10 @@
                 <div fxFlex="50%" class="km-card-list-key">Node Size</div>
                 <div fxFlex="50%">{{ nodeData.node.spec.cloud.openstack.flavor }}</div>
               </div>
+              <div class="km-card-list-content" fxFlex="50%">
+                <div fxFlex="50%" class="km-card-list-key">Node Image</div>
+                <div fxFlex="50%">{{ nodeData.node.spec.cloud.openstack.image }}</div>
+              </div>
             </ng-container>
 
             <!-- Hetzner Nodes -->


### PR DESCRIPTION
**What this PR does / why we need it**: Show chosen OpenStack image in create cluster summary step

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #691

**Special notes for your reviewer**:

**Release note**:
```release-note cloud provider
Openstack: show selected image in cluster creation summary
```