### PR TITLE
fix openstack tenant when returning from summary page

### DIFF
--- a/src/app/wizard/set-settings/provider-settings/openstack/openstack.component.ts
+++ b/src/app/wizard/set-settings/provider-settings/openstack/openstack.component.ts
@@ -31,6 +31,8 @@ export class OpenstackClusterSettingsComponent implements OnInit, OnDestroy {
       network: new FormControl(this.cluster.spec.cloud.openstack.network, []),
     });
 
+    this.loadTenants();
+
     this.subscriptions.push(this.openstackSettingsForm.valueChanges.debounceTime(1000).subscribe(data => {
       this.loadTenants();
       this.wizardService.changeClusterProviderSettings({


### PR DESCRIPTION
**What this PR does / why we need it**:
fix openstack tenant when going back from summary page

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #700

**Special notes for your reviewer**:
/

**Release note**:
```release-note bugfix
Openstack: fixed an issue, where list of tenants wouldn't get loaded when returning from summary page
```