### PR TITLE
fix k8s dashboard link

### DIFF
--- a/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.html
+++ b/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.html
@@ -13,8 +13,8 @@
     <p class="code-block copy" ngxClipboard [cbContent]="copy('kubectlProxy')" matTooltip="click to copy">$ kubectl proxy</p>
     <p>Then open the Dashboard interface by navigating to the following location in your browser:</p>
     <p class="km-button-link">
-      <a href="http://localhost:8001/ui" target="_blank" class="button white">
-        http://localhost:8001/ui
+      <a href="http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/" target="_blank" class="button white">
+        http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
       </a>
     </p>
   </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

The `http://localhost:8001/ui` is deprecated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #738

**Release note**:
```release-note bugfix
Fixed the link to Kubernetes dashboard
```