### PR TITLE
cluster-details: try to load nodes before first health check arrives

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -223,8 +223,9 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   public reloadClusterNodes() {
-
-    if (this.cluster && this.health && this.health.apiserver && this.health.machineController) {
+    // FIXME: We're also trying to reload when the health info is missing. Otherwise
+    // the node list will be empty until the first health check arrives.
+    if (this.cluster && (!this.health || (this.health.apiserver && this.health.machineController))) {
       this.api.getClusterNodes(this.cluster.id, this.datacenter.metadata.name, this.projectID)
         .takeUntil(this.unsubscribe)
         .subscribe(nodes => {


### PR DESCRIPTION
**What this PR does / why we need it**:
With the changed health check logic, note list might show up as empty before the first health check arrives. This change ensures the node list will be fetched even before the first health check.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
