### PR TITLE
changed a couple of /clusters routes to /projects

### DIFF
--- a/src/app/pages/frontpage/frontpage.component.ts
+++ b/src/app/pages/frontpage/frontpage.component.ts
@@ -29,7 +29,7 @@ export class FrontpageComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.auth.authenticated()) {
-      this.router.navigate(['clusters']);
+      this.router.navigate(['/projects']);
       this.isAuth = true;
     }
 

--- a/src/app/pages/page-not-found/page-not-found.component.spec.ts
+++ b/src/app/pages/page-not-found/page-not-found.component.spec.ts
@@ -62,7 +62,7 @@ describe('PageNotFoundComponent', () => {
 
     const navArgs = spyNavigate.calls.first().args[0];
     expect(spyNavigate.and.callThrough()).toHaveBeenCalledTimes(1);
-    expect(navArgs[0]).toBe('clusters', 'should navigate to the clusters list');
+    expect(navArgs[0]).toBe('/projects', 'should navigate to the projects list');
   });
 
   it('should navigate to the front apge', () => {

--- a/src/app/pages/page-not-found/page-not-found.component.ts
+++ b/src/app/pages/page-not-found/page-not-found.component.ts
@@ -13,7 +13,7 @@ export class PageNotFoundComponent {
 
   backToApp(): void {
     if (this.auth.authenticated()) {
-      this.router.navigate(['clusters']);
+      this.router.navigate(['/projects']);
     } else {
       this.router.navigate(['']);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes the user would still be routed to `/clusters`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
