### PR TITLE
Remove fragment with token from URL after login

### DIFF
--- a/src/app/core/services/auth/auth.service.ts
+++ b/src/app/core/services/auth/auth.service.ts
@@ -6,6 +6,8 @@ export class Auth {
   constructor() {
     const token = this.getTokenFromQuery();
     if (token) {
+      // remove URL fragment with token, so that users can't accidentally copy&paste it and send it to others
+      this.removeFragment();
       localStorage.setItem('token', token);
     }
   }
@@ -40,6 +42,11 @@ export class Auth {
   private getTokenFromQuery(): string {
     const results = new RegExp('[\?&]id_token=([^&#]*)').exec(window.location.href);
     return results == null ? null : results[1] || '';
+  }
+
+  private removeFragment() {
+    const currentHref = window.location.href;
+    history.replaceState({}, '', currentHref.slice(0, currentHref.indexOf('#')));
   }
 
   // Helper Functions for decoding JWT token:


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a potential security vulnerability when users copy&paste
the current URL, share them with other and by this accidentally disclose
their token

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Login token is now removed from URL for security reasons
```
