### PR TITLE
removes Admin button

### DIFF
--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.html
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.html
@@ -130,13 +130,7 @@
           <div fxFlex="50%">
             <strong>Tokens</strong>
           </div>
-          <div fxFlex="50%">
-            <!-- <div class="clickable inline copy" ngxClipboard [cbContent]="cluster.address['adminToken']" matTooltip="click to copy"> -->
-            <div class="clickable inline copy" matTooltip="click to copy">
-              <span class="iconDocuments"></span>
-              <strong>Admin</strong>
-            </div>
-            <strong class="inlineSeperator"> / </strong>
+          <div>
             <div class="clickable inline" (click)="revokeAdminTokenDialog()">
               <button [disabled]="!!userGroup && !userGroupConfig[userGroup].clusters.edit">Revoke</button>
             </div>


### PR DESCRIPTION
**What this PR does / why we need it**: simply removes `Admin` button as it allowed to copy the admin token into the clipboard since this is a security concern we decided to remove this functionality.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
`Admin` button has been removed from `Certificates and Keys` panel as it allowed to copy the admin token into the clipboard. Since this is a security concern we decided to remove this functionality.
```
