### PR TITLE
Adjust create cluster icon size

### DIFF
--- a/src/app/core/components/sidenav/sidenav.component.html
+++ b/src/app/core/components/sidenav/sidenav.component.html
@@ -20,7 +20,7 @@
       </mat-list-item>
 
       <mat-list-item [ngClass]="isProjectSelected('create-cluster')">
-        <a mat-line [routerLink]="getRouterLink('wizard')" [routerLinkActive]="['active']"><i class="fa fa-magic"></i> Create Cluster</a>
+        <a mat-line [routerLink]="getRouterLink('wizard')" [routerLinkActive]="['active']"><i class="fa fa-magic fa-lg"></i> Create Cluster</a>
       </mat-list-item>
 
       <mat-list-item [ngClass]="isProjectSelected('clusters')">


### PR DESCRIPTION
**What this PR does / why we need it**:  Adjust create cluster icon size to be more like other icons in the menu.

Before `13x14 px`:

<img width="217" alt="zrzut ekranu 2018-10-17 o 12 46 54" src="https://user-images.githubusercontent.com/2823399/47081478-0844cd00-d20b-11e8-9fb4-8a86ce417bd2.png">

After `17.31x19 px`:

<img width="219" alt="zrzut ekranu 2018-10-17 o 12 47 11" src="https://user-images.githubusercontent.com/2823399/47081488-0e3aae00-d20b-11e8-962c-99f3da6eff29.png">

Other icons are `20x20 px`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: n/a

**Special notes for your reviewer**: n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
