### PR TITLE
Allow configuring a dedicated vsphere user for the cloud provider functionalities

### DIFF
--- a/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.html
@@ -1,14 +1,20 @@
 <form [formGroup]="vsphereProviderSettingsForm" fxLayout="column">
   <mat-form-field fxFlex>
-    <input matInput formControlName="username" type="text" placeholder="Username*:" autocomplete="off">
-    <mat-error *ngIf="vsphereProviderSettingsForm.controls.username.hasError('required')">
+    <input matInput formControlName="infraManagementUsername" type="text" placeholder="Username*:" autocomplete="off">
+    <mat-error *ngIf="vsphereProviderSettingsForm.controls.infraManagementUsername.hasError('required')">
       Username is <strong>required</strong>
     </mat-error>
   </mat-form-field>
   <mat-form-field fxFlex>
-    <input matInput formControlName="password" type="password" placeholder="Password*:" autocomplete="off">
-    <mat-error *ngIf="vsphereProviderSettingsForm.controls.password.hasError('required')">
+    <input matInput formControlName="infraManagementPassword" type="password" placeholder="Password*:" autocomplete="off">
+    <mat-error *ngIf="vsphereProviderSettingsForm.controls.infraManagementPassword.hasError('required')">
       Password is <strong>required</strong>
     </mat-error>
+  </mat-form-field>
+  <mat-form-field fxFlex>
+    <input matInput formControlName="username" type="text" placeholder="VSphere Cloud Provider Username:" autocomplete="off">
+  </mat-form-field>
+  <mat-form-field fxFlex>
+    <input matInput formControlName="password" type="password" placeholder="VSphere Cloud Provider Password:" autocomplete="off">
   </mat-form-field>
 </form>

--- a/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.spec.ts
@@ -56,6 +56,10 @@ describe('VSphereProviderSettingsComponent', () => {
       username: '',
       password: '',
       vmNetName: '',
+      infraManagementUser: {
+        username: '',
+        password: ''
+      }
     };
     fixture.detectChanges();
   });
@@ -70,14 +74,14 @@ describe('VSphereProviderSettingsComponent', () => {
 
   it('required fields', () => {
     expect(component.vsphereProviderSettingsForm.valid).toBeFalsy('form is initially not valid');
-    expect(component.vsphereProviderSettingsForm.controls.username.valid).toBeFalsy('username field is initially not valid');
-    expect(component.vsphereProviderSettingsForm.controls.username.hasError('required')).toBeTruthy('username field has initially required error');
-    expect(component.vsphereProviderSettingsForm.controls.password.valid).toBeFalsy('password field is initially not valid');
-    expect(component.vsphereProviderSettingsForm.controls.password.hasError('required')).toBeTruthy('password field has initially required error');
+    expect(component.vsphereProviderSettingsForm.controls.infraManagementUsername.valid).toBeFalsy('username field is initially not valid');
+    expect(component.vsphereProviderSettingsForm.controls.infraManagementUsername.hasError('required')).toBeTruthy('username field has initially required error');
+    expect(component.vsphereProviderSettingsForm.controls.infraManagementPassword.valid).toBeFalsy('password field is initially not valid');
+    expect(component.vsphereProviderSettingsForm.controls.infraManagementPassword.hasError('required')).toBeTruthy('password field has initially required error');
 
-    component.vsphereProviderSettingsForm.controls.username.patchValue('foo');
-    expect(component.vsphereProviderSettingsForm.controls.username.hasError('required')).toBeFalsy('username field has no required error after setting foo');
-    component.vsphereProviderSettingsForm.controls.password.patchValue('foo');
-    expect(component.vsphereProviderSettingsForm.controls.password.hasError('required')).toBeFalsy('password field has no required error after setting foo');
+    component.vsphereProviderSettingsForm.controls.infraManagementUsername.patchValue('foo');
+    expect(component.vsphereProviderSettingsForm.controls.infraManagementUsername.hasError('required')).toBeFalsy('username field has no required error after setting foo');
+    component.vsphereProviderSettingsForm.controls.infraManagementPassword.patchValue('foo');
+    expect(component.vsphereProviderSettingsForm.controls.infraManagementPassword.hasError('required')).toBeFalsy('password field has no required error after setting foo');
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.ts
@@ -19,8 +19,11 @@ export class VSphereProviderSettingsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.vsphereProviderSettingsForm = new FormGroup({
-      username: new FormControl(this.cluster.spec.cloud.vsphere.username, [Validators.required]),
-      password: new FormControl(this.cluster.spec.cloud.vsphere.password, [Validators.required]),
+      infraManagementUsername: new FormControl(this.cluster.spec.cloud.vsphere.infraManagementUser.username, Validators.required),
+      infraManagementPassword: new FormControl(this.cluster.spec.cloud.vsphere.infraManagementUser.password, Validators.required),
+      username: new FormControl(this.cluster.spec.cloud.vsphere.username),
+      password: new FormControl(this.cluster.spec.cloud.vsphere.password),
+      vmNetName: new FormControl(this.cluster.spec.cloud.vsphere.vmNetName),
     });
 
     this.subscriptions.push(this.vsphereProviderSettingsForm.valueChanges.subscribe(() => {
@@ -42,7 +45,11 @@ export class VSphereProviderSettingsComponent implements OnInit, OnDestroy {
         vsphere: {
           password: this.vsphereProviderSettingsForm.controls.password.value,
           username: this.vsphereProviderSettingsForm.controls.username.value,
-        },
+          infraManagementUser: {
+            username: this.vsphereProviderSettingsForm.controls.infraManagementUsername.value,
+            password: this.vsphereProviderSettingsForm.controls.infraManagementPassword.value
+          }
+        }
       },
       isValid: this.vsphereProviderSettingsForm.valid,
     };

--- a/src/app/shared/entity/ClusterEntity.ts
+++ b/src/app/shared/entity/ClusterEntity.ts
@@ -90,6 +90,10 @@ export function getEmptyCloudProviderSpec(provider: string): object {
         username: '',
         password: '',
         vmNetName: '',
+        infraManagementUser: {
+          username: '',
+          password: '',
+        }
       };
       return vsSpec;
     case NodeProvider.HETZNER:

--- a/src/app/shared/entity/ClusterEntityPatch.ts
+++ b/src/app/shared/entity/ClusterEntityPatch.ts
@@ -49,4 +49,10 @@ export class AzureCloudSpecPatch {
 export class VSphereCloudSpecPatch {
   username?: string;
   password?: string;
+  infraManagementUser?: VSphereInfraManagementUser;
+}
+
+export class VSphereInfraManagementUser {
+  username?: string;
+  password?: string;
 }

--- a/src/app/shared/entity/cloud/VSphereCloudSpec.ts
+++ b/src/app/shared/entity/cloud/VSphereCloudSpec.ts
@@ -2,4 +2,10 @@ export class VSphereCloudSpec {
   username: string;
   password: string;
   vmNetName: string;
+  infraManagementUser: VSphereInfraManagementUser;
+}
+
+export class VSphereInfraManagementUser {
+  username: string;
+  password: string;
 }

--- a/src/app/testing/fake-data/cluster.fake.ts
+++ b/src/app/testing/fake-data/cluster.fake.ts
@@ -98,7 +98,11 @@ export function fakeVSphereCluster(): ClusterEntity {
         vsphere: {
           username: 'foo',
           password: 'bar',
-          vmNetName: ''
+          vmNetName: '',
+          infraManagementUser: {
+            username: 'foo',
+            password: 'bar',
+          }
         },
         hetzner: null,
         azure: null

--- a/src/app/wizard/set-settings/provider-settings/vsphere/vsphere.component.html
+++ b/src/app/wizard/set-settings/provider-settings/vsphere/vsphere.component.html
@@ -1,15 +1,21 @@
 <form [formGroup]="vsphereSettingsForm" fxLayout="column">
   <mat-form-field fxFlex>
-    <input matInput formControlName="username" type="text" placeholder="Username*:" autocomplete="off">
-    <mat-error *ngIf="vsphereSettingsForm.controls.username.hasError('required')">
+    <input matInput formControlName="infraManagementUsername" type="text" placeholder="Username*:" autocomplete="off">
+    <mat-error *ngIf="vsphereSettingsForm.controls.infraManagementUsername.hasError('required')">
       Username is <strong>required</strong>
     </mat-error>
   </mat-form-field>
   <mat-form-field fxFlex>
-    <input matInput formControlName="password" type="password" placeholder="Password*:" autocomplete="off">
-    <mat-error *ngIf="vsphereSettingsForm.controls.password.hasError('required')">
+    <input matInput formControlName="infraManagementPassword" type="password" placeholder="Password*:" autocomplete="off">
+    <mat-error *ngIf="vsphereSettingsForm.controls.infraManagementPassword.hasError('required')">
       Password is <strong>required</strong>
     </mat-error>
+  </mat-form-field>
+  <mat-form-field fxFlex *ngIf="!hideOptional">
+    <input matInput formControlName="username" type="text" placeholder="VSphere Cloud Provider Username:" autocomplete="off">
+  </mat-form-field>
+  <mat-form-field fxFlex *ngIf="!hideOptional">
+    <input matInput formControlName="password" type="password" placeholder="VSphere Cloud Provider Password:" autocomplete="off">
   </mat-form-field>
   <mat-form-field fxFlex *ngIf="!hideOptional">
     <mat-select placeholder="Network:" formControlName="vmNetName">

--- a/src/app/wizard/set-settings/provider-settings/vsphere/vsphere.component.spec.ts
+++ b/src/app/wizard/set-settings/provider-settings/vsphere/vsphere.component.spec.ts
@@ -36,6 +36,8 @@ describe('VSphereClusterSettingsComponent', () => {
     component.cluster = fakeVSphereCluster();
     component.cluster.spec.cloud.vsphere.username = '';
     component.cluster.spec.cloud.vsphere.password = '';
+    component.cluster.spec.cloud.vsphere.infraManagementUser.username = '';
+    component.cluster.spec.cloud.vsphere.infraManagementUser.password = '';
     fixture.detectChanges();
   });
 
@@ -49,15 +51,15 @@ describe('VSphereClusterSettingsComponent', () => {
 
   it('required fields', () => {
     expect(component.vsphereSettingsForm.valid).toBeFalsy('form is initially not valid');
-    expect(component.vsphereSettingsForm.controls.username.valid).toBeFalsy('username field is initially not valid');
-    expect(component.vsphereSettingsForm.controls.username.hasError('required')).toBeTruthy('username field has initially required error');
-    expect(component.vsphereSettingsForm.controls.password.valid).toBeFalsy('password field is initially not valid');
-    expect(component.vsphereSettingsForm.controls.password.hasError('required')).toBeTruthy('password field has initially required error');
+    expect(component.vsphereSettingsForm.controls.infraManagementUsername.valid).toBeFalsy('username field is initially not valid');
+    expect(component.vsphereSettingsForm.controls.infraManagementUsername.hasError('required')).toBeTruthy('username field has initially required error');
+    expect(component.vsphereSettingsForm.controls.infraManagementPassword.valid).toBeFalsy('password field is initially not valid');
+    expect(component.vsphereSettingsForm.controls.infraManagementPassword.hasError('required')).toBeTruthy('password field has initially required error');
 
-    component.vsphereSettingsForm.controls.username.patchValue('foo');
-    expect(component.vsphereSettingsForm.controls.username.hasError('required')).toBeFalsy('username field has no required error after setting foo');
-    component.vsphereSettingsForm.controls.password.patchValue('foo');
-    expect(component.vsphereSettingsForm.controls.password.hasError('required')).toBeFalsy('password field has no required error after setting foo');
+    component.vsphereSettingsForm.controls.infraManagementUsername.patchValue('foo');
+    expect(component.vsphereSettingsForm.controls.infraManagementUsername.hasError('required')).toBeFalsy('username field has no required error after setting foo');
+    component.vsphereSettingsForm.controls.infraManagementPassword.patchValue('foo');
+    expect(component.vsphereSettingsForm.controls.infraManagementPassword.hasError('required')).toBeFalsy('password field has no required error after setting foo');
 
   });
 });

--- a/src/app/wizard/set-settings/provider-settings/vsphere/vsphere.component.ts
+++ b/src/app/wizard/set-settings/provider-settings/vsphere/vsphere.component.ts
@@ -23,20 +23,35 @@ export class VSphereClusterSettingsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.vsphereSettingsForm = new FormGroup({
-      username: new FormControl(this.cluster.spec.cloud.vsphere.username, Validators.required),
-      password: new FormControl(this.cluster.spec.cloud.vsphere.password, Validators.required),
+      infraManagementUsername: new FormControl(this.cluster.spec.cloud.vsphere.infraManagementUser.username, Validators.required),
+      infraManagementPassword: new FormControl(this.cluster.spec.cloud.vsphere.infraManagementUser.password, Validators.required),
+      username: new FormControl(this.cluster.spec.cloud.vsphere.username),
+      password: new FormControl(this.cluster.spec.cloud.vsphere.password),
       vmNetName: new FormControl(this.cluster.spec.cloud.vsphere.vmNetName),
     });
 
     this.subscriptions.push(this.vsphereSettingsForm.valueChanges.pipe(debounceTime(1000)).subscribe(data => {
       this.loadNetworks();
 
+      let cloudUser = this.vsphereSettingsForm.controls.infraManagementUsername.value;
+      let cloudPassword = this.vsphereSettingsForm.controls.infraManagementPassword.value;
+
+      if (this.vsphereSettingsForm.controls.username.value !== '' &&
+        this.vsphereSettingsForm.controls.password.value !== '') {
+        cloudUser = this.vsphereSettingsForm.controls.username.value;
+        cloudPassword = this.vsphereSettingsForm.controls.password.value;
+      }
+
       this.wizardService.changeClusterProviderSettings({
         cloudSpec: {
           vsphere: {
-            username: this.vsphereSettingsForm.controls.username.value,
-            password: this.vsphereSettingsForm.controls.password.value,
+            username: cloudUser,
+            password: cloudPassword,
             vmNetName: this.vsphereSettingsForm.controls.vmNetName.value,
+            infraManagementUser: {
+              username: this.vsphereSettingsForm.controls.infraManagementUsername.value,
+              password: this.vsphereSettingsForm.controls.infraManagementPassword.value
+            }
           },
           dc: this.cluster.spec.cloud.dc,
         },

--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -145,10 +145,20 @@
           <ng-container *ngIf="cluster.spec.cloud.vsphere">
             <div fxLayout class="km-card-list-content">
               <div fxFlex="50%" class="km-card-list-key">Username</div>
-              <div fxFlex="50%">{{ cluster.spec.cloud.vsphere.username }}</div>
+              <div fxFlex="50%">{{ cluster.spec.cloud.vsphere.infraManagementUser.username }}</div>
             </div>
             <div fxLayout class="km-card-list-content">
               <div fxFlex="50%" class="km-card-list-key">Password</div>
+              <div fxFlex="50%">
+                <input class="km-card-list-secret" type="password" value="{{ cluster.spec.cloud.vsphere.infraManagementUser.password }}" disabled/>
+              </div>
+            </div>
+            <div fxLayout class="km-card-list-content">
+              <div fxFlex="50%" class="km-card-list-key">VSphere Cloud Provider Username</div>
+              <div fxFlex="50%">{{ cluster.spec.cloud.vsphere.username }}</div>
+            </div>
+            <div fxLayout class="km-card-list-content">
+              <div fxFlex="50%" class="km-card-list-key">VSphere Cloud Provider Password</div>
               <div fxFlex="50%">
                 <input class="km-card-list-secret" type="password" value="{{ cluster.spec.cloud.vsphere.password }}" disabled/>
               </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allowes to configure a dedicated vsphere user for the cloud provider functionalities. 
Therefor `infraManagementUser` was introduced in struct, which "replace" the existing Username/Password in the current view. The "old" `user` and `password` fields from the struct will now be found in the extended view and be filled like this:
- if they are filled out in the extended view, they are used
- if they are not filled out in extended view, they will be the same as the credentials in `infraManagementUser`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #711 

**Special notes for your reviewer**:
/

**Release note**:
```release-note
VSphere: Setting a dedicated VSphere user for cloud provider functionalities is now possible.
```
