### PR TITLE
Fix that the cluster upgrade link does not appear directly

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -106,6 +106,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
           this.isClusterRunning = this.healthService.isClusterRunning(this.cluster, health);
           this.clusterHealthClass = this.healthService.getClusterHealthStatus(this.cluster, health);
           this.reloadClusterNodes();
+          this.reloadVersions();
         });
       });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix that the cluster upgrade link does not appear directly when the detail page is loaded but only after a few seconds

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard-v2/issues/827

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed that the cluster upgrade link did not appear directly when the details page is loaded
```
