### PR TITLE
Require tslint whitespace rule for check-module

### DIFF
--- a/src/app/add-node/add-node.component.spec.ts
+++ b/src/app/add-node/add-node.component.spec.ts
@@ -9,7 +9,7 @@ import { DigitaloceanOptionsComponent } from './digitalocean-add-node/digitaloce
 import { OpenstackAddNodeComponent } from './openstack-add-node/openstack-add-node.component';
 import { OpenstackOptionsComponent } from './openstack-add-node/openstack-options/openstack-options.component';
 import { fakeAWSCluster, fakeDigitaloceanCluster, fakeOpenstackCluster } from '../testing/fake-data/cluster.fake';
-import { AddNodeService} from '../core/services/add-node/add-node.service';
+import { AddNodeService } from '../core/services/add-node/add-node.service';
 import { ProjectService, WizardService, ApiService, DatacenterService } from '../core/services';
 import { asyncData } from '../testing/services/api-mock.service';
 import { fakeDigitaloceanSizes, fakeOpenstackFlavors } from '../testing/fake-data/addNodeModal.fake';

--- a/src/app/add-node/add-node.component.ts
+++ b/src/app/add-node/add-node.component.ts
@@ -3,10 +3,9 @@ import { ClusterEntity } from '../shared/entity/ClusterEntity';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { AddNodeService } from '../core/services/add-node/add-node.service';
-import {WizardService, DatacenterService, ProjectService} from '../core/services';
+import { WizardService, DatacenterService, ProjectService } from '../core/services';
 import { NodeData, NodeProviderData } from '../shared/model/NodeSpecChange';
-import { OperatingSystemSpec} from '../shared/entity/NodeEntity';
-import { ActivatedRoute } from '@angular/router';
+import { OperatingSystemSpec } from '../shared/entity/NodeEntity';
 
 @Component({
   selector: 'kubermatic-add-node',

--- a/src/app/add-node/digitalocean-add-node/digitalocean-add-node.component.spec.ts
+++ b/src/app/add-node/digitalocean-add-node/digitalocean-add-node.component.spec.ts
@@ -10,7 +10,7 @@ import { fakeDigitaloceanSizes } from '../../testing/fake-data/addNodeModal.fake
 import { AddNodeService } from '../../core/services/add-node/add-node.service';
 import { fakeDigitaloceanCluster } from '../../testing/fake-data/cluster.fake';
 import Spy = jasmine.Spy;
-import {nodeDataFake} from '../../testing/fake-data/node.fake';
+import { nodeDataFake } from '../../testing/fake-data/node.fake';
 
 const modules: any[] = [
   BrowserModule,

--- a/src/app/add-node/digitalocean-add-node/digitalocean-options/digitalocean-options.component.ts
+++ b/src/app/add-node/digitalocean-add-node/digitalocean-options/digitalocean-options.component.ts
@@ -1,9 +1,9 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { AddNodeService } from '../../../core/services/add-node/add-node.service';
 import { Subscription } from 'rxjs';
 import { ApiService } from '../../../core/services';
-import {NodeData, NodeProviderData} from '../../../shared/model/NodeSpecChange';
+import { NodeData, NodeProviderData } from '../../../shared/model/NodeSpecChange';
 
 @Component({
   selector: 'kubermatic-digitalocean-options',

--- a/src/app/add-project/add-project.component.spec.ts
+++ b/src/app/add-project/add-project.component.spec.ts
@@ -2,7 +2,7 @@ import { SharedModule } from '../shared/shared.module';
 import { SlimLoadingBarModule } from 'ng2-slim-loading-bar';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { AddProjectComponent } from './add-project.component';
 import { MatDialogRefMock } from '../testing/services/mat-dialog-ref-mock';
 import { ProjectMockService } from '../testing/services/project-mock.service';

--- a/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.ts
+++ b/src/app/cluster/cluster-details/cluster-connect/cluster-connect.component.ts
@@ -2,7 +2,6 @@ import { Component, Input } from '@angular/core';
 import { DataCenterEntity } from '../../../shared/entity/DatacenterEntity';
 import { ClusterEntity } from '../../../shared/entity/ClusterEntity';
 import { ApiService } from '../../../core/services';
-import {ProjectEntity} from '../../../shared/entity/ProjectEntity';
 
 @Component({
   selector: 'kubermatic-cluster-connect',

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material';
 
 import { lt, gt } from 'semver';
-import { Subscription, ObservableInput, Subject, interval, combineLatest} from 'rxjs';
+import { Subscription, ObservableInput, Subject, interval, combineLatest } from 'rxjs';
 import { retry, takeUntil } from 'rxjs/operators';
 
 import { NotificationActions } from '../../redux/actions/notification.actions';

--- a/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/hetzner-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/hetzner-provider-settings.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { ClusterService } from '../../../../core/services';
-import { ClusterEntity} from '../../../../shared/entity/ClusterEntity';
+import { ClusterEntity } from '../../../../shared/entity/ClusterEntity';
 import { ProviderSettingsPatch } from '../../../../core/services/cluster/cluster.service';
 
 @Component({

--- a/src/app/core/components/navigation/navigation.component.ts
+++ b/src/app/core/components/navigation/navigation.component.ts
@@ -7,8 +7,6 @@ import { environment } from '../../../../environments/environment';
 import { AppConstants } from '../../../shared/constants/constants';
 import { MobileNavigationComponent } from '../../../overlays';
 import { MemberEntity } from '../../../shared/entity/MemberEntity';
-import {Subscription} from 'rxjs/index';
-
 
 @Component({
   selector: 'kubermatic-navigation',

--- a/src/app/core/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/core/components/sidenav/sidenav.component.spec.ts
@@ -24,7 +24,7 @@ import { AppConfigMockService } from '../../../testing/services/app-config-mock.
 
 import { fakeProjects } from '../../../testing/fake-data/project.fake';
 import Spy = jasmine.Spy;
-import {ProjectEntity} from '../../../shared/entity/ProjectEntity';
+import { ProjectEntity } from '../../../shared/entity/ProjectEntity';
 
 const modules: any[] = [
   BrowserModule,

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import {catchError, map} from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { Auth } from '../auth/auth.service';
 import { environment } from './../../../../environments/environment';
 import { MemberEntity } from '../../../shared/entity/MemberEntity';
-import { MasterVersion } from '../../../shared/entity/ClusterEntity';
 
 @Injectable()
 export class UserService {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -2,7 +2,7 @@ import { BreadcrumbActions } from './../redux/actions/breadcrumb.actions';
 import { Component, OnInit } from '@angular/core';
 import { Auth } from '../core/services';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { filter, mergeMap, map} from 'rxjs/operators';
+import { filter, mergeMap, map } from 'rxjs/operators';
 import { ApiService } from '../core/services/api/api.service';
 import { DatacenterService } from '../core/services/datacenter/datacenter.service';
 

--- a/src/app/kubermatic.component.spec.ts
+++ b/src/app/kubermatic.component.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { SlimLoadingBarModule } from 'ng2-slim-loading-bar';
 import { BrowserModule, By } from '@angular/platform-browser';
-import { SimpleNotificationsModule} from 'angular2-notifications';
+import { SimpleNotificationsModule } from 'angular2-notifications';
 import { NgReduxTestingModule } from '@angular-redux/store/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';

--- a/src/app/wizard/set-settings/provider-settings/azure/azure.component.spec.ts
+++ b/src/app/wizard/set-settings/provider-settings/azure/azure.component.spec.ts
@@ -1,11 +1,11 @@
-import {BrowserModule} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ReactiveFormsModule} from '@angular/forms';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {SharedModule} from '../../../../shared/shared.module';
-import {fakeAzureCluster} from '../../../../testing/fake-data/cluster.fake';
-import {WizardService} from '../../../../core/services/wizard/wizard.service';
-import {AzureClusterSettingsComponent} from './azure.component';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ReactiveFormsModule } from '@angular/forms';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SharedModule } from '../../../../shared/shared.module';
+import { fakeAzureCluster } from '../../../../testing/fake-data/cluster.fake';
+import { WizardService } from '../../../../core/services/wizard/wizard.service';
+import { AzureClusterSettingsComponent } from './azure.component';
 
 describe('AzureClusterSettingsComponent', () => {
   let fixture: ComponentFixture<AzureClusterSettingsComponent>;

--- a/src/app/wizard/set-settings/provider-settings/hetzner/hetzner.component.spec.ts
+++ b/src/app/wizard/set-settings/provider-settings/hetzner/hetzner.component.spec.ts
@@ -1,11 +1,11 @@
-import {BrowserModule} from '@angular/platform-browser';
-import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ReactiveFormsModule} from '@angular/forms';
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {SharedModule} from '../../../../shared/shared.module';
-import {fakeHetznerCluster} from '../../../../testing/fake-data/cluster.fake';
-import {WizardService} from '../../../../core/services/wizard/wizard.service';
-import {HetznerClusterSettingsComponent} from './hetzner.component';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ReactiveFormsModule } from '@angular/forms';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SharedModule } from '../../../../shared/shared.module';
+import { fakeHetznerCluster } from '../../../../testing/fake-data/cluster.fake';
+import { WizardService } from '../../../../core/services/wizard/wizard.service';
+import { HetznerClusterSettingsComponent } from './hetzner.component';
 
 describe('HetznerClusterSettingsComponent', () => {
   let fixture: ComponentFixture<HetznerClusterSettingsComponent>;

--- a/tslint.json
+++ b/tslint.json
@@ -117,6 +117,7 @@
       true,
       "check-branch",
       "check-decl",
+      "check-module",
       "check-operator",
       "check-separator",
       "check-type"


### PR DESCRIPTION
**What this PR does / why we need it**:
We have been mostly using spaces between the curly braces in import statements anyways,
this rule enforces this.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
