### PR TITLE
fix duplicated ssh keys in summary

### DIFF
--- a/src/app/cluster/cluster-details/edit-sshkeys/add-cluster-sshkeys/add-cluster-sshkeys.component.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/add-cluster-sshkeys/add-cluster-sshkeys.component.ts
@@ -44,7 +44,9 @@ export class AddClusterSSHKeysComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.keysSub.unsubscribe();
+    if (this.keysSub) {
+      this.keysSub.unsubscribe();
+    }
   }
 
   reloadKeys(): void {

--- a/src/app/wizard/set-settings/ssh-keys/cluster-ssh-keys.component.html
+++ b/src/app/wizard/set-settings/ssh-keys/cluster-ssh-keys.component.html
@@ -3,8 +3,8 @@
 </h4>
 <form [formGroup]="keysForm">
   <mat-form-field *ngIf="keys.length > 0">
-    <mat-select placeholder="SSH keys" formControlName="keys" multiple>
-      <mat-option *ngFor="let key of keys" value="{{key.name}}">{{key.name}}</mat-option>
+    <mat-select placeholder="SSH keys" formControlName="keys" multiple [compareWith]="compareValues">
+      <mat-option *ngFor="let key of keys" [value]="key">{{key.name}}</mat-option>
     </mat-select>
   </mat-form-field>
   <button *ngIf="keys.length > 0" style="margin-top: 10px; padding: 0 10px;" mat-button color="primary" (click)="addSshKeyDialog()" mat-raised-button [disabled]="!!userGroup && !userGroupConfig[userGroup].sshKeys.create">Add new SSH key</button>

--- a/src/app/wizard/set-settings/ssh-keys/cluster-ssh-keys.component.ts
+++ b/src/app/wizard/set-settings/ssh-keys/cluster-ssh-keys.component.ts
@@ -46,11 +46,7 @@ export class ClusterSSHKeysComponent implements OnInit, OnDestroy {
       });
     }));
 
-    const keyNames: string[] = [];
-    for (const key of this.selectedKeys) {
-      keyNames.push(key.name);
-    }
-    this.keysForm.controls.keys.patchValue(keyNames);
+    this.keysForm.controls.keys.patchValue(this.selectedKeys);
 
     this.keysFormSub = this.keysForm.valueChanges.subscribe((data) => {
       this.setClusterSSHKeysSpec();
@@ -83,7 +79,9 @@ export class ClusterSSHKeysComponent implements OnInit, OnDestroy {
           this.keysSub.unsubscribe();
         }
         this.reloadKeys();
-        this.keysForm.controls.keys.patchValue([result.name]);
+        const newValue = this.keysForm.controls.keys.value;
+        newValue.push(result);
+        this.keysForm.controls.keys.patchValue(newValue);
       }
     });
   }
@@ -92,11 +90,15 @@ export class ClusterSSHKeysComponent implements OnInit, OnDestroy {
     const clusterKeys: SSHKeyEntity[] = [];
     for (const selectedKey of this.keysForm.controls.keys.value) {
       for (const key of this.keys) {
-        if (selectedKey === key.name) {
+        if (selectedKey.id === key.id) {
           clusterKeys.push(key);
         }
       }
     }
     this.wizardService.changeClusterSSHKeys(clusterKeys);
+  }
+
+  compareValues(value1: SSHKeyEntity, value2: SSHKeyEntity): boolean {
+    return value1 && value2 ? value1.id === value2.id : value1 === value2;
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the bug, that causes duplicated SSH keys in summary view when going back and forth between the wizard steps. This was only happening, when there are two keys with the exact same name. We now compare the whole SSH key entity instead of only comparing the name. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #874 

**Special notes for your reviewer**:
Can't reproduce point one in the issue (`kubectl get usersskeies | grep xrstf only shows a single SSH key with my name attached, yet Kubermatic shows me two keys. I only have a single project on dev with one member (myself).`). 
But related to that we might want to think about if we want to ban the possibility to add SSH keys with an already existing name (of course only per project). WDYT? Might make sense to implement it in backend as well... /cc @maciaszczykm @p0lyn0mial @zreigz 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed duplicated SSH keys in summary view during cluster creation.
```
