### PR TITLE
disable sidenav closing when pressing esc

### DIFF
--- a/src/app/kubermatic.component.html
+++ b/src/app/kubermatic.component.html
@@ -9,7 +9,7 @@
     <kubermatic-notification></kubermatic-notification>
 
     <mat-sidenav-container>
-      <mat-sidenav #sidenav opened mode="side" *ngIf="auth.authenticated()">
+      <mat-sidenav #sidenav opened disableClose mode="side" *ngIf="auth.authenticated()">
         <kubermatic-sidenav></kubermatic-sidenav>
       </mat-sidenav>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously sidenav closed when pressing esc without possibility to get it back open. As we don't have a "burger-menu", I just disabled closing at all.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #883

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
