### PR TITLE
Set no-cache headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,12 @@ func main() {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
+	// Forces caches to submit the request to the origin server for validation before releasing a cached copy.
+	w.Header().Add("Cache-Control", "no-cache")
+
+	// It is used for backwards compatibility with HTTP/1.0 caches.
+	w.Header().Add("Pragma", "no-cache")
+
 	// Don't list directories, a directory has a / suffix.
 	if r.URL.Path != "/" && strings.HasSuffix(r.URL.Path, "/") {
 		http.NotFound(w, r)


### PR DESCRIPTION
**What this PR does / why we need it**: It fixes the problem described in #887.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #887 

**Special notes for your reviewer**: I have added two additional headers. `Pragma` header is used as a fallback for HTTP/1.0. Headers are added in Go as it is advised by many:

> Note: It may be better to specify cache commands in HTTP than in META statements, where they can influence more than the browser, but proxies and other intermediaries that may cache information.

Result:

![zrzut ekranu 2018-12-4 o 09 17 51](https://user-images.githubusercontent.com/2823399/49428519-8dc61180-f7a6-11e8-9768-4931896e6514.png)


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed issues with caching the main page.
```
