### PR TITLE
changes share cluster dialog box's title

### DIFF
--- a/src/app/cluster/cluster-details/share-kubeconfig/share-kubeconfig.component.html
+++ b/src/app/cluster/cluster-details/share-kubeconfig/share-kubeconfig.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar>
-  Share Kubeconfig
+  Give access to your cluster
   <button mat-icon-button
           mat-dialog-close>
     <i class="fa fa-times"


### PR DESCRIPTION
**What this PR does / why we need it**: simply changes the title of the "share cluster" window, see attached pictures.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
