### PR TITLE
adds a link to oidc auth documentation

### DIFF
--- a/src/app/cluster/cluster-details/share-kubeconfig/share-kubeconfig.component.html
+++ b/src/app/cluster/cluster-details/share-kubeconfig/share-kubeconfig.component.html
@@ -9,6 +9,7 @@
 <mat-dialog-content>
   <div class="mat-dialog-content">
     <p>You can share this cluster with users by giving them the following link. They can use it to authenticate with an OIDC provider and then generate a kubeconfig.</p>
+    <p>Please visit our <a href="https://docs.kubermatic.io/advanced/oidc_auth" target="_blank">documentation</a> for more details.</p>
     <div class="code-block">{{kubeconfigLink}}</div>
   </div>
 </mat-dialog-content>


### PR DESCRIPTION
**What this PR does / why we need it**: simply adds a link to documentation that describes how to use `oidc` authentication feature.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
