### PR TITLE
don't call `dist` target when `building` go sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ e2e:
 dist:
 	@$(CC) run build -prod
 
-build: dist
+build:
 	CGO_ENABLED=0 go build -ldflags '-w -extldflags '-static'' -o dashboard-v2 .
 
 docker-build:


### PR DESCRIPTION
**What this PR does / why we need it**: the image we use in CI doesn't have `npm` installed thus the `build` step fails.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
