### PR TITLE
push images to quay in addition to dockerhub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,11 +77,61 @@ pipeline:
     when:
       event: [tag]
 
+  quay-always:
+    group: push
+    image: plugins/docker
+    registry: quay.io
+    repo: quay.io/kubermatic/ui-v2
+    password: ${QUAY_PASSWORD}
+    username: ${QUAY_USERNAME}
+    tags:
+      - ${DRONE_COMMIT}
+    secrets:
+    - source: quay_username
+      target: docker_username
+    - source: quay_password
+      target: docker_password
+
+  quay-master:
+    group: push
+    image: plugins/docker
+    registry: quay.io
+    repo: quay.io/kubermatic/ui-v2
+    password: ${QUAY_PASSWORD}
+    username: ${QUAY_USERNAME}
+    tags:
+      - master
+    secrets:
+    - source: quay_username
+      target: docker_username
+    - source: quay_password
+      target: docker_password
+    when:
+      branch: master
+
+  quay-release:
+    group: push
+    image: plugins/docker
+    registry: quay.io
+    repo: quay.io/kubermatic/ui-v2
+    password: ${QUAY_PASSWORD}
+    username: ${QUAY_USERNAME}
+    tags:
+      - ${DRONE_TAG}
+      - latest
+    secrets:
+    - source: quay_username
+      target: docker_username
+    - source: quay_password
+      target: docker_password
+    when:
+      event: [tag]
+
   deploy-dev:
     group: deploy
     image: kubeciio/kubectl:0.2
     pull: true
-    kubectl: set image deployment/kubermatic-ui-v2 webserver=kubermatic/ui-v2:{{ .DroneCommit }}
+    kubectl: set image deployment/kubermatic-ui-v2 webserver=quay.io/kubermatic/ui-v2:{{ .DroneCommit }}
     namespace: kubermatic
     secrets:
       - source: kubeconfig_dev
@@ -93,7 +143,7 @@ pipeline:
     group: deploy
     image: kubeciio/kubectl:0.2
     pull: true
-    kubectl: set image deployment/kubermatic-ui-v2 webserver=kubermatic/ui-v2:{{ .DroneCommit }}
+    kubectl: set image deployment/kubermatic-ui-v2 webserver=quay.io/kubermatic/ui-v2:{{ .DroneCommit }}
     namespace: kubermatic
     secrets:
     - source: kubeconfig_cloud

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL=/bin/bash
-REPO=kubermatic/ui-v2
+REPO=quay.io/kubermatic/ui-v2
 TAGS=dev
 BUILD_FLAG += $(foreach tag, $(TAGS), -t $(REPO):$(tag))
 CC=npm


### PR DESCRIPTION
**What this PR does / why we need it**:
We're moving all of our Docker images from Docker Hub to quay.io and the Dashboard is one of the last components on the hub. This PR makes the quay.io an additional destination for the image uploads. Docker Hub upload will be preserved for a while to ensure backwards compatibility.

In addition, the automatic deployments on dev and cloud will already be switched over to the quay repos.

```release-note
NONE
```
