### PR TITLE
add missing display: block to css class

### DIFF
--- a/src/assets/css/app.scss
+++ b/src/assets/css/app.scss
@@ -317,6 +317,7 @@ mat-button-toggle-group[group='providerGroup'] {
 }
 
 .provider-logo {
+  display: block;
   height: 100% !important;
   width: 100% !important;
   max-height: 40px !important;


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems like I've introduced a very little bug with my last PR. Provider logo on cluster details view was not displayed correctly. Therefor I added missing `display: block` to css class. 😅 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
/

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
