### PR TITLE
updates the names of variables that set dex user and password

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ pipeline:
 
   e2e:
     image: atlassianlabs/docker-node-jdk-chrome-firefox:2018-12-10
-    secrets: [kubermatic_e2e_username, kubermatic_e2e_password]
+    secrets: [kubermatic_dex_dev_e2e_username, kubermatic_dex_dev_e2e_password]
     commands:
       - npm run e2e
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To automatically fix issues run `npm run fix` command.
 Run `npm test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
 ### Running the end-to-end tests
-Currently e2e tests are being executed against `dev.kubermatic.io` server. Before running tests make sure that `KUBERMATIC_E2E_USERNAME` and `KUBERMATIC_E2E_PASSWORD` environment variables are set. To run end-to-end tests via [Protractor](http://www.protractortest.org/), simply execute `npm run e2e`.
+Currently e2e tests are being executed against `dev.kubermatic.io` server. Before running tests make sure that `KUBERMATIC_DEX_DEV_E2E_USERNAME` and `KUBERMATIC_DEX_DEV_E2E_PASSWORD` environment variables are set. To run end-to-end tests via [Protractor](http://www.protractortest.org/), simply execute `npm run e2e`.
 
 ### Building the application
 Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.

--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -27,13 +27,13 @@ exports.config = {
   baseUrl: 'http://localhost:8000/',
 
   onPrepare() {
-    if (process.env.KUBERMATIC_E2E_USERNAME === undefined ||
-      process.env.KUBERMATIC_E2E_PASSWORD === undefined) {
-      throw new Error(`'KUBERMATIC_E2E_USERNAME' and 'KUBERMATIC_E2E_PASSWORD' environment variables have to be set.`)
+    if (process.env.KUBERMATIC_DEX_DEV_E2E_USERNAME === undefined ||
+      process.env.KUBERMATIC_DEX_DEV_E2E_PASSWORD === undefined) {
+      throw new Error(`'KUBERMATIC_DEX_DEV_E2E_USERNAME' and 'KUBERMATIC_DEX_DEV_E2E_PASSWORD' environment variables have to be set.`)
     }
 
-    browser.params.KUBERMATIC_E2E_USERNAME = process.env.KUBERMATIC_E2E_USERNAME;
-    browser.params.KUBERMATIC_E2E_PASSWORD = process.env.KUBERMATIC_E2E_PASSWORD;
+    browser.params.KUBERMATIC_E2E_USERNAME = process.env.KUBERMATIC_DEX_DEV_E2E_USERNAME;
+    browser.params.KUBERMATIC_E2E_PASSWORD = process.env.KUBERMATIC_DEX_DEV_E2E_PASSWORD;
 
     require('ts-node').register({
       project: require('path').join(__dirname, './tsconfig.e2e.json')


### PR DESCRIPTION
**What this PR does / why we need it**: changes the names of variables that set dex user and password to match the ones defined in `prow`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
