### PR TITLE
replacing npm install with npm ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,7 +27,7 @@ pipeline:
       - make dist
 
   test:
-    image: kubermatic/chrome-headless:v0.2
+    image: quay.io/kubermatic/chrome-headless:v0.3
     commands:
       - make test-headless
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ CC=npm
 all: install run
 
 install:
-	@$(CC) install
+	@$(CC) ci
 
-check:
+check: install
 	@$(CC) run check
 
 run:
@@ -20,13 +20,13 @@ test-full: test e2e
 test:
 	@$(CC) run test
 
-test-headless:
+test-headless: install
 	@$(CC) run test:headless
 
-e2e:
+run-e2e: install
 	@$(CC) run e2e
 
-dist:
+dist: install
 	@$(CC) run build -prod
 
 build:

--- a/containers/test-chrome/Dockerfile
+++ b/containers/test-chrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8.15
 
 # Install Google Chrome
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/containers/test-chrome/release.sh
+++ b/containers/test-chrome/release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+TAG=v0.3
+
+set -euox pipefail
+
+docker build --no-cache --pull -t quay.io/kubermatic/chrome-headless:${TAG} .
+docker push quay.io/kubermatic/chrome-headless:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**: changes `npm install` with `npm ci` as the latter seems to be more reliable and is a recommended way of managing dependencies https://docs.npmjs.com/cli/ci.html

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
