### PR TITLE
Add tooltip related to Node Deployments feature

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -129,8 +129,14 @@
                                      [hasInitialNodes]="hasInitialNodes"></kubermatic-node-deployment-list>
   </div>
 
-  <div>
-    <div class="km-pre-card-title">Nodes</div>
+  <div *ngIf="!isNodeDeploymentAPIAvailable || nodes.length > 0">
+    <div class="km-pre-card-title">
+      <ng-container>Nodes&nbsp;</ng-container>
+        <span *ngIf="isNodeDeploymentAPIAvailable"
+              matTooltip="Single Node management is being deprecated in favour of Node Deployments. This table displays only the Nodes that are not controlled by other resources (i.e. children of Node Deployment).">
+          <i class="fa fa-warning" aria-hidden="true"></i>
+        </span>
+    </div>
     <kubermatic-node-list [cluster]="cluster"
                           [nodes]="nodes"
                           (deleteNode)="reloadClusterNodes()"


### PR DESCRIPTION
**What this PR does / why we need it**: It enhances UX with Node Deployments feature. Explains controlled Nodes are not visible in Nodes table and hides the table when it is empty and user cannot create new Nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #964

**Special notes for your reviewer**: 
![zrzut ekranu 2019-01-14 o 11 23 26](https://user-images.githubusercontent.com/2823399/51107423-10eb7600-17ef-11e9-8033-3021b91bf8ff.png)
![zrzut ekranu 2019-01-14 o 11 25 18](https://user-images.githubusercontent.com/2823399/51107430-1648c080-17ef-11e9-957b-2ef7148fc236.png)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
