### PR TITLE
Add option to cleanup resources during cluster deletion

### DIFF
--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.html
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.html
@@ -1,4 +1,4 @@
-<div id="km-delete-cluster-dialog" class="km-dialog-box" (keydown.enter)="deleteCluster()">
+<form [formGroup]="deleteForm" id="km-delete-cluster-dialog" class="km-dialog-box" (keydown.enter)="deleteCluster()">
  <mat-toolbar>
     Delete Cluster confirmation
     <button mat-icon-button mat-dialog-close>
@@ -9,9 +9,25 @@
   <mat-dialog-content>
     <div class="mat-dialog-content">
       <p>You are on the way to delete the cluster "{{cluster.name}}". Deletion of clusters cannot be UNDONE!</p>
+
+      <div class="km-delete-cluster-checkbox">
+        <label fxFlex="60%">Cleanup connected Load Balancers</label>
+        <mat-checkbox fxFlex="40%" formControlName="clusterLBCleanupCheckbox"></mat-checkbox>
+      </div>
+
+      <div class="km-delete-cluster-checkbox">
+        <label fxFlex="60%">Cleanup connected volumes (PVs and PVCs)</label>
+        <mat-checkbox fxFlex="40%" formControlName="clusterVolumeCleanupCheckbox"></mat-checkbox>
+      </div>
+
+      <div class="km-delete-cluster-warning">
+        <mat-icon fxFlexAlign="center">warning</mat-icon>
+        <span>Be aware, that some leftover resources might still exist at your cloud provider. Please delete them manually.</span>
+      </div>
+
       <p>If you know what you are doing, <strong>please type the name of the cluster</strong>:</p>
 
-      <mat-form-field style="width: 100%" >
+      <mat-form-field class="km-delete-cluster-name-input">
         <input id="km-delete-cluster-dialog-input" matInput type="text" placeholder="Name of the Cluster:"
                title="Cluster name" (blur)="onChange($event)" (keyup)="onChange($event)" #clusterNameInput>
       </mat-form-field>
@@ -26,7 +42,7 @@
       Delete
     </button>
   </mat-dialog-actions>
-</div>
+</form>
 
 
 

--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.scss
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.scss
@@ -1,0 +1,21 @@
+@import "../../../../assets/css/variables";
+@import "../../../../assets/css/colors";
+
+.km-delete-cluster-name-input {
+  width: 100%;
+}
+
+.km-delete-cluster-checkbox {
+  font-size: $body-font-size-base;
+  margin-bottom: $baseline-grid;
+}
+
+.km-delete-cluster-warning {
+  display: flex;
+  font-size: $body-font-size-base;
+
+  mat-icon {
+    color: $waiting-status-color;
+    margin-right: $baseline-grid;
+  }
+}

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -5,7 +5,7 @@ import {catchError} from 'rxjs/operators';
 
 import {environment} from '../../../../environments/environment';
 import {AppConfigService} from '../../../app-config.service';
-import {ClusterEntity, MasterVersion, Token} from '../../../shared/entity/ClusterEntity';
+import {ClusterEntity, Finalizer, MasterVersion, Token} from '../../../shared/entity/ClusterEntity';
 import {ClusterEntityPatch} from '../../../shared/entity/ClusterEntityPatch';
 import {CreateMemberEntity, MemberEntity} from '../../../shared/entity/MemberEntity';
 import {NodeDeploymentEntity} from '../../../shared/entity/NodeDeploymentEntity';
@@ -26,7 +26,7 @@ export class ApiService {
   private location: string = window.location.protocol + '//' + window.location.host;
   private restRoot: string = environment.restRoot;
   private headers: HttpHeaders = new HttpHeaders();
-  private token: string;
+  private readonly token: string;
   private isNodeDeploymentAPIAvailable_ = false;
 
   constructor(
@@ -117,8 +117,15 @@ export class ApiService {
     return this.http.patch<ClusterEntity>(url, patch, {headers: this.headers});
   }
 
-  deleteCluster(cluster: string, dc: string, projectID: string): Observable<any> {
+  deleteCluster(cluster: string, dc: string, projectID: string, finalizers?: {[key in Finalizer]: boolean}):
+      Observable<any> {
     const url = `${this.restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}`;
+    if (finalizers !== undefined) {
+      for (const key of Object.keys(finalizers)) {
+        this.headers = this.headers.set(key, finalizers[key].toString());
+      }
+    }
+
     return this.http.delete(url, {headers: this.headers});
   }
 

--- a/src/app/shared/entity/ClusterEntity.ts
+++ b/src/app/shared/entity/ClusterEntity.ts
@@ -39,6 +39,11 @@ export function getClusterProvider(cluster: ClusterEntity): string {
   return '';
 }
 
+export const enum Finalizer {
+  DeleteVolumes = 'DeleteVolumes',
+  DeleteLoadBalancers = 'DeleteLoadBalancers',
+}
+
 export class ClusterEntity {
   creationTimestamp?: Date;
   deletionTimestamp?: Date;

--- a/src/assets/css/_variables.scss
+++ b/src/assets/css/_variables.scss
@@ -1,0 +1,12 @@
+@function rem($multiplier) {
+  $font-size: 10px;
+
+  @return $multiplier * $font-size;
+}
+
+$subhead-font-size-base-lg: rem(1.8) !default;
+$subhead-font-size-base: rem(1.6) !default;
+$body-font-size-base: rem(1.4) !default;
+$caption-font-size-base: rem(1.2) !default;
+
+$baseline-grid: 8px;


### PR DESCRIPTION
**What this PR does / why we need it**:
Add option to cleanup volumes and load balancers during cluster deletion. Additionally, informs the user about possibility of some leftover resources that might need to be cleaned up manually. I have also added `_variables.scss` to export some font/base variables.

![zrzut ekranu z 2019-01-14 13-39-36](https://user-images.githubusercontent.com/2285385/51116330-1bb40400-180b-11e9-8667-75ca114d85dd.png)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #961
Related to https://github.com/kubermatic/kubermatic/issues/2449

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
