### PR TITLE
updates Makefile targets for building and publishing docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHELL=/bin/bash
 REPO=quay.io/kubermatic/ui-v2
-TAGS=dev
-BUILD_FLAG += $(foreach tag, $(TAGS), -t $(REPO):$(tag))
+IMAGE_TAG = $(shell echo $$(git rev-parse HEAD && if [[ -n $$(git status --porcelain) ]]; then echo '-dirty'; fi)|tr -d ' ')
 CC=npm
 
 all: install run
@@ -32,10 +31,8 @@ dist: install
 build:
 	CGO_ENABLED=0 go build -ldflags '-w -extldflags '-static'' -o dashboard-v2 .
 
-docker-build:
-	docker build $(BUILD_FLAG) .
+docker-build: build dist
+	docker build -t $(REPO):$(IMAGE_TAG) .
 
 docker-push:
-	for TAG in $(TAGS) ; do \
-		docker push $(REPO):$$TAG ; \
-	done
+	docker push $(REPO):$(IMAGE_TAG)

--- a/containers/go-111-node-8-with-docker/Dockerfile
+++ b/containers/go-111-node-8-with-docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/kubermatic/go-111-docker:11.2-1806-0
+
+RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
+    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && apt install nodejs

--- a/containers/go-111-node-8-with-docker/README.md
+++ b/containers/go-111-node-8-with-docker/README.md
@@ -1,0 +1,11 @@
+# go-111-node8-with-docker
+
+A simple image that contains go, nodejs and docker in order to publish images via docker in docker
+
+## Usage
+
+* Bump the image tag and run `release.sh` script to publish a new version
+
+## Development
+
+This image is a customized version of https://github.com/kubermatic/infra/tree/master/docker_images/go-111-with-docker

--- a/containers/go-111-node-8-with-docker/release.sh
+++ b/containers/go-111-node-8-with-docker/release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+TAG=v0.1
+
+set -euox pipefail
+
+docker build --no-cache --pull -t quay.io/kubermatic/go-111-node8-docker:${TAG} .
+docker push quay.io/kubermatic/go-111-node8-docker:${TAG}


### PR DESCRIPTION
**What this PR does / why we need it**: updates Makefile targets for building and publishing docker image

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
