### PR TITLE
fix selecting a provider after going back

### DIFF
--- a/src/app/wizard/set-datacenter/set-datacenter.component.html
+++ b/src/app/wizard/set-datacenter/set-datacenter.component.html
@@ -9,7 +9,7 @@
   <p *ngIf="cluster.spec.cloud.bringyourown">This is the kubermatic datacenter you want your master components to run in.</p>
   <form [formGroup]="setDatacenterForm" fxLayoutAlign="left" fxLayout="row wrap">
     <mat-button-toggle-group group="datacenterGroup" formControlName="datacenter">
-      <mat-button-toggle *ngFor="let datacenter of datacenters;" value="{{datacenter.metadata.name}}">
+      <mat-button-toggle *ngFor="let datacenter of datacenters;" value="{{datacenter.metadata.name}}" (click)="this.changeClusterDatacenter()">
         <span class="flag-icon flag-icon-{{ datacenter.spec.country.toLowerCase() }}">
         </span>
         <div class="km-location">

--- a/src/app/wizard/set-datacenter/set-datacenter.component.ts
+++ b/src/app/wizard/set-datacenter/set-datacenter.component.ts
@@ -41,17 +41,21 @@ export class SetDatacenterComponent implements OnInit, OnDestroy {
     }));
 
     this.subscriptions.push(this.setDatacenterForm.valueChanges.subscribe((data) => {
-      let dc: DataCenterEntity = null;
-      for (const datacenter of this.datacenters) {
-        if (this.setDatacenterForm.controls.datacenter.value === datacenter.metadata.name) {
-          dc = datacenter;
-        }
-      }
-      this.wizardService.changeClusterDatacenter({
-        datacenter: dc,
-        valid: this.setDatacenterForm.valid,
-      });
+      this.changeClusterDatacenter();
     }));
+  }
+
+  changeClusterDatacenter(): void {
+    let dc: DataCenterEntity = null;
+    for (const datacenter of this.datacenters) {
+      if (this.setDatacenterForm.controls.datacenter.value === datacenter.metadata.name) {
+        dc = datacenter;
+      }
+    }
+    this.wizardService.changeClusterDatacenter({
+      datacenter: dc,
+      valid: this.setDatacenterForm.valid,
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/wizard/set-provider/set-provider.component.html
+++ b/src/app/wizard/set-provider/set-provider.component.html
@@ -9,7 +9,7 @@
   </p>
   <form [formGroup]="setProviderForm" fxLayoutAlign="left" fxLayout="row wrap">
     <mat-button-toggle-group group="providerGroup" formControlName="provider">
-      <mat-button-toggle *ngFor="let provider of providers;" value="{{provider}}">
+      <mat-button-toggle *ngFor="let provider of providers;" value="{{provider}}" (click)="this.changeClusterProvider()">
         <span class="km-provider-logo km-provider-logo-{{provider}}"></span>
       </mat-button-toggle>
     </mat-button-toggle-group>

--- a/src/app/wizard/set-provider/set-provider.component.ts
+++ b/src/app/wizard/set-provider/set-provider.component.ts
@@ -24,10 +24,7 @@ export class SetProviderComponent implements OnInit, OnDestroy {
     });
 
     this.subscriptions.push(this.setProviderForm.valueChanges.subscribe((data) => {
-      this.wizardService.changeClusterProvider({
-        provider: this.setProviderForm.controls.provider.value,
-        valid: this.setProviderForm.valid,
-      });
+      this.changeClusterProvider();
     }));
 
     this.subscriptions.push(this.dcService.getDataCenters().subscribe((datacenters) => {
@@ -47,6 +44,13 @@ export class SetProviderComponent implements OnInit, OnDestroy {
       }
       this.providers = providers;
     }));
+  }
+
+  changeClusterProvider(): void {
+    this.wizardService.changeClusterProvider({
+      provider: this.setProviderForm.controls.provider.value,
+      valid: this.setProviderForm.valid,
+    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
**What this PR does / why we need it**:
When going back in wizard, it was not possible to select same provider/datacenter again by just clicking on the icon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #931 

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
