### PR TITLE
Add bash script for running e2e tests in prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,16 @@ check: install
 run:
 	@$(CC) start
 
-test-full: test e2e
+test-full: test run-e2e
 
 test:
 	@$(CC) run test
 
 test-headless: install
 	@$(CC) run test:headless
+
+run-e2e-ci: install
+	./hack/run_ci_e2e_test.sh
 
 run-e2e: install
 	@$(CC) run e2e

--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+RUNNING_IN_CI=${JOB_NAME:=""}
+KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+DEX_CLIENT_DIR="tools/simple-dex-client"
+DEX_CLIENT_BIN="${DEX_CLIENT_DIR}/bin/simple-dex-client"
+
+E2E_USER_EMAIL_DOMAIN="kubermatic.io"
+E2E_USERNAME_PREFIX="e2e-"
+KUBERMATIC_DEX_DEV_E2E_USERNAME=""
+KUBERMATIC_DEX_DEV_E2E_PASSWORD=""
+
+if [[ -z ${JOB_NAME} ]]; then
+	echo "This script should only be running in a CI environment."
+	exit 0
+fi
+
+echo "Downloading and installing kubectl ${KUBECTL_VERSION}"
+curl --silent -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl > /dev/null
+chmod +x ./kubectl
+mv ./kubectl /usr/bin/kubectl
+
+echo "Exposing dex gRPC API on localhost:5557..."
+kubectl --kubeconfig=/etc/kubeconfig/kubeconfig -n oauth port-forward service/dex 5557 5557 > /dev/null 2> /dev/null &
+PID=$?
+sleep 5
+
+echo "Building the Dex client"
+make -C ${DEX_CLIENT_DIR} > /dev/null
+
+KUBERMATIC_DEX_DEV_E2E_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 12 | head -n 1)
+echo "Generating user password: ${KUBERMATIC_DEX_DEV_E2E_PASSWORD}"
+
+KUBERMATIC_DEX_DEV_E2E_USERNAME=$(${DEX_CLIENT_BIN} --dex-host=localhost:5557 --action=create --randomize --prefix=${E2E_USERNAME_PREFIX} --email-domain=${E2E_USER_EMAIL_DOMAIN} --password=${KUBERMATIC_DEX_DEV_E2E_PASSWORD})
+echo "Created user: ${KUBERMATIC_DEX_DEV_E2E_USERNAME}"
+
+function cleanup {
+	set +e
+	if [[ -z "${KUBERMATIC_DEX_DEV_E2E_USERNAME}" ]]; then
+		echo "Deleting user: ${KUBERMATIC_DEX_DEV_E2E_USERNAME}"
+		${DEX_CLIENT_BIN} --dex-host=localhost:5557 --action=delete --email=${KUBERMATIC_DEX_DEV_E2E_USERNAME}
+	fi
+}
+trap cleanup EXIT
+
+npm run e2e
+
+kill ${PID}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a bash script used by the prow for running e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #958

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
