### PR TITLE
defines deploy target for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ docker-build: build dist
 
 docker-push: docker-build
 	docker push $(REPO):$(IMAGE_TAG)
+
+deploy:
+	kubectl set image deployment/kubermatic-ui-v2 webserver=$(REPO):$(IMAGE_TAG)


### PR DESCRIPTION
**What this PR does / why we need it**: simply defines deploy target for makefile

**Special notes for your reviewer**: meant to be run from prow, kubeconfig determines where the image will be deployed. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
