### PR TITLE
Print version info during JSON generation

### DIFF
--- a/git-version.js
+++ b/git-version.js
@@ -9,6 +9,9 @@ const gitInfo = gitDescribeSync({
   dirtyMark: false,
   dirtySemver: false
 });
+
 const versionInfoJson = JSON.stringify(gitInfo, null, 2);
+
+console.log(versionInfoJson + '\n');
 
 writeFileSync(resolve(__dirname, 'src', 'assets', 'config', 'git-version.json'), versionInfoJson);


### PR DESCRIPTION
**What this PR does / why we need it**: With this change we will print version info each time it will be generated. Thanks to it we will be able to match build from CI and versions from different deployments, i.e. dev.kubermatic.io. See: https://github.com/kubermatic/dashboard-v2/pull/1004#issuecomment-456388371.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: n/a

**Special notes for your reviewer**: n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
