### PR TITLE
Fix the kubermatic cleanup part

### DIFF
--- a/hack/run_ci_e2e_test.sh
+++ b/hack/run_ci_e2e_test.sh
@@ -29,7 +29,7 @@ function delete::user {
 }
 
 function cleanup {
-	K8C_USER_ID=$(kubectl get users -o json | jq -r ".items[] | select(.spec.email == \"${KUBERMATIC_DEX_DEV_E2E_USERNAME}\") | .metadata.name")
+	K8C_USER_ID=$(kubectl get users -o json | jq -r ".items[] | select(.spec.email == \"${KUBERMATIC_DEX_DEV_E2E_USERNAME,,}\") | .metadata.name")
 
 	if [[ -z ${K8C_USER_ID} ]]; then
 	 	echo "User with email: ${KUBERMATIC_DEX_DEV_E2E_USERNAME} not found in Kubermatic"


### PR DESCRIPTION
**What this PR does / why we need it**:
This time user should be deleted from kubermatic. The `${x,,}` syntax is used to map string to lower case, as kubermatic somehow converts original email to lower case.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
