### PR TITLE
Disable cleanup load balancer option until backend gets fixed

### DIFF
--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.html
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.html
@@ -10,7 +10,8 @@
     <div class="mat-dialog-content">
       <p>You are on the way to delete the cluster "{{cluster.name}}". Deletion of clusters cannot be UNDONE!</p>
 
-      <div class="km-delete-cluster-checkbox">
+      <!-- TODO(floreks): Reeneable once backend for deleting LBs will be fixed -->
+      <div class="km-delete-cluster-checkbox" *ngIf="false">
         <label fxFlex="60%">Cleanup connected Load Balancers</label>
         <mat-checkbox fxFlex="40%" formControlName="clusterLBCleanupCheckbox"></mat-checkbox>
       </div>

--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.ts
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.ts
@@ -29,7 +29,7 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck {
 
   ngOnInit(): void {
     this.deleteForm = new FormGroup({
-      clusterLBCleanupCheckbox: new FormControl(!!this._appConfig.getConfig().cleanup_cluster),
+      clusterLBCleanupCheckbox: new FormControl(false),
       clusterVolumeCleanupCheckbox: new FormControl(!!this._appConfig.getConfig().cleanup_cluster),
     });
     this.googleAnalyticsService.emitEvent('clusterOverview', 'deleteClusterDialogOpened');


### PR DESCRIPTION
**What this PR does / why we need it**:
Hide the `Cleanup Load Balancers` option in cluster delete dialog until backend gets fixed.

@alvaroaleman Should there be a release note?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
