### PR TITLE
Don't display seed datacenter inside node deployment detail view

### DIFF
--- a/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.html
+++ b/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.html
@@ -93,7 +93,7 @@
       </km-property>
       <km-property>
         <div key>Datacenter location</div>
-        <div value>{{datacenter.spec.location}}, {{datacenter.spec.country}}</div>
+        <div value>{{datacenter.spec.country}}, {{datacenter.spec.location}}</div>
       </km-property>
       <km-property>
         <div key>Creation date</div>

--- a/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.ts
+++ b/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.ts
@@ -77,7 +77,6 @@ export class NodeDeploymentDetailsComponent implements OnInit, OnDestroy {
     this.loadNodes();
     this.loadNodesEvents();
     this.loadCluster();
-    this.loadDatacenter();
     this.loadUserGroupData();
 
     interval(this._refreshInterval).pipe(takeUntil(this._unsubscribe)).subscribe(() => {
@@ -122,11 +121,12 @@ export class NodeDeploymentDetailsComponent implements OnInit, OnDestroy {
       this.cluster = c;
       this.clusterProvider = NodeDeploymentDetailsComponent._getClusterProvider(this.cluster);
       this._isClusterLoaded = true;
+      this.loadDatacenter();
     });
   }
 
   loadDatacenter(): void {
-    this._datacenterService.getDataCenter(this._dcName).pipe(first()).subscribe((d) => {
+    this._datacenterService.getDataCenter(this.cluster.spec.cloud.dc).pipe(first()).subscribe((d) => {
       this.datacenter = d;
       this._isDatacenterLoaded = true;
     });


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't display seed datacenter inside node deployment detail view.
Also switched location and country, to be more consistent with other views.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1058

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
