### PR TITLE
Update event-list components when passed in events changed

### DIFF
--- a/src/app/shared/components/event-list/event-list.component.ts
+++ b/src/app/shared/components/event-list/event-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit, ViewChild} from '@angular/core';
+import {Component, Input, OnChanges, OnInit, ViewChild} from '@angular/core';
 import {MatPaginator, MatSort, MatTableDataSource} from '@angular/material';
 
 import {EventEntity} from '../../entity/EventEntity';
@@ -7,7 +7,7 @@ import {EventEntity} from '../../entity/EventEntity';
   selector: 'km-event-list',
   templateUrl: './event-list.component.html',
 })
-export class EventListComponent implements OnInit {
+export class EventListComponent implements OnInit, OnChanges {
   @Input() events: EventEntity[] = [];
   @Input() involvedObjectColumnName = 'Involved Object';
 
@@ -21,6 +21,10 @@ export class EventListComponent implements OnInit {
     this.dataSource.data = this.events;
     this.dataSource.sort = this.sort;
     this.dataSource.paginator = this.paginator;
+  }
+
+  ngOnChanges(): void {
+    this.dataSource.data = this.events;
   }
 
   getTypeIcon(event: EventEntity): string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Update event-list components when passed in events changed. Otherwise new events are only displayed after a full reload of the page.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
