### PR TITLE
Revert "Disable cleanup load balancer option until backend gets fixed…

### DIFF
--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.html
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.html
@@ -15,9 +15,7 @@
     <div class="mat-dialog-content">
       <p>You are on the way to delete the cluster "{{cluster.name}}". Deletion of clusters cannot be UNDONE!</p>
 
-      <!-- TODO(floreks): Reeneable once backend for deleting LBs will be fixed -->
-      <div class="km-delete-cluster-checkbox"
-           *ngIf="false">
+      <div class="km-delete-cluster-checkbox">
         <label fxFlex="60%">Cleanup connected Load Balancers</label>
         <mat-checkbox fxFlex="40%"
                       formControlName="clusterLBCleanupCheckbox"></mat-checkbox>

--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.ts
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.ts
@@ -29,7 +29,7 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck {
 
   ngOnInit(): void {
     this.deleteForm = new FormGroup({
-      clusterLBCleanupCheckbox: new FormControl(false),
+      clusterLBCleanupCheckbox: new FormControl(!!this._appConfig.getConfig().cleanup_cluster),
       clusterVolumeCleanupCheckbox: new FormControl(!!this._appConfig.getConfig().cleanup_cluster),
     });
     this.googleAnalyticsService.emitEvent('clusterOverview', 'deleteClusterDialogOpened');


### PR DESCRIPTION
… (#1053)"

This reverts commit f88b76245a3c972cd1275c258d4a411487d7de8b.

**What this PR does / why we need it**:

Re-Enables the cleanup load balancer option as the corresponding functionality got fixed in the backend via https://github.com/kubermatic/kubermatic/pull/2780

**Note:** This was no clean revert, there was some conflict which I fixed so please make sure this is actually working code :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
```

/assign @floreks 