### PR TITLE
Use existing image when editing node deployments on openstack

### DIFF
--- a/src/app/node-data/openstack-node-data/openstack-options/openstack-options.component.ts
+++ b/src/app/node-data/openstack-node-data/openstack-options/openstack-options.component.ts
@@ -46,15 +46,12 @@ export class OpenstackOptionsComponent implements OnInit, OnDestroy {
     }));
 
     this.subscriptions.push(this.addNodeService.nodeOperatingSystemDataChanges$.subscribe((data) => {
-      if (this.nodeData.spec.cloud.openstack.image !== '' &&
-          ((!!this.nodeData.spec.operatingSystem.ubuntu && !!data.ubuntu) ||
-           (!!this.nodeData.spec.operatingSystem.centos && !!data.centos) ||
-           (!!this.nodeData.spec.operatingSystem.containerLinux && !!data.containerLinux))) {
-        this.addNodeService.changeNodeProviderData(this.getOsOptionsData());
-      } else {
+      if ((!!this.nodeData.spec.operatingSystem.ubuntu && !data.ubuntu) ||
+          (!!this.nodeData.spec.operatingSystem.centos && !data.centos) ||
+          (!!this.nodeData.spec.operatingSystem.containerLinux && !data.containerLinux)) {
         this.setImage(data);
-        this.addNodeService.changeNodeProviderData(this.getOsOptionsData());
       }
+      this.addNodeService.changeNodeProviderData(this.getOsOptionsData());
     }));
 
     this.subscriptions.push(this.wizardService.clusterSettingsFormViewChanged$.subscribe((data) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use existing image when editing node deployments on openstack.  Don't set default image from datacenter.

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```


EDIT by @alvaroaleman : 
Fixes #1074