### PR TITLE
fix loading of azure sizes in wizard

### DIFF
--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -281,19 +281,19 @@ export class ApiService {
 
   getAzureSizesForWizard(
       clientID: string, clientSecret: string, subscriptionID: string, tenantID: string,
-      location: string): Observable<AzureSizes> {
+      location: string): Observable<AzureSizes[]> {
     this.headers = this.headers.set('ClientID', clientID);
     this.headers = this.headers.set('ClientSecret', clientSecret);
     this.headers = this.headers.set('SubscriptionID', subscriptionID);
     this.headers = this.headers.set('TenantID', tenantID);
     this.headers = this.headers.set('Location', location);
     const url = `${this.restRoot}/providers/azure/sizes`;
-    return this.http.get<AzureSizes>(url, {headers: this.headers});
+    return this.http.get<AzureSizes[]>(url, {headers: this.headers});
   }
 
-  getAzureSizes(projectId: string, dc: string, cluster: string): Observable<AzureSizes> {
+  getAzureSizes(projectId: string, dc: string, cluster: string): Observable<AzureSizes[]> {
     const url = `${this.restRoot}/projects/${projectId}/dc/${dc}/clusters/${cluster}/providers/azure/sizes`;
-    return this.http.get<AzureSizes>(url, {headers: this.headers});
+    return this.http.get<AzureSizes[]>(url, {headers: this.headers});
   }
 
   getVSphereNetworks(username: string, password: string, datacenterName: string): Observable<VSphereNetwork[]> {

--- a/src/app/node-data/azure-node-data/azure-node-data.component.html
+++ b/src/app/node-data/azure-node-data/azure-node-data.component.html
@@ -3,7 +3,7 @@
   <div fxFlex
        class="mat-select-container">
     <mat-form-field>
-      <mat-select placeholder="Node size*:"
+      <mat-select [placeholder]="getSizesFormState()"
                   formControlName="size">
         <mat-option *ngFor="let size of sizes"
                     [value]="size.name">

--- a/src/app/node-data/azure-node-data/azure-node-data.component.ts
+++ b/src/app/node-data/azure-node-data/azure-node-data.component.ts
@@ -21,7 +21,7 @@ export class AzureNodeDataComponent implements OnInit, OnDestroy, OnChanges {
   @Input() clusterId: string;
   @Input() seedDCName: string;
 
-  sizes: AzureSizes;
+  sizes: AzureSizes[] = [];
   azureNodeForm: FormGroup;
   tags: FormArray;
   datacenter: DataCenterEntity;
@@ -72,6 +72,19 @@ export class AzureNodeDataComponent implements OnInit, OnDestroy, OnChanges {
 
   isInWizard(): boolean {
     return !this.clusterId || this.clusterId.length === 0;
+  }
+
+  getSizesFormState(): string {
+    if ((!this.cloudSpec.azure.clientID || this.cloudSpec.azure.clientID === '') &&
+        (!this.cloudSpec.azure.clientSecret || this.cloudSpec.azure.clientSecret === '') &&
+        (!this.cloudSpec.azure.tenantID || this.cloudSpec.azure.tenantID === '') &&
+        (!this.cloudSpec.azure.subscriptionID || this.cloudSpec.azure.subscriptionID === '') && this.isInWizard()) {
+      return 'Please enter a valid token first!';
+    } else if (this.sizes.length === 0) {
+      return 'Loading sizes...';
+    } else {
+      return 'Node Size*:';
+    }
   }
 
   reloadAzureSizes(): void {

--- a/src/app/shared/entity/NodeEntity.ts
+++ b/src/app/shared/entity/NodeEntity.ts
@@ -116,7 +116,7 @@ export function getEmptyNodeProviderSpec(provider: string): object {
       } as HetznerNodeSpec;
     case NodeProvider.AZURE:
       return {
-        size: 'Standard_A0',
+        size: '',
         assignPublicIP: false,
         tags: {'': ''},
       } as AzureNodeSpec;


### PR DESCRIPTION
**What this PR does / why we need it**:
`Standard_A0` was set by default as azure size, even if it does not exists for the given credentials.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1043

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
