### PR TITLE
Display cluster ID on cluster details page

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -55,31 +55,40 @@
       <mat-card-title>
         <span ngxClipboard
               [cbContent]="cluster.name"
-              matTooltip="click to copy"
+              matTooltip="Click to copy"
               class="km-copy km-cluster-name">{{cluster.name}}</span>
         <kubermatic-cluster-health-status [cluster]="cluster"
                                           [datacenter]="datacenter"
                                           [projectID]="projectID"></kubermatic-cluster-health-status>
       </mat-card-title>
     </mat-card-header>
-    <mat-card-content fxLayout
+    <mat-card-content fxLayout="row wrap"
                       class="km-row">
-      <div fxFlex="20%">
-        <strong>Master Version:</strong>
-      </div>
-      <div fxFlex="35%"
-           class="km-change-version"
-           *ngIf="isClusterRunning && (updatesAvailable || downgradesAvailable)">
-        <span (click)="changeClusterVersionDialog()"
-              matTooltip="click to change version"
-              class="km-copy">{{cluster.spec.version}}
-          <small [hidden]="!updatesAvailable">upgrade available</small></span>
-      </div>
-      <div fxFlex="35%"
-           class="km-change-version"
-           [hidden]="isClusterRunning && (updatesAvailable || downgradesAvailable)">
-        {{cluster.spec.version}}
-      </div>
+      <km-property>
+        <div key>Cluster ID</div>
+        <div value
+             ngxClipboard
+             [cbContent]="cluster.id"
+             matTooltip="Click to copy"
+             class="km-copy">
+          {{cluster.id}}
+        </div>
+      </km-property>
+      <km-property>
+        <div key>Master Version</div>
+        <div value>
+          <span *ngIf="isClusterRunning && (updatesAvailable || downgradesAvailable)"
+                (click)="changeClusterVersionDialog()"
+                matTooltip="Click to change the version"
+                class="km-copy">{{cluster.spec.version}}
+            <i *ngIf="updatesAvailable"
+               class="fa fa-arrow-up"></i>
+          </span>
+          <span *ngIf="!isClusterRunning || !(updatesAvailable || downgradesAvailable)">
+            {{cluster.spec.version}}
+          </span>
+        </div>
+      </km-property>
     </mat-card-content>
   </mat-card>
   <kubermatic-cluster-secrets [cluster]="cluster"


### PR DESCRIPTION
**What this PR does / why we need it**: Displays cluster ID on details page. Used `km-property` component to display cluster details. It makes the page more silimar to node deployment details. Also switched from `[hidden]` to `*ngIf`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #1079.

**Special notes for your reviewer**:

![zrzut ekranu 2019-03-4 o 13 07 36](https://user-images.githubusercontent.com/2823399/53732620-d3b27480-3e7e-11e9-805e-ab0535b8d412.png)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
