### PR TITLE
Use Subnet ID during cluster creation

### DIFF
--- a/src/app/wizard/set-settings/provider-settings/openstack/openstack.component.html
+++ b/src/app/wizard/set-settings/provider-settings/openstack/openstack.component.html
@@ -103,7 +103,7 @@
       <mat-select [placeholder]="getSubnetIDFormState()"
                   formControlName="subnetId">
         <mat-option *ngFor="let subnet of subnetIds"
-                    [value]="subnet.name">
+                    [value]="subnet.id">
           {{subnet.name}}
         </mat-option>
       </mat-select>


### PR DESCRIPTION
**What this PR does / why we need it**:
Use Subnet ID during cluster creation as thats what kubermatic requires.

**Release note**:
```release-note
NONE
```
