### PR TITLE
Update AWS instance types

### DIFF
--- a/src/app/shared/model/NodeProviderConstants.ts
+++ b/src/app/shared/model/NodeProviderConstants.ts
@@ -22,21 +22,8 @@ export class NodeProvider {
 // Keep in sync with https://aws.amazon.com/ec2/instance-types/.
 export namespace NodeInstanceFlavors {
   export const AWS: string[] = [
-    't3.nano',
-    't3.micro',
-    't3.small',
-    't3.medium',
-    't3.large',
-    't3.xlarge',
-    't3.2xlarge',
-    'm5.large',
-    'm5d.large',
-    'm5.xlarge',
-    'm5.2xlarge',
-    'm3.medium',
-    'c5.large',
-    'c5.xlarge',
-    'c5.2xlarge',
+    't3.nano', 't3.micro', 't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge', 'm5.large', 'm5d.large',
+    'm5.xlarge', 'm5.2xlarge', 'm3.medium', 'c5.large', 'c5.xlarge', 'c5.2xlarge'
   ];
   export const Openstack: string[] = ['m1.micro', 'm1.tiny', 'm1.small', 'm1.medium', 'm1.large'];
   export const Hetzner: string[] =


### PR DESCRIPTION
**What this PR does / why we need it**: Updates AWS instance types to be in sync with https://aws.amazon.com/ec2/instance-types/.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #1120.

**Special notes for your reviewer**:
1. Is it enough? Do we want to add some more types?
2. Can we safely replace `t2.x` with `t3.x` types?
3. Can we safely replace `m3.x` and `m4.x` with `m5.x` types (with `m5.metal`)?
4. Is it okay to add `c5.x` types? Should we also add `c5d.x` types?
5. Shouldn't we use some API to list all the instances (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes, https://github.com/cristim/ec2-instances-info)?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Updated list of AWS instance types to match latest available.
```
