### PR TITLE
Fix displaying number of replicas if field is empty

### DIFF
--- a/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.html
+++ b/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.html
@@ -53,7 +53,7 @@
       <km-property>
         <div key>Replicas</div>
         <div value>
-          <span>{{!!nodeDeployment.status?.availableReplicas ? nodeDeployment.status.availableReplicas : 0}}/{{nodeDeployment.spec.replicas}}&nbsp;</span>
+          <span>{{!!nodeDeployment.status?.availableReplicas ? nodeDeployment.status.availableReplicas : 0}}/{{!!nodeDeployment.spec?.replicas ? nodeDeployment.spec.replicas : 0}}</span>
           <span *ngIf="nodeDeployment.status?.availableReplicas > nodeDeployment.spec.replicas"
                 matTooltip="Number of available machines may be higher than number of desired machines from the template if deployment is updating.">
             <i class="fa fa-question-circle"

--- a/src/app/cluster/cluster-details/node-deployment-list/node-deployment-list.component.html
+++ b/src/app/cluster/cluster-details/node-deployment-list/node-deployment-list.component.html
@@ -35,7 +35,7 @@
         </th>
         <td mat-cell
             *matCellDef="let element">
-          <span>{{!!element.status?.availableReplicas ? element.status.availableReplicas : 0}}/{{element.spec.replicas}}&nbsp;</span>
+          <span>{{!!element.status?.availableReplicas ? element.status.availableReplicas : 0}}/{{!!element.spec?.replicas ? element.spec.replicas : 0}}</span>
           <span *ngIf="element.status?.availableReplicas > element.spec.replicas"
                 matTooltip="Number of available machines may be higher than number of desired machines from the template if deployment is updating.">
             <i class="fa fa-question-circle"


### PR DESCRIPTION
**What this PR does / why we need it**: Fix displaying number of replicas if field is empty. It may be empty because of `omitempty` that is used in API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: n/a

**Special notes for your reviewer**: n/a

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed display number of replicas if the field is empty (0 replicas).
```
