### PR TITLE
[release/v1.1] Use Subnet ID during cluster creation (#1119)

### DIFF
--- a/src/app/wizard/set-settings/provider-settings/openstack/openstack.component.html
+++ b/src/app/wizard/set-settings/provider-settings/openstack/openstack.component.html
@@ -67,7 +67,7 @@
   <div fxFlex class="mat-select-container" *ngIf="!hideOptional">
     <mat-form-field>
       <mat-select [placeholder]="getSubnetIDFormState()" formControlName="subnetId">
-        <mat-option *ngFor="let subnet of subnetIds" [value]="subnet.name">
+        <mat-option *ngFor="let subnet of subnetIds" [value]="subnet.id">
           {{subnet.name}}
         </mat-option>
       </mat-select>


### PR DESCRIPTION
(cherry picked from commit 609ab6c171ed3fbcc84f085ebc65bfda9a1edde8)

**What this PR does / why we need it**:
Cherry pick of #1119 

**Release note**:
```release-note
NONE
```
