### PR TITLE
Remove aws instance types t3.nano & t3.micro as they are too small

### DIFF
--- a/src/app/shared/model/NodeProviderConstants.ts
+++ b/src/app/shared/model/NodeProviderConstants.ts
@@ -22,8 +22,8 @@ export class NodeProvider {
 // Keep in sync with https://aws.amazon.com/ec2/instance-types/.
 export namespace NodeInstanceFlavors {
   export const AWS: string[] = [
-    't3.nano', 't3.micro', 't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge', 'm5.large', 'm5d.large',
-    'm5.xlarge', 'm5.2xlarge', 'm3.medium', 'c5.large', 'c5.xlarge', 'c5.2xlarge'
+    't3.small', 't3.medium', 't3.large', 't3.xlarge', 't3.2xlarge', 'm5.large', 'm5d.large', 'm5.xlarge', 'm5.2xlarge',
+    'm3.medium', 'c5.large', 'c5.xlarge', 'c5.2xlarge'
   ];
   export const Openstack: string[] = ['m1.micro', 'm1.tiny', 'm1.small', 'm1.medium', 'm1.large'];
   export const Hetzner: string[] =


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove aws instance types t3.nano & t3.micro as they are too small

**Release note**:
```release-note
Removed AWS instance types t3.nano & t3.micro as they are too small to schedule any workload on them
```
