### PR TITLE
adds user controller manager to HealthEntity

### DIFF
--- a/src/app/shared/entity/HealthEntity.ts
+++ b/src/app/shared/entity/HealthEntity.ts
@@ -5,10 +5,11 @@ export class HealthEntity {
   machineController: boolean;
   scheduler: boolean;
   cloudProviderInfrastructure: boolean;
+  userClusterControllerManager: boolean;
 
   static allHealthy(health: HealthEntity): boolean {
     return (
         health && !!health.apiserver && !!health.controller && !!health.etcd && !!health.machineController &&
-        !!health.scheduler && !!health.cloudProviderInfrastructure);
+        !!health.scheduler && !!health.cloudProviderInfrastructure && !!health.userClusterControllerManager);
   }
 }

--- a/src/app/testing/fake-data/health.fake.ts
+++ b/src/app/testing/fake-data/health.fake.ts
@@ -8,6 +8,7 @@ export function fakeHealth(): HealthEntity {
     machineController: true,
     scheduler: true,
     cloudProviderInfrastructure: true,
+    userClusterControllerManager: true,
   };
 }
 
@@ -19,6 +20,7 @@ export function fakeHealthProvisioning(): HealthEntity {
     machineController: true,
     scheduler: false,
     cloudProviderInfrastructure: false,
+    userClusterControllerManager: false,
   };
 }
 
@@ -30,5 +32,6 @@ export function fakeHealthFailed(): HealthEntity {
     machineController: false,
     scheduler: false,
     cloudProviderInfrastructure: false,
+    userClusterControllerManager: false,
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**: simply takes the user controller manager into account when determining cluster health.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
