### PR TITLE
shows the health of UCMM

### DIFF
--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.html
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.html
@@ -42,16 +42,22 @@
         <mat-card-content fxLayout
                           class="km-row km-small">
           <div fxFlex="50%">
-            <strong>Controllers</strong>
+            <strong>Controller</strong>
           </div>
           <div fxFlex="50%">
             <span [ngClass]="getIcon('controller')"></span>
             {{ getStatus('controller') }}
           </div>
-          <!-- <div class="km-clickable" fxFlex="33%">
-            <span class="km-icon-logs"></span>
-            <strong>View Logs</strong>
-          </div> -->
+        </mat-card-content>
+        <mat-card-content fxLayout
+                          class="km-row km-small">
+          <div fxFlex="50%">
+            <strong>User Controller Manager</strong>
+          </div>
+          <div fxFlex="50%">
+            <span [ngClass]="getIcon('controller')"></span>
+            {{ getStatus('uccm') }}
+          </div>
         </mat-card-content>
         <mat-card-content fxLayout
                           class="km-row km-small">

--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.ts
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.ts
@@ -130,13 +130,15 @@ export class ClusterSecretsComponent implements OnInit, OnChanges {
         case 'apiserver':
           return this.getHealthStatus(this.health.apiserver);
         case 'controller':
-          return this.getHealthStatus(this.health.controller & this.health.userClusterControllerManager);
+          return this.getHealthStatus(this.health.controller);
         case 'etcd':
           return this.getHealthStatus(this.health.etcd);
         case 'scheduler':
           return this.getHealthStatus(this.health.scheduler);
         case 'machineController':
           return this.getHealthStatus(this.health.machineController);
+        case 'uccm':
+          return this.getHealthStatus(this.health.userClusterControllerManager);
         default:
           return '';
       }


### PR DESCRIPTION
**What this PR does / why we need it**: some time ago we have extended `health` EP and the UI do also track the health of user controller manager, however this wasn't reflected on the cluster health page.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```
NONE
```
