### PR TITLE
Add coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,9 @@ coverage:
 
   status:
     project: yes
+      default:
+        target: auto
+        threshold: 1%
     patch: yes
     changes: no
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Low coverage drops will still be posted as a success.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
