### PR TITLE
Add support to specify taints when creating/updating NodeDeployments

### DIFF
--- a/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.html
+++ b/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.html
@@ -114,6 +114,12 @@
             <km-labels [labels]="nodeDeployment.spec.template.labels"></km-labels>
           </div>
         </km-property>
+        <km-property>
+          <div key>Node Taints</div>
+          <div value>
+            <km-taints [taints]="nodeDeployment.spec.template.taints"></km-taints>
+          </div>
+        </km-property>
       </div>
     </mat-card-content>
   </mat-card>

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -5,6 +5,7 @@ import {catchError} from 'rxjs/operators';
 
 import {environment} from '../../../../environments/environment';
 import {LabelFormComponent} from '../../../shared/components/label-form/label-form.component';
+import {TaintFormComponent} from '../../../shared/components/taint-form/taint-form.component';
 import {ClusterEntity, Finalizer, MasterVersion, Token} from '../../../shared/entity/ClusterEntity';
 import {ClusterEntityPatch} from '../../../shared/entity/ClusterEntityPatch';
 import {EventEntity} from '../../../shared/entity/EventEntity';
@@ -40,6 +41,7 @@ export class ApiService {
   createNodeDeployment(cluster: ClusterEntity, nd: NodeDeploymentEntity, dc: string, projectID: string):
       Observable<NodeDeploymentEntity> {
     nd.spec.template.labels = LabelFormComponent.filterNullifiedKeys(nd.spec.template.labels);
+    nd.spec.template.taints = TaintFormComponent.filterNullifiedTaints(nd.spec.template.taints);
 
     const url = `${this.restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster.id}/nodedeployments`;
     return this.http.post<NodeDeploymentEntity>(url, nd, {headers: this.headers});
@@ -70,6 +72,9 @@ export class ApiService {
   patchNodeDeployment(
       nd: NodeDeploymentEntity, patch: NodeDeploymentPatch, clusterId: string, dc: string,
       projectID: string): Observable<NodeDeploymentEntity> {
+    patch.spec.template.labels = LabelFormComponent.filterNullifiedKeys(patch.spec.template.labels);
+    patch.spec.template.taints = TaintFormComponent.filterNullifiedTaints(patch.spec.template.taints);
+
     const url = `${this.restRoot}/projects/${projectID}/dc/${dc}/clusters/${clusterId}/nodedeployments/${nd.id}`;
     return this.http.patch<NodeDeploymentEntity>(url, patch, {headers: this.headers});
   }
@@ -115,6 +120,11 @@ export class ApiService {
   }
 
   createCluster(createClusterModel: CreateClusterModel, dc: string, projectID: string): Observable<ClusterEntity> {
+    createClusterModel.nodeDeployment.spec.template.labels =
+        LabelFormComponent.filterNullifiedKeys(createClusterModel.nodeDeployment.spec.template.labels);
+    createClusterModel.nodeDeployment.spec.template.taints =
+        TaintFormComponent.filterNullifiedTaints(createClusterModel.nodeDeployment.spec.template.taints);
+
     const url = `${this.restRoot}/projects/${projectID}/dc/${dc}/clusters`;
     return this.http.post<ClusterEntity>(url, createClusterModel, {headers: this.headers});
   }

--- a/src/app/node-data/node-data.component.html
+++ b/src/app/node-data/node-data.component.html
@@ -128,6 +128,9 @@
 <km-label-form title="Node Labels"
                [(labels)]="nodeData.spec.labels"></km-label-form>
 
+<km-taint-form title="Node Taints"
+               [(taints)]="nodeData.spec.taints"></km-taint-form>
+
 <kubermatic-openstack-options *ngIf="cluster.spec.cloud.openstack"
                               [nodeData]="nodeData"
                               [cloudSpec]="cluster.spec.cloud"></kubermatic-openstack-options>

--- a/src/app/node-data/node-data.component.ts
+++ b/src/app/node-data/node-data.component.ts
@@ -167,6 +167,7 @@ export class NodeDataComponent implements OnInit, OnDestroy {
         cloud: this.providerData.spec,
         operatingSystem: this.getOSSpec(),
         labels: this.nodeData.spec.labels,
+        taints: this.nodeData.spec.taints,
         versions,
       },
       name: this.nodeForm.controls.name.value,

--- a/src/app/shared/components/taint-form/taint-form.component.html
+++ b/src/app/shared/components/taint-form/taint-form.component.html
@@ -1,0 +1,77 @@
+<mat-card-header>
+  <mat-card-title>
+    <h4>{{title}}</h4>
+  </mat-card-title>
+</mat-card-header>
+<form [formGroup]="taintsForm"
+      fxLayout="column">
+  <div formArrayName="taints">
+    <div *ngFor="let taint of taintArray.controls; let i = index;"
+         [formGroupName]="i"
+         fxLayout="row"
+         fxLayoutGap="10px">
+      <mat-form-field fxFlex="30">
+        <input matInput
+               (keyup)="check(i)"
+               name="key"
+               formControlName="key"
+               placeholder="Key">
+        <mat-error *ngIf="taint.get('key').errors?.validLabelKeyUniqueness"
+                   i18n>
+          Key is not unique
+        </mat-error>
+        <mat-error *ngIf="taint.get('key').errors?.validLabelKeyPrefixPattern"
+                   i18n>
+          Prefix not allowed
+        </mat-error>
+        <mat-error *ngIf="taint.get('key').errors?.validLabelKeyNamePattern"
+                   i18n>
+          Name not allowed
+        </mat-error>
+        <mat-error *ngIf="taint.get('key').errors?.validLabelKeyPrefixLength"
+                   i18n>
+          Prefix is too long
+        </mat-error>
+        <mat-error *ngIf="taint.get('key').errors?.validLabelKeyNameLength"
+                   i18n>
+          Name is too long
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field fxFlex="30">
+        <input matInput
+               (keyup)="check(i)"
+               name="value"
+               formControlName="value"
+               placeholder="Value">
+        <mat-error *ngIf="taint.get('value').errors?.validLabelValuePattern"
+                   i18n>
+          Value not allowed
+        </mat-error>
+        <mat-error *ngIf="taint.get('value').errors?.validLabelValueLength"
+                   i18n>
+          Value is too long
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field fxFlex="30">
+        <mat-select formControlName="effect"
+                    placeholder="Effect"
+                    (keyup)="check(i)"
+                    (change)="check(i)"
+                    (valueChange)="check(i)"
+                    (selectionChange)="check(i)">
+          <mat-option *ngFor="let effect of availableEffects"
+                      value="{{ effect }}">
+            {{ effect }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <button mat-icon-button
+              class="km-label-form-delete-button"
+              *ngIf="isRemovable()"
+              (click)="deleteTaint(i)">
+        <i class="fa fa-trash-o"
+           aria-hidden="true"></i>
+      </button>
+    </div>
+  </div>
+</form>

--- a/src/app/shared/components/taint-form/taint-form.component.scss
+++ b/src/app/shared/components/taint-form/taint-form.component.scss
@@ -1,0 +1,3 @@
+.km-taint-form-delete-button {
+  font-size: 21px;
+}

--- a/src/app/shared/components/taint-form/taint-form.component.spec.ts
+++ b/src/app/shared/components/taint-form/taint-form.component.spec.ts
@@ -1,0 +1,56 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {BrowserModule} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
+
+import {Taint} from '../../entity/NodeEntity';
+import {SharedModule} from '../../shared.module';
+
+import {TaintFormComponent} from './taint-form.component';
+
+const modules: any[] = [
+  BrowserModule,
+  BrowserAnimationsModule,
+  SlimLoadingBarModule.forRoot(),
+  SharedModule,
+];
+
+describe('TaintFormComponent', () => {
+  let fixture: ComponentFixture<TaintFormComponent>;
+  let component: TaintFormComponent;
+
+  beforeEach(() => {
+    TestBed
+        .configureTestingModule({
+          imports: [...modules],
+        })
+        .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TaintFormComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should initialize', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize taints object', () => {
+    expect(component.taints).toBeUndefined();
+
+    component.ngOnInit();
+
+    expect(component.taints).not.toBeUndefined();
+  });
+
+  it('should delete labels', () => {
+    expect(component.taints).toBeUndefined();
+
+    component.taints = [{key: 'key', value: 'value', effect: Taint.NO_SCHEDULE}];
+    component.ngOnInit();
+    component.deleteTaint(0);
+
+    expect(component.taints).toEqual([]);
+  });
+});

--- a/src/app/shared/components/taint-form/taint-form.component.ts
+++ b/src/app/shared/components/taint-form/taint-form.component.ts
@@ -1,0 +1,152 @@
+import {Component, EventEmitter, forwardRef, Input, OnInit, Output} from '@angular/core';
+import {AbstractControl, FormArray, FormBuilder, FormGroup, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {SlideInOut} from '../../animations/slideinout';
+import {Taint} from '../../entity/NodeEntity';
+import {LabelFormValidators} from '../../validators/label-form.validators';
+import {TaintFormValidators} from '../../validators/taint-form.validators';
+
+@Component({
+  selector: 'km-taint-form',
+  templateUrl: './taint-form.component.html',
+  styleUrls: ['./taint-form.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TaintFormComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => TaintFormComponent),
+      multi: true,
+    }
+  ],
+  animations: [SlideInOut]
+})
+export class TaintFormComponent implements OnInit {
+  @Input() title = 'Taints';
+  @Input() taints: Taint[];
+  @Output() taintsChange = new EventEmitter<object>();
+  taintsForm: FormGroup;
+  availableEffects = Taint.getAvailableEffects();
+
+  constructor(private readonly _formBuilder: FormBuilder) {}
+
+  get taintArray(): FormArray {
+    return this.taintsForm.get('taints') as FormArray;
+  }
+
+  static filterNullifiedTaints(taints: Taint[]): Taint[] {
+    const filteredTaints = [];
+    if (taints instanceof Object) {
+      taints.forEach(taint => {
+        if (taint.key && taint.value && taint.effect) {
+          filteredTaints.push(taint);
+        }
+      });
+    }
+    return filteredTaints;
+  }
+
+  ngOnInit(): void {
+    // Initialize taints form.
+    this.taintsForm = this._formBuilder.group({taints: this._formBuilder.array([])});
+
+    // Make sure that taints array exist.
+    if (!this.taints) {
+      this.taints = [];
+    }
+
+    // Setup taints form with taint data.
+    this.taints.forEach(taint => {
+      this._addTaint(taint);
+    });
+
+    // Add initial taint for the user.
+    this._addTaint();
+  }
+
+  deleteTaint(index: number): void {
+    this.taintArray.removeAt(index);
+    this._updateTaints();
+  }
+
+  isRemovable(): boolean {
+    return this.taintArray.length > 1;
+  }
+
+  check(index: number): void {
+    this._addTaintIfNeeded();
+    this._validateKey(index);
+    this._updateTaints();
+  }
+
+  private _addTaintIfNeeded(): void {
+    const lastLabel = this.taintArray.at(this.taintArray.length - 1);
+    if (TaintFormComponent._isFilled(lastLabel)) {
+      this._addTaint();
+    }
+  }
+
+  private static _isFilled(taint: AbstractControl): boolean {
+    return taint.get('key').value.length !== 0 && taint.get('value').value.length !== 0 &&
+        taint.get('effect').value.length !== 0;
+  }
+
+  private _addTaint(taint: Taint = null): void {
+    this.taintArray.push(this._formBuilder.group({
+      key: [
+        {value: taint ? taint.key : '', disabled: false}, Validators.compose([
+          LabelFormValidators.labelKeyNameLength,
+          LabelFormValidators.labelKeyPrefixLength,
+          LabelFormValidators.labelKeyNamePattern,
+          LabelFormValidators.labelKeyPrefixPattern,
+        ])
+      ],
+      value: [
+        {value: taint ? taint.value : '', disabled: false}, Validators.compose([
+          TaintFormValidators.taintValueLength,
+          LabelFormValidators.labelValuePattern,
+        ])
+      ],
+      effect: [
+        {value: taint ? taint.effect : '', disabled: false},
+        Validators.compose([
+          TaintFormValidators.taintValidEffect,
+        ]),
+      ],
+    }));
+  }
+
+  private _validateKey(index: number): void {
+    const elem = this.taintArray.at(index).get('key');
+
+    if (this._isKeyDuplicated(index)) {
+      elem.setErrors({validLabelKeyUniqueness: true});
+    }
+
+    this.taintsForm.updateValueAndValidity();
+  }
+
+  private _isKeyDuplicated(index: number): boolean {
+    let duplications = 0;
+    const currentKey = this.taintArray.at(index).get('key').value;
+    for (let i = 0; i < this.taintArray.length; i++) {
+      const key = this.taintArray.at(i).get('key').value;
+      if (key.length !== 0 && key === currentKey) {
+        duplications++;
+      }
+      if (duplications > 1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private _updateTaints(): void {
+    this.taints = TaintFormComponent.filterNullifiedTaints(this.taintArray.getRawValue());
+
+    // Emit the change event.
+    this.taintsChange.emit(this.taints);
+  }
+}

--- a/src/app/shared/components/taints/taints.component.html
+++ b/src/app/shared/components/taints/taints.component.html
@@ -1,0 +1,8 @@
+<mat-chip-list *ngIf="taints && taints.length > 0">
+  <ng-container *ngFor="let taint of taints">
+    <mat-chip>
+      {{taint.key}}: {{taint.value}}: {{taint.effect}}
+    </mat-chip>
+  </ng-container>
+</mat-chip-list>
+<div *ngIf="!taints || taints.length === 0">-</div>

--- a/src/app/shared/components/taints/taints.component.ts
+++ b/src/app/shared/components/taints/taints.component.ts
@@ -1,0 +1,10 @@
+import {Component, Input} from '@angular/core';
+import {Taint} from '../../entity/NodeEntity';
+
+@Component({
+  selector: 'km-taints',
+  templateUrl: './taints.component.html',
+})
+export class TaintsComponent {
+  @Input() taints: Taint[] = [];
+}

--- a/src/app/shared/entity/NodeDeploymentPatch.ts
+++ b/src/app/shared/entity/NodeDeploymentPatch.ts
@@ -1,4 +1,4 @@
-import {NodeCloudSpec, NodeVersionInfo, OperatingSystemSpec} from './NodeEntity';
+import {NodeCloudSpec, NodeVersionInfo, OperatingSystemSpec, Taint} from './NodeEntity';
 
 export class NodeDeploymentPatch {
   spec: NodeDeploymentSpecPatch;
@@ -14,6 +14,8 @@ export class NodeSpecPatch {
   cloud?: NodeCloudSpec;
   operatingSystem?: OperatingSystemSpec;
   versions?: NodeVersionInfo;
+  labels?: object;
+  taints?: Taint[];
 }
 
 export class NodeDeploymentStatus {

--- a/src/app/shared/entity/NodeEntity.ts
+++ b/src/app/shared/entity/NodeEntity.ts
@@ -22,6 +22,21 @@ export class NodeSpec {
   operatingSystem: OperatingSystemSpec;
   versions?: NodeVersionInfo;
   labels?: object;
+  taints?: Taint[];
+}
+
+export class Taint {
+  static NO_SCHEDULE = 'NoSchedule';
+  static PREFER_NO_SCHEDULE = 'PreferNoSchedule';
+  static NO_EXECUTE = 'NoExecute';
+
+  static getAvailableEffects(): string[] {
+    return [Taint.NO_SCHEDULE, Taint.PREFER_NO_SCHEDULE, Taint.NO_EXECUTE];
+  }
+
+  key: string;
+  value: string;
+  effect: string;
 }
 
 export class NodeCloudSpec {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -18,6 +18,8 @@ import {EventListComponent} from './components/event-list/event-list.component';
 import {LabelFormComponent} from './components/label-form/label-form.component';
 import {LabelsComponent} from './components/labels/labels.component';
 import {PropertyComponent} from './components/property/property.component';
+import {TaintFormComponent} from './components/taint-form/taint-form.component';
+import {TaintsComponent} from './components/taints/taints.component';
 
 const modules: any[] = [
   CommonModule,
@@ -71,6 +73,8 @@ const modules: any[] = [
     EventListComponent,
     LabelFormComponent,
     LabelsComponent,
+    TaintFormComponent,
+    TaintsComponent,
   ],
   exports: [
     ...modules,
@@ -82,6 +86,8 @@ const modules: any[] = [
     EventListComponent,
     LabelFormComponent,
     LabelsComponent,
+    TaintFormComponent,
+    TaintsComponent,
   ],
   entryComponents: [
     AddProjectDialogComponent,

--- a/src/app/shared/validators/taint-form.validators.spec.ts
+++ b/src/app/shared/validators/taint-form.validators.spec.ts
@@ -1,0 +1,36 @@
+import {FormControl} from '@angular/forms';
+import {TaintFormValidators} from './taint-form.validators';
+
+const tooLongValue = 'L1txKHOWiSe5dSUakuYw82l2IepfxxBMbDA6JFCzp1TeFQbEvQmpJkcBDU4Npv50';
+
+describe('TaintFormValidators', () => {
+  it('taintEffect should be valid', () => {
+    const control = {value: `NoSchedule`} as FormControl;
+    const result = TaintFormValidators.taintValidEffect(control);
+    expect(result).toBe(null);
+  });
+
+  it('taintEffect should be invalid', () => {
+    const control = {value: 'invalid'} as FormControl;
+    const result = TaintFormValidators.taintValidEffect(control);
+    expect(result).not.toBe(null);
+  });
+
+  it('taintValueLength should be valid', () => {
+    const control = {value: 'value'} as FormControl;
+    const result = TaintFormValidators.taintValueLength(control);
+    expect(result).toBe(null);
+  });
+
+  it('taintValueLength should be invalid if too short', () => {
+    const control = {value: tooLongValue} as FormControl;
+    const result = TaintFormValidators.taintValueLength(control);
+    expect(result).not.toBe(null);
+  });
+
+  it('taintValueLength should be invalid if too long', () => {
+    const control = {value: ''} as FormControl;
+    const result = TaintFormValidators.taintValueLength(control);
+    expect(result).not.toBe(null);
+  });
+});

--- a/src/app/shared/validators/taint-form.validators.ts
+++ b/src/app/shared/validators/taint-form.validators.ts
@@ -1,0 +1,20 @@
+import {FormControl} from '@angular/forms';
+import {Taint} from '../entity/NodeEntity';
+
+export class TaintFormValidators {
+  /**
+   * Checks if taint value is minimum 1 char and not longer than 63 chars.
+   */
+  static taintValueLength(control: FormControl): {[key: string]: object} {
+    const value = control.value;
+    return value.length > 1 && value.length <= 63 ? null : {validLabelValueLength: {value: true}};
+  }
+
+  /**
+   * Checks if the effect of a taint is valid.
+   */
+  static taintValidEffect(control: FormControl): {[key: string]: object} {
+    const value = control.value;
+    return Taint.getAvailableEffects().includes(value) ? null : {validTaintEffect: {value: true}};
+  }
+}

--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -498,6 +498,20 @@
               </div>
             </div>
 
+            <div class="km-card-list-content"
+                 fxFlex="100%"
+                 fxLayout="column">
+              <div fxFlex="100%">
+                <div fxFlex="25%"
+                     class="km-card-list-key">
+                  Node Taints
+                </div>
+                <div fxFlex="75%">
+                  <km-taints [taints]="nodeData.spec.taints"></km-taints>
+                </div>
+              </div>
+            </div>
+
             <!-- DO Nodes -->
             <ng-container *ngIf="cluster.spec.cloud.digitalocean">
               <div class="km-card-list-content"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support to specify taints when creating/updating NodeDeployments.

This also ensures that no empty labels and taints from the UI are added during NodeDeployments updates and cluster creation.

See https://github.com/kubermatic/kubermatic/pull/3477 for API PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added option to specify taints when creating/updating NodeDeployments
```
