### PR TITLE
correctly place provider icon in cluster detail view

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.scss
+++ b/src/app/cluster/cluster-details/cluster-details.component.scss
@@ -84,7 +84,7 @@ kubermatic-cluster-health-status {
 }
 
 .km-details-provider {
-  align-self: center;
+  align-self: baseline;
   padding-top: 5px;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Correctly place provider icon in cluster detail view. Looked weird when there are more than one ssh keys

**Special notes for your reviewer**:
from:
![prov2](https://user-images.githubusercontent.com/19547196/58420776-7c432f80-808e-11e9-8675-762c34f9f974.JPG)

to:
![prov](https://user-images.githubusercontent.com/19547196/58420761-73eaf480-808e-11e9-9886-443b95b798b1.JPG)



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
