### PR TITLE
Update deployment scripts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,38 +14,6 @@ pipeline:
     commands:
       - make build
 
-  quay-always:
-    group: push
-    image: plugins/docker
-    registry: quay.io
-    repo: quay.io/kubermatic/ui-v2
-    password: ${QUAY_PASSWORD}
-    username: ${QUAY_USERNAME}
-    tags:
-      - ${DRONE_COMMIT}
-    secrets:
-    - source: quay_username
-      target: docker_username
-    - source: quay_password
-      target: docker_password
-
-  quay-master:
-    group: push
-    image: plugins/docker
-    registry: quay.io
-    repo: quay.io/kubermatic/ui-v2
-    password: ${QUAY_PASSWORD}
-    username: ${QUAY_USERNAME}
-    tags:
-      - master
-    secrets:
-    - source: quay_username
-      target: docker_username
-    - source: quay_password
-      target: docker_password
-    when:
-      branch: master
-
   quay-release:
     group: push
     image: plugins/docker
@@ -115,7 +83,6 @@ pipeline:
       - kgroschoff=kristin.groschoff
       - kron4eg=artiom
       - mrIncompetent=henrik
-      - p0lyn0mial=lukasz
       - scheeles=sebastian
       - thz=tobias.hintze
       - toschneck=tobias.schneck


### PR DESCRIPTION
**What this PR does / why we need it**:

- Removes `quay-always` job that was always pushing the images from each branch.
- Removes `quay-master` as it is covered by https://github.com/kubermatic/infra/blob/master/prow/jobs/dashboard/dashboard-postsubmits.yaml#L2. I will update it to add `master` tag too.
- Adds `ADDITIONAL_TAGS` argument for `make docker-push` to enable adding multiple tags on the image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
