### PR TITLE
Show error message if cluster name in wizard is too short

### DIFF
--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
@@ -28,6 +28,9 @@
           <mat-error *ngIf="clusterSpecForm.controls.name.hasError('required')">
             Name is <strong>required</strong>.
           </mat-error>
+          <mat-error *ngIf="clusterSpecForm.controls.name.hasError('minlength')">
+            Name must be at least {{ clusterSpecForm.controls.name.getError('minlength').requiredLength }} characters.
+          </mat-error>
         </mat-form-field>
       </form>
     </mat-card-content>


### PR DESCRIPTION
**What this PR does / why we need it**:
Show error message if cluster name in wizard is too short

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
