### PR TITLE
Fix image used in postsubmit jobs

### DIFF
--- a/containers/go-111-node-11-docker/Dockerfile
+++ b/containers/go-111-node-11-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubermatic/go-111-docker:11.2-1806-0
+FROM quay.io/kubermatic/go-docker:12.1-1806-0
 
 RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
     && curl -sL https://deb.nodesource.com/setup_11.x | bash - \


### PR DESCRIPTION
**What this PR does / why we need it**: Updates image used in postsubmit jobs to be based on newer base image. Previous base image had no valut binary amongst other issues. It is already pushed to quay.io to fix the infra.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
