### PR TITLE
Fix deployment script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ docker-run-custom: build dist
 	./dashboard-v2
 
 deploy:
-	kubectl set image deployment/kubermatic-ui-v2 webserver=$(REPO):$(IMAGE_TAG)
+	kubectl -n kubermatic set image deployment/kubermatic-ui-v2 webserver=$(REPO):$(IMAGE_TAG)


### PR DESCRIPTION
**What this PR does / why we need it**: `make deploy` script is stale as it does not specify correct namespace of the app deployment. This should fix the problem.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**: Tested with:

```
$ kubectl set image deployment/kubermatic-ui-v2 webserver=quay.io/kubermatic/ui-v2:72cf835ee2f0ac744ce95b607f3d70b36aafbb94
Error from server (NotFound): deployments.extensions "kubermatic-ui-v2" not found

$ kubectl -n kubermatic set image deployment/kubermatic-ui-v2 webserver=quay.io/kubermatic/ui-v2:72cf835ee2f0ac744ce95b607f3d70b36aafbb94
deployment.extensions/kubermatic-ui-v2 image updated
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
