### PR TITLE
Refactor cluster related views

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test:
 
 test-headless: install
 	@$(CC) run test:headless
-	curl -s https://codecov.io/bash | bash -s - -c -F unit -K -C ${PULL_PULL_SHA}
+	bash <(curl -s https://codecov.io/bash) -c -K -C ${PULL_PULL_SHA} -P ${PULL_NUMBER} -b ${BUILD_ID}
 
 run-e2e-ci: install
 	./hack/e2e/run_ci_e2e_test.sh

--- a/src/app/cluster/cluster-details/change-cluster-version/change-cluster-version.component.spec.ts
+++ b/src/app/cluster/cluster-details/change-cluster-version/change-cluster-version.component.spec.ts
@@ -5,19 +5,18 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Router} from '@angular/router';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 import {of} from 'rxjs';
-import Spy = jasmine.Spy;
 
-import {ApiService, ProjectService} from '../../../core/services';
+import {ClusterService, ProjectService} from '../../../core/services';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
 import {SharedModule} from '../../../shared/shared.module';
 import {fakeDigitaloceanCluster} from '../../../testing/fake-data/cluster.fake';
 import {fakeDigitaloceanDatacenter} from '../../../testing/fake-data/datacenter.fake';
 import {fakeProject} from '../../../testing/fake-data/project.fake';
 import {RouterStub} from '../../../testing/router-stubs';
-import {asyncData} from '../../../testing/services/api-mock.service';
 import {MatDialogRefMock} from '../../../testing/services/mat-dialog-ref-mock';
 import {ProjectMockService} from '../../../testing/services/project-mock.service';
 import {ChangeClusterVersionComponent} from './change-cluster-version.component';
+import Spy = jasmine.Spy;
 
 const modules: any[] = [
   BrowserModule,
@@ -33,9 +32,9 @@ describe('ChangeClusterVersionComponent', () => {
   let upgradeClusterNodeDeploymentsSpy: Spy;
 
   beforeEach(async(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['patchCluster', 'upgradeClusterNodeDeployments']);
-    patchClusterSpy = apiMock.patchCluster.and.returnValue(asyncData(fakeDigitaloceanCluster()));
-    upgradeClusterNodeDeploymentsSpy = apiMock.upgradeClusterNodeDeployments.and.returnValue(of(null));
+    const clusterServiceMock = jasmine.createSpyObj('ClusterService', ['patch', 'upgradeNodeDeployments']);
+    patchClusterSpy = clusterServiceMock.patch.and.returnValue(of(fakeDigitaloceanCluster()));
+    upgradeClusterNodeDeploymentsSpy = clusterServiceMock.upgradeNodeDeployments.and.returnValue(of(null));
 
     TestBed
         .configureTestingModule({
@@ -48,7 +47,7 @@ describe('ChangeClusterVersionComponent', () => {
           providers: [
             {provide: MAT_DIALOG_DATA, useValue: {clusterName: 'clustername'}},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
-            {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useValue: clusterServiceMock},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: Router, useClass: RouterStub},
             GoogleAnalyticsService,

--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.spec.ts
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.spec.ts
@@ -7,15 +7,15 @@ import {Router} from '@angular/router';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 import {of} from 'rxjs';
 import {AppConfigService} from '../../../app-config.service';
-import {ApiService, DatacenterService} from '../../../core/services';
+import {ClusterService, DatacenterService} from '../../../core/services';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
 import {SharedModule} from '../../../shared/shared.module';
 import {fakeDigitaloceanCluster} from '../../../testing/fake-data/cluster.fake';
 import {fakeDigitaloceanDatacenter} from '../../../testing/fake-data/datacenter.fake';
 import {fakeProject} from '../../../testing/fake-data/project.fake';
 import {RouterStub, RouterTestingModule} from '../../../testing/router-stubs';
-import {ApiMockService} from '../../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../../../testing/services/cluster-mock-service';
 import {DatacenterMockService} from '../../../testing/services/datacenter-mock.service';
 import {MatDialogRefMock} from '../../../testing/services/mat-dialog-ref-mock';
 import {ClusterDeleteConfirmationComponent} from './cluster-delete-confirmation.component';
@@ -32,7 +32,7 @@ const modules: any[] = [
 describe('ClusterDeleteConfirmationComponent', () => {
   let fixture: ComponentFixture<ClusterDeleteConfirmationComponent>;
   let component: ClusterDeleteConfirmationComponent;
-  let apiService: ApiService;
+  let clusterService: ClusterService;
 
   beforeEach(() => {
     TestBed
@@ -45,7 +45,7 @@ describe('ClusterDeleteConfirmationComponent', () => {
           ],
           providers: [
             {provide: MatDialogRef, useClass: MatDialogRefMock},
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: DatacenterService, useClass: DatacenterMockService},
             {provide: Router, useClass: RouterStub},
             GoogleAnalyticsService,
@@ -59,7 +59,7 @@ describe('ClusterDeleteConfirmationComponent', () => {
     fixture = TestBed.createComponent(ClusterDeleteConfirmationComponent);
     component = fixture.componentInstance;
 
-    apiService = fixture.debugElement.injector.get(ApiService);
+    clusterService = fixture.debugElement.injector.get(ClusterService);
     fixture.debugElement.injector.get(Router);
   });
 
@@ -90,7 +90,7 @@ describe('ClusterDeleteConfirmationComponent', () => {
        component.projectID = fakeProject().id;
 
        fixture.detectChanges();
-       const spyDeleteCluster = spyOn(apiService, 'deleteCluster').and.returnValue(of(null));
+       const spyDeleteCluster = spyOn(clusterService, 'delete').and.returnValue(of(null));
 
        component.deleteCluster();
        tick();

--- a/src/app/cluster/cluster-details/cluster-secrets/add-machine-network/add-machine-network.component.spec.ts
+++ b/src/app/cluster/cluster-details/cluster-secrets/add-machine-network/add-machine-network.component.spec.ts
@@ -5,14 +5,14 @@ import {MatDialogRef} from '@angular/material';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
-import {ApiService, WizardService} from '../../../../core/services';
+import {ClusterService, WizardService} from '../../../../core/services';
 import {MachineNetworksComponent} from '../../../../machine-networks/machine-networks.component';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakeClusterWithMachineNetwork} from '../../../../testing/fake-data/clusterWithMachineNetworks.fake';
 import {fakeDigitaloceanDatacenter} from '../../../../testing/fake-data/datacenter.fake';
 import {fakeProject} from '../../../../testing/fake-data/project.fake';
 import {RouterTestingModule} from '../../../../testing/router-stubs';
-import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AddMachineNetworkComponent} from './add-machine-network.component';
 
@@ -42,7 +42,7 @@ describe('AddMachineNetworkComponent', () => {
           ],
           providers: [
             WizardService,
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],
         })

--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.spec.ts
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.spec.ts
@@ -6,12 +6,13 @@ import {Router} from '@angular/router';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 
 import {AppConfigService} from '../../../app-config.service';
-import {ApiService, ProjectService, UserService} from '../../../core/services';
+import {ClusterService, ProjectService, UserService} from '../../../core/services';
 import {SharedModule} from '../../../shared/shared.module';
 import {fakeHealth, fakeHealthFailed, fakeHealthProvisioning} from '../../../testing/fake-data/health.fake';
 import {RouterStub} from '../../../testing/router-stubs';
 import {asyncData} from '../../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../../../testing/services/cluster-mock-service';
 import {ProjectMockService} from '../../../testing/services/project-mock.service';
 import {UserMockService} from '../../../testing/services/user-mock.service';
 
@@ -41,7 +42,7 @@ describe('ClusterSecretsComponent', () => {
             ClusterSecretsComponent,
           ],
           providers: [
-            {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: AppConfigService, useClass: AppConfigMockService},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: Router, useClass: RouterStub},

--- a/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/aws-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/aws-provider-settings.component.spec.ts
@@ -3,10 +3,10 @@ import {MatDialogRef} from '@angular/material';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
-import {ApiService, ClusterService} from '../../../../core/services';
+import {ClusterService} from '../../../../core/services';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakeAWSCluster} from '../../../../testing/fake-data/cluster.fake';
-import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AzureProviderSettingsComponent} from '../azure-provider-settings/azure-provider-settings.component';
 import {DigitaloceanProviderSettingsComponent} from '../digitalocean-provider-settings/digitalocean-provider-settings.component';
@@ -45,8 +45,7 @@ describe('AWSProviderSettingsComponent', () => {
             PacketProviderSettingsComponent,
           ],
           providers: [
-            ClusterService,
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],
         })

--- a/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/azure-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/azure-provider-settings.component.spec.ts
@@ -3,10 +3,10 @@ import {MatDialogRef} from '@angular/material';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
-import {ApiService, ClusterService} from '../../../../core/services';
+import {ClusterService} from '../../../../core/services';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakeAzureCluster} from '../../../../testing/fake-data/cluster.fake';
-import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AWSProviderSettingsComponent} from '../aws-provider-settings/aws-provider-settings.component';
 import {DigitaloceanProviderSettingsComponent} from '../digitalocean-provider-settings/digitalocean-provider-settings.component';
@@ -45,8 +45,7 @@ describe('AzureProviderSettingsComponent', () => {
             PacketProviderSettingsComponent,
           ],
           providers: [
-            ClusterService,
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],
         })

--- a/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/digitalocean-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/digitalocean-provider-settings.component.spec.ts
@@ -3,10 +3,10 @@ import {MatDialogRef} from '@angular/material';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
-import {ApiService, ClusterService} from '../../../../core/services';
+import {ClusterService} from '../../../../core/services';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakeDigitaloceanCluster} from '../../../../testing/fake-data/cluster.fake';
-import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AWSProviderSettingsComponent} from '../aws-provider-settings/aws-provider-settings.component';
 import {AzureProviderSettingsComponent} from '../azure-provider-settings/azure-provider-settings.component';
@@ -45,8 +45,7 @@ describe('DigitaloceanProviderSettingsComponent', () => {
             PacketProviderSettingsComponent,
           ],
           providers: [
-            ClusterService,
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],
         })

--- a/src/app/cluster/cluster-details/edit-provider-settings/edit-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/edit-provider-settings.component.spec.ts
@@ -3,9 +3,8 @@ import {MatDialogRef} from '@angular/material';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Router} from '@angular/router';
-import Spy = jasmine.Spy;
 
-import {ApiService, ClusterService, ProjectService} from '../../../core/services';
+import {ClusterService, ProjectService} from '../../../core/services';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
 import {SharedModule} from '../../../shared/shared.module';
 import {doCloudSpecFake} from '../../../testing/fake-data/cloud-spec.fake';
@@ -13,7 +12,7 @@ import {fakeDigitaloceanCluster} from '../../../testing/fake-data/cluster.fake';
 import {fakeDigitaloceanDatacenter} from '../../../testing/fake-data/datacenter.fake';
 import {fakeProject} from '../../../testing/fake-data/project.fake';
 import {RouterStub} from '../../../testing/router-stubs';
-import {asyncData} from '../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../testing/services/mat-dialog-ref-mock';
 import {ProjectMockService} from '../../../testing/services/project-mock.service';
 import {AWSProviderSettingsComponent} from './aws-provider-settings/aws-provider-settings.component';
@@ -22,8 +21,8 @@ import {DigitaloceanProviderSettingsComponent} from './digitalocean-provider-set
 import {EditProviderSettingsComponent} from './edit-provider-settings.component';
 import {HetznerProviderSettingsComponent} from './hetzner-provider-settings/hetzner-provider-settings.component';
 import {OpenstackProviderSettingsComponent} from './openstack-provider-settings/openstack-provider-settings.component';
-import {VSphereProviderSettingsComponent} from './vsphere-provider-settings/vsphere-provider-settings.component';
 import {PacketProviderSettingsComponent} from './packet-provider-settings/packet-provider-settings.component';
+import {VSphereProviderSettingsComponent} from './vsphere-provider-settings/vsphere-provider-settings.component';
 
 const modules: any[] = [
   BrowserModule,
@@ -34,12 +33,9 @@ const modules: any[] = [
 describe('EditProviderSettingsComponent', () => {
   let fixture: ComponentFixture<EditProviderSettingsComponent>;
   let component: EditProviderSettingsComponent;
-  let patchClusterSpy: Spy;
+  let clusterMockService;
 
   beforeEach(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['patchCluster']);
-    patchClusterSpy = apiMock.patchCluster.and.returnValue(asyncData(fakeDigitaloceanCluster));
-
     TestBed
         .configureTestingModule({
           imports: [
@@ -56,8 +52,7 @@ describe('EditProviderSettingsComponent', () => {
             PacketProviderSettingsComponent,
           ],
           providers: [
-            ClusterService,
-            {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
             {provide: Router, useClass: RouterStub},
@@ -69,6 +64,7 @@ describe('EditProviderSettingsComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(EditProviderSettingsComponent);
+    clusterMockService = fixture.debugElement.injector.get(ClusterService);
     component = fixture.componentInstance;
     component.cluster = fakeDigitaloceanCluster();
     fixture.detectChanges();
@@ -79,6 +75,7 @@ describe('EditProviderSettingsComponent', () => {
   });
 
   it('should call patchCluster method', fakeAsync(() => {
+       const patchClusterSpy = spyOn(clusterMockService, 'patch').and.callThrough();
        component.cluster = fakeDigitaloceanCluster();
        component.datacenter = fakeDigitaloceanDatacenter();
        component.project = fakeProject();

--- a/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/hetzner-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/hetzner-provider-settings.component.spec.ts
@@ -3,10 +3,10 @@ import {MatDialogRef} from '@angular/material';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
-import {ApiService, ClusterService} from '../../../../core/services';
+import {ClusterService} from '../../../../core/services';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakeHetznerCluster} from '../../../../testing/fake-data/cluster.fake';
-import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AWSProviderSettingsComponent} from '../aws-provider-settings/aws-provider-settings.component';
 import {AzureProviderSettingsComponent} from '../azure-provider-settings/azure-provider-settings.component';
@@ -45,8 +45,7 @@ describe('HetznerProviderSettingsComponent', () => {
             PacketProviderSettingsComponent,
           ],
           providers: [
-            ClusterService,
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],
         })

--- a/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/openstack-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/openstack-provider-settings.component.spec.ts
@@ -8,6 +8,7 @@ import {ApiService} from '../../../../core/services/api/api.service';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakeOpenstackCluster} from '../../../../testing/fake-data/cluster.fake';
 import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AWSProviderSettingsComponent} from '../aws-provider-settings/aws-provider-settings.component';
 import {AzureProviderSettingsComponent} from '../azure-provider-settings/azure-provider-settings.component';
@@ -45,7 +46,7 @@ describe('OpenstackProviderSettingsComponent', () => {
             PacketProviderSettingsComponent,
           ],
           providers: [
-            ClusterService,
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: ApiService, useClass: ApiMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],

--- a/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/packet-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/packet-provider-settings.component.spec.ts
@@ -7,6 +7,7 @@ import {ApiService, ClusterService} from '../../../../core/services';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakePacketCluster} from '../../../../testing/fake-data/cluster.fake';
 import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AWSProviderSettingsComponent} from '../aws-provider-settings/aws-provider-settings.component';
 import {AzureProviderSettingsComponent} from '../azure-provider-settings/azure-provider-settings.component';
@@ -46,8 +47,8 @@ describe('PacketProviderSettingsComponent', () => {
             PacketProviderSettingsComponent,
           ],
           providers: [
-            ClusterService,
             {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],
         })

--- a/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.spec.ts
@@ -3,10 +3,10 @@ import {MatDialogRef} from '@angular/material';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
-import {ApiService, ClusterService} from '../../../../core/services';
+import {ClusterService} from '../../../../core/services';
 import {SharedModule} from '../../../../shared/shared.module';
 import {fakeVSphereCluster} from '../../../../testing/fake-data/cluster.fake';
-import {ApiMockService} from '../../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {AWSProviderSettingsComponent} from '../aws-provider-settings/aws-provider-settings.component';
 import {AzureProviderSettingsComponent} from '../azure-provider-settings/azure-provider-settings.component';
@@ -46,7 +46,7 @@ describe('VSphereProviderSettingsComponent', () => {
           ],
           providers: [
             ClusterService,
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: MatDialogRef, useClass: MatDialogRefMock},
           ],
         })

--- a/src/app/cluster/cluster-details/edit-sshkeys/add-cluster-sshkeys/add-cluster-sshkeys.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/add-cluster-sshkeys/add-cluster-sshkeys.component.spec.ts
@@ -4,11 +4,11 @@ import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 import {AppConfigService} from '../../../../app-config.service';
-import {ApiService, ProjectService, UserService} from '../../../../core/services';
+import {ApiService, ClusterService, ProjectService, UserService} from '../../../../core/services';
 import {SharedModule} from '../../../../shared/shared.module';
-import {fakeSSHKeys} from '../../../../testing/fake-data/sshkey.fake';
-import {asyncData} from '../../../../testing/services/api-mock.service';
+import {ApiMockService} from '../../../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../../../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../../../../testing/services/cluster-mock-service';
 import {MatDialogRefMock} from '../../../../testing/services/mat-dialog-ref-mock';
 import {ProjectMockService} from '../../../../testing/services/project-mock.service';
 import {UserMockService} from '../../../../testing/services/user-mock.service';
@@ -26,10 +26,6 @@ describe('AddClusterSSHKeysComponent', () => {
   let component: AddClusterSSHKeysComponent;
 
   beforeEach(async(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['getSSHKeys', 'addClusterSSHKey']);
-    apiMock.getSSHKeys.and.returnValue(asyncData(fakeSSHKeys()));
-    apiMock.addClusterSSHKey.and.returnValue(asyncData(fakeSSHKeys()[0]));
-
     TestBed
         .configureTestingModule({
           imports: [
@@ -40,7 +36,8 @@ describe('AddClusterSSHKeysComponent', () => {
           ],
           providers: [
             {provide: MatDialogRef, useClass: MatDialogRefMock},
-            {provide: ApiService, useValue: apiMock},
+            {provide: ApiService, useValue: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: UserService, useClass: UserMockService},
             {provide: AppConfigService, useClass: AppConfigMockService},

--- a/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys-item/edit-sshkeys-item.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys-item/edit-sshkeys-item.component.spec.ts
@@ -4,20 +4,20 @@ import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 import {of} from 'rxjs';
-import Spy = jasmine.Spy;
 
 import {AppConfigService} from '../../../../app-config.service';
-import {ApiService, UserService} from '../../../../core/services';
+import {ClusterService, UserService} from '../../../../core/services';
 import {GoogleAnalyticsService} from '../../../../google-analytics.service';
 import {SharedModule} from '../../../../shared/shared.module';
 import {DialogTestModule, NoopConfirmDialogComponent} from '../../../../testing/components/noop-confirmation-dialog.component';
 import {fakeDigitaloceanCluster} from '../../../../testing/fake-data/cluster.fake';
 import {fakeDigitaloceanDatacenter} from '../../../../testing/fake-data/datacenter.fake';
-import {fakeSSHKeys} from '../../../../testing/fake-data/sshkey.fake';
 import {fakeProject} from '../../../../testing/fake-data/project.fake';
+import {fakeSSHKeys} from '../../../../testing/fake-data/sshkey.fake';
 import {AppConfigMockService} from '../../../../testing/services/app-config-mock.service';
 import {UserMockService} from '../../../../testing/services/user-mock.service';
 import {EditSSHKeysItemComponent} from './edit-sshkeys-item.component';
+import Spy = jasmine.Spy;
 
 describe('EditSSHKeysItemComponent', () => {
   let fixture: ComponentFixture<EditSSHKeysItemComponent>;
@@ -26,8 +26,8 @@ describe('EditSSHKeysItemComponent', () => {
   let deleteClusterSSHKeySpy: Spy;
 
   beforeEach(async(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['deleteClusterSSHKey']);
-    deleteClusterSSHKeySpy = apiMock.deleteClusterSSHKey.and.returnValue(of(null));
+    const clusterServiceMock = jasmine.createSpyObj('ClusterService', ['deleteSSHKey']);
+    deleteClusterSSHKeySpy = clusterServiceMock.deleteSSHKey.and.returnValue(of(null));
 
     TestBed
         .configureTestingModule({
@@ -43,7 +43,7 @@ describe('EditSSHKeysItemComponent', () => {
           ],
           providers: [
             MatDialog,
-            {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useValue: clusterServiceMock},
             {provide: UserService, useClass: UserMockService},
             {provide: AppConfigService, useClass: AppConfigMockService},
             GoogleAnalyticsService,

--- a/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys.component.spec.ts
@@ -4,11 +4,10 @@ import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 import {AppConfigService} from '../../../app-config.service';
-import {ApiService, UserService} from '../../../core/services';
+import {ClusterService, UserService} from '../../../core/services';
 import {SharedModule} from '../../../shared/shared.module';
-import {fakeSSHKeys} from '../../../testing/fake-data/sshkey.fake';
-import {asyncData} from '../../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../../../testing/services/cluster-mock-service';
 import {UserMockService} from '../../../testing/services/user-mock.service';
 import {EditSSHKeysItemComponent} from './edit-sshkeys-item/edit-sshkeys-item.component';
 import {EditSSHKeysComponent} from './edit-sshkeys.component';
@@ -25,9 +24,6 @@ describe('EditSSHKeysComponent', () => {
   let component: EditSSHKeysComponent;
 
   beforeEach(async(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['getClusterSSHKeys']);
-    apiMock.getClusterSSHKeys.and.returnValue(asyncData(fakeSSHKeys()));
-
     TestBed
         .configureTestingModule({
           imports: [
@@ -38,7 +34,7 @@ describe('EditSSHKeysComponent', () => {
             EditSSHKeysItemComponent,
           ],
           providers: [
-            {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: UserService, useClass: UserMockService},
             {provide: AppConfigService, useClass: AppConfigMockService},
             MatDialog,

--- a/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys.component.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys.component.ts
@@ -4,7 +4,7 @@ import {find} from 'lodash';
 import {Subject, timer} from 'rxjs';
 import {retry, takeUntil} from 'rxjs/operators';
 import {AppConfigService} from '../../../app-config.service';
-import {ApiService, UserService} from '../../../core/services';
+import {ClusterService, UserService} from '../../../core/services';
 import {ClusterEntity} from '../../../shared/entity/ClusterEntity';
 import {DataCenterEntity} from '../../../shared/entity/DatacenterEntity';
 import {SSHKeyEntity} from '../../../shared/entity/SSHKeyEntity';
@@ -31,8 +31,8 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
   private _unsubscribe: Subject<any> = new Subject();
 
   constructor(
-      private readonly _api: ApiService, private readonly _userService: UserService,
-      private readonly _appConfig: AppConfigService, public dialog: MatDialog) {}
+      private readonly _userService: UserService, private readonly _appConfig: AppConfigService,
+      private readonly _dialog: MatDialog, private readonly _clusterService: ClusterService) {}
 
   ngOnInit(): void {
     this.userGroupConfig = this._appConfig.getUserGroupConfig();
@@ -51,7 +51,7 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
   }
 
   refreshSSHKeys(): void {
-    this._api.getClusterSSHKeys(this.cluster.id, this.datacenter.metadata.name, this.projectID)
+    this._clusterService.sshKeys(this.projectID, this.cluster.id, this.datacenter.metadata.name)
         .pipe(retry(3))
         .pipe(takeUntil(this._unsubscribe))
         .subscribe((res) => {
@@ -62,7 +62,7 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
   }
 
   addSshKey(): void {
-    const dialogRef = this.dialog.open(AddClusterSSHKeysComponent);
+    const dialogRef = this._dialog.open(AddClusterSSHKeysComponent);
     dialogRef.componentInstance.projectID = this.projectID;
     dialogRef.componentInstance.cluster = this.cluster;
     dialogRef.componentInstance.datacenter = this.datacenter;

--- a/src/app/cluster/cluster-details/node-data-modal/node-data-modal.component.spec.ts
+++ b/src/app/cluster/cluster-details/node-data-modal/node-data-modal.component.spec.ts
@@ -7,8 +7,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ActivatedRoute, Router} from '@angular/router';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 
-import {ApiService, ProjectService} from '../../../core/services';
-import {DatacenterService, WizardService} from '../../../core/services';
+import {ApiService, ClusterService, DatacenterService, ProjectService, WizardService} from '../../../core/services';
 import {NodeDataService} from '../../../core/services/node-data/node-data.service';
 import {ClusterNameGenerator} from '../../../core/util/name-generator.service';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
@@ -24,15 +23,15 @@ import {PacketNodeDataComponent} from '../../../node-data/packet-node-data/packe
 import {VSphereNodeDataComponent} from '../../../node-data/vsphere-add-node/vsphere-node-data.component';
 import {VSphereOptionsComponent} from '../../../node-data/vsphere-add-node/vsphere-options/vsphere-options.component';
 import {SharedModule} from '../../../shared/shared.module';
-import {fakeDigitaloceanSizes} from '../../../testing/fake-data/addNodeModal.fake';
-import {masterVersionsFake} from '../../../testing/fake-data/cluster-spec.fake';
 import {fakeDigitaloceanCluster} from '../../../testing/fake-data/cluster.fake';
 import {fakeDigitaloceanDatacenter} from '../../../testing/fake-data/datacenter.fake';
 import {fakeDigitaloceanCreateNode, nodeDataFake} from '../../../testing/fake-data/node.fake';
 import {ActivatedRouteStub, RouterStub, RouterTestingModule} from '../../../testing/router-stubs';
-import {asyncData} from '../../../testing/services/api-mock.service';
+import {ApiMockService} from '../../../testing/services/api-mock.service';
+import {ClusterMockService} from '../../../testing/services/cluster-mock-service';
 import {DatacenterMockService} from '../../../testing/services/datacenter-mock.service';
 import {ClusterNameGeneratorMock} from '../../../testing/services/name-generator-mock.service';
+import {NodeMockService} from '../../../testing/services/node-mock.service';
 import {ProjectMockService} from '../../../testing/services/project-mock.service';
 import {NodeService} from '../../services/node.service';
 
@@ -44,12 +43,6 @@ describe('NodeDataModalData', () => {
   let activatedRoute: ActivatedRouteStub;
 
   beforeEach(async(() => {
-    const apiMock = jasmine.createSpyObj(
-        'ApiService', ['getDigitaloceanSizes', 'createClusterNode', 'patchNodeDeployment', 'getClusterNodeUpgrades']);
-    apiMock.getDigitaloceanSizes.and.returnValue(asyncData(fakeDigitaloceanSizes()));
-    apiMock.getClusterNodeUpgrades.and.returnValue(asyncData(masterVersionsFake()));
-    const nodeMock = jasmine.createSpyObj('NodeService', ['createNodeDeployment']);
-
     TestBed
         .configureTestingModule({
           imports: [
@@ -79,11 +72,12 @@ describe('NodeDataModalData', () => {
           providers: [
             {provide: MAT_DIALOG_DATA, useValue: {cluster: fakeDigitaloceanCluster()}},
             {provide: MatDialogRef, useValue: {}},
-            {provide: ApiService, useValue: apiMock},
+            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: ActivatedRoute, useClass: ActivatedRouteStub},
             {provide: DatacenterService, useClass: DatacenterMockService},
             {provide: ProjectService, useClass: ProjectMockService},
-            {provide: NodeService, useValue: nodeMock},
+            {provide: NodeService, useClass: NodeMockService},
             {provide: Router, useClass: RouterStub},
             {provide: ClusterNameGenerator, useClass: ClusterNameGeneratorMock},
             NodeDataService,

--- a/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.spec.ts
+++ b/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.spec.ts
@@ -7,7 +7,7 @@ import {RouterTestingModule} from '@angular/router/testing';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 
 import {AppConfigService} from '../../../app-config.service';
-import {ApiService, Auth, DatacenterService, ProjectService, UserService} from '../../../core/services';
+import {ApiService, Auth, ClusterService, DatacenterService, ProjectService, UserService} from '../../../core/services';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
 import {SharedModule} from '../../../shared/shared.module';
 import {NodeDeploymentHealthStatus} from '../../../shared/utils/health-status/node-deployment-health-status';
@@ -18,6 +18,7 @@ import {ActivatedRouteStub, RouterStub} from '../../../testing/router-stubs';
 import {asyncData} from '../../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../../testing/services/app-config-mock.service';
 import {AuthMockService} from '../../../testing/services/auth-mock.service';
+import {ClusterMockService} from '../../../testing/services/cluster-mock-service';
 import {NodeMockService} from '../../../testing/services/node-mock.service';
 import {ProjectMockService} from '../../../testing/services/project-mock.service';
 import {UserMockService} from '../../../testing/services/user-mock.service';
@@ -36,8 +37,7 @@ describe('NodeDeploymentDetailsComponent', () => {
 
   beforeEach(async(() => {
     apiMock = jasmine.createSpyObj(
-        'ApiService', ['getCluster', 'getNodeDeploymentNodes', 'getNodeDeployment', 'getNodeDeploymentNodesEvents']);
-    apiMock.getCluster.and.returnValue(asyncData(fakeDigitaloceanCluster()));
+        'ApiService', ['getNodeDeploymentNodes', 'getNodeDeployment', 'getNodeDeploymentNodesEvents']);
     apiMock.getNodeDeployment.and.returnValue(asyncData(nodeDeploymentsFake()[0]));
     apiMock.getNodeDeploymentNodes.and.returnValue(asyncData(nodesFake()));
     apiMock.getNodeDeploymentNodesEvents.and.returnValue(asyncData([]));
@@ -60,6 +60,7 @@ describe('NodeDeploymentDetailsComponent', () => {
           ],
           providers: [
             {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: DatacenterService, useValue: dcMock},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: Auth, useClass: AuthMockService},

--- a/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.ts
+++ b/src/app/cluster/cluster-details/node-deployment-details/node-deployment-details.component.ts
@@ -4,7 +4,7 @@ import {Subject, timer} from 'rxjs';
 import {first, takeUntil} from 'rxjs/operators';
 import {AppConfigService} from '../../../app-config.service';
 
-import {ApiService, DatacenterService, UserService} from '../../../core/services';
+import {ApiService, ClusterService, DatacenterService, UserService} from '../../../core/services';
 import {ClusterEntity} from '../../../shared/entity/ClusterEntity';
 import {DataCenterEntity} from '../../../shared/entity/DatacenterEntity';
 import {EventEntity} from '../../../shared/entity/EventEntity';
@@ -48,7 +48,7 @@ export class NodeDeploymentDetailsComponent implements OnInit, OnDestroy {
       private readonly _activatedRoute: ActivatedRoute, private readonly _router: Router,
       private readonly _apiService: ApiService, private readonly _datacenterService: DatacenterService,
       private readonly _nodeService: NodeService, private readonly _appConfig: AppConfigService,
-      private readonly _userService: UserService) {}
+      private readonly _userService: UserService, private readonly _clusterService: ClusterService) {}
 
   ngOnInit(): void {
     this._clusterName = this._activatedRoute.snapshot.paramMap.get('clusterName');
@@ -101,7 +101,7 @@ export class NodeDeploymentDetailsComponent implements OnInit, OnDestroy {
   }
 
   loadCluster(): void {
-    this._apiService.getCluster(this._clusterName, this._dcName, this._projectID).pipe(first()).subscribe((c) => {
+    this._clusterService.cluster(this._projectID, this._clusterName, this._dcName).pipe(first()).subscribe((c) => {
       this.cluster = c;
       this.clusterProvider = ClusterUtils.getProvider(this.cluster.spec.cloud);
       this._isClusterLoaded = true;

--- a/src/app/cluster/cluster-details/node-list/node-list.component.spec.ts
+++ b/src/app/cluster/cluster-details/node-list/node-list.component.spec.ts
@@ -6,15 +6,15 @@ import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 import {of} from 'rxjs';
 
 import {AppConfigService} from '../../../app-config.service';
-import {ApiService, UserService} from '../../../core/services';
+import {ClusterService, UserService} from '../../../core/services';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
 import {SharedModule} from '../../../shared/shared.module';
 import {fakeDigitaloceanCluster} from '../../../testing/fake-data/cluster.fake';
 import {fakeDigitaloceanDatacenter} from '../../../testing/fake-data/datacenter.fake';
 import {nodeFake} from '../../../testing/fake-data/node.fake';
 import {fakeProject} from '../../../testing/fake-data/project.fake';
-import {ApiMockService} from '../../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../../../testing/services/cluster-mock-service';
 import {UserMockService} from '../../../testing/services/user-mock.service';
 
 import {NodeListComponent} from './node-list.component';
@@ -35,7 +35,7 @@ const modules: any[] = [
 describe('NodeComponent', () => {
   let fixture: ComponentFixture<NodeListComponent>;
   let component: NodeListComponent;
-  let apiService: ApiService;
+  let clusterService: ClusterService;
 
   beforeEach(async(() => {
     TestBed
@@ -47,7 +47,7 @@ describe('NodeComponent', () => {
             NodeListComponent,
           ],
           providers: [
-            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: UserService, useClass: UserMockService},
             {provide: AppConfigService, useClass: AppConfigMockService},
             {provide: MatDialog, useClass: MatDialogMock},
@@ -60,21 +60,21 @@ describe('NodeComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(NodeListComponent);
     component = fixture.componentInstance;
-    apiService = fixture.debugElement.injector.get(ApiService);
+    clusterService = fixture.debugElement.injector.get(ClusterService);
   });
 
   it('should create the cluster details cmp', async(() => {
        expect(component).toBeTruthy();
      }));
 
-  it('should call deleteClusterNode', fakeAsync(() => {
+  it('should call deleteNode', fakeAsync(() => {
        component.cluster = fakeDigitaloceanCluster();
        component.datacenter = fakeDigitaloceanDatacenter();
        component.projectID = fakeProject().id;
        const event = new MouseEvent('click');
 
        fixture.detectChanges();
-       const spyDeleteClusterNode = spyOn(apiService, 'deleteClusterNode').and.returnValue(of(null));
+       const spyDeleteClusterNode = spyOn(clusterService, 'deleteNode').and.returnValue(of(null));
 
        component.deleteNodeDialog(nodeFake(), event);
        tick();

--- a/src/app/cluster/cluster-details/node-list/node-list.component.ts
+++ b/src/app/cluster/cluster-details/node-list/node-list.component.ts
@@ -1,7 +1,7 @@
 import {Component, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
 import {MatDialog, MatDialogConfig, MatSort, MatTableDataSource} from '@angular/material';
 
-import {ApiService} from '../../../core/services';
+import {ClusterService} from '../../../core/services';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
 import {NotificationActions} from '../../../redux/actions/notification.actions';
 import {ConfirmationDialogComponent} from '../../../shared/components/confirmation-dialog/confirmation-dialog.component';
@@ -43,7 +43,7 @@ export class NodeListComponent implements OnInit {
   shouldToggleNodeItem = (index, item) => this.isShowNodeItem[item.id];
 
   constructor(
-      private readonly _matDialog: MatDialog, private readonly _apiService: ApiService,
+      private readonly _matDialog: MatDialog, private readonly _clusterService: ClusterService,
       private readonly _googleAnalyticsService: GoogleAnalyticsService) {}
 
   ngOnInit(): void {
@@ -79,7 +79,7 @@ export class NodeListComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe((isConfirmed: boolean) => {
       if (isConfirmed) {
-        this._apiService.deleteClusterNode(this.cluster.id, node, this.datacenter.metadata.name, this.projectID)
+        this._clusterService.deleteNode(this.projectID, this.cluster.id, this.datacenter.metadata.name, node.id)
             .subscribe(() => {
               NotificationActions.success('Success', `Node removed successfully from ${this.cluster.name}`);
               this._googleAnalyticsService.emitEvent('clusterOverview', 'nodeDeleted');

--- a/src/app/cluster/cluster-list/cluster-list.component.spec.ts
+++ b/src/app/cluster/cluster-list/cluster-list.component.spec.ts
@@ -6,21 +6,20 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 
 import {AppConfigService} from '../../app-config.service';
-import {ApiService, Auth, DatacenterService, ProjectService, UserService} from '../../core/services';
+import {ApiService, Auth, ClusterService, DatacenterService, ProjectService, UserService} from '../../core/services';
 import {SharedModule} from '../../shared/shared.module';
 import {fakeAWSCluster} from '../../testing/fake-data/cluster.fake';
 import {fakeHealth} from '../../testing/fake-data/health.fake';
 import {ActivatedRouteStub, RouterStub, RouterTestingModule} from '../../testing/router-stubs';
-import {asyncData} from '../../testing/services/api-mock.service';
+import {ApiMockService, asyncData} from '../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../testing/services/app-config-mock.service';
 import {AuthMockService} from '../../testing/services/auth-mock.service';
 import {DatacenterMockService} from '../../testing/services/datacenter-mock.service';
+import {ProjectMockService} from '../../testing/services/project-mock.service';
 import {UserMockService} from '../../testing/services/user-mock.service';
 
 import {ClusterListComponent} from './cluster-list.component';
-
 import Spy = jasmine.Spy;
-import {ProjectMockService} from '../../testing/services/project-mock.service';
 
 describe('ClusterListComponent', () => {
   let fixture: ComponentFixture<ClusterListComponent>;
@@ -29,9 +28,9 @@ describe('ClusterListComponent', () => {
   let activatedRoute: ActivatedRouteStub;
 
   beforeEach(async(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['getAllClusters', 'getClusterHealth']);
-    getClustersSpy = apiMock.getAllClusters.and.returnValue(asyncData([fakeAWSCluster()]));
-    apiMock.getClusterHealth.and.returnValue(asyncData([fakeHealth()]));
+    const clusterServiceMock = jasmine.createSpyObj('ClusterService', ['clusters', 'health']);
+    getClustersSpy = clusterServiceMock.clusters.and.returnValue(asyncData([fakeAWSCluster()]));
+    clusterServiceMock.health.and.returnValue(asyncData([fakeHealth()]));
 
     TestBed
         .configureTestingModule({
@@ -47,7 +46,8 @@ describe('ClusterListComponent', () => {
             ClusterListComponent,
           ],
           providers: [
-            {provide: ApiService, useValue: apiMock},
+            {provide: ApiService, useValue: ApiMockService},
+            {provide: ClusterService, useValue: clusterServiceMock},
             {provide: Auth, useClass: AuthMockService},
             {provide: ActivatedRoute, useClass: ActivatedRouteStub},
             {provide: UserService, useClass: UserMockService},

--- a/src/app/core/components/navigation/navigation.component.ts
+++ b/src/app/core/components/navigation/navigation.component.ts
@@ -14,17 +14,17 @@ export class NavigationComponent implements OnInit {
   environment: any = environment;
   currentUser: MemberEntity;
 
-  constructor(public auth: Auth, private router: Router, private userService: UserService) {}
+  constructor(public auth: Auth, private readonly _router: Router, private readonly _userService: UserService) {}
 
   ngOnInit(): void {
     if (this.auth.authenticated()) {
-      this.userService.loggedInUser.subscribe(user => this.currentUser = user);
+      this._userService.loggedInUser.subscribe(user => this.currentUser = user);
     }
   }
 
   logout(): void {
-    this.router.navigate(['']);
     this.auth.logout();
+    this._router.navigate(['']);
     delete this.currentUser;
   }
 

--- a/src/app/core/components/sidenav/project/selector.component.ts
+++ b/src/app/core/components/sidenav/project/selector.component.ts
@@ -23,8 +23,11 @@ export class ProjectSelectorComponent implements OnInit, OnDestroy {
     this._projectService.projects.pipe(takeUntil(this._unsubscribe))
         .subscribe(projects => this.projects = projects.sort((a, b) => a.name.localeCompare(b.name)));
 
-    this._projectService.selectedProject.subscribe(project => this.selectedProject = project);
-    this._projectService.onProjectChange.subscribe(project => this.selectedProject = project);
+    this._projectService.selectedProject.pipe(takeUntil(this._unsubscribe))
+        .subscribe(project => this.selectedProject = project);
+
+    this._projectService.onProjectChange.pipe(takeUntil(this._unsubscribe))
+        .subscribe(project => this.selectedProject = project);
   }
 
   onSelectionChange(event: MatSelectChange): void {

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -1,15 +1,12 @@
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Observable, of} from 'rxjs';
-import {catchError} from 'rxjs/operators';
+import {Observable} from 'rxjs';
 
 import {environment} from '../../../../environments/environment';
 import {LabelFormComponent} from '../../../shared/components/label-form/label-form.component';
 import {TaintFormComponent} from '../../../shared/components/taint-form/taint-form.component';
-import {ClusterEntity, Finalizer, MasterVersion, Token} from '../../../shared/entity/ClusterEntity';
-import {ClusterEntityPatch} from '../../../shared/entity/ClusterEntityPatch';
+import {ClusterEntity, MasterVersion, Token} from '../../../shared/entity/ClusterEntity';
 import {EventEntity} from '../../../shared/entity/EventEntity';
-import {HealthEntity} from '../../../shared/entity/HealthEntity';
 import {CreateMemberEntity, MemberEntity} from '../../../shared/entity/MemberEntity';
 import {NodeDeploymentEntity} from '../../../shared/entity/NodeDeploymentEntity';
 import {NodeDeploymentPatch} from '../../../shared/entity/NodeDeploymentPatch';
@@ -17,12 +14,11 @@ import {NodeEntity} from '../../../shared/entity/NodeEntity';
 import {EditProjectEntity, ProjectEntity} from '../../../shared/entity/ProjectEntity';
 import {AzureSizes} from '../../../shared/entity/provider/azure/AzureSizeEntity';
 import {DigitaloceanSizes} from '../../../shared/entity/provider/digitalocean/DropletSizeEntity';
-import {OpenstackFlavor, OpenstackNetwork, OpenstackSecurityGroup, OpenstackSubnet, OpenstackTenant,} from '../../../shared/entity/provider/openstack/OpenstackSizeEntity';
+import {OpenstackFlavor, OpenstackNetwork, OpenstackSecurityGroup, OpenstackSubnet, OpenstackTenant} from '../../../shared/entity/provider/openstack/OpenstackSizeEntity';
 import {VSphereNetwork} from '../../../shared/entity/provider/vsphere/VSphereEntity';
 
 import {CreateServiceAccountEntity, CreateTokenEntity, ServiceAccountEntity, ServiceAccountTokenEntity, ServiceAccountTokenPatch} from '../../../shared/entity/ServiceAccountEntity';
 import {SSHKeyEntity} from '../../../shared/entity/SSHKeyEntity';
-import {CreateClusterModel} from '../../../shared/model/CreateClusterModel';
 import {CreateProjectModel} from '../../../shared/model/CreateProjectModel';
 import {Auth} from '../auth/auth.service';
 
@@ -98,92 +94,6 @@ export class ApiService {
     return this._http.put(url, editProjectEntity);
   }
 
-  deleteProject(projectID: string): Observable<any> {
-    const url = `${this._restRoot}/projects/${projectID}`;
-    return this._http.delete(url);
-  }
-
-  getAllClusters(projectID: string): Observable<ClusterEntity[]> {
-    const url = `${this._restRoot}/projects/${projectID}/clusters`;
-    return this._http.get<ClusterEntity[]>(url);
-  }
-  getCluster(cluster: string, dc: string, projectID: string): Observable<ClusterEntity> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}`;
-    return this._http.get<ClusterEntity>(url);
-  }
-
-  createCluster(createClusterModel: CreateClusterModel, dc: string, projectID: string): Observable<ClusterEntity> {
-    createClusterModel.nodeDeployment.spec.template.labels =
-        LabelFormComponent.filterNullifiedKeys(createClusterModel.nodeDeployment.spec.template.labels);
-    createClusterModel.nodeDeployment.spec.template.taints =
-        TaintFormComponent.filterNullifiedTaints(createClusterModel.nodeDeployment.spec.template.taints);
-
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters`;
-    return this._http.post<ClusterEntity>(url, createClusterModel);
-  }
-
-  patchCluster(patch: ClusterEntityPatch, clusterId: string, dc: string, projectID: string): Observable<ClusterEntity> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${clusterId}`;
-    return this._http.patch<ClusterEntity>(url, patch);
-  }
-
-  deleteCluster(cluster: string, dc: string, projectID: string, finalizers?: {[key in Finalizer]: boolean}):
-      Observable<any> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}`;
-    if (finalizers !== undefined) {
-      for (const key of Object.keys(finalizers)) {
-        this._headers = this._headers.set(key, finalizers[key].toString());
-      }
-    }
-
-    return this._http.delete(url, {headers: this._headers});
-  }
-
-  getClusterEvents(cluster: string, dc: string, projectID: string): Observable<EventEntity[]> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/events`;
-    return this._http.get<EventEntity[]>(url);
-  }
-
-  getClusterHealth(cluster: string, dc: string, projectID: string): Observable<HealthEntity> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/health`;
-    return this._http.get<HealthEntity>(url);
-  }
-
-  upgradeClusterNodeDeployments(version: string, cluster: string, dc: string, projectID: string): Observable<any> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/nodes/upgrades`;
-    return this._http.put(url, {version} as MasterVersion);
-  }
-
-  getClusterNodes(cluster: string, dc: string, projectID: string): Observable<NodeEntity[]> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/nodes?hideInitialConditions=true`;
-    return this._http.get<NodeEntity[]>(url);
-  }
-
-  createClusterNode(cluster: ClusterEntity, node: NodeEntity, dc: string, projectID: string): Observable<NodeEntity> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster.id}/nodes`;
-    return this._http.post<NodeEntity>(url, node);
-  }
-
-  deleteClusterNode(cluster: string, node: NodeEntity, dc: string, projectID: string): Observable<any> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/nodes/${node.id}`;
-    return this._http.delete(url);
-  }
-
-  getClusterSSHKeys(cluster: string, dc: string, projectID: string): Observable<SSHKeyEntity[]> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/sshkeys`;
-    return this._http.get<SSHKeyEntity[]>(url);
-  }
-
-  deleteClusterSSHKey(sshkeyID: string, cluster: string, dc: string, projectID: string): Observable<any> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/sshkeys/${sshkeyID}`;
-    return this._http.delete(url);
-  }
-
-  addClusterSSHKey(sshkeyID: string, cluster: string, dc: string, projectID: string): Observable<any> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/sshkeys/${sshkeyID}`;
-    return this._http.put(url, null);
-  }
-
   getSSHKeys(projectID: string): Observable<SSHKeyEntity[]> {
     const url = `${this._restRoot}/projects/${projectID}/sshkeys`;
     return this._http.get<SSHKeyEntity[]>(url);
@@ -208,20 +118,6 @@ export class ApiService {
   getDigitaloceanSizes(projectId: string, dc: string, clusterId: string): Observable<DigitaloceanSizes> {
     const url = `${this._restRoot}/projects/${projectId}/dc/${dc}/clusters/${clusterId}/providers/digitalocean/sizes`;
     return this._http.get<DigitaloceanSizes>(url);
-  }
-
-  getClusterUpgrades(projectID: string, dc: string, clusterID: string): Observable<MasterVersion[]> {
-    const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${clusterID}/upgrades`;
-    return this._http.get<MasterVersion[]>(url).pipe(catchError(() => {
-      return of<MasterVersion[]>([]);
-    }));
-  }
-
-  getClusterNodeUpgrades(controlPlaneVersion: string, type: string): Observable<MasterVersion[]> {
-    const url = `${this._restRoot}/upgrades/node?control_plane_version=${controlPlaneVersion}&type=${type}`;
-    return this._http.get<MasterVersion[]>(url).pipe(catchError(() => {
-      return of<MasterVersion[]>([]);
-    }));
   }
 
   editToken(cluster: ClusterEntity, dc: string, projectID: string, token: Token): Observable<Token> {

--- a/src/app/core/services/cluster/cluster.service.ts
+++ b/src/app/core/services/cluster/cluster.service.ts
@@ -1,6 +1,19 @@
+import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
+import {merge, Observable, of, timer} from 'rxjs';
+import {catchError, publishReplay, refCount, switchMapTo} from 'rxjs/operators';
 import {Subject} from 'rxjs/Subject';
-import {CloudSpecPatch} from '../../../shared/entity/ClusterEntityPatch';
+import {environment} from '../../../../environments/environment';
+import {AppConfigService} from '../../../app-config.service';
+import {LabelFormComponent} from '../../../shared/components/label-form/label-form.component';
+import {TaintFormComponent} from '../../../shared/components/taint-form/taint-form.component';
+import {ClusterEntity, Finalizer, MasterVersion} from '../../../shared/entity/ClusterEntity';
+import {CloudSpecPatch, ClusterEntityPatch} from '../../../shared/entity/ClusterEntityPatch';
+import {EventEntity} from '../../../shared/entity/EventEntity';
+import {HealthEntity} from '../../../shared/entity/HealthEntity';
+import {NodeEntity} from '../../../shared/entity/NodeEntity';
+import {SSHKeyEntity} from '../../../shared/entity/SSHKeyEntity';
+import {CreateClusterModel} from '../../../shared/model/CreateClusterModel';
 
 export class ProviderSettingsPatch {
   cloudSpecPatch: CloudSpecPatch;
@@ -10,9 +23,141 @@ export class ProviderSettingsPatch {
 @Injectable()
 export class ClusterService {
   private _providerSettingsPatch = new Subject<ProviderSettingsPatch>();
+  private _restRoot: string = environment.restRoot;
+  private _headers: HttpHeaders = new HttpHeaders();
+  private _clusters$ = new Map<string, Observable<ClusterEntity[]>>();
+  private _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * 10);
+  private _onClustersUpdate = new Subject<void>();
+
   providerSettingsPatchChanges$ = this._providerSettingsPatch.asObservable();
+  onClusterUpdate = new Subject<void>();
+
+  constructor(private readonly _http: HttpClient, private readonly _appConfig: AppConfigService) {}
 
   changeProviderSettingsPatch(patch: ProviderSettingsPatch): void {
     this._providerSettingsPatch.next(patch);
+  }
+
+  clusters(projectID: string): Observable<ClusterEntity[]> {
+    if (!this._clusters$.get(projectID)) {
+      const clusters$ = merge(this._onClustersUpdate, this._refreshTimer$)
+                            .pipe(switchMapTo(this._getClusters(projectID)))
+                            .pipe(publishReplay(1))
+                            .pipe(refCount());
+      this._clusters$.set(projectID, clusters$);
+    }
+
+    return this._clusters$.get(projectID);
+  }
+
+  refreshClusters() {
+    this._onClustersUpdate.next();
+    this._clusters$.clear();
+  }
+
+  cluster(projectID: string, clusterID: string, datacenter: string): Observable<ClusterEntity> {
+    return merge(this.onClusterUpdate, this._refreshTimer$)
+        .pipe(switchMapTo(this._getCluster(projectID, clusterID, datacenter)))
+        .pipe(publishReplay(1))
+        .pipe(refCount())
+        .pipe(catchError(() => of(undefined)));
+  }
+
+  create(projectID: string, datacenter: string, createClusterModel: CreateClusterModel): Observable<ClusterEntity> {
+    createClusterModel.nodeDeployment.spec.template.labels =
+        LabelFormComponent.filterNullifiedKeys(createClusterModel.nodeDeployment.spec.template.labels);
+    createClusterModel.nodeDeployment.spec.template.taints =
+        TaintFormComponent.filterNullifiedTaints(createClusterModel.nodeDeployment.spec.template.taints);
+
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters`;
+    return this._http.post<ClusterEntity>(url, createClusterModel);
+  }
+
+  patch(projectID: string, clusterID: string, datacenter: string, patch: ClusterEntityPatch):
+      Observable<ClusterEntity> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}`;
+    return this._http.patch<ClusterEntity>(url, patch);
+  }
+
+  delete(projectID: string, clusterID: string, datacenter: string, finalizers?: {[key in Finalizer]: boolean}):
+      Observable<any> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}`;
+    if (finalizers !== undefined) {
+      for (const key of Object.keys(finalizers)) {
+        this._headers = this._headers.set(key, finalizers[key].toString());
+      }
+    }
+
+    return this._http.delete(url, {headers: this._headers});
+  }
+
+  upgrades(projectID: string, clusterID: string, datacenter: string): Observable<MasterVersion[]> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/upgrades`;
+    return this._http.get<MasterVersion[]>(url).pipe(catchError(() => {
+      return of<MasterVersion[]>([]);
+    }));
+  }
+
+  events(projectID: string, clusterID: string, datacenter: string): Observable<EventEntity[]> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/events`;
+    return this._http.get<EventEntity[]>(url);
+  }
+
+  health(projectID: string, clusterID: string, datacenter: string): Observable<HealthEntity> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/health`;
+    return this._http.get<HealthEntity>(url);
+  }
+
+  upgradeNodeDeployments(projectID: string, clusterID: string, datacenter: string, version: string): Observable<any> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/nodes/upgrades`;
+    return this._http.put(url, {version} as MasterVersion);
+  }
+
+  nodes(projectID: string, clusterID: string, datacenter: string): Observable<NodeEntity[]> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${
+        clusterID}/nodes?hideInitialConditions=true`;
+    return this._http.get<NodeEntity[]>(url);
+  }
+
+  createNode(projectID: string, clusterID: string, datacenter: string, node: NodeEntity): Observable<NodeEntity> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/nodes`;
+    return this._http.post<NodeEntity>(url, node);
+  }
+
+  deleteNode(projectID: string, clusterID: string, datacenter: string, nodeID: string): Observable<any> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/nodes/${nodeID}`;
+    return this._http.delete(url);
+  }
+
+  nodeUpgrades(controlPlaneVersion: string, type: string): Observable<MasterVersion[]> {
+    const url = `${this._restRoot}/upgrades/node?control_plane_version=${controlPlaneVersion}&type=${type}`;
+    return this._http.get<MasterVersion[]>(url).pipe(catchError(() => {
+      return of<MasterVersion[]>([]);
+    }));
+  }
+
+  sshKeys(projectID: string, clusterID: string, datacenter: string): Observable<SSHKeyEntity[]> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/sshkeys`;
+    return this._http.get<SSHKeyEntity[]>(url);
+  }
+
+  createSSHKey(projectID: string, clusterID: string, datacenter: string, sshKeyID: string): Observable<any> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/sshkeys/${sshKeyID}`;
+    return this._http.put(url, null);
+  }
+
+  deleteSSHKey(projectID: string, clusterID: string, datacenter: string, sshKeyID: string): Observable<any> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/sshkeys/${sshKeyID}`;
+    return this._http.delete(url);
+  }
+
+  private _getClusters(projectID: string) {
+    const url = `${this._restRoot}/projects/${projectID}/clusters`;
+    return this._http.get<ClusterEntity[]>(url);
+  }
+
+  private _getCluster(projectID: string, clusterID: string, datacenter: string): Observable<ClusterEntity> {
+    const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}`;
+    return this._http.get<ClusterEntity>(url);
   }
 }

--- a/src/app/node-data/node-data.component.spec.ts
+++ b/src/app/node-data/node-data.component.spec.ts
@@ -3,7 +3,7 @@ import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Router} from '@angular/router';
 
-import {ApiService, DatacenterService, ProjectService, WizardService} from '../core/services';
+import {ApiService, ClusterService, DatacenterService, ProjectService, WizardService} from '../core/services';
 import {NodeDataService} from '../core/services/node-data/node-data.service';
 import {ClusterNameGenerator} from '../core/util/name-generator.service';
 import {SharedModule} from '../shared/shared.module';
@@ -13,6 +13,7 @@ import {fakeAWSCluster, fakeDigitaloceanCluster, fakeOpenstackCluster} from '../
 import {nodeDataFake} from '../testing/fake-data/node.fake';
 import {RouterStub} from '../testing/router-stubs';
 import {asyncData} from '../testing/services/api-mock.service';
+import {ClusterMockService} from '../testing/services/cluster-mock-service';
 import {DatacenterMockService} from '../testing/services/datacenter-mock.service';
 import {ClusterNameGeneratorMock} from '../testing/services/name-generator-mock.service';
 import {ProjectMockService} from '../testing/services/project-mock.service';
@@ -36,13 +37,13 @@ describe('NodeDataComponent', () => {
   beforeEach(async(() => {
     const apiMock = jasmine.createSpyObj('ApiService', [
       'getDigitaloceanSizes', 'getDigitaloceanSizesForWizard', 'getOpenStackFlavors', 'getOpenStackFlavorsForWizard',
-      'getClusterNodeUpgrades'
+      'nodeUpgrades'
     ]);
     apiMock.getDigitaloceanSizes.and.returnValue(asyncData(fakeDigitaloceanSizes()));
     apiMock.getDigitaloceanSizesForWizard.and.returnValue(asyncData(fakeDigitaloceanSizes()));
     apiMock.getOpenStackFlavors.and.returnValue(asyncData(fakeOpenstackFlavors()));
     apiMock.getOpenStackFlavorsForWizard.and.returnValue(asyncData(fakeOpenstackFlavors()));
-    apiMock.getClusterNodeUpgrades.and.returnValue(asyncData(masterVersionsFake()));
+    apiMock.nodeUpgrades.and.returnValue(asyncData(masterVersionsFake()));
 
     TestBed
         .configureTestingModule({
@@ -68,6 +69,7 @@ describe('NodeDataComponent', () => {
             NodeDataService,
             WizardService,
             {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: DatacenterService, useClass: DatacenterMockService},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: Router, useClass: RouterStub},

--- a/src/app/node-data/node-data.component.ts
+++ b/src/app/node-data/node-data.component.ts
@@ -3,7 +3,7 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {Subject} from 'rxjs';
 import {first, takeUntil} from 'rxjs/operators';
 
-import {ApiService, DatacenterService, ProjectService, WizardService} from '../core/services';
+import {ClusterService, DatacenterService, ProjectService, WizardService} from '../core/services';
 import {NodeDataService} from '../core/services/node-data/node-data.service';
 import {ClusterNameGenerator} from '../core/util/name-generator.service';
 import {ClusterEntity, MasterVersion} from '../shared/entity/ClusterEntity';
@@ -35,7 +35,7 @@ export class NodeDataComponent implements OnInit, OnDestroy {
   constructor(
       private nameGenerator: ClusterNameGenerator, private addNodeService: NodeDataService,
       private wizardService: WizardService, private _dc: DatacenterService, private _project: ProjectService,
-      private readonly _apiService: ApiService) {}
+      private readonly _clusterService: ClusterService) {}
 
   ngOnInit(): void {
     const initialKubeletVersion = this.nodeData.spec.versions.kubelet;
@@ -97,7 +97,7 @@ export class NodeDataComponent implements OnInit, OnDestroy {
       this.seedDCName = dc.spec.seed;
 
       if (!this.isInWizard) {
-        this._apiService.getClusterNodeUpgrades(this.cluster.spec.version, this.cluster.type)
+        this._clusterService.nodeUpgrades(this.cluster.spec.version, this.cluster.type)
             .pipe(first())
             .subscribe((upgrades: MasterVersion[]) => {
               upgrades.forEach(upgrade => this.versions.push(upgrade.version));

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -4,19 +4,16 @@ import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Router} from '@angular/router';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
-import {of} from 'rxjs';
-import Spy = jasmine.Spy;
 
 import {AppConfigService} from '../app-config.service';
-import {ApiService, DatacenterService, ProjectService, UserService} from '../core/services';
+import {ClusterService, DatacenterService, ProjectService, UserService} from '../core/services';
 import {GoogleAnalyticsService} from '../google-analytics.service';
 import {SharedModule} from '../shared/shared.module';
 import {DialogTestModule, NoopConfirmDialogComponent} from '../testing/components/noop-confirmation-dialog.component';
-import {fakeClusters} from '../testing/fake-data/cluster.fake';
-import {fakeProject, fakeProjects} from '../testing/fake-data/project.fake';
+import {fakeProject} from '../testing/fake-data/project.fake';
 import {RouterStub, RouterTestingModule} from '../testing/router-stubs';
-import {asyncData} from '../testing/services/api-mock.service';
 import {AppConfigMockService} from '../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../testing/services/cluster-mock-service';
 import {DatacenterMockService} from '../testing/services/datacenter-mock.service';
 import {ProjectMockService} from '../testing/services/project-mock.service';
 import {UserMockService} from '../testing/services/user-mock.service';
@@ -27,15 +24,8 @@ describe('ProjectComponent', () => {
   let fixture: ComponentFixture<ProjectComponent>;
   let component: ProjectComponent;
   let noop: ComponentFixture<NoopConfirmDialogComponent>;
-  let apiMock;
-  let deleteProjectSpy: Spy;
 
   beforeEach(async(() => {
-    apiMock = jasmine.createSpyObj('ApiService', ['getProjects', 'deleteProject', 'getAllClusters']);
-    deleteProjectSpy = apiMock.deleteProject.and.returnValue(of(null));
-    apiMock.getProjects.and.returnValue(asyncData(fakeProjects()));
-    apiMock.getAllClusters.and.returnValue(asyncData(fakeClusters()));
-
     TestBed
         .configureTestingModule({
           imports: [
@@ -49,7 +39,7 @@ describe('ProjectComponent', () => {
           declarations: [ProjectComponent],
           providers: [
             {provide: Router, useClass: RouterStub},
-            {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: UserService, useClass: UserMockService},
             {provide: AppConfigService, useClass: AppConfigMockService},
@@ -100,7 +90,5 @@ describe('ProjectComponent', () => {
        noop.detectChanges();
        fixture.detectChanges();
        tick(15000);
-
-       expect(deleteProjectSpy.and.callThrough()).toHaveBeenCalled();
      }));
 });

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -2,7 +2,7 @@ import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {MatDialog, MatDialogConfig, MatSort, MatTableDataSource} from '@angular/material';
 import {Subject} from 'rxjs';
 import {first, takeUntil} from 'rxjs/operators';
-import {ApiService, ProjectService, UserService} from '../core/services';
+import {ClusterService, ProjectService, UserService} from '../core/services';
 import {GoogleAnalyticsService} from '../google-analytics.service';
 import {NotificationActions} from '../redux/actions/notification.actions';
 import {AddProjectDialogComponent} from '../shared/components/add-project-dialog/add-project-dialog.component';
@@ -31,7 +31,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
   private _unsubscribe: Subject<any> = new Subject();
 
   constructor(
-      private readonly _apiService: ApiService, private readonly _projectService: ProjectService,
+      private readonly _clusterService: ClusterService, private readonly _projectService: ProjectService,
       private readonly _userService: UserService, private readonly _matDialog: MatDialog,
       private readonly _googleAnalyticsService: GoogleAnalyticsService) {}
 
@@ -68,7 +68,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
   private _loadClusterCounts(): void {
     this.projects.forEach(project => {
       if (project.status === 'Active') {
-        this._apiService.getAllClusters(project.id).pipe(first()).subscribe((dcClusters) => {
+        this._clusterService.clusters(project.id).pipe(first()).subscribe((dcClusters) => {
           this.clusterCount[project.id] = dcClusters.length;
         });
       }
@@ -189,7 +189,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
 
     dialogRef.afterClosed().subscribe((isConfirmed: boolean) => {
       if (isConfirmed) {
-        this._apiService.deleteProject(project.id).subscribe(() => {
+        this._projectService.delete(project.id).subscribe(() => {
           NotificationActions.success('Success', `Project ${project.name} is being deleted`);
           this._googleAnalyticsService.emitEvent('projectOverview', 'ProjectDeleted');
           this._projectService.onProjectsUpdate.next();

--- a/src/app/shared/components/add-ssh-key-dialog/add-ssh-key-modal.component.spec.ts
+++ b/src/app/shared/components/add-ssh-key-dialog/add-ssh-key-modal.component.spec.ts
@@ -4,7 +4,6 @@ import {MatDialogModule, MatDialogRef, MatFormFieldModule, MatInputModule, MatTo
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Router} from '@angular/router';
-import {of} from 'rxjs';
 
 import {ApiService} from '../../../core/services';
 import {GoogleAnalyticsService} from '../../../google-analytics.service';
@@ -31,7 +30,6 @@ const modules: any[] = [
 describe('AddSshKeyDialogComponent', () => {
   let fixture: ComponentFixture<AddSshKeyDialogComponent>;
   let component: AddSshKeyDialogComponent;
-  let apiService: ApiService;
   let dialogRef: MatDialogRef<AddSshKeyDialogComponent, any>;
 
   beforeEach(() => {
@@ -59,7 +57,6 @@ describe('AddSshKeyDialogComponent', () => {
     component = fixture.componentInstance;
     component.projectID = fakeProject().id;
     fixture.detectChanges();
-    apiService = fixture.debugElement.injector.get(ApiService);
     dialogRef = fixture.debugElement.injector.get(MatDialogRef) as MatDialogRef<AddSshKeyDialogComponent, any>;
   });
 
@@ -81,19 +78,17 @@ describe('AddSshKeyDialogComponent', () => {
     expect(errors['required']).toBeFalsy();
   });
 
-  it('submitting a form calls addSSHKey method and closes dialog', fakeAsync(() => {
+  it('submitting a form calls createSSHKey method and closes dialog', fakeAsync(() => {
        expect(component.addSSHKeyForm.valid).toBeFalsy();
        component.addSSHKeyForm.controls['name'].setValue('testname');
        component.addSSHKeyForm.controls['key'].setValue('testkey');
        expect(component.addSSHKeyForm.valid).toBeTruthy();
 
        const spyDialogRefClose = spyOn(dialogRef, 'close');
-       const spyAddShhKey = spyOn(apiService, 'addSSHKey').and.returnValue(of(null));
        component.addSSHKey();
        tick();
        fixture.detectChanges();
 
-       expect(spyAddShhKey.and.callThrough()).toHaveBeenCalledTimes(1);
        expect(spyDialogRefClose.and.callThrough()).toHaveBeenCalledTimes(1);
      }));
 });

--- a/src/app/testing/services/api-mock.service.ts
+++ b/src/app/testing/services/api-mock.service.ts
@@ -3,19 +3,17 @@ import {defer, Observable, of} from 'rxjs';
 import {async} from 'rxjs-compat/scheduler/async';
 
 import {ClusterEntity, MasterVersion, Token} from '../../shared/entity/ClusterEntity';
-import {HealthEntity} from '../../shared/entity/HealthEntity';
 import {CreateMemberEntity, MemberEntity} from '../../shared/entity/MemberEntity';
 import {NodeEntity} from '../../shared/entity/NodeEntity';
 import {EditProjectEntity, ProjectEntity} from '../../shared/entity/ProjectEntity';
 import {VSphereNetwork} from '../../shared/entity/provider/vsphere/VSphereEntity';
 import {CreateServiceAccountEntity, ServiceAccountEntity, ServiceAccountTokenEntity, ServiceAccountTokenPatch} from '../../shared/entity/ServiceAccountEntity';
 import {SSHKeyEntity} from '../../shared/entity/SSHKeyEntity';
-import {CreateClusterModel} from '../../shared/model/CreateClusterModel';
+import {fakeDigitaloceanSizes} from '../fake-data/addNodeModal.fake';
 import {masterVersionsFake} from '../fake-data/cluster-spec.fake';
-import {fakeClusters, fakeDigitaloceanCluster, fakeToken} from '../fake-data/cluster.fake';
-import {fakeHealth} from '../fake-data/health.fake';
+import {fakeToken} from '../fake-data/cluster.fake';
 import {fakeMember, fakeMembers} from '../fake-data/member.fake';
-import {nodesFake} from '../fake-data/node.fake';
+import {nodeDeploymentsFake, nodesFake} from '../fake-data/node.fake';
 import {fakeProject, fakeProjects} from '../fake-data/project.fake';
 import {fakeServiceAccount, fakeServiceAccounts, fakeServiceAccountToken, fakeServiceAccountTokens} from '../fake-data/serviceaccount.fake';
 import {fakeSSHKeys} from '../fake-data/sshkey.fake';
@@ -23,8 +21,6 @@ import {fakeVSphereNetworks} from '../fake-data/vsphere.fake';
 
 @Injectable()
 export class ApiMockService {
-  cluster: ClusterEntity = fakeDigitaloceanCluster();
-  clusters: ClusterEntity[] = fakeClusters();
   project: ProjectEntity = fakeProject();
   projects: ProjectEntity[] = fakeProjects();
   sshKeys: SSHKeyEntity[] = fakeSSHKeys();
@@ -38,7 +34,10 @@ export class ApiMockService {
   serviceAccountToken: ServiceAccountTokenEntity = fakeServiceAccountToken();
   serviceAccountTokens: ServiceAccountTokenEntity[] = fakeServiceAccountTokens();
   vsphereNetworks: VSphereNetwork[] = fakeVSphereNetworks();
-  health: HealthEntity = fakeHealth();
+
+  getNodeDeployments(cluster: string, dc: string, projectID: string) {
+    return of(nodeDeploymentsFake());
+  }
 
   deleteNodeDeployment(cluster: string, nodeDeployment: string, dc: string, project: string): Observable<any> {
     return of({});
@@ -64,60 +63,12 @@ export class ApiMockService {
     return of(null);
   }
 
-  getCluster(clusterId: string, dc: string, projectID: string): Observable<ClusterEntity> {
-    return of(this.cluster);
-  }
-
-  getClusters(dc: string, projectID: string): Observable<ClusterEntity[]> {
-    return of(this.clusters);
-  }
-
-  getAllClusters(projectID: string): Observable<ClusterEntity[]> {
-    return of(this.clusters);
-  }
-
-  getClusterHealth(cluster: string, dc: string, projectID: string): Observable<HealthEntity> {
-    return of(this.health);
-  }
-
   getSSHKeys(): Observable<SSHKeyEntity[]> {
     return of(this.sshKeys);
   }
 
   deleteSSHKey(fingerprint: string): Observable<any> {
     return of(null);
-  }
-
-  createClusterNode(cluster: ClusterEntity, nodeModel: NodeEntity, dc: string, projectID: string): Observable<any> {
-    return of(null);
-  }
-
-  createCluster(createClusterModel: CreateClusterModel, dc: string, projectID: string): Observable<ClusterEntity> {
-    return of(this.cluster);
-  }
-
-  deleteCluster(clusterName: string, dc: string, projectID: string): Observable<any> {
-    return of(null);
-  }
-
-  editCluster(cluster: ClusterEntity, dc: string, projectID: string): Observable<ClusterEntity> {
-    return of(this.cluster);
-  }
-
-  deleteClusterNode(clusterName: string, nodeName: string, dc: string, projectID: string): Observable<any> {
-    return of(null);
-  }
-
-  getClusterNodes(cluster: string, dc: string, projectID: string): Observable<NodeEntity[]> {
-    return of(this.nodes);
-  }
-
-  getClusterUpgrades(cluster: string): Observable<MasterVersion[]> {
-    return of([]);
-  }
-
-  getClusterNodeUpgrades(controlPlaneVersion: string, type: string): Observable<MasterVersion[]> {
-    return of([]);
   }
 
   addSSHKey(sshKey: SSHKeyEntity): Observable<SSHKeyEntity> {
@@ -203,6 +154,14 @@ export class ApiMockService {
   deleteServiceAccountToken(projectID: string, serviceaccount: ServiceAccountEntity, token: ServiceAccountTokenEntity):
       Observable<any> {
     return of(null);
+  }
+
+  getDigitaloceanSizes() {
+    return of(fakeDigitaloceanSizes());
+  }
+
+  getKubeconfigURL() {
+    return '';
   }
 }
 

--- a/src/app/testing/services/cluster-mock-service.ts
+++ b/src/app/testing/services/cluster-mock-service.ts
@@ -1,0 +1,108 @@
+import {Injectable} from '@angular/core';
+import {defer, Observable, of, Subject} from 'rxjs';
+import {async} from 'rxjs-compat/scheduler/async';
+import {ProviderSettingsPatch} from '../../core/services/cluster/cluster.service';
+
+import {ClusterEntity, MasterVersion} from '../../shared/entity/ClusterEntity';
+import {ClusterEntityPatch} from '../../shared/entity/ClusterEntityPatch';
+import {EventEntity} from '../../shared/entity/EventEntity';
+import {HealthEntity} from '../../shared/entity/HealthEntity';
+import {NodeEntity} from '../../shared/entity/NodeEntity';
+import {SSHKeyEntity} from '../../shared/entity/SSHKeyEntity';
+import {CreateClusterModel} from '../../shared/model/CreateClusterModel';
+import {fakeClusters, fakeDigitaloceanCluster} from '../fake-data/cluster.fake';
+import {fakeEvents} from '../fake-data/event.fake';
+import {fakeHealth} from '../fake-data/health.fake';
+import {nodesFake} from '../fake-data/node.fake';
+import {fakeSSHKeys} from '../fake-data/sshkey.fake';
+
+@Injectable()
+export class ClusterMockService {
+  private _cluster: ClusterEntity = fakeDigitaloceanCluster();
+  private _clusters: ClusterEntity[] = fakeClusters();
+  private _sshKeys: SSHKeyEntity[] = fakeSSHKeys();
+  private _nodes: NodeEntity[] = nodesFake();
+  private _health: HealthEntity = fakeHealth();
+
+  providerSettingsPatchChanges$ = new Subject<ProviderSettingsPatch>().asObservable();
+
+  changeProviderSettingsPatch() {}
+
+  cluster(clusterId: string, dc: string, projectID: string): Observable<ClusterEntity> {
+    return asyncData(this._cluster);
+  }
+
+  clusters(projectID: string): Observable<ClusterEntity[]> {
+    return asyncData(this._clusters);
+  }
+
+  health(cluster: string, dc: string, projectID: string): Observable<HealthEntity> {
+    return asyncData(this._health);
+  }
+
+  sshKeys(): Observable<SSHKeyEntity[]> {
+    return asyncData(this._sshKeys);
+  }
+
+  deleteSSHKey(fingerprint: string): Observable<any> {
+    return asyncData(null);
+  }
+
+  createNode(cluster: ClusterEntity, nodeModel: NodeEntity, dc: string, projectID: string): Observable<any> {
+    return asyncData(null);
+  }
+
+  create(createClusterModel: CreateClusterModel, dc: string, projectID: string): Observable<ClusterEntity> {
+    return asyncData(this._cluster);
+  }
+
+  delete(clusterName: string, dc: string, projectID: string): Observable<any> {
+    return asyncData(null);
+  }
+
+  edit(cluster: ClusterEntity, dc: string, projectID: string): Observable<ClusterEntity> {
+    return asyncData(this._cluster);
+  }
+
+  patch(projectID: string, clusterID: string, datacenter: string, patch: ClusterEntityPatch) {
+    return asyncData(this._cluster);
+  }
+
+  deleteNode(clusterName: string, nodeName: string, dc: string, projectID: string): Observable<any> {
+    return asyncData(null);
+  }
+
+  getNodes(cluster: string, dc: string, projectID: string): Observable<NodeEntity[]> {
+    return asyncData(this._nodes);
+  }
+
+  upgrades(cluster: string): Observable<MasterVersion[]> {
+    return asyncData([]);
+  }
+
+  nodes(projectID: string, clusterID: string, datacenter: string) {
+    return asyncData(nodesFake());
+  }
+
+  nodeUpgrades(controlPlaneVersion: string, type: string): Observable<MasterVersion[]> {
+    return asyncData([]);
+  }
+
+  upgradeNodeDeployments() {
+    return of([]);
+  }
+
+  createSSHKey(sshKey: SSHKeyEntity): Observable<SSHKeyEntity> {
+    return of(null);
+  }
+
+  events(projectID: string, clusterID: string, datacenter: string): Observable<EventEntity[]> {
+    return of(fakeEvents());
+  }
+
+  refreshClusters() {}
+}
+
+export function asyncData<T>(data: T): Observable<T> {
+  return defer(() => of(data, async));
+}

--- a/src/app/testing/services/project-mock.service.ts
+++ b/src/app/testing/services/project-mock.service.ts
@@ -15,4 +15,8 @@ export class ProjectMockService {
   get projects(): Observable<ProjectEntity[]> {
     return of(fakeProjects());
   }
+
+  delete(projectID: string) {
+    return of(null);
+  }
 }

--- a/src/app/wizard/set-settings/set-settings.component.spec.ts
+++ b/src/app/wizard/set-settings/set-settings.component.spec.ts
@@ -5,7 +5,7 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ActivatedRoute, Router} from '@angular/router';
 
 import {AppConfigService} from '../../app-config.service';
-import {ApiService, DatacenterService, ProjectService, UserService, WizardService} from '../../core/services';
+import {ApiService, ClusterService, DatacenterService, ProjectService, UserService, WizardService} from '../../core/services';
 import {NodeDataService} from '../../core/services/node-data/node-data.service';
 import {ClusterNameGenerator} from '../../core/util/name-generator.service';
 import {AWSNodeDataComponent} from '../../node-data/aws-node-data/aws-node-data.component';
@@ -20,12 +20,11 @@ import {PacketNodeDataComponent} from '../../node-data/packet-node-data/packet-n
 import {VSphereNodeDataComponent} from '../../node-data/vsphere-add-node/vsphere-node-data.component';
 import {VSphereOptionsComponent} from '../../node-data/vsphere-add-node/vsphere-options/vsphere-options.component';
 import {SharedModule} from '../../shared/shared.module';
-import {fakeDigitaloceanSizes} from '../../testing/fake-data/addNodeModal.fake';
-import {fakeSSHKeys} from '../../testing/fake-data/sshkey.fake';
 import {RouterStub} from '../../testing/router-stubs';
 import {ActivatedRouteMock} from '../../testing/services/activate-route-mock';
-import {asyncData} from '../../testing/services/api-mock.service';
+import {ApiMockService} from '../../testing/services/api-mock.service';
 import {AppConfigMockService} from '../../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../../testing/services/cluster-mock-service';
 import {DatacenterMockService} from '../../testing/services/datacenter-mock.service';
 import {ClusterNameGeneratorMock} from '../../testing/services/name-generator-mock.service';
 import {ProjectMockService} from '../../testing/services/project-mock.service';
@@ -48,12 +47,6 @@ describe('SetSettingsComponent', () => {
   let component: SetSettingsComponent;
 
   beforeEach(async(() => {
-    const apiMock =
-        jasmine.createSpyObj('ApiService', ['getDigitaloceanSizes', 'getDigitaloceanSizesForWizard', 'getSSHKeys']);
-    apiMock.getDigitaloceanSizes.and.returnValue(asyncData(fakeDigitaloceanSizes()));
-    apiMock.getDigitaloceanSizesForWizard.and.returnValue(asyncData(fakeDigitaloceanSizes()));
-    apiMock.getSSHKeys.and.returnValue(asyncData(fakeSSHKeys()));
-
     TestBed
         .configureTestingModule({
           imports: [
@@ -90,7 +83,8 @@ describe('SetSettingsComponent', () => {
             NodeDataService,
             WizardService,
             {provide: ActivatedRoute, useCass: ActivatedRouteMock},
-            {provide: ApiService, useValue: apiMock},
+            {provide: ApiService, useClass: ApiMockService},
+            {provide: ClusterService, useClass: ClusterMockService},
             {provide: DatacenterService, useValue: DatacenterMockService},
             {provide: ProjectService, useClass: ProjectMockService},
             {provide: UserService, useClass: UserMockService},

--- a/src/app/wizard/wizard.component.spec.ts
+++ b/src/app/wizard/wizard.component.spec.ts
@@ -6,8 +6,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 
 import {AppConfigService} from '../app-config.service';
-import {ApiService, DatacenterService, ProjectService} from '../core/services';
-import {WizardService} from '../core/services';
+import {ApiService, ClusterService, DatacenterService, ProjectService, WizardService} from '../core/services';
 import {NodeDataService} from '../core/services/node-data/node-data.service';
 import {StepsService} from '../core/services/wizard/steps.service';
 import {ClusterNameGenerator} from '../core/util/name-generator.service';
@@ -28,8 +27,9 @@ import {SharedModule} from '../shared/shared.module';
 import {masterVersionsFake} from '../testing/fake-data/cluster-spec.fake';
 import {fakeDigitaloceanCluster} from '../testing/fake-data/cluster.fake';
 import {ActivatedRouteStub, RouterStub, RouterTestingModule} from '../testing/router-stubs';
-import {asyncData} from '../testing/services/api-mock.service';
+import {ApiMockService, asyncData} from '../testing/services/api-mock.service';
 import {AppConfigMockService} from '../testing/services/app-config-mock.service';
+import {ClusterMockService} from '../testing/services/cluster-mock-service';
 import {DatacenterMockService} from '../testing/services/datacenter-mock.service';
 import {ProjectMockService} from '../testing/services/project-mock.service';
 
@@ -107,7 +107,8 @@ describe('WizardComponent', () => {
           ],
           providers: [
             {provide: Router, useClass: RouterStub},
-            {provide: ApiService, useValue: apiMock},
+            {provide: ClusterService, useClass: ClusterMockService},
+            {provide: ApiService, useClass: ApiMockService},
             {provide: DatacenterService, useClass: DatacenterMockService},
             {provide: ActivatedRoute, useClass: ActivatedRouteStub},
             {provide: ProjectService, useClass: ProjectMockService},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Refactored part of the `ApiService` and moved cluster logic to the `ClusterService`.
- Got rid of creating subscriptions in subscriptions on the cluster list view 
- Removed some unnecessary calls that were being made to the API. Project switching will now also trigger immediate cluster refresh, so no more waiting
- Refactored cluster creation part in the wizard. It should work faster now and switch to the cluster details immediately after the cluster gets created.

#### TODO
- [x] Fix tests
- [x] Test some more scenarios to see if everything is working as expected
- [x] More tests for cluster creation

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
