### PR TITLE
Fix coverage upload for master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test:
 
 test-headless: install
 	@$(CC) run test:headless
-	bash <(curl -s https://codecov.io/bash) -c -K -C ${PULL_PULL_SHA} -P ${PULL_NUMBER} -b ${BUILD_ID}
+	./hack/upload-coverage.sh
 
 run-e2e-ci: install
 	./hack/e2e/run_ci_e2e_test.sh

--- a/hack/upload-coverage.sh
+++ b/hack/upload-coverage.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMIT_SHA=${PULL_PULL_SHA:-$PULL_BASE_SHA}
+
+bash <(curl -s https://codecov.io/bash) -c -K -C ${COMMIT_SHA} -b ${BUILD_ID}


### PR DESCRIPTION
**What this PR does / why we need it**:
Prow does not expose `PULL_PULL_SHA` for `postsubmit` jobs. Added script to fix that and use `PULL_BASE_SHA`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
