### PR TITLE
Increase jasmine timeout for async operations

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,10 @@ module.exports = function (config) {
       require('@angular/material')
     ],
     client:{
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+      jasmine: {
+        timeoutInterval: 10000,
+      }
     },
     files: [
       { pattern: './node_modules/@angular/material/prebuilt-themes/indigo-pink.css' }


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases timeout for async operations as wizard component unit tests often fail with related error.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
