### PR TITLE
Add error message when node deployment name or cluster name are invalid

### DIFF
--- a/src/app/node-data/node-data.component.html
+++ b/src/app/node-data/node-data.component.html
@@ -15,6 +15,9 @@
          (click)="generateName()"
          *ngIf="!isNameDisabled"></i>
       <mat-hint *ngIf="!isNameDisabled">Leave it empty to use server-side generation.</mat-hint>
+      <mat-error *ngIf="nodeForm.controls.name.hasError('pattern')">
+        Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -).
+      </mat-error>
     </mat-form-field>
 
   </div>

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
@@ -29,6 +29,9 @@
           <mat-error *ngIf="clusterSpecForm.controls.name.hasError('minlength')">
             Name must be at least {{ clusterSpecForm.controls.name.getError('minlength').requiredLength }} characters.
           </mat-error>
+          <mat-error *ngIf="clusterSpecForm.controls.name.hasError('pattern')">
+            Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -).
+          </mat-error>
         </mat-form-field>
       </form>
     </mat-card-content>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add error message when node deployment name or cluster name are invalid

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
