### PR TITLE
use correct vsphere default templates from datacenter

### DIFF
--- a/src/app/node-data/vsphere-add-node/vsphere-options/vsphere-options.component.ts
+++ b/src/app/node-data/vsphere-add-node/vsphere-options/vsphere-options.component.ts
@@ -17,7 +17,7 @@ export class VSphereOptionsComponent implements OnInit, OnDestroy {
   @Input() cloudSpec: CloudSpec;
   vsphereOptionsForm: FormGroup;
   hideOptional = true;
-  defaultTemplate = 'ubuntu-template';
+  defaultTemplate = '';
   private subscriptions: Subscription[] = [];
 
   constructor(
@@ -28,6 +28,10 @@ export class VSphereOptionsComponent implements OnInit, OnDestroy {
     this.vsphereOptionsForm = new FormGroup({
       diskSizeGB: new FormControl(this.nodeData.spec.cloud.vsphere.diskSizeGB),
       template: new FormControl(this.nodeData.spec.cloud.vsphere.template),
+    });
+
+    this.dcService.getDataCenter(this.cloudSpec.dc).subscribe((res) => {
+      this.defaultTemplate = res.spec.vsphere.templates.ubuntu;
     });
 
     this.subscriptions.push(this.vsphereOptionsForm.valueChanges.subscribe(() => {

--- a/src/app/shared/entity/NodeEntity.ts
+++ b/src/app/shared/entity/NodeEntity.ts
@@ -130,7 +130,7 @@ export function getEmptyNodeProviderSpec(provider: string): object {
       return {
         cpus: 1,
         memory: 512,
-        template: 'ubuntu-template',
+        template: '',
       } as VSphereNodeSpec;
     case NodeProvider.HETZNER:
       return {


### PR DESCRIPTION
**What this PR does / why we need it**:
use correct default vsphere templates from datacenter

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1344

**Special notes for your reviewer**:
@maciaszczykm I think the openstack issue was already fixed here https://github.com/kubermatic/dashboard-v2/pull/1215. At least I cannot reproduce it atm

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
