### PR TITLE
add GCP credentials to presets

### DIFF
--- a/containers/cypress/utils/yamls/presets.yaml
+++ b/containers/cypress/utils/yamls/presets.yaml
@@ -17,3 +17,7 @@ presets:
         subscriptionId: ${AZURE_E2E_TESTS_SUBSCRIPTION_ID}
         clientId: ${AZURE_E2E_TESTS_CLIENT_ID}
         clientSecret: ${AZURE_E2E_TESTS_CLIENT_SECRET}
+  gcp:
+    credentials:
+      - name: gcp
+        serviceAccount: ${GOOGLE_SERVICE_ACCOUNT}

--- a/containers/e2e/utils/yamls/presets.yaml
+++ b/containers/e2e/utils/yamls/presets.yaml
@@ -17,3 +17,7 @@ presets:
         subscriptionId: ${AZURE_E2E_TESTS_SUBSCRIPTION_ID}
         clientId: ${AZURE_E2E_TESTS_CLIENT_ID}
         clientSecret: ${AZURE_E2E_TESTS_CLIENT_SECRET}
+  gcp:
+    credentials:
+      - name: gcp
+        serviceAccount: ${GOOGLE_SERVICE_ACCOUNT}


### PR DESCRIPTION
**What this PR does / why we need it**: add GCP credentials to presets for e2e


```release-note
NONE
```
