### PR TITLE
Add support for extended health statuses

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -9,7 +9,7 @@ import {ApiService, ClusterService, DatacenterService, UserService} from '../../
 import {ClusterEntity, getClusterProvider, MasterVersion} from '../../shared/entity/ClusterEntity';
 import {DataCenterEntity} from '../../shared/entity/DatacenterEntity';
 import {EventEntity} from '../../shared/entity/EventEntity';
-import {HealthEntity, HealthStatus} from '../../shared/entity/HealthEntity';
+import {HealthEntity, HealthState} from '../../shared/entity/HealthEntity';
 import {NodeDeploymentEntity} from '../../shared/entity/NodeDeploymentEntity';
 import {NodeEntity} from '../../shared/entity/NodeEntity';
 import {SSHKeyEntity} from '../../shared/entity/SSHKeyEntity';
@@ -128,8 +128,8 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   private _canReloadVersions(): boolean {
-    return this.cluster && this.health && this.health.apiserver === HealthStatus.up &&
-        this.health.machineController === HealthStatus.up;
+    return this.cluster && this.health && HealthState.isUp(this.health.apiserver) &&
+        HealthState.isUp(this.health.machineController);
   }
 
   private _canReloadNodes(): boolean {

--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.spec.ts
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.spec.ts
@@ -7,6 +7,7 @@ import {SlimLoadingBarModule} from 'ng2-slim-loading-bar';
 
 import {AppConfigService} from '../../../app-config.service';
 import {ClusterService, ProjectService, UserService} from '../../../core/services';
+import {HealthState} from '../../../shared/entity/HealthEntity';
 import {SharedModule} from '../../../shared/shared.module';
 import {fakeHealth, fakeHealthFailed, fakeHealthProvisioning} from '../../../testing/fake-data/health.fake';
 import {RouterStub} from '../../../testing/router-stubs';
@@ -63,17 +64,17 @@ describe('ClusterSecretsComponent', () => {
      }));
 
   it('should set icon class `km-icon-running`', () => {
-    expect(component.getIconClass(true)).toBe('km-icon-running');
+    expect(component.getIconClass(HealthState.up)).toBe('km-icon-running');
   });
 
   it('should set icon class `km-icon-failed`', () => {
     component.health = fakeHealthFailed();
-    expect(component.getIconClass(false)).toBe('km-icon-failed');
+    expect(component.getIconClass(HealthState.down)).toBe('km-icon-failed');
   });
 
   it('should set icon class `fa fa-circle orange`', () => {
     component.health = fakeHealthProvisioning();
-    expect(component.getIconClass(false)).toBe('fa fa-circle orange');
+    expect(component.getIconClass(HealthState.provisioning)).toBe('fa fa-circle orange');
   });
 
   it('should set correct icon for controllers', () => {
@@ -88,17 +89,17 @@ describe('ClusterSecretsComponent', () => {
   });
 
   it('should set health status `Running`', () => {
-    expect(component.getHealthStatus(true)).toBe('Running');
+    expect(component.getHealthStatus(HealthState.up)).toBe('Running');
   });
 
   it('should set health status `Failed`', () => {
     component.health = fakeHealthFailed();
-    expect(component.getHealthStatus(false)).toBe('Failed');
+    expect(component.getHealthStatus(HealthState.down)).toBe('Failed');
   });
 
   it('should set health status `Pending`', () => {
     component.health = fakeHealthProvisioning();
-    expect(component.getHealthStatus(false)).toBe('Pending');
+    expect(component.getHealthStatus(HealthState.provisioning)).toBe('Pending');
   });
 
   it('should set correct status for controllers', () => {

--- a/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.ts
+++ b/src/app/cluster/cluster-details/cluster-secrets/cluster-secrets.component.ts
@@ -2,7 +2,7 @@ import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material';
 import {Subject} from 'rxjs';
 import {ClusterEntity} from '../../../shared/entity/ClusterEntity';
-import {HealthEntity, HealthStatus} from '../../../shared/entity/HealthEntity';
+import {HealthEntity, HealthState} from '../../../shared/entity/HealthEntity';
 import {ClusterHealthStatus} from '../../../shared/utils/health-status/cluster-health-status';
 
 @Component({
@@ -53,13 +53,13 @@ export class ClusterSecretsComponent implements OnInit, OnDestroy {
     }
   }
 
-  getIconClass(isHealthy: HealthStatus): string {
+  getIconClass(isHealthy: HealthState): string {
     switch (isHealthy) {
-      case HealthStatus.up:
+      case HealthState.up:
         return 'km-icon-running';
-      case HealthStatus.down:
+      case HealthState.down:
         return 'km-icon-failed';
-      case HealthStatus.provisioning:
+      case HealthState.provisioning:
         return 'fa fa-circle orange';
       default:
         return '';
@@ -89,11 +89,11 @@ export class ClusterSecretsComponent implements OnInit, OnDestroy {
     }
   }
 
-  getHealthStatus(isHealthy: HealthStatus): string {
-    if (isHealthy === HealthStatus.up) {
+  getHealthStatus(isHealthy: HealthState): string {
+    if (HealthState.isUp(isHealthy)) {
       return 'Running';
     } else {
-      if (this.health.apiserver === HealthStatus.down) {
+      if (HealthState.isDown(this.health.apiserver)) {
         return 'Failed';
       } else {
         return 'Pending';

--- a/src/app/shared/entity/HealthEntity.ts
+++ b/src/app/shared/entity/HealthEntity.ts
@@ -1,19 +1,33 @@
 export class HealthEntity {
-  apiserver: HealthStatus;
-  controller: HealthStatus;
-  etcd: HealthStatus;
-  machineController: HealthStatus;
-  scheduler: HealthStatus;
-  cloudProviderInfrastructure: HealthStatus;
-  userClusterControllerManager: HealthStatus;
+  apiserver: HealthState;
+  controller: HealthState;
+  etcd: HealthState;
+  machineController: HealthState;
+  scheduler: HealthState;
+  cloudProviderInfrastructure: HealthState;
+  userClusterControllerManager: HealthState;
 
   static allHealthy(health: HealthEntity): boolean {
-    return Object.values(health).every(status => status === HealthStatus.up);
+    return Object.values(health).every(status => HealthState.isUp(status));
   }
 }
 
-export enum HealthStatus {
+export enum HealthState {
   down = 0,
   up = 1,
-  provisioning = 2
+  provisioning = 2,
+}
+
+export namespace HealthState {
+  export function isUp(state: HealthState): boolean {
+    return HealthState.up === state;
+  }
+
+  export function isDown(state: HealthState): boolean {
+    return HealthState.down === state;
+  }
+
+  export function isProvisioning(state: HealthState): boolean {
+    return HealthState.provisioning === state;
+  }
 }

--- a/src/app/shared/utils/health-status/cluster-health-status.ts
+++ b/src/app/shared/utils/health-status/cluster-health-status.ts
@@ -1,5 +1,5 @@
 import {ClusterEntity} from '../../entity/ClusterEntity';
-import {HealthEntity} from '../../entity/HealthEntity';
+import {HealthEntity, HealthState} from '../../entity/HealthEntity';
 
 import {HealthStatus, HealthStatusColor, HealthStatusMessage} from './health-status';
 
@@ -14,7 +14,9 @@ export class ClusterHealthStatus extends HealthStatus {
   static getHealthStatus(c: ClusterEntity, h: HealthEntity): ClusterHealthStatus {
     if (!!c.deletionTimestamp) {
       return new ClusterHealthStatus(HealthStatusMessage.Deleting, HealthStatusColor.Red, HealthStatusCss.Deleting);
-    } else if (!!h && !!h.apiserver && !!h.scheduler && !!h.controller && !!h.machineController && !!h.etcd) {
+    } else if (
+        !!h && HealthState.isUp(h.apiserver) && HealthState.isUp(h.scheduler) && HealthState.isUp(h.controller) &&
+        HealthState.isUp(h.machineController) && HealthState.isUp(h.etcd)) {
       return new ClusterHealthStatus(HealthStatusMessage.Running, HealthStatusColor.Green, HealthStatusCss.Running);
     } else {
       return new ClusterHealthStatus(

--- a/src/app/testing/fake-data/health.fake.ts
+++ b/src/app/testing/fake-data/health.fake.ts
@@ -1,37 +1,37 @@
-import {HealthEntity, HealthStatus} from '../../shared/entity/HealthEntity';
+import {HealthEntity, HealthState} from '../../shared/entity/HealthEntity';
 
 export function fakeHealth(): HealthEntity {
   return {
-    apiserver: HealthStatus.up,
-    controller: HealthStatus.up,
-    etcd: HealthStatus.up,
-    machineController: HealthStatus.up,
-    scheduler: HealthStatus.up,
-    cloudProviderInfrastructure: HealthStatus.up,
-    userClusterControllerManager: HealthStatus.up,
+    apiserver: HealthState.up,
+    controller: HealthState.up,
+    etcd: HealthState.up,
+    machineController: HealthState.up,
+    scheduler: HealthState.up,
+    cloudProviderInfrastructure: HealthState.up,
+    userClusterControllerManager: HealthState.up,
   };
 }
 
 export function fakeHealthProvisioning(): HealthEntity {
   return {
-    apiserver: HealthStatus.up,
-    controller: HealthStatus.up,
-    etcd: HealthStatus.down,
-    machineController: HealthStatus.up,
-    scheduler: HealthStatus.down,
-    cloudProviderInfrastructure: HealthStatus.down,
-    userClusterControllerManager: HealthStatus.down,
+    apiserver: HealthState.up,
+    controller: HealthState.up,
+    etcd: HealthState.provisioning,
+    machineController: HealthState.up,
+    scheduler: HealthState.provisioning,
+    cloudProviderInfrastructure: HealthState.down,
+    userClusterControllerManager: HealthState.provisioning,
   };
 }
 
 export function fakeHealthFailed(): HealthEntity {
   return {
-    apiserver: HealthStatus.down,
-    controller: HealthStatus.down,
-    etcd: HealthStatus.down,
-    machineController: HealthStatus.down,
-    scheduler: HealthStatus.down,
-    cloudProviderInfrastructure: HealthStatus.down,
-    userClusterControllerManager: HealthStatus.down,
+    apiserver: HealthState.down,
+    controller: HealthState.down,
+    etcd: HealthState.down,
+    machineController: HealthState.down,
+    scheduler: HealthState.down,
+    cloudProviderInfrastructure: HealthState.down,
+    userClusterControllerManager: HealthState.down,
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for new extended health statuses introduced by https://github.com/kubermatic/kubermatic/pull/3784

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
