### PR TITLE
Disable download button if cluster is not running

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -19,15 +19,16 @@
               matTooltip="Share">
         <i class="km-icon-share"></i>
       </button>
-      <a class="km-download-kubeconfig-btn"
-         mat-icon-button
-         [ngClass]="!isClusterRunning ? 'isDisabled' : ''"
-         href="{{getDownloadURL()}}"
-         target="_blank"
-         rel="noopener"
-         [matTooltip]="!isClusterRunning ? '' : 'Download config'">
-        <i class="km-icon-download"></i>
-      </a>
+      <button class="km-download-kubeconfig-btn"
+              mat-icon-button
+              [disabled]="!isClusterRunning"
+              matTooltip="Download config">
+        <a href="{{getDownloadURL()}}"
+           target="_blank"
+           rel="noopener">
+          <i class="km-icon-download"></i>
+        </a>
+      </button>
       <button mat-flat-button
               color="alternative"
               (click)="addNode()"

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -184,7 +184,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   getDownloadURL(): string {
-    return !!this.isClusterRunning ?
+    return this.isClusterRunning ?
         this._api.getKubeconfigURL(this.projectID, this.datacenter.metadata.name, this.cluster.id) :
         '';
   }

--- a/src/assets/css/app.scss
+++ b/src/assets/css/app.scss
@@ -885,6 +885,11 @@ div.km-form-group-labels {
     background-color: $text-color;
   }
 
+  a {
+    display: flex;
+    justify-content: center;
+  }
+
   &:hover:not([disabled]) {
     background-color: $separator;
   }
@@ -893,19 +898,10 @@ div.km-form-group-labels {
     background-color: $disabled-button-color;
   }
 
-  // if button is a link
-  &.isDisabled {
+  &:disabled a {
     cursor: default;
     text-decoration: none;
     pointer-events: none;
-
-    i {
-      background-color: $disabled-button-color;
-    }
-
-    &:hover {
-      background-color: transparent;
-    }
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add rules to disable download button if cluster is not running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1367

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
