### PR TITLE
Do not display dropdown arrow for version upgrades if there is no upgrade

### DIFF
--- a/src/app/cluster/cluster-details/version-picker/version-picker.component.html
+++ b/src/app/cluster/cluster-details/version-picker/version-picker.component.html
@@ -4,7 +4,7 @@
      fxLayoutAlign="center center">
 
   <div class="km-version-picker"
-       [ngClass]="{'km-version-picker-enabled': isEnabled()}"
+       [ngClass]="{'km-version-picker-enabled': isEnabled(), 'km-version-picker-disabled': !isEnabled()}"
        fxFlex
        fxLayoutAlign="center center"
        (click)="changeClusterVersionDialog()">

--- a/src/app/cluster/cluster-details/version-picker/version-picker.component.scss
+++ b/src/app/cluster/cluster-details/version-picker/version-picker.component.scss
@@ -55,6 +55,12 @@
     }
   }
 
+  .km-version-picker-disabled {
+    ::ng-deep .mat-select-arrow {
+      visibility: hidden;
+    }
+  }
+
   .km-version-picker-enabled:hover {
     ::ng-deep * {
       cursor: pointer;


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not display dropdown arrow for version upgrades if there is no upgrade, otherwise users may think this is clickable

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
