### PR TITLE
Add missing wait to the e2e tests/fix e2e flakes

### DIFF
--- a/cypress/integration/stories/basic.spec.ts
+++ b/cypress/integration/stories/basic.spec.ts
@@ -112,6 +112,8 @@ describe('Basic story', () => {
     projectName = `${projectName}-edited`;
     ProjectsPage.editDialogInput().type('-edited').should(Condition.HaveValue, projectName);
     ProjectsPage.editDialogConfirmBtn().click();
+
+    wait('**/projects', 'GET', 'list projects');
   });
   
   it('should delete created project', () => {


### PR DESCRIPTION
**What this PR does / why we need it**: This wait is missing and sometimes e2e are failing due to that:

```
 1) Basic story should delete the project: CypressError: cy.click() failed because it requires a DOM element
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**: In #1390 I will send more improvements but it will take a while.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
