### PR TITLE
Disable video recording for cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,6 @@
   "requestTimeout": 30000,
   "viewportHeight": 1080,
   "viewportWidth": 1920,
-  "projectId": "mdsuba"
+  "projectId": "mdsuba",
+  "video": false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Let's disable cypress video recording for now as it slows down tests significantly and we are not using it anyway. In example basic user story: 1m30 test run, 3m40s video compression of the test

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
