### PR TITLE
Hides cluster type toggle in wizard if only one cluster type is active

### DIFF
--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
@@ -42,7 +42,7 @@
   <mat-card class="km-set-cluster-spec"
             fxFlex>
     <mat-card-header>
-      <mat-card-title class="km-color-primary">Type</mat-card-title>
+      <mat-card-title class="km-color-primary">Specification</mat-card-title>
     </mat-card-header>
     <mat-card-content>
       <form [formGroup]="clusterSpecForm"
@@ -50,7 +50,8 @@
 
         <mat-button-toggle-group group="clusterSpecTypeGroup"
                                  class="km-cluster-spec-type"
-                                 formControlName="type">
+                                 formControlName="type"
+                                 *ngIf="hasMultipleTypes()">
           <mat-button-toggle value="kubernetes"
                              *ngIf="!hideType('kubernetes')">
             <i class="km-icon-kubernetes"></i>

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.scss
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.scss
@@ -30,6 +30,8 @@
 }
 
 .km-cluster-spec-type {
+  margin-right: 20px;
+
   mat-button-toggle {
     min-height: 50px;
     max-height: 50px;
@@ -87,5 +89,4 @@
 .km-version-inline {
   width: auto;
   max-width: 130px;
-  margin-left: 20px;
 }

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.spec.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.spec.ts
@@ -3,15 +3,19 @@ import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {BrowserModule, By} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+
 import {AppConfigService} from '../../app-config.service';
 import {ApiService, WizardService} from '../../core/services';
 import {ClusterNameGenerator} from '../../core/util/name-generator.service';
 import {MachineNetworksModule} from '../../machine-networks/machine-networks.module';
+import {Config} from '../../shared/model/Config';
 import {SharedModule} from '../../shared/shared.module';
+import {ClusterType} from '../../shared/utils/cluster-utils/cluster-utils';
+import {fakeAppConfig} from '../../testing/fake-data/appConfig.fake';
 import {masterVersionsFake} from '../../testing/fake-data/cluster-spec.fake';
 import {asyncData} from '../../testing/services/api-mock.service';
-import {AppConfigMockService} from '../../testing/services/app-config-mock.service';
 import {ClusterNameGeneratorMock} from '../../testing/services/name-generator-mock.service';
+
 import {SetClusterSpecComponent} from './set-cluster-spec.component';
 
 const modules: any[] = [
@@ -27,11 +31,14 @@ describe('SetClusterSpecComponent', () => {
   let fixture: ComponentFixture<SetClusterSpecComponent>;
   let component: SetClusterSpecComponent;
   let nameGenerator: ClusterNameGenerator;
+  let config: Config;
 
   beforeEach(async(() => {
     const apiMock = jasmine.createSpyObj('ApiService', ['getMasterVersions']);
     apiMock.getMasterVersions.and.returnValue(asyncData(masterVersionsFake()));
-
+    const appConfigServiceMock = jasmine.createSpyObj('AppConfigService', ['getConfig']);
+    config = fakeAppConfig() as Config;
+    appConfigServiceMock.getConfig.and.returnValue(config);
     TestBed
         .configureTestingModule({
           imports: [
@@ -44,14 +51,14 @@ describe('SetClusterSpecComponent', () => {
             HttpClient,
             WizardService,
             {provide: ApiService, useValue: apiMock},
-            {provide: AppConfigService, useClass: AppConfigMockService},
+            {provide: AppConfigService, useValue: appConfigServiceMock},
             {provide: ClusterNameGenerator, useClass: ClusterNameGeneratorMock},
           ],
         })
         .compileComponents();
   }));
 
-  beforeEach(() => {
+  const createComponent = () => {
     fixture = TestBed.createComponent(SetClusterSpecComponent);
     component = fixture.componentInstance;
     component.cluster = {
@@ -71,7 +78,9 @@ describe('SetClusterSpecComponent', () => {
     };
     fixture.detectChanges();
     nameGenerator = fixture.debugElement.injector.get(ClusterNameGenerator);
-  });
+  };
+
+  beforeEach(createComponent);
 
   it('should create the set-cluster-spec cmp', () => {
     expect(component).toBeTruthy();
@@ -104,5 +113,31 @@ describe('SetClusterSpecComponent', () => {
     expect(spyGenerateName.and.callThrough()).toHaveBeenCalledTimes(1);
     expect(component.clusterSpecForm.controls['name'].value).toBe(generatedName, 'should patch value');
     expect(nameElement.value).toBe(generatedName, 'should display value in template');
+  });
+
+  it('should set type to kubernetes as default', () => {
+    expect(component.clusterSpecForm.controls['type'].value).toEqual(ClusterType.Kubernetes);
+  });
+
+  it('should set type to openshift as default if kubernetes is hidden', () => {
+    config.hide_kubernetes = true;
+    createComponent();
+    expect(component.clusterSpecForm.controls['type'].value).toEqual(ClusterType.OpenShift);
+  });
+
+  it('should show type toggle by default', () => {
+    expect(component.hasMultipleTypes()).toBeTruthy();
+  });
+
+  it('should not show type toggle if type openshift is hidden', () => {
+    config.hide_openshift = true;
+    createComponent();
+    expect(component.hasMultipleTypes()).toBeFalsy();
+  });
+
+  it('should not show type toggle if type kubernetes is hidden', () => {
+    config.hide_kubernetes = true;
+    createComponent();
+    expect(component.hasMultipleTypes()).toBeFalsy();
   });
 });

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
@@ -6,7 +6,7 @@ import {AppConfigService} from '../../app-config.service';
 import {ApiService, WizardService} from '../../core/services';
 import {ClusterNameGenerator} from '../../core/util/name-generator.service';
 import {ClusterEntity, MasterVersion} from '../../shared/entity/ClusterEntity';
-import {ClusterUtils} from '../../shared/utils/cluster-utils/cluster-utils';
+import {ClusterType, ClusterUtils} from '../../shared/utils/cluster-utils/cluster-utils';
 
 @Component({
   selector: 'kubermatic-set-cluster-spec',
@@ -33,7 +33,11 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
     });
 
     if (this.clusterSpecForm.controls.type.value === '') {
-      this.clusterSpecForm.controls.type.setValue('kubernetes');
+      if (!this.hideType(ClusterType.Kubernetes)) {
+        this.clusterSpecForm.controls.type.setValue(ClusterType.Kubernetes);
+      } else if (!this.hideType(ClusterType.OpenShift)) {
+        this.clusterSpecForm.controls.type.setValue(ClusterType.OpenShift);
+      }
     }
 
     this._api.getMasterVersions(this.clusterSpecForm.controls.type.value)
@@ -65,6 +69,10 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
 
   hideType(type: string): boolean {
     return !!this._appConfig.getConfig()['hide_' + type] ? this._appConfig.getConfig()['hide_' + type] : false;
+  }
+
+  hasMultipleTypes(): boolean {
+    return !this.hideType(ClusterType.Kubernetes) && !this.hideType(ClusterType.OpenShift);
   }
 
   setClusterSpec(): void {


### PR DESCRIPTION
**What this PR does / why we need it**:

Hides cluster type toggle in wizard if only one cluster type is active.
Also the default type is set to Openshift if Kubernetes is not active.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Cluster type toggle in wizard is now hidden if only one cluster type is active
```
