### PR TITLE
Add spinner to wizard to indicate that the cluster is in the process of being created

### DIFF
--- a/src/app/wizard/wizard.component.html
+++ b/src/app/wizard/wizard.component.html
@@ -41,8 +41,10 @@
          color="tertiary"
          routerLink="/projects/{{project?.id}}/clusters">Cancel</a>
       <div fxFlex></div>
-      <mat-icon class="fa fa-spinner fa-spin"
-                *ngIf="creating"></mat-icon>
+      <mat-spinner [diameter]="30"
+                   class="km-spinner"
+                   color="accent"
+                   *ngIf="creating"></mat-spinner>
       <button type="button"
               class="km-btn-back"
               mat-flat-button

--- a/src/app/wizard/wizard.component.scss
+++ b/src/app/wizard/wizard.component.scss
@@ -54,10 +54,3 @@
 ::ng-deep .mat-card-header .mat-card-title {
   padding: (2 * $baseline-grid) 0 0 0;
 }
-
-.fa-spinner {
-  font-size: 24px;
-  margin-top: 8px;
-  height: 24px;
-  width: 24px;
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the creation of a new cluster may take a few more seconds if the rbac controller is not running or too slow, it would be nice to have a visual indicator for the user, that something is still happening. The easiest solution was to just use `fa-spinner`, if you have a better solution or idea, I'm happy to change it :).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
