### PR TITLE
Fix labels and taints removal

### DIFF
--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -66,9 +66,6 @@ export class ApiService {
   patchNodeDeployment(
       nd: NodeDeploymentEntity, patch: NodeDeploymentPatch, clusterId: string, dc: string,
       projectID: string): Observable<NodeDeploymentEntity> {
-    patch.spec.template.labels = LabelFormComponent.filterNullifiedKeys(patch.spec.template.labels);
-    patch.spec.template.taints = TaintFormComponent.filterNullifiedTaints(patch.spec.template.taints);
-
     const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${clusterId}/nodedeployments/${nd.id}`;
     return this._http.patch<NodeDeploymentEntity>(url, patch);
   }

--- a/src/app/shared/components/taints/taints.component.html
+++ b/src/app/shared/components/taints/taints.component.html
@@ -6,4 +6,4 @@
     <div>{{taint.effect}}</div>
   </mat-chip>
 </mat-chip-list>
-<div *ngIf="!taints || taints.length === 0">-</div>
+<div *ngIf="!taints || taints.length === 0">No assigned taints</div>


### PR DESCRIPTION
**What this PR does / why we need it**: We need it to restore nullifying behavior of the patch endpoint to allow removal of labels and taints.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes #1430.

**Special notes for your reviewer**: When using patch endpoint the only way to remove some property from an object (in our case "some label from labels") is to nullify it. So if the labels object has the following structure:

``` json
{
   "env": "test",
   "abc": "",
   "test": "1"
}
```

And we would like to remove `"env": "test"` label, we need to send following patch request:
``` json
{
   "env": null
}
```

It can also be:

``` json
{
   "env": null,
   "abc": "",
   "test": "1"
}
```

The output will be:

```json
{
   "abc": "",
   "test": "1"
}
```

In our case, we send patch requests like in the second example (with all the fields, changing only what was changed by the user) as it is easier for us.

Changing label values doesn't require much explanation as the patch object only needs the updated value:

``` json
{
   "env": "test",
   "abc": "",
   "test": "1"
}
```

Patch:
``` json
{
   "env": "xyz",
   "abc": "",
   "test": ""
}
```

Output:
``` json
{
   "env": "xyz",
   "abc": "",
   "test": ""
}
```

Notice that the field value of `"test"` was changed to empty string `""` instead of `null` which would remove the label. Kubernetes allow empty label values.

From https://github.com/kubermatic/dashboard-v2/pull/1244:
> This also ensures that no empty labels and taints from the UI are added during NodeDeployments updates and cluster creation.

The label value can be empty, Kubernetes and our validation allow that. The labels itself cannot be empty.

During edit or creation only the already existing labels are nullified (only the labels that were existing and user wants to remove), all the new labels (added after node data modal was opened) will be completely removed instead of nullifying them.

```ts
private _updateLabelsObject(): void {
    // Create a new labels object.
    const labelsObject = {};

    // Fill it with current labels data.
    this.labelArray.getRawValue().forEach(kv => {
      if (kv.key.length !== 0) {
        labelsObject[kv.key] = kv.value;
      }
    });

    // Nullify initial labels data (it is needed to make edit work as it uses JSON Merge Patch).
    Object.keys(this.initialLabels).forEach(initialKey => {
      if (!labelsObject.hasOwnProperty(initialKey)) {
        labelsObject[initialKey] = null;
      }
    });

    // Update labels object.
    this.labels = labelsObject;

    // Emit the change event.
    this.labelsChange.emit(this.labels);
  }
```

Sorry for keeping it so long, but this may seem tricky. If you have any concerns please let me know, I may have missed something.

One last thing: `filterNullifiedKeys` was removing only `null` valued fields. Not those with `""` or `undefined` (this should not happen anyways) values.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed deletion of labels and taints.
```
