### PR TITLE
Keep refreshing cluster details on error

### DIFF
--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -1,6 +1,7 @@
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, of} from 'rxjs';
+import {catchError} from 'rxjs/operators';
 
 import {environment} from '../../../../environments/environment';
 import {LabelFormComponent} from '../../../shared/components/label-form/label-form.component';
@@ -43,7 +44,7 @@ export class ApiService {
 
   getNodeDeployments(cluster: string, dc: string, projectID: string): Observable<NodeDeploymentEntity[]> {
     const url = `${this._restRoot}/projects/${projectID}/dc/${dc}/clusters/${cluster}/nodedeployments`;
-    return this._http.get<NodeDeploymentEntity[]>(url);
+    return this._http.get<NodeDeploymentEntity[]>(url).pipe(catchError(() => of<NodeDeploymentEntity[]>()));
   }
 
   getNodeDeployment(ndId: string, cluster: string, dc: string, projectID: string): Observable<NodeDeploymentEntity> {

--- a/src/app/core/services/cluster/cluster.service.ts
+++ b/src/app/core/services/cluster/cluster.service.ts
@@ -91,18 +91,18 @@ export class ClusterService {
   upgrades(projectID: string, clusterID: string, datacenter: string): Observable<MasterVersion[]> {
     const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/upgrades`;
     return this._http.get<MasterVersion[]>(url).pipe(catchError(() => {
-      return of<MasterVersion[]>([]);
+      return of<MasterVersion[]>([]).pipe(catchError(() => of<MasterVersion[]>()));
     }));
   }
 
   events(projectID: string, clusterID: string, datacenter: string): Observable<EventEntity[]> {
     const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/events`;
-    return this._http.get<EventEntity[]>(url);
+    return this._http.get<EventEntity[]>(url).pipe(catchError(() => of<EventEntity[]>()));
   }
 
   health(projectID: string, clusterID: string, datacenter: string): Observable<HealthEntity> {
     const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/health`;
-    return this._http.get<HealthEntity>(url);
+    return this._http.get<HealthEntity>(url).pipe(catchError(() => of<HealthEntity>()));
   }
 
   upgradeNodeDeployments(projectID: string, clusterID: string, datacenter: string, version: string): Observable<any> {
@@ -113,7 +113,7 @@ export class ClusterService {
   nodes(projectID: string, clusterID: string, datacenter: string): Observable<NodeEntity[]> {
     const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${
         clusterID}/nodes?hideInitialConditions=true`;
-    return this._http.get<NodeEntity[]>(url);
+    return this._http.get<NodeEntity[]>(url).pipe(catchError(() => of<NodeEntity[]>()));
   }
 
   createNode(projectID: string, clusterID: string, datacenter: string, node: NodeEntity): Observable<NodeEntity> {
@@ -135,7 +135,7 @@ export class ClusterService {
 
   sshKeys(projectID: string, clusterID: string, datacenter: string): Observable<SSHKeyEntity[]> {
     const url = `${this._restRoot}/projects/${projectID}/dc/${datacenter}/clusters/${clusterID}/sshkeys`;
-    return this._http.get<SSHKeyEntity[]>(url);
+    return this._http.get<SSHKeyEntity[]>(url).pipe(catchError(() => of<SSHKeyEntity[]>()));
   }
 
   createSSHKey(projectID: string, clusterID: string, datacenter: string, sshKeyID: string): Observable<any> {


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up fix for #1428. I have fixed it for other views, but actually not for details :slightly_smiling_face: 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed an issue with handling resources refresh on error conditions
```
