### PR TITLE
Fix e2e for API

### DIFF
--- a/containers/e2e/utils/deploy.sh
+++ b/containers/e2e/utils/deploy.sh
@@ -157,7 +157,7 @@ function deploy::kubermatic {
 		--set=kubermatic.controller.replicas=1 \
 		--set=kubermatic.controller.datacenterName=${KUBECONFIG_CLUSTER_NAME} \
 		--set=kubermatic.controller.image.tag=${KUBERMATIC_IMAGE_TAG} \
-		--set=kubermatic.controller.addons.kubernetes.image.tag=${KUBERMATIC_IMAGE_TAG} \
+		--set=kubermatic.controller.addons.kubernetes.image.tag="latest" \
 		--set=kubermatic.api.image.tag=${KUBERMATIC_IMAGE_TAG} \
 		--set=kubermatic.api.replicas=1 \
 		--set=kubermatic.apiserverDefaultReplicas=1 \


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes e2e for the API. API handles image loading differently and requires addons image to use fixed `latest` tag.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
