### PR TITLE
Load packet sizes from the API

### DIFF
--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -12,6 +12,7 @@ import {CreateMemberEntity, MemberEntity} from '../../../shared/entity/MemberEnt
 import {NodeDeploymentEntity} from '../../../shared/entity/NodeDeploymentEntity';
 import {NodeDeploymentPatch} from '../../../shared/entity/NodeDeploymentPatch';
 import {NodeEntity} from '../../../shared/entity/NodeEntity';
+import {PacketSize} from '../../../shared/entity/packet/PacketSizeEntity';
 import {EditProjectEntity, ProjectEntity} from '../../../shared/entity/ProjectEntity';
 import {AWSAvailabilityZone} from '../../../shared/entity/provider/aws/AWS';
 import {AzureSizes} from '../../../shared/entity/provider/azure/AzureSizeEntity';
@@ -115,6 +116,11 @@ export class ApiService {
   getHetznerTypes(projectId: string, dc: string, clusterId: string): Observable<HetznerTypes> {
     const url = `${this._restRoot}/projects/${projectId}/dc/${dc}/clusters/${clusterId}/providers/hetzner/sizes`;
     return this._http.get<HetznerTypes>(url);
+  }
+
+  getPacketSizes(projectId: string, dc: string, clusterId: string): Observable<PacketSize[]> {
+    const url = `${this._restRoot}/projects/${projectId}/dc/${dc}/clusters/${clusterId}/providers/packet/sizes`;
+    return this._http.get<PacketSize[]>(url);
   }
 
   editToken(cluster: ClusterEntity, dc: string, projectID: string, token: Token): Observable<Token> {

--- a/src/app/core/services/wizard/provider/packet.ts
+++ b/src/app/core/services/wizard/provider/packet.ts
@@ -1,10 +1,16 @@
 import {HttpClient} from '@angular/common/http';
-import {NodeInstanceFlavor, NodeInstanceFlavors, NodeProvider} from '../../../../shared/model/NodeProviderConstants';
+import {EMPTY, Observable} from 'rxjs';
+
+import {PacketSize} from '../../../../shared/entity/packet/PacketSizeEntity';
+import {NodeProvider} from '../../../../shared/model/NodeProviderConstants';
+
 import {Provider} from './provider';
 
 export class Packet extends Provider {
   constructor(http: HttpClient, provider: NodeProvider) {
     super(http, provider);
+
+    this._setRequiredHeaders(Packet.Header.APIKey, Packet.Header.ProjectID);
   }
 
   credential(credential: string): Packet {
@@ -12,7 +18,29 @@ export class Packet extends Provider {
     return this;
   }
 
-  flavors(): NodeInstanceFlavor[] {
-    return NodeInstanceFlavors.Packet;
+  apiKey(key: string): Packet {
+    if (key) {
+      this._headers = this._headers.set(Packet.Header.APIKey, key);
+    }
+    return this;
   }
+
+  projectID(id: string): Packet {
+    if (id) {
+      this._headers = this._headers.set(Packet.Header.ProjectID, id);
+    }
+    return this;
+  }
+
+  flavors(): Observable<PacketSize[]> {
+    if (!this._hasRequiredHeaders()) {
+      return EMPTY;
+    }
+
+    return this._http.get<PacketSize[]>(this._url, {headers: this._headers});
+  }
+}
+
+export namespace Packet {
+  export enum Header {APIKey = 'apiKey', ProjectID = 'projectID'}
 }

--- a/src/app/node-data/hetzner-node-data/hetzner-node-data.component.html
+++ b/src/app/node-data/hetzner-node-data/hetzner-node-data.component.html
@@ -16,7 +16,7 @@
           </mat-option>
         </mat-optgroup>
         <mat-optgroup *ngIf="types.dedicated.length > 0"
-                      label="Dedicated vCPU Instanzen">
+                      label="Dedicated vCPU Instances">
           <mat-option *ngFor="let type of types.dedicated"
                       [value]="type.name">
             {{type.name}} ({{ type.cores }} vCPU, {{type.memory}} GB RAM)

--- a/src/app/node-data/node-data.component.html
+++ b/src/app/node-data/node-data.component.html
@@ -71,8 +71,10 @@
 
   <kubermatic-packet-node-data *ngIf="cluster.spec.cloud.packet"
                                [cloudSpec]="cluster.spec.cloud"
+                               [projectId]="projectId"
                                [clusterId]="cluster.id"
-                               [nodeData]="nodeData"></kubermatic-packet-node-data>
+                               [nodeData]="nodeData"
+                               [seedDCName]="seedDCName"></kubermatic-packet-node-data>
 
   <kubermatic-hetzner-node-data *ngIf="cluster.spec.cloud.hetzner"
                                 [cloudSpec]="cluster.spec.cloud"

--- a/src/app/node-data/packet-node-data/packet-node-data.component.html
+++ b/src/app/node-data/packet-node-data/packet-node-data.component.html
@@ -1,17 +1,19 @@
-<form [formGroup]="packetNodeForm"
+<form [formGroup]="form"
       fxLayout="column">
   <div fxFlex
        class="mat-select-container">
     <mat-form-field>
-      <mat-label>Node Size*</mat-label>
-      <mat-select formControlName="type"
+      <mat-label>{{getSizesFormState()}}</mat-label>
+      <mat-select formControlName="size"
+                  disableOptionCentering
                   [panelClass]="isInWizard() ? '' : 'km-add-dialog-dropdown'"
-                  disableOptionCentering>
-        <mat-option *ngFor="let type of instanceTypes"
-                    [value]="type.id">
-          {{type}}
+                  [placeholder]="getSizesFormState()">
+        <mat-option *ngFor="let size of sizes"
+                    [value]="size.name">
+          {{size.name}} {{getPlanDetails(size)}}
         </mat-option>
       </mat-select>
+      <mat-hint *ngIf="showSizeHint()">Please enter a valid API Key and Project ID first.</mat-hint>
     </mat-form-field>
   </div>
 

--- a/src/app/node-data/packet-node-data/packet-node-data.component.spec.ts
+++ b/src/app/node-data/packet-node-data/packet-node-data.component.spec.ts
@@ -3,11 +3,14 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {ReactiveFormsModule} from '@angular/forms';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {WizardService} from '../../core/services';
+
+import {ApiService, WizardService} from '../../core/services';
 import {NodeDataService} from '../../core/services/node-data/node-data.service';
 import {SharedModule} from '../../shared/shared.module';
 import {fakePacketCluster} from '../../testing/fake-data/cluster.fake';
 import {nodeDataFake} from '../../testing/fake-data/node.fake';
+import {ApiMockService} from '../../testing/services/api-mock.service';
+
 import {PacketNodeDataComponent} from './packet-node-data.component';
 
 const modules: any[] = [
@@ -34,6 +37,7 @@ describe('PacketNodeDataComponent', () => {
           providers: [
             NodeDataService,
             WizardService,
+            {provide: ApiService, useClass: ApiMockService},
           ],
         })
         .compileComponents();
@@ -53,6 +57,6 @@ describe('PacketNodeDataComponent', () => {
 
   it('form valid when initializing since Packet has sane defaults for required fields', () => {
     fixture.detectChanges();
-    expect(component.packetNodeForm.valid).toBeTruthy();
+    expect(component.form.valid).toBeTruthy();
   });
 });

--- a/src/app/node-data/packet-node-data/packet-node-data.component.ts
+++ b/src/app/node-data/packet-node-data/packet-node-data.component.ts
@@ -1,12 +1,13 @@
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
-import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
+import {iif, Subject} from 'rxjs';
+import {first, takeUntil} from 'rxjs/operators';
 
-import {WizardService} from '../../core/services';
+import {ApiService, WizardService} from '../../core/services';
 import {NodeDataService} from '../../core/services/node-data/node-data.service';
 import {CloudSpec} from '../../shared/entity/ClusterEntity';
-import {NodeInstanceFlavor, NodeProvider} from '../../shared/model/NodeProviderConstants';
+import {PacketSize} from '../../shared/entity/packet/PacketSizeEntity';
+import {NodeProvider} from '../../shared/model/NodeProviderConstants';
 import {NodeData, NodeProviderData} from '../../shared/model/NodeSpecChange';
 
 @Component({
@@ -17,56 +18,148 @@ import {NodeData, NodeProviderData} from '../../shared/model/NodeSpecChange';
 export class PacketNodeDataComponent implements OnInit, OnDestroy {
   @Input() cloudSpec: CloudSpec;
   @Input() nodeData: NodeData;
+  @Input() projectId: string;
   @Input() clusterId: string;
+  @Input() seedDCName: string;
 
-  instanceTypes: NodeInstanceFlavor[] = this._wizard.provider(NodeProvider.PACKET).flavors();
-  packetNodeForm: FormGroup;
+  sizes: PacketSize[] = [];
+  form: FormGroup;
   hideOptional = true;
+  loadingSizes = false;
 
   private _unsubscribe: Subject<any> = new Subject();
+  private _selectedCredentials: string;
 
-  constructor(private readonly _addNodeService: NodeDataService, private readonly _wizard: WizardService) {}
+  constructor(
+      private readonly _addNodeService: NodeDataService, private readonly _wizard: WizardService,
+      private readonly _api: ApiService) {}
 
   ngOnInit(): void {
-    this.packetNodeForm = new FormGroup({
-      type: new FormControl(this.nodeData.spec.cloud.packet.instanceType, Validators.required),
+    this.form = new FormGroup({
+      size: new FormControl(this.nodeData.spec.cloud.packet.instanceType, Validators.required),
       tags: new FormControl(this.nodeData.spec.cloud.packet.tags.toString().replace(/\,/g, ', ')),
     });
 
-    if (this.nodeData.spec.cloud.packet.instanceType === '') {
-      this.packetNodeForm.controls.type.setValue(this.instanceTypes[0].id);
-    }
-
-    this.packetNodeForm.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
-      this._addNodeService.changeNodeProviderData(this.getNodeProviderData());
-    });
+    this.form.valueChanges.pipe(takeUntil(this._unsubscribe))
+        .subscribe(() => this._addNodeService.changeNodeProviderData(this._getNodeProviderData()));
 
     this._wizard.clusterSettingsFormViewChanged$.pipe(takeUntil(this._unsubscribe)).subscribe((data) => {
       this.hideOptional = data.hideOptional;
     });
 
-    this._addNodeService.changeNodeProviderData(this.getNodeProviderData());
+    this._wizard.clusterProviderSettingsFormChanges$.pipe(takeUntil(this._unsubscribe)).subscribe((data) => {
+      this.cloudSpec = data.cloudSpec;
+      this.form.controls.size.setValue('');
+      this.sizes = [];
+      this._checkSizeState();
+
+      if (this._canLoadSizes()) {
+        this._reloadPacketSizes();
+      }
+    });
+
+    this._wizard.onCustomPresetSelect.pipe(takeUntil(this._unsubscribe)).subscribe(credentials => {
+      this._selectedCredentials = credentials;
+    });
+
+    this._checkSizeState();
+    this._reloadPacketSizes();
+    this._addNodeService.changeNodeProviderData(this._getNodeProviderData());
   }
 
   isInWizard(): boolean {
     return !this.clusterId || this.clusterId.length === 0;
   }
 
-  getNodeProviderData(): NodeProviderData {
+  getSizesFormState(): string {
+    if (!this.loadingSizes && (!this.cloudSpec.packet.apiKey || !this.cloudSpec.packet.projectID) &&
+        this.isInWizard()) {
+      return 'Plan*';
+    } else if (this.loadingSizes) {
+      return 'Loading Plans...';
+    } else if (!this.loadingSizes && this.sizes.length === 0) {
+      return 'No Plans available';
+    } else {
+      return 'Plan*';
+    }
+  }
+
+  getPlanDetails(size: PacketSize): string {
+    let description = '';
+    size.drives = size.drives ? size.drives : [];
+    size.cpus = size.cpus ? size.cpus : [];
+
+    for (const cpu of size.cpus) {
+      description += `${cpu.count} CPU(s) ${cpu.type}`;
+    }
+
+    if (size.memory && size.memory !== 'N/A') {
+      description += `, ${size.memory} RAM`;
+    }
+
+    for (const drive of size.drives) {
+      description += `, ${drive.count}x${drive.size} ${drive.type}`;
+    }
+
+    return description ? `(${description})` : '';
+  }
+
+  showSizeHint(): boolean {
+    return !this._canLoadSizes() && this.isInWizard();
+  }
+
+  private _getNodeProviderData(): NodeProviderData {
     let packetTags: string[] = [];
-    if ((this.packetNodeForm.controls.tags.value).length > 0) {
-      packetTags = (this.packetNodeForm.controls.tags.value).split(',').map(tag => tag.trim());
+    if ((this.form.controls.tags.value).length > 0) {
+      packetTags = (this.form.controls.tags.value).split(',').map(tag => tag.trim());
     }
 
     return {
       spec: {
         packet: {
-          instanceType: this.packetNodeForm.controls.type.value,
+          instanceType: this.form.controls.size.value,
           tags: packetTags,
         },
       },
-      valid: this.packetNodeForm.valid,
+      valid: this.form.valid,
     };
+  }
+
+  private _reloadPacketSizes(): void {
+    if (this._canLoadSizes() || !this.isInWizard()) {
+      this.loadingSizes = true;
+    }
+
+    iif(() => this.isInWizard(),
+        this._wizard.provider(NodeProvider.PACKET)
+            .apiKey(this.cloudSpec.packet.apiKey)
+            .projectID(this.cloudSpec.packet.projectID)
+            .credential(this._selectedCredentials)
+            .flavors(),
+        this._api.getPacketSizes(this.projectId, this.seedDCName, this.clusterId))
+        .pipe(first())
+        .pipe(takeUntil(this._unsubscribe))
+        .subscribe((sizes: PacketSize[]) => {
+          this.sizes = sizes;
+          if (this.nodeData.spec.cloud.packet.instanceType === '' && this.sizes.length) {
+            this.form.controls.size.setValue(this.sizes[0].name);
+          }
+
+          this.loadingSizes = false;
+          this._checkSizeState();
+        }, () => this.loadingSizes = false);
+  }
+
+  private _checkSizeState(): void {
+    if (this.sizes.length === 0) {
+      this.form.controls.size.disable();
+    } else {
+      this.form.controls.size.enable();
+    }
+  }
+
+  private _canLoadSizes(): boolean {
+    return (!!this.cloudSpec.packet.apiKey && !!this.cloudSpec.packet.projectID) || !!this._selectedCredentials;
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/entity/packet/PacketSizeEntity.ts
+++ b/src/app/shared/entity/packet/PacketSizeEntity.ts
@@ -1,0 +1,17 @@
+export class PacketSize {
+  name: string;
+  cpus: PacketCPU[];
+  memory: string;
+  drives: PacketDrive[];
+}
+
+export class PacketDrive {
+  count: number;
+  size: string;
+  type: string;
+}
+
+export class PacketCPU {
+  count: number;
+  type: string;
+}

--- a/src/app/shared/model/NodeProviderConstants.ts
+++ b/src/app/shared/model/NodeProviderConstants.ts
@@ -43,15 +43,4 @@ export namespace NodeInstanceFlavors {
     new NodeInstanceFlavor('c5.xlarge', '4 vCPU, 8 GB'),
     new NodeInstanceFlavor('c5.2xlarge', '8 vCPU, 16 GB'),
   ];
-
-  // Keep in sync with https://www.packet.com/cloud/servers/.
-  export const Packet: NodeInstanceFlavor[] = [
-    new NodeInstanceFlavor('t1.small.x86', '4 Cores, 8 GB'),
-    new NodeInstanceFlavor('c1.small.x86', '4 Cores, 32 GB'),
-    new NodeInstanceFlavor('c2.medium.x86', '24 Cores, 64 GB'),
-    new NodeInstanceFlavor('c1.large.x86', '16 Cores, 128 GB'),
-    new NodeInstanceFlavor('m1.large.x86', '24 Cores, 256 GB'),
-    new NodeInstanceFlavor('m2.large.x86', '28 Cores, 384 GB'),
-    new NodeInstanceFlavor('s1.large.x86', '16 Cores, 128 GB'),
-  ];
 }

--- a/src/app/testing/fake-data/addNodeModal.fake.ts
+++ b/src/app/testing/fake-data/addNodeModal.fake.ts
@@ -1,3 +1,4 @@
+import {PacketSize} from '../../shared/entity/packet/PacketSizeEntity';
 import {AzureSizes} from '../../shared/entity/provider/azure/AzureSizeEntity';
 import {DigitaloceanSizes} from '../../shared/entity/provider/digitalocean/DropletSizeEntity';
 import {HetznerTypes} from '../../shared/entity/provider/hetzner/TypeEntity';
@@ -56,4 +57,13 @@ export function fakeHetznerTypes(): HetznerTypes {
     ],
     dedicated: [],
   };
+}
+
+export function fakePacketSizes(): PacketSize[] {
+  return [{
+    name: 'x1.small.x86',
+    memory: '32GB',
+    cpus: [],
+    drives: [],
+  }];
 }

--- a/src/app/testing/services/api-mock.service.ts
+++ b/src/app/testing/services/api-mock.service.ts
@@ -6,13 +6,14 @@ import {ClusterEntity, MasterVersion, Token} from '../../shared/entity/ClusterEn
 import {CreateMemberEntity, MemberEntity} from '../../shared/entity/MemberEntity';
 import {NodeDeploymentEntity} from '../../shared/entity/NodeDeploymentEntity';
 import {NodeEntity} from '../../shared/entity/NodeEntity';
+import {PacketSize} from '../../shared/entity/packet/PacketSizeEntity';
 import {EditProjectEntity, ProjectEntity} from '../../shared/entity/ProjectEntity';
 import {DigitaloceanSizes} from '../../shared/entity/provider/digitalocean/DropletSizeEntity';
 import {GCPDiskType, GCPMachineSize, GCPZone} from '../../shared/entity/provider/gcp/GCP';
 import {VSphereNetwork} from '../../shared/entity/provider/vsphere/VSphereEntity';
 import {CreateServiceAccountEntity, ServiceAccountEntity, ServiceAccountTokenEntity, ServiceAccountTokenPatch} from '../../shared/entity/ServiceAccountEntity';
 import {SSHKeyEntity} from '../../shared/entity/SSHKeyEntity';
-import {fakeDigitaloceanSizes} from '../fake-data/addNodeModal.fake';
+import {fakeDigitaloceanSizes, fakePacketSizes} from '../fake-data/addNodeModal.fake';
 import {masterVersionsFake} from '../fake-data/cluster-spec.fake';
 import {fakeToken} from '../fake-data/cluster.fake';
 import {fakeMember, fakeMembers} from '../fake-data/member.fake';
@@ -177,6 +178,10 @@ export class ApiMockService {
 
   getKubeconfigURL(): string {
     return '';
+  }
+
+  getPacketSizes(): Observable<PacketSize[]> {
+    return of(fakePacketSizes());
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Gets Packet node sizes from the API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1245 

**Special notes for your reviewer**:
Hold until https://github.com/kubermatic/kubermatic/pull/4026 gets merged
/hold

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Load Packet machine types in the wizard from the API.
```
