### PR TITLE
Add missing cluster and NodeDeployment name validators

### DIFF
--- a/src/app/node-data/node-data.component.ts
+++ b/src/app/node-data/node-data.component.ts
@@ -49,7 +49,8 @@ export class NodeDataComponent implements OnInit, OnDestroy {
       operatingSystem: new FormControl(
           this.isClusterOpenshift() ? 'centos' : Object.keys(this.nodeData.spec.operatingSystem)[0],
           Validators.required),
-      name: new FormControl({value: this.nodeData.name, disabled: this.isNameDisabled}),
+      name: new FormControl(
+          {value: this.nodeData.name, disabled: this.isNameDisabled}, [Validators.pattern('[a-zA-Z0-9-]*')]),
     });
 
     if (!this.isInWizard) {

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
@@ -27,7 +27,8 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.clusterSpecForm = new FormGroup({
-      name: new FormControl(this.cluster.name, [Validators.required, Validators.minLength(5)]),
+      name: new FormControl(
+          this.cluster.name, [Validators.required, Validators.minLength(5), Validators.pattern('[a-zA-Z0-9-]*')]),
       version: new FormControl(this.cluster.spec.version),
       type: new FormControl(this.cluster.type),
     });


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing cluster and NodeDeployment name validators. For some reason I forgot to cherry-pick these from our fork in https://github.com/kubermatic/dashboard-v2/pull/1337.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1488

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
