### PR TITLE
AWS: make role name required if instance profile is specified

### DIFF
--- a/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/aws-provider-settings.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/aws-provider-settings.component.spec.ts
@@ -66,6 +66,7 @@ describe('AWSProviderSettingsComponent', () => {
       routeTableId: '',
       securityGroup: '',
       instanceProfileName: '',
+      roleName: '',
     };
     fixture.detectChanges();
   });

--- a/src/app/shared/entity/ClusterEntity.ts
+++ b/src/app/shared/entity/ClusterEntity.ts
@@ -74,6 +74,7 @@ export function getEmptyCloudProviderSpec(provider: string): object {
         securityGroup: '',
         subnetId: '',
         instanceProfileName: '',
+        roleName: '',
       } as AWSCloudSpec;
     case NodeProvider.DIGITALOCEAN:
       return {

--- a/src/app/shared/entity/cloud/AWSCloudSpec.ts
+++ b/src/app/shared/entity/cloud/AWSCloudSpec.ts
@@ -6,4 +6,5 @@ export class AWSCloudSpec {
   routeTableId: string;
   securityGroup: string;
   instanceProfileName: string;
+  roleName: string;
 }

--- a/src/app/testing/fake-data/cluster.fake.ts
+++ b/src/app/testing/fake-data/cluster.fake.ts
@@ -209,6 +209,7 @@ export function fakeAWSCluster(): ClusterEntity {
           subnetId: '',
           routeTableId: '',
           instanceProfileName: '',
+          roleName: '',
         },
         openstack: null,
         baremetal: null,

--- a/src/app/wizard/set-settings/provider-settings/aws/aws.component.html
+++ b/src/app/wizard/set-settings/provider-settings/aws/aws.component.html
@@ -93,4 +93,14 @@
            autocomplete="off">
     <mat-hint>When specified, the worker nodes will use this instance profile. If not specified, a new instance profile will be created.</mat-hint>
   </mat-form-field>
+  <mat-form-field fxFlex
+                  *ngIf="!hideOptional">
+    <mat-label>{{getRolePlaceholder()}}</mat-label>
+    <input matInput
+           formControlName="roleName"
+           name="roleName"
+           type="text"
+           autocomplete="off">
+    <mat-hint>{{getRoleHint()}}</mat-hint>
+  </mat-form-field>
 </form>

--- a/src/app/wizard/set-settings/provider-settings/aws/aws.component.spec.ts
+++ b/src/app/wizard/set-settings/provider-settings/aws/aws.component.spec.ts
@@ -42,6 +42,7 @@ describe('AWSClusterSettingsComponent', () => {
       securityGroup: '',
       vpcId: '',
       instanceProfileName: '',
+      roleName: '',
     };
     fixture.detectChanges();
   });

--- a/src/app/wizard/set-settings/provider-settings/aws/aws.component.ts
+++ b/src/app/wizard/set-settings/provider-settings/aws/aws.component.ts
@@ -28,7 +28,18 @@ export class AWSClusterSettingsComponent implements OnInit, OnDestroy {
       routeTableId:
           new FormControl(this.cluster.spec.cloud.aws.routeTableId, Validators.pattern('rtb-(\\w{8}|\\w{17})')),
       instanceProfileName: new FormControl(this.cluster.spec.cloud.aws.instanceProfileName),
+      roleName: new FormControl(this.cluster.spec.cloud.aws.roleName),
     });
+
+    this.subscriptions.push(
+        this.awsSettingsForm.controls.instanceProfileName.valueChanges.pipe(debounceTime(1000)).subscribe(() => {
+          if (this.awsSettingsForm.controls.instanceProfileName.value !== '') {
+            this.awsSettingsForm.controls.roleName.setValidators(Validators.required);
+          } else {
+            this.awsSettingsForm.controls.roleName.setValidators(null);
+          }
+          this.awsSettingsForm.controls.roleName.updateValueAndValidity();
+        }));
 
     this.subscriptions.push(this.awsSettingsForm.valueChanges.pipe(debounceTime(1000)).subscribe((data) => {
       this.wizardService.changeClusterProviderSettings({
@@ -41,6 +52,7 @@ export class AWSClusterSettingsComponent implements OnInit, OnDestroy {
             subnetId: this.awsSettingsForm.controls.subnetId.value,
             routeTableId: this.awsSettingsForm.controls.routeTableId.value,
             instanceProfileName: this.awsSettingsForm.controls.instanceProfileName.value,
+            roleName: this.awsSettingsForm.controls.roleName.value,
           },
           dc: this.cluster.spec.cloud.dc,
         },
@@ -51,6 +63,16 @@ export class AWSClusterSettingsComponent implements OnInit, OnDestroy {
     this.subscriptions.push(this.wizardService.clusterSettingsFormViewChanged$.subscribe((data) => {
       this.hideOptional = data.hideOptional;
     }));
+  }
+
+  getRolePlaceholder(): string {
+    return this.awsSettingsForm.controls.instanceProfileName.value !== '' ? 'Role Name*' : 'Role Name';
+  }
+
+  getRoleHint(): string {
+    return this.awsSettingsForm.controls.instanceProfileName.value !== '' ?
+        'Instance Profile is specified. Please set a Role Name.' :
+        '';
   }
 
   ngOnDestroy(): void {

--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -217,6 +217,13 @@
                    class="km-card-list-key">Instance Profile Name</div>
               <div fxFlex="50%">{{ cluster.spec.cloud.aws.instanceProfileName }}</div>
             </div>
+            <div fxLayout
+                 class="km-card-list-content"
+                 *ngIf="cluster.spec.cloud.aws.roleName">
+              <div fxFlex="50%"
+                   class="km-card-list-key">Role Name</div>
+              <div fxFlex="50%">{{ cluster.spec.cloud.aws.roleName }}</div>
+            </div>
           </ng-container>
 
           <!-- Open Stack -->


### PR DESCRIPTION
**What this PR does / why we need it**:
AWS: make role name required if instance profile is specified

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1484

**Special notes for your reviewer**:
This change is **only** required in `ui v1.3.x` / `api v2.11.x`, as master will handle it differently by now.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix AWS: Make Role Name required if Instance Profile Name is specified.
```
