### PR TITLE
Make oidc client id configurable

### DIFF
--- a/src/app/core/services/auth/auth.service.ts
+++ b/src/app/core/services/auth/auth.service.ts
@@ -39,7 +39,11 @@ export class Auth {
         this._appConfigService.getConfig().oidc_provider_scope :
         this._defaultScope;
 
-    return `${baseUrl}?response_type=${this._responseType}&client_id=${this._clientId}` +
+    const clientId = this._appConfigService.getConfig().oidc_provider_client_id ?
+        this._appConfigService.getConfig().oidc_provider_client_id :
+        this._clientId;
+
+    return `${baseUrl}?response_type=${this._responseType}&client_id=${clientId}` +
         `&redirect_uri=${this._redirectUri}&scope=${scope}&nonce=${this._nonce}`;
   }
 

--- a/src/app/shared/model/Config.ts
+++ b/src/app/shared/model/Config.ts
@@ -14,6 +14,7 @@ export interface Config {
   custom_links?: CustomLink[];
   oidc_provider_url?: string;
   oidc_provider_scope?: string;
+  oidc_provider_client_id?: string;
   hide_kubernetes?: boolean;
   hide_openshift?: boolean;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the oidc client id configurable, so it can be something different then "kubermatic".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
oidc client id is now configurable
```
