### PR TITLE
Correctly support id_token in fragment part of the url

### DIFF
--- a/src/app/core/services/auth/auth.service.ts
+++ b/src/app/core/services/auth/auth.service.ts
@@ -90,7 +90,7 @@ export class Auth {
   }
 
   private getTokenFromQuery(): string {
-    const results = new RegExp('[\?&]id_token=([^&#]*)').exec(window.location.href);
+    const results = new RegExp('[\?&#]id_token=([^&#]*)').exec(window.location.href);
     return results == null ? null : results[1] || '';
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Depending on the OIDC provider the id_token can be passend int the fragment instead of the query of the url.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
