### PR TITLE
Add support to configure Pod Security Policy in cluster

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -89,6 +89,11 @@
             <span>Revoke Admin Token</span>
           </button>
 
+          <button mat-menu-item
+                  (click)="configPodSecurity()"
+                  [disabled]="!isEditEnabled()">
+            <span>Configure Pod Security Policy</span>
+          </button>
         </mat-menu>
       </div>
     </mat-card-header>

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -20,6 +20,7 @@ import {NodeService} from '../services/node.service';
 
 import {ClusterConnectComponent} from './cluster-connect/cluster-connect.component';
 import {ClusterDeleteConfirmationComponent} from './cluster-delete-confirmation/cluster-delete-confirmation.component';
+import {ConfigurePodSecurityComponent} from './configure-pod-security/configure-pod-security.component';
 import {EditClusterComponent} from './edit-cluster/edit-cluster.component';
 import {EditProviderSettingsComponent} from './edit-provider-settings/edit-provider-settings.component';
 import {EditSSHKeysComponent} from './edit-sshkeys/edit-sshkeys.component';
@@ -236,6 +237,13 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
 
   revokeAdminToken(): void {
     const dialogRef = this._matDialog.open(RevokeAdminTokenComponent);
+    dialogRef.componentInstance.cluster = this.cluster;
+    dialogRef.componentInstance.datacenter = this.datacenter;
+    dialogRef.componentInstance.projectID = this.projectID;
+  }
+
+  configPodSecurity(): void {
+    const dialogRef = this._matDialog.open(ConfigurePodSecurityComponent);
     dialogRef.componentInstance.cluster = this.cluster;
     dialogRef.componentInstance.datacenter = this.datacenter;
     dialogRef.componentInstance.projectID = this.projectID;

--- a/src/app/cluster/cluster-details/configure-pod-security/configure-pod-security.component.html
+++ b/src/app/cluster/cluster-details/configure-pod-security/configure-pod-security.component.html
@@ -1,0 +1,53 @@
+<km-dialog-title title="Configure Pod Security Policy"></km-dialog-title>
+
+<ng-container *ngIf="!isPodSecurityPolicyActive()">
+  <mat-dialog-content>
+    <p>Pod Security Policy is currently not active in this cluster.</p>
+
+    <p class="km-warning">Activating Pod Security Policy will mean that a lot of Pod specifications, Operators and Helm charts will not work out of the box. Make sure that you know the consequences of activating this feature.</p>
+
+    <p>For more information have a look at the <a href="https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+         target="_blank"
+         rel="noopener">Documentation</a>.</p>
+
+    <p>Click here to activate Pod Security Policy for cluster "<strong>{{cluster.name}}</strong>" and confirm by entering</p>
+    <p class="km-code-block">{{ expectedConfirmation }}</p>
+    <p>below:</p>
+
+    <mat-form-field>
+      <mat-label>Confirmation*</mat-label>
+      <input matInput
+             type="text"
+             title="Confirmation"
+             (blur)="onChange($event)"
+             (keyup)="onChange($event)">
+    </mat-form-field>
+
+  </mat-dialog-content>
+
+  <mat-dialog-actions>
+    <button (click)="activatePodSecurity()"
+            mat-dialog-close
+            mat-flat-button
+            [disabled]="!inputConfirmationMatches()">
+      Activate
+    </button>
+  </mat-dialog-actions>
+</ng-container>
+<ng-container *ngIf="isPodSecurityPolicyActive()">
+  <mat-dialog-content>
+    <p>Pod Security Policy is currently active in this cluster.</p>
+    <p>For more information have a look at the <a href="https://kubernetes.io/docs/concepts/policy/pod-security-policy/"
+         target="_blank"
+         rel="noopener">Documentation</a>.</p>
+    <p>Click here to deactivate Pod Security Policy for cluster "<strong>{{cluster.name}}</strong>":</p>
+  </mat-dialog-content>
+
+  <mat-dialog-actions>
+    <button (click)="deactivatePodSecurity()"
+            mat-dialog-close
+            mat-flat-button>
+      Deactivate
+    </button>
+  </mat-dialog-actions>
+</ng-container>

--- a/src/app/cluster/cluster-details/configure-pod-security/configure-pod-security.component.ts
+++ b/src/app/cluster/cluster-details/configure-pod-security/configure-pod-security.component.ts
@@ -1,0 +1,61 @@
+import {Component, Input} from '@angular/core';
+import {MatDialogRef} from '@angular/material';
+
+import {ClusterService} from '../../../core/services';
+import {NotificationActions} from '../../../redux/actions/notification.actions';
+import {ClusterEntity} from '../../../shared/entity/ClusterEntity';
+import {ClusterEntityPatch} from '../../../shared/entity/ClusterEntityPatch';
+import {DataCenterEntity} from '../../../shared/entity/DatacenterEntity';
+
+@Component({
+  selector: 'kubermatic-configure-pod-security',
+  templateUrl: './configure-pod-security.component.html',
+})
+export class ConfigurePodSecurityComponent {
+  @Input() cluster: ClusterEntity;
+  @Input() datacenter: DataCenterEntity;
+  @Input() projectID: string;
+  confirmation = '';
+  expectedConfirmation = 'i know what i am doing';
+
+  constructor(
+      private readonly _clusterService: ClusterService,
+      private readonly _dialogRef: MatDialogRef<ConfigurePodSecurityComponent>) {}
+
+  isPodSecurityPolicyActive(): boolean {
+    return this.cluster.spec.usePodSecurityPolicyAdmissionPlugin;
+  }
+
+  inputConfirmationMatches(): boolean {
+    return this.confirmation === this.expectedConfirmation;
+  }
+
+  onChange(event: any): void {
+    this.confirmation = event.target.value;
+  }
+
+  activatePodSecurity(): void {
+    if (!this.inputConfirmationMatches()) {
+      return;
+    } else {
+      const clusterPatch: ClusterEntityPatch = {
+        spec: {usePodSecurityPolicyAdmissionPlugin: true},
+      };
+
+      this._clusterService.patch(this.projectID, this.cluster.id, this.datacenter.metadata.name, clusterPatch)
+          .subscribe(() => {
+            NotificationActions.success(`PodSecurityPolicy for cluster ${this.cluster.name} is activated`);
+          });
+      this._dialogRef.close(true);
+    }
+  }
+
+  deactivatePodSecurity(): void {
+    const clusterPatch: ClusterEntityPatch = {spec: {usePodSecurityPolicyAdmissionPlugin: false}};
+    this._clusterService.patch(this.projectID, this.cluster.id, this.datacenter.metadata.name, clusterPatch)
+        .subscribe(() => {
+          NotificationActions.success(`PodSecurityPolicy for cluster ${this.cluster.name} is deactivated`);
+        });
+    this._dialogRef.close(true);
+  }
+}

--- a/src/app/cluster/cluster.module.ts
+++ b/src/app/cluster/cluster.module.ts
@@ -10,6 +10,7 @@ import {ClusterConnectComponent} from './cluster-details/cluster-connect/cluster
 import {ClusterDeleteConfirmationComponent} from './cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component';
 import {ClusterDetailsComponent} from './cluster-details/cluster-details.component';
 import {ClusterSecretsComponent} from './cluster-details/cluster-secrets/cluster-secrets.component';
+import {ConfigurePodSecurityComponent} from './cluster-details/configure-pod-security/configure-pod-security.component';
 import {EditClusterComponent} from './cluster-details/edit-cluster/edit-cluster.component';
 import {AWSProviderSettingsComponent} from './cluster-details/edit-provider-settings/aws-provider-settings/aws-provider-settings.component';
 import {AzureProviderSettingsComponent} from './cluster-details/edit-provider-settings/azure-provider-settings/azure-provider-settings.component';
@@ -54,6 +55,7 @@ const entryComponents: any[] = [
   RevokeAdminTokenComponent,
   AddMachineNetworkComponent,
   EditProviderSettingsComponent,
+  ConfigurePodSecurityComponent,
   AWSProviderSettingsComponent,
   DigitaloceanProviderSettingsComponent,
   HetznerProviderSettingsComponent,

--- a/src/app/shared/entity/ClusterEntity.ts
+++ b/src/app/shared/entity/ClusterEntity.ts
@@ -128,6 +128,7 @@ export class ClusterSpec {
   cloud: CloudSpec;
   machineNetworks?: MachineNetwork[];
   version?: string;
+  usePodSecurityPolicyAdmissionPlugin?: boolean;
 }
 
 export class MachineNetwork {

--- a/src/app/shared/entity/ClusterEntityPatch.ts
+++ b/src/app/shared/entity/ClusterEntityPatch.ts
@@ -11,6 +11,7 @@ export class ClusterSpecPatch {
   cloud?: CloudSpecPatch;
   version?: string;
   humanReadableName?: string;
+  usePodSecurityPolicyAdmissionPlugin?: boolean;
 }
 
 export class CloudSpecPatch {


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables configuring Pod Security Policy from the cluster detail page. Since activating it means that a lot of helm charts and examples out there won't work out of the box anymore, we decided to link the documentation for it and ask for a confirmation message, so that users won't just activate it without knowing the consequences and break their cluster.

If you have an idea how to do this in a nicer or prettier way, I'll gladly adapt it :).

API support was added in https://github.com/kubermatic/kubermatic/pull/4062.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Allow to configure Pod Security Policy from the cluster detail page
```
