### PR TITLE
added e2e tests for creating and deleting a project

### DIFF
--- a/cypress/integration/stories/tutorials.spec.ts
+++ b/cypress/integration/stories/tutorials.spec.ts
@@ -1,0 +1,37 @@
+import {TutorialProjectsPage} from "../../pages/tutorial-projects.po";
+import {login, logout} from "../../utils/auth";
+import {Condition} from "../../utils/condition";
+import {prefixedString} from "../../utils/random";
+
+
+
+describe('Tutorials Story', () => {
+  const email = Cypress.env('KUBERMATIC_DEX_DEV_E2E_USERNAME');
+  const password = Cypress.env('KUBERMATIC_DEX_DEV_E2E_PASSWORD');
+  let projectName = prefixedString('e2e-test-project');
+
+ 
+  before(() => {
+    cy.clearCookies();
+  });
+  
+  beforeEach(() => {
+    cy.server();
+    Cypress.Cookies.preserveOnce('token', 'nonce');
+  });
+  
+
+  it('tutorials 01: should create a new project', () => {
+    login(email, password);
+    cy.url().should(Condition.Include, 'projects');
+    TutorialProjectsPage.addProject(projectName);
+  });
+
+
+  it('tutorials 01: should delete the project', () => {
+    TutorialProjectsPage.deleteProject(projectName);
+    logout();
+  });
+  
+});
+

--- a/cypress/pages/tutorial-projects.po.ts
+++ b/cypress/pages/tutorial-projects.po.ts
@@ -1,0 +1,55 @@
+import {Condition} from "../utils/condition";
+import {wait} from "../utils/wait";
+
+export class TutorialProjectsPage {
+  static getProjectItem(projectName: string): Cypress.Chainable<any> {
+    return cy.get(`#km-project-name-${projectName}`);
+  }
+
+  static getActiveProjects(): Cypress.Chainable<any> {
+    return cy.get('i.km-health-state.fa.fa-circle.green');
+  }
+
+  // main difference to projects.po: this selects the button not by id but by the text "Add Project"
+  static getAddProjectBtn(): Cypress.Chainable<any> {
+    return cy.contains('Add Project');
+  }
+
+  static getAddProjectInput(): Cypress.Chainable<any> {
+    return cy.get(`#km-add-project-dialog-input`);
+  }
+
+  static addProject(projectName: string): void {
+    this.getAddProjectBtn().should(Condition.NotBe, 'disabled').click();
+    this.getAddProjectInput().type(projectName).should(Condition.HaveValue, projectName);
+    this.getAddProjectConfirmBtn().should(Condition.NotBe, 'disabled').click();
+    this.waitForRefresh();
+    this.getTable().should(Condition.Contain, projectName);
+  }
+
+  static getAddProjectConfirmBtn(): Cypress.Chainable<any> {
+    return cy.get(`#km-add-project-dialog-save`);
+  }
+
+  static getTable(): Cypress.Chainable<any> {
+    return cy.get('tbody');
+  }
+
+  // Utils.
+
+  static waitForRefresh(): void {
+    wait('**/projects', 'GET', 'list projects');
+  }
+
+  static getDeleteProjectBtn(projectName: string): Cypress.Chainable<any> {
+    return cy.get(`#km-delete-project-${projectName}`);
+  }
+
+  static deleteProject(projectName: string): void {
+    this.getDeleteProjectBtn(projectName).should(Condition.NotBe, 'disabled').click();
+    cy.get('#km-confirmation-dialog-input').type(projectName).should(Condition.HaveValue, projectName);
+    cy.get('#km-confirmation-dialog-confirm-btn').should(Condition.NotBe, 'disabled').click();
+  }
+}
+
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds e2e testing with cypress which ensures that the first tutorial (https://github.com/kubermatic/docs/pull/161) from docs will run as explicitly described in the tutorial.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The test specifically checks that buttons have the names that are stated in the docs. Where this is impossible because images are used, it selects by id, though this is not the desired behavior.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
```
