### PR TITLE
Remove templateNetName from VSphere

### DIFF
--- a/src/app/shared/entity/node/VSphereNodeSpec.ts
+++ b/src/app/shared/entity/node/VSphereNodeSpec.ts
@@ -3,5 +3,4 @@ export class VSphereNodeSpec {
   memory: number;
   template: string;
   diskSizeGB?: number;
-  templateNetName?: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `templateNetName` from VSphere NodeSpec as it is not supported anymore.

**Special notes for your reviewer**:
Related to https://github.com/kubermatic/kubermatic/pull/4180 - we didn't use it anyways 😅 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Remove `templateNetName` from VSphere NodeSpec as it is not supported anymore.
```
