### PR TITLE
Preload kind image

### DIFF
--- a/containers/cypress/Dockerfile
+++ b/containers/cypress/Dockerfile
@@ -31,6 +31,7 @@ COPY --from=download /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=download /usr/local/bin/kind /usr/local/bin/kind
 COPY start.sh /start.sh
 COPY utils/ opt/e2e/
+COPY kindest.tar /kindest.tar
 
 RUN ln -s /opt/e2e/deploy.sh /usr/local/bin && \
     ln -s /opt/e2e/expose.sh /usr/local/bin && \

--- a/containers/cypress/build-and-release.sh
+++ b/containers/cypress/build-and-release.sh
@@ -6,5 +6,13 @@ IMG_REPO="quay.io/kubermatic"
 IMG_NAME="e2e-kind-cypress"
 IMG_VERSION="v1.0.3"
 
+# Preloaded images
+IMG_KIND="kindest/node:v1.13.4"
+IMG_KIND_NAME="kindest.tar"
+
+docker pull ${IMG_KIND}
+docker save -o ${IMG_KIND_NAME} ${IMG_KIND}
 docker build -t ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION} .
 docker push ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION}
+
+rm ${IMG_KIND_NAME}

--- a/containers/e2e/Dockerfile
+++ b/containers/e2e/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=download /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=download /usr/local/bin/kind /usr/local/bin/kind
 COPY utils/ opt/e2e/
 COPY start.sh /start.sh
+COPY kindest.tar /kindest.tar
 
 RUN ln -s /opt/e2e/deploy.sh /usr/local/bin && \
     ln -s /opt/e2e/expose.sh /usr/local/bin && \

--- a/containers/e2e/build-and-release.sh
+++ b/containers/e2e/build-and-release.sh
@@ -6,5 +6,13 @@ IMG_REPO="quay.io/kubermatic"
 IMG_NAME="e2e-kind"
 IMG_VERSION="v1.0.10"
 
+# Preloaded images
+IMG_KIND="kindest/node:v1.13.4"
+IMG_KIND_NAME="kindest.tar"
+
+docker pull ${IMG_KIND}
+docker save -o ${IMG_KIND_NAME} ${IMG_KIND}
 docker build -t ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION} .
 docker push ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION}
+
+rm ${IMG_KIND_NAME}

--- a/hack/e2e/run_ci_e2e_test.sh
+++ b/hack/e2e/run_ci_e2e_test.sh
@@ -37,6 +37,16 @@ cat /hosts > /etc/hosts
 # Start docker daemon
 dockerd > /dev/null 2> /dev/null &
 
+# Wait for it to start
+while (! docker stats --no-stream ); do
+  # Docker takes a few seconds to initialize
+  echo "Waiting for Docker..."
+  sleep 1
+done
+
+# Load kind image
+docker load --input /kindest.tar
+
 deploy.sh
 DOCKER_CONFIG=/ docker run --name controller -d -v /root/.kube/config:/inner -v /etc/kubeconfig/kubeconfig:/outer --network host --privileged ${CONTROLLER_IMAGE} --kubeconfig-inner "/inner" --kubeconfig-outer "/outer" --namespace "default" --build-id "$PROW_JOB_ID"
 docker logs -f controller &


### PR DESCRIPTION
**What this PR does / why we need it**:
Add kind image during e2e image build to avoid downloading it every time during the test run.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
