### PR TITLE
Remove AWS Availability Zone endpoint

### DIFF
--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -14,7 +14,7 @@ import {NodeDeploymentPatch} from '../../../shared/entity/NodeDeploymentPatch';
 import {NodeEntity} from '../../../shared/entity/NodeEntity';
 import {PacketSize} from '../../../shared/entity/packet/PacketSizeEntity';
 import {EditProjectEntity, ProjectEntity} from '../../../shared/entity/ProjectEntity';
-import {AWSAvailabilityZone, AWSSize, AWSSubnet} from '../../../shared/entity/provider/aws/AWS';
+import {AWSSize, AWSSubnet} from '../../../shared/entity/provider/aws/AWS';
 import {AzureSizes} from '../../../shared/entity/provider/azure/AzureSizeEntity';
 import {DigitaloceanSizes} from '../../../shared/entity/provider/digitalocean/DropletSizeEntity';
 import {GCPDiskType, GCPMachineSize, GCPZone} from '../../../shared/entity/provider/gcp/GCP';

--- a/src/app/core/services/wizard/provider/aws.ts
+++ b/src/app/core/services/wizard/provider/aws.ts
@@ -1,7 +1,7 @@
 import {HttpClient} from '@angular/common/http';
 import {EMPTY, Observable} from 'rxjs';
 
-import {AWSAvailabilityZone, AWSSize, AWSSubnet, AWSVPC} from '../../../../shared/entity/provider/aws/AWS';
+import {AWSSize, AWSSubnet, AWSVPC} from '../../../../shared/entity/provider/aws/AWS';
 import {NodeProvider} from '../../../../shared/model/NodeProviderConstants';
 
 import {Provider} from './provider';

--- a/src/app/node-data/aws-node-data/aws-node-data.component.spec.ts
+++ b/src/app/node-data/aws-node-data/aws-node-data.component.spec.ts
@@ -7,7 +7,6 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ApiService, DatacenterService, WizardService} from '../../core/services';
 import {NodeDataService} from '../../core/services/node-data/node-data.service';
 import {SharedModule} from '../../shared/shared.module';
-import {fakeAwsZones} from '../../testing/fake-data/availabilyZones.fake';
 import {fakeAwsSubnets} from '../../testing/fake-data/aws-subnets.fake';
 import {fakeAWSCluster} from '../../testing/fake-data/cluster.fake';
 import {fakeAWSDatacenter} from '../../testing/fake-data/datacenter.fake';
@@ -29,8 +28,7 @@ describe('AWSNodeDataComponent', () => {
   let component: AWSNodeDataComponent;
 
   beforeEach(() => {
-    const apiMock = jasmine.createSpyObj('ApiService', ['getAWSZones', 'getAWSSubnets']);
-    apiMock.getAWSZones.and.returnValue(asyncData(fakeAwsZones()));
+    const apiMock = jasmine.createSpyObj('ApiService', ['getAWSSubnets']);
     apiMock.getAWSSubnets.and.returnValue(asyncData(fakeAwsSubnets()));
     const datacenterMock = jasmine.createSpyObj('DatacenterService', ['getDataCenter']);
     datacenterMock.getDataCenter.and.returnValue(asyncData(fakeAWSDatacenter()));

--- a/src/app/node-data/node-data.component.spec.ts
+++ b/src/app/node-data/node-data.component.spec.ts
@@ -9,7 +9,6 @@ import {NodeDataService} from '../core/services/node-data/node-data.service';
 import {ClusterNameGenerator} from '../core/util/name-generator.service';
 import {SharedModule} from '../shared/shared.module';
 import {fakeDigitaloceanSizes, fakeOpenstackFlavors} from '../testing/fake-data/addNodeModal.fake';
-import {fakeAwsZones} from '../testing/fake-data/availabilyZones.fake';
 import {fakeAwsSubnets} from '../testing/fake-data/aws-subnets.fake';
 import {masterVersionsFake} from '../testing/fake-data/cluster-spec.fake';
 import {fakeAWSCluster, fakeDigitaloceanCluster, fakeOpenstackCluster} from '../testing/fake-data/cluster.fake';
@@ -41,14 +40,13 @@ describe('NodeDataComponent', () => {
   beforeEach(async(() => {
     const apiMock = jasmine.createSpyObj('ApiService', [
       'getDigitaloceanSizes', 'getDigitaloceanSizesForWizard', 'getOpenStackFlavors', 'getOpenStackFlavorsForWizard',
-      'nodeUpgrades', 'getAWSZones', 'getAWSSubnets'
+      'nodeUpgrades', 'getAWSSubnets'
     ]);
     apiMock.getDigitaloceanSizes.and.returnValue(asyncData(fakeDigitaloceanSizes()));
     apiMock.getDigitaloceanSizesForWizard.and.returnValue(asyncData(fakeDigitaloceanSizes()));
     apiMock.getOpenStackFlavors.and.returnValue(asyncData(fakeOpenstackFlavors()));
     apiMock.getOpenStackFlavorsForWizard.and.returnValue(asyncData(fakeOpenstackFlavors()));
     apiMock.nodeUpgrades.and.returnValue(asyncData(masterVersionsFake()));
-    apiMock.getAWSZones.and.returnValue(asyncData(fakeAwsZones()));
     apiMock.getAWSSubnets.and.returnValue(asyncData(fakeAwsSubnets()));
 
     TestBed

--- a/src/app/shared/entity/provider/aws/AWS.ts
+++ b/src/app/shared/entity/provider/aws/AWS.ts
@@ -1,7 +1,3 @@
-export class AWSAvailabilityZone {
-  name: string;
-}
-
 export class AWSSubnet {
   name: string;
   id: string;

--- a/src/app/testing/fake-data/availabilyZones.fake.ts
+++ b/src/app/testing/fake-data/availabilyZones.fake.ts
@@ -1,5 +1,0 @@
-import {AWSAvailabilityZone} from '../../shared/entity/provider/aws/AWS';
-
-export function fakeAwsZones(): AWSAvailabilityZone[] {
-  return [{'name': 'eu-central-1a'}, {'name': 'eu-central-1b'}, {'name': 'eu-central-1c'}];
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove AWS Availability Zone endpoint as it is not used anymore due to Subnets Endpoint.

**Special notes for your reviewer**:
Related to https://github.com/kubermatic/kubermatic/pull/4291
cc @alvaroaleman 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
