### PR TITLE
Firefox: Fix form overflows wizard

### DIFF
--- a/src/app/wizard/set-settings/set-settings.component.html
+++ b/src/app/wizard/set-settings/set-settings.component.html
@@ -5,7 +5,10 @@
        fxLayout.sm="column"
        fxLayout.xs="column"
        fxLayoutGap="30px">
-    <mat-card fxFlex="50%">
+    <mat-card fxFlex="50%"
+              fxFlex.md="100%"
+              fxFlex.sm="100%"
+              fxFlex.xs="100%">
       <mat-card-header>
         <mat-card-title class="km-color-primary">Provider Credentials</mat-card-title>
       </mat-card-header>
@@ -15,7 +18,10 @@
       </mat-card-content>
     </mat-card>
     <mat-card class="node-settings-card"
-              fxFlex="50%">
+              fxFlex="50%"
+              fxFlex.md="100%"
+              fxFlex.sm="100%"
+              fxFlex.xs="100%">
       <mat-card-header>
         <mat-card-title class="km-color-primary">Node Settings</mat-card-title>
       </mat-card-header>


### PR DESCRIPTION
**What this PR does / why we need it**:
On Firefox the form overflows card in step `Settings` in the wizard.
This was caused, because Firefox seems to handle `fxFlex` different as Chrome. Adding explicit `fxFlex` for smaller windows, seem to fix the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1594

**Special notes for your reviewer**:
![firefox-wizard](https://user-images.githubusercontent.com/19547196/65673994-24bccc80-e04c-11e9-8980-ea5f7e2300f1.JPG)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
