### PR TITLE
add check for Assign Public IP (AWS) on summary page

### DIFF
--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -309,14 +309,17 @@
                  class="km-warning">Not enough IPs left. Reduce number of nodes or add more machine networks.</p>
             </div>
 
-            <div *ngIf="nodeData.spec.cloud.aws.assignPublicIP !== undefined">
-              <div class="km-summary-row">
-                <span class="km-summary-left">
-                  <i [ngClass]="{'km-icon-disabled': !nodeData.spec.cloud.aws.assignPublicIP, 'km-icon-running': nodeData.spec.cloud.aws.assignPublicIP}"></i>
-                </span>
-                <span>Assign Public IP</span>
+            <!-- AWS Node Options -->
+            <ng-container *ngIf="cluster.spec.cloud.aws">
+              <div *ngIf="nodeData.spec.cloud.aws.assignPublicIP !== undefined">
+                <div class="km-summary-row">
+                  <span class="km-summary-left">
+                    <i [ngClass]="{'km-icon-disabled': !nodeData.spec.cloud.aws.assignPublicIP, 'km-icon-running': nodeData.spec.cloud.aws.assignPublicIP}"></i>
+                  </span>
+                  <span>Assign Public IP</span>
+                </div>
               </div>
-            </div>
+            </ng-container>
 
             <!-- DO Node Options -->
             <ng-container *ngIf="cluster.spec.cloud.digitalocean">


### PR DESCRIPTION
**What this PR does / why we need it**:
Atm we'll get following error inside browser dev console, when entering summary page in wizard: `ERROR TypeError: Cannot read property 'assignPublicIP' of undefined`.
This was caused by a missing check, if provider is aws.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
