### PR TITLE
Add ids to a few HTML elements to use for SSH key addition test

### DIFF
--- a/src/app/core/components/sidenav/sidenav.component.html
+++ b/src/app/core/components/sidenav/sidenav.component.html
@@ -17,7 +17,8 @@
 
       <div [matTooltip]="getTooltip('sshKeys')">
         <mat-list-item [ngClass]="getMenuItemClass('sshKeys')">
-          <a mat-line
+          <a id="km-nav-item-sshkeys"
+             mat-line
              fxLayoutAlign=" center"
              [routerLink]="getRouterLink('sshkeys')"
              [ngClass]="getLinkClass('sshkeys')">

--- a/src/app/shared/components/add-ssh-key-dialog/add-ssh-key-dialog.component.html
+++ b/src/app/shared/components/add-ssh-key-dialog/add-ssh-key-dialog.component.html
@@ -37,7 +37,8 @@
     </div>
   </mat-dialog-content>
   <mat-dialog-actions>
-    <button (click)="addSSHKey()"
+    <button id="km-add-ssh-key-dialog-save"
+            (click)="addSSHKey()"
             mat-flat-button
             [disabled]="!addSSHKeyForm.valid">
       Add SSH key

--- a/src/app/sshkey/sshkey.component.html
+++ b/src/app/sshkey/sshkey.component.html
@@ -1,7 +1,8 @@
 <div fxLayout>
   <div fxFlex
        align="right">
-    <button mat-flat-button
+    <button id="km-add-ssh-key-top-btn"
+            mat-flat-button
             type="button"
             (click)="addSshKey()"
             [disabled]="!!userGroup && !userGroupConfig[userGroup].sshKeys.create">


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces IDs to a few HTML elements so that I can use them for a Cypress test for adding SSH keys to projects. 

**release-note**:
```release-note
NONE
```

**Special notes for your reviewer**:
The Cypress test is already written and tested using these IDs locally. 

