### PR TITLE
Silence 403 error for cluster GET

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7326,9 +7326,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz",
+      "integrity": "sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -15610,13 +15610,13 @@
       "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.1.tgz",
+      "integrity": "sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       }
     },

--- a/src/app/core/interceptors/error-notifications/error-notifications.service.ts
+++ b/src/app/core/interceptors/error-notifications/error-notifications.service.ts
@@ -8,14 +8,28 @@ import {NotificationActions} from '../../../redux/actions/notification.actions';
 export class ErrorNotificationsInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(tap(() => {}, (errorInstance) => {
-      if (errorInstance) {
-        if (!!errorInstance.error && !!errorInstance.error.error) {
-          NotificationActions.error(`Error ${errorInstance.status}: ${
-              errorInstance.error.error.message || errorInstance.message || errorInstance.statusText}`);
-        } else {
-          NotificationActions.error(`${errorInstance.status}: ${errorInstance.statusText}`);
+      if (!errorInstance) {
+        return;
+      }
+
+      if (!!errorInstance.error && !!errorInstance.error.error) {
+        // Silence the 403 error for GET cluster until API gets fixed
+        if (errorInstance.error.error.code === 403 && this.isGetClusterEndpoint(errorInstance.url)) {
+          return;
         }
+
+        NotificationActions.error(`Error ${errorInstance.status}: ${
+            errorInstance.error.error.message || errorInstance.message || errorInstance.statusText}`);
+      } else {
+        NotificationActions.error(`${errorInstance.status}: ${errorInstance.statusText}`);
       }
     }));
+  }
+
+  // TODO(#1677): remove this after fixing API
+  isGetClusterEndpoint(url: string): boolean {
+    // Simple regex to check if it was an endpoint to GET cluster
+    const regex = new RegExp('^http[s]?:\\/\\/.*\\/api\\/v1\\/projects\\/.*\\/dc\\/.*\\/clusters\\/[a-zA-Z0-9]+$');
+    return regex.test(url);
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
During cluster creation often there is an error about missing privileges to get a cluster for the user. A proper fix has to be done on the API side. For now, I have silenced all `403` errors for cluster GET endpoint.

`package-lock.json` change is due to `npm audit fix`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
