### PR TITLE
Enable edit options for kubeAdm

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -62,8 +62,7 @@
       <div class="km-provider-menu">
         <button mat-icon-button
                 class="km-provider-menu-btn"
-                [matMenuTriggerFor]="menu"
-                *ngIf="!cluster.spec.cloud.bringyourown">
+                [matMenuTriggerFor]="menu">
           <mat-icon>more_vert</mat-icon>
         </button>
         <mat-menu #menu="matMenu"
@@ -75,7 +74,8 @@
           </button>
           <button mat-menu-item
                   (click)="editSSHKeys()"
-                  [disabled]="!isSSHKeysEditEnabled()">
+                  [disabled]="!isSSHKeysEditEnabled()"
+                  *ngIf="!cluster.spec.cloud.bringyourown">
             <span>Manage SSH keys</span>
           </button>
 

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
@@ -31,7 +31,8 @@
                        [asyncKeyValidators]=asyncLabelValidators
                        formControlName="labels"></km-label-form>
       </form>
-      <kubermatic-edit-provider-settings [cluster]="cluster"></kubermatic-edit-provider-settings>
+      <kubermatic-edit-provider-settings [cluster]="cluster"
+                                         *ngIf="!cluster.spec.cloud.bringyourown"></kubermatic-edit-provider-settings>
     </div>
   </mat-dialog-content>
   <mat-dialog-actions>


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable edit options for kubeAdm, in detail:
- Edit Cluster (Name, Labels, Audit Logging)
- Revoke Token (Admin & Viewer)
- Configure Pod Security Policy

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard-v2/issues/1733

**Special notes for your reviewer**:
Original issue was just for enabling `Revoke Token`, but during implementation I noticed, that `Edit Cluster` (partly) & `Configure Pod Security Policy` should also be possible, because you can specify related fields in step 1 during cluster creation. If this should not be editable for kubeAdm we could remove them easily.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Enable edit options for kubeAdm
```
