### PR TITLE
Fix node name validation.

### DIFF
--- a/src/app/node-data/node-data.component.ts
+++ b/src/app/node-data/node-data.component.ts
@@ -58,7 +58,8 @@ export class NodeDataComponent implements OnInit, OnDestroy {
           this.isClusterOpenshift() ? 'centos' : Object.keys(this.nodeData.spec.operatingSystem)[0],
           Validators.required),
       name: new FormControl(
-          {value: this.nodeData.name, disabled: this.isNameDisabled}, [Validators.pattern('[a-zA-Z0-9-]*')]),
+          {value: this.nodeData.name, disabled: this.isNameDisabled},
+          [Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]),
     });
 
     if (!this.isInWizard) {

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
@@ -37,7 +37,7 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
           [
             Validators.required,
             Validators.minLength(5),
-            Validators.pattern('[a-zA-Z0-9-]*'),
+            Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),
           ]),
       version: new FormControl(this.cluster.spec.version),
       type: new FormControl(this.cluster.type),


### PR DESCRIPTION
**What this PR does / why we need it**:

The node name validation that has been introduced by PR #1489 was not as
restrictive as the server side validation from the Kubernetes API
machinery. This change uses the same regex in the dashboard.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1488

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix node name validation while creating clusters and node deployments
```
