### PR TITLE
Do not allow to edit inherited labels

### DIFF
--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
@@ -28,6 +28,7 @@
         </mat-checkbox>
         <km-label-form title="Labels"
                        [(labels)]="labels"
+                       [inheritedLabels]="cluster.inheritedLabels"
                        [asyncKeyValidators]=asyncLabelValidators
                        formControlName="labels"></km-label-form>
       </form>

--- a/src/app/shared/components/label-form/label-form.component.ts
+++ b/src/app/shared/components/label-form/label-form.component.ts
@@ -25,6 +25,7 @@ import {LabelFormValidators} from '../../validators/label-form.validators';
 export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccessor, AsyncValidator, DoCheck {
   @Input() title = 'Labels';
   @Input() labels: object;
+  @Input() inheritedLabels: object = {};
   @Input() asyncKeyValidators: AsyncValidatorFn[] = [];
   @Output() labelsChange = new EventEmitter<object>();
   form: FormGroup;
@@ -62,6 +63,8 @@ export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccess
     if (!this.labels) {
       this.labels = {};
     }
+
+    this.inheritedLabels = this.inheritedLabels ? this.inheritedLabels : {};
 
     // Save initial state of labels.
     this.initialLabels = this.labels;
@@ -112,7 +115,7 @@ export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccess
   }
 
   isRemovable(index: number): boolean {
-    return index < this.labelArray.length - 1;
+    return index < this.labelArray.length - 1 && !this._isInherited(Object.keys(this.labels)[index]);
   }
 
   deleteLabel(index: number): void {
@@ -126,6 +129,10 @@ export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccess
     this._updateLabelsObject();
   }
 
+  private _isInherited(labelKey: string): boolean {
+    return Object.keys(this.inheritedLabels).includes(labelKey);
+  }
+
   private _addLabelIfNeeded(): void {
     const lastLabel = this.labelArray.at(this.labelArray.length - 1);
     if (LabelFormComponent._isFilled(lastLabel)) {
@@ -136,7 +143,7 @@ export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccess
   private _addLabel(key = '', value = ''): void {
     this.labelArray.push(this._formBuilder.group({
       key: [
-        {value: key, disabled: false}, Validators.compose([
+        {value: key, disabled: this._isInherited(key)}, Validators.compose([
           LabelFormValidators.labelKeyNameLength,
           LabelFormValidators.labelKeyPrefixLength,
           LabelFormValidators.labelKeyNamePattern,
@@ -145,7 +152,7 @@ export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccess
         Validators.composeAsync(this.asyncKeyValidators)
       ],
       value: [
-        {value, disabled: false}, Validators.compose([
+        {value, disabled: this._isInherited(key)}, Validators.compose([
           LabelFormValidators.labelValueLength,
           LabelFormValidators.labelValuePattern,
         ])

--- a/src/app/shared/entity/ClusterEntity.ts
+++ b/src/app/shared/entity/ClusterEntity.ts
@@ -35,6 +35,7 @@ export class ClusterEntity {
   status?: Status;
   type: string;
   labels?: object;
+  inheritedLabels?: object;
   credential?: string;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables option to edit inherited labels on cluster level.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1731

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Blocked option to edit cluster labels inherited from the project.
```
