### PR TITLE
Update Open Dashboard button to work for viewer

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -41,7 +41,7 @@
          [href]="getProxyURL()"
          target="_blank"
          mat-flat-button
-         [disabled]="!isClusterRunning || !isEditEnabled()">
+         [disabled]="!isClusterRunning || (!isEditEnabled() && isOpenshiftCluster())">
         {{getConnectName()}}
       </a>
     </div>

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -255,6 +255,10 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     return !this._currentGroupConfig || this._currentGroupConfig.clusters.edit;
   }
 
+  isOpenshiftCluster(): boolean {
+    return this.cluster.type === ClusterType.OpenShift;
+  }
+
   editCluster(): void {
     const modal = this._matDialog.open(EditClusterComponent);
     modal.componentInstance.cluster = this.cluster;


### PR DESCRIPTION
**What this PR does / why we need it**:
`Open Dashboard` button now allows connecting to Kubernetes Dashboard as a viewer also.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
