### PR TITLE
Handle enableDashboard setting and fix node name validation

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -41,7 +41,8 @@
          [href]="getProxyURL()"
          target="_blank"
          mat-flat-button
-         [disabled]="!isClusterRunning || (!isEditEnabled() && isOpenshiftCluster())">
+         [disabled]="!isClusterRunning || (!isEditEnabled() && isOpenshiftCluster())"
+         *ngIf="(settings.adminSettings | async).enableDashboard">
         {{getConnectName()}}
       </a>
     </div>

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -6,6 +6,7 @@ import {first, switchMap, takeUntil} from 'rxjs/operators';
 
 import {AppConfigService} from '../../app-config.service';
 import {ApiService, ClusterService, DatacenterService, RBACService, UserService} from '../../core/services';
+import {SettingsService} from '../../core/services/settings/settings.service';
 import {NotificationActions} from '../../redux/actions/notification.actions';
 import {AddonEntity} from '../../shared/entity/AddonEntity';
 import {ClusterEntity, getClusterProvider, MasterVersion} from '../../shared/entity/ClusterEntity';
@@ -61,7 +62,8 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
       private readonly _clusterService: ClusterService, private readonly _matDialog: MatDialog,
       private readonly _datacenterService: DatacenterService, private readonly _appConfigService: AppConfigService,
       private readonly _node: NodeService, private readonly _userService: UserService,
-      private readonly _api: ApiService, private readonly _rbacService: RBACService) {}
+      private readonly _api: ApiService, private readonly _rbacService: RBACService,
+      readonly settings: SettingsService) {}
 
   ngOnInit(): void {
     this.config = this._appConfigService.getConfig();

--- a/src/app/core/services/settings/settings.service.ts
+++ b/src/app/core/services/settings/settings.service.ts
@@ -25,6 +25,8 @@ const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
   displayAPIDocs: true,
   displayDemoInfo: false,
   displayTermsOfService: false,
+  enableDashboard: true,
+  enableOIDCKubeconfig: false,
 };
 
 @Injectable()

--- a/src/app/node-data/node-data.component.ts
+++ b/src/app/node-data/node-data.component.ts
@@ -86,6 +86,8 @@ export class NodeDataComponent implements OnInit, OnDestroy {
       this.addNodeService.changeNodeData(this.getAddNodeData());
       this.addNodeService.changeNodeOperatingSystemData(this.getOSSpec());
       this.valid.emit(this.form.valid);
+      this.providerData.valid = this.form.valid;
+      this.addNodeService.changeNodeProviderData(this.providerData);
     });
 
     this.operatingSystemForm.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {

--- a/src/app/settings/admin/admin-settings.component.html
+++ b/src/app/settings/admin/admin-settings.component.html
@@ -52,7 +52,7 @@
       <div fxLayout="row">
         <div class="km-admin-settings-label">
           <span>Cleanup on Cluster Deletion</span>
-          <div class="km-icon-icon"
+          <div class="km-icon-info"
                matTooltip="Set &quot;clean up connected load balancers&quot; and &quot;clean up connected volumes (PVs and PVCS)&quot; checkboxes on Cluster Deletion to enabled by default. Enable &quot;Enforce&quot; to make users unable to edit the checkboxes."></div>
         </div>
         <mat-checkbox [(ngModel)]="settings.cleanupOptions.Enabled"
@@ -92,7 +92,6 @@
            class="km-admin-settings-nd-container">
         <div class="km-admin-settings-label">Node Deployment</div>
         <mat-form-field class="km-admin-settings-field-nd">
-          <mat-label>Initial Node Deployment Replicas</mat-label>
           <input matInput
                  type="number"
                  min="0"
@@ -102,6 +101,17 @@
                  (change)="onSettingsChange()">
         </mat-form-field>
         <km-settings-status [isSaved]="isEqual(settings.defaultNodeCount, apiSettings.defaultNodeCount)"></km-settings-status>
+      </div>
+
+      <div fxLayout="row">
+        <div class="km-admin-settings-label">
+          <span>Enable Kubernetes Dashboard</span>
+          <div class="km-icon-info"
+               matTooltip="Show/Hide &quot;Open Dashboard&quot; button on cluster details and allow/block Kubernetes Dashboard access through the API."></div>
+        </div>
+        <mat-checkbox [(ngModel)]="settings.enableDashboard"
+                      (change)="onSettingsChange()"></mat-checkbox>
+        <km-settings-status [isSaved]="isEqual(settings.enableDashboard, apiSettings.enableDashboard)"></km-settings-status>
       </div>
     </div>
   </mat-card-content>

--- a/src/app/shared/entity/AdminSettings.ts
+++ b/src/app/shared/entity/AdminSettings.ts
@@ -8,6 +8,8 @@ export class AdminSettings {
   displayAPIDocs: boolean;
   displayDemoInfo: boolean;
   displayTermsOfService: boolean;
+  enableDashboard: boolean;
+  enableOIDCKubeconfig: boolean;
 }
 
 export class CleanupOptions {

--- a/src/app/testing/services/settings-mock.service.ts
+++ b/src/app/testing/services/settings-mock.service.ts
@@ -20,6 +20,8 @@ export const DEFAULT_ADMIN_SETTINGS_MOCK: AdminSettings = {
   displayAPIDocs: true,
   displayDemoInfo: false,
   displayTermsOfService: false,
+  enableDashboard: true,
+  enableOIDCKubeconfig: false,
 };
 
 @Injectable()


### PR DESCRIPTION
**What this PR does / why we need it**:
Added new `Enable Kubernetes Dashboard` setting to the admin panel that shows/hides `Open Dashboard` button and handles access to it through the API.

Also fixed the issue in wizard that allowed to go to the next step when invalid node name was provided.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1821

![Zrzut ekranu z 2019-12-18 10-02-22](https://user-images.githubusercontent.com/2285385/71071793-89845080-217d-11ea-825c-a60b37e541f5.png)


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
