### PR TITLE
Update e2e test config for new e2e-Dex in Kubermatic

### DIFF
--- a/cypress/pages/dex.po.ts
+++ b/cypress/pages/dex.po.ts
@@ -1,8 +1,4 @@
 export class DexPage {
-  static getLoginWithEmailBtn(): Cypress.Chainable<any> {
-    return cy.get('a').contains('Log in with Email');
-  }
-
   static getLoginInput(): Cypress.Chainable<any> {
     return cy.get('input#login');
   }

--- a/cypress/utils/auth.ts
+++ b/cypress/utils/auth.ts
@@ -5,10 +5,11 @@ import {ProjectsPage} from "../pages/projects.po";
 
 export function login(email: string, password: string): void {
   LoginPage.visit();
-
   LoginPage.getLoginBtn().click();
 
-  DexPage.getLoginWithEmailBtn().click();
+  // The Dex created for e2e tests has only one connector (static passwords),
+  // so there is no need to click on a "Log-in via e-Mail" button, as opposed to
+  // dev/cloud.
 
   DexPage.getLoginInput().type(email).should(Condition.HaveValue, email);
   DexPage.getPasswordInput().type(password).should(Condition.HaveValue, password);

--- a/hack/e2e/ci-e2e.sh
+++ b/hack/e2e/ci-e2e.sh
@@ -23,5 +23,4 @@ source ${GOPATH}/src/github.com/kubermatic/kubermatic/api/hack/ci/ci-setup-kuber
 echodate "Applying user"
 retry 2 kubectl apply -f $(dirname $0)/fixtures/user.yaml
 
-npm run versioninfo
 WAIT_ON_TIMEOUT=600000 npm run e2e:local

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-SNAPSHOT",
   "description": "Kubermatic",
   "repository": "https://github.com/kubermatic/dashboard-v2",
-  "license": "propietary",
+  "license": "proprietary",
   "angular-cli": {},
   "scripts": {
     "start": "npm run versioninfo && ng serve --hmr",

--- a/src/app/core/services/auth/auth.service.ts
+++ b/src/app/core/services/auth/auth.service.ts
@@ -31,20 +31,20 @@ export class Auth {
   }
 
   getOIDCProviderURL(): string {
-    const baseUrl = this._appConfigService.getConfig().oidc_provider_url ?
-        this._appConfigService.getConfig().oidc_provider_url :
-        environment.oidcProviderUrl;
+    const config = this._appConfigService.getConfig();
+    const baseUrl = config.oidc_provider_url ? config.oidc_provider_url : environment.oidcProviderUrl;
+    const connectorId = config.oidc_connector_id ? config.oidc_connector_id : environment.oidcConnectorId;
+    const scope = config.oidc_provider_scope ? config.oidc_provider_scope : this._defaultScope;
+    const clientId = config.oidc_provider_client_id ? config.oidc_provider_client_id : this._clientId;
 
-    const scope = this._appConfigService.getConfig().oidc_provider_scope ?
-        this._appConfigService.getConfig().oidc_provider_scope :
-        this._defaultScope;
-
-    const clientId = this._appConfigService.getConfig().oidc_provider_client_id ?
-        this._appConfigService.getConfig().oidc_provider_client_id :
-        this._clientId;
-
-    return `${baseUrl}?response_type=${this._responseType}&client_id=${clientId}` +
+    let url = `${baseUrl}?response_type=${this._responseType}&client_id=${clientId}` +
         `&redirect_uri=${this._redirectUri}&scope=${scope}&nonce=${this._nonce}`;
+
+    if (connectorId) {
+      url += `&connector_id=${connectorId}`;
+    }
+
+    return url;
   }
 
   getBearerToken(): string {

--- a/src/app/pages/frontpage/frontpage.component.ts
+++ b/src/app/pages/frontpage/frontpage.component.ts
@@ -25,7 +25,7 @@ export class FrontpageComponent implements OnInit {
       this._router.navigate(['/projects']);
     }
 
-    const nonceRegExp = /&nonce=(.*)$/;
+    const nonceRegExp = /[\?&#]nonce=([^&]+)/;
     const nonceStr = nonceRegExp.exec(this._auth.getOIDCProviderURL());
     if (!!nonceStr && nonceStr.length >= 2 && !!nonceStr[1]) {
       this._cookieService.set(Auth.Cookie.Nonce, nonceStr[1], null, '/', null, true);

--- a/src/app/shared/model/Config.ts
+++ b/src/app/shared/model/Config.ts
@@ -6,6 +6,7 @@ export interface Config {
   oidc_provider_url?: string;
   oidc_provider_scope?: string;
   oidc_provider_client_id?: string;
+  oidc_connector_id?: string;
 }
 
 export interface UserGroupConfig {

--- a/src/environments/environment.e2e.local.ts
+++ b/src/environments/environment.e2e.local.ts
@@ -8,6 +8,7 @@ export const environment = {
   restRoot: 'api/v1',
   restRootV3: 'api/v3',
   digitalOceanRestRoot: 'https://api.digitalocean.com/v2',
-  oidcProviderUrl: 'http://dex.oauth:5556/auth',
+  oidcProviderUrl: 'http://dex.oauth:5556/dex/auth',
+  oidcConnectorId: 'local',
   animations: false,
 };

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -9,5 +9,6 @@ export const environment = {
   restRootV3: 'api/v3',
   digitalOceanRestRoot: 'https://api.digitalocean.com/v2',
   oidcProviderUrl: 'https://dev.kubermatic.io/dex/auth',
+  oidcConnectorId: 'local',
   animations: false,
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -9,5 +9,6 @@ export const environment = {
   restRootV3: '/api/v3',
   digitalOceanRestRoot: 'https://api.digitalocean.com/v2',
   oidcProviderUrl: window.location.protocol + '//' + window.location.host + '/dex/auth',
+  oidcConnectorId: null,
   animations: true,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,5 +14,6 @@ export const environment = {
   restRootV3: 'api/v3',
   digitalOceanRestRoot: 'https://api.digitalocean.com/v2',
   oidcProviderUrl: 'https://dev.kubermatic.io/dex/auth',
+  oidcConnectorId: null,
   animations: true,
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubermatic/kubermatic/pull/4886 there have been some major updates to how Dex is deployed during e2e tests. Thankfully only a minimal set of adjustments is needed to make the e2e tests here work again.

This PR will not build successfully until the PR mentioned above is merged.

**Release note**:
```release-note
NONE
```
