### PR TITLE
fix project owner field in cards

### DIFF
--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -214,7 +214,7 @@ export class ProjectComponent implements OnInit, OnDestroy {
   }
 
   getName(name: string): string {
-    return name.length > 19 ? `${name.substring(0, 19)}...` : `${name}`;
+    return name.length > 19 ? `${name.substring(0, 15)}...` : `${name}`;
   }
 
   getProjectTooltip(name: string): string {

--- a/src/app/shared/components/short-name-in-circle/short-name-in-circle.component.ts
+++ b/src/app/shared/components/short-name-in-circle/short-name-in-circle.component.ts
@@ -31,10 +31,11 @@ export class ShortNameInCircleComponent implements OnInit, OnChanges {
 
   private _updateLabelKeys(): void {
     this.shortNames = [];
+
     for (const owner in this.owners) {
       if (this.owners.hasOwnProperty(owner)) {
         const capitalLetters = this.owners[owner].name.match(/\b(\w)/g);
-        const short = capitalLetters.join('').toUpperCase();
+        const short = capitalLetters.slice(0, 3).join('').toUpperCase();
         this.shortNames.push(short);
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix project owner field in cards, meaning: 
- cut names that are longer than 19 chars
- only display the first three letters of a name, if short-name-in-circle is used, as more letters will flow out of the circle. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1865

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
