### PR TITLE
Display azure node sizes in size dropdown

### DIFF
--- a/src/app/node-data/azure-node-data/azure-node-data.component.html
+++ b/src/app/node-data/azure-node-data/azure-node-data.component.html
@@ -12,7 +12,7 @@
       <mat-autocomplete #autoSizes="matAutocomplete">
         <mat-option *ngFor="let size of filteredSizes"
                     [value]="size.name">
-          {{size.name}}
+          {{size.name}} ({{size.numberOfCores}} vCPU, {{size.memoryInMB}} MB RAM)
         </mat-option>
       </mat-autocomplete>
       <mat-error *ngIf="form.controls.size.hasError('mustBeInList') && !form.controls.size.hasError('required')">Input doesn't match options. Please choose from given options.</mat-error>


### PR DESCRIPTION
**What this PR does / why we need it**:

Display azure node sizes in size dropdown when creating/updating a node deployment. This is similar to AWS and OpenStack.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Display azure node sizes in size dropdown when creating/updating a node deployment
```
