### PR TITLE
Fix node name regex and form validation

### DIFF
--- a/src/app/node-data/node-data.component.ts
+++ b/src/app/node-data/node-data.component.ts
@@ -61,7 +61,7 @@ export class NodeDataComponent implements OnInit, OnDestroy {
           Validators.required),
       name: new FormControl(
           {value: this.nodeData.name, disabled: this.isNameDisabled},
-          [Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]),
+          [Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]),
     });
 
     if (!this.isInWizard) {
@@ -95,8 +95,10 @@ export class NodeDataComponent implements OnInit, OnDestroy {
       this.addNodeService.changeNodeData(this.getAddNodeData());
       this.addNodeService.changeNodeOperatingSystemData(this.getOSSpec());
       this.valid.emit(this.form.valid);
+      this.nodeData.valid = this.form.valid;
       this.providerData.valid = this.form.valid;
       this.addNodeService.changeNodeProviderData(this.providerData);
+      this.addNodeService.changeNodeData(this.getAddNodeData());
     });
 
     this.operatingSystemForm.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(() => {
@@ -106,6 +108,7 @@ export class NodeDataComponent implements OnInit, OnDestroy {
 
     this.addNodeService.nodeProviderDataChanges$.pipe(takeUntil(this._unsubscribe)).subscribe((data) => {
       this.providerData = data;
+      this.providerData.valid = this.providerData.valid && this.form.valid;
       this.addNodeService.changeNodeData(this.getAddNodeData());
     });
 

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
@@ -38,7 +38,7 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
           [
             Validators.required,
             Validators.minLength(5),
-            Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),
+            Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),
           ]),
       version: new FormControl(this.cluster.spec.version),
       type: new FormControl(this.cluster.type),


### PR DESCRIPTION
**What this PR does / why we need it**:
There were actually 2 issues:
- Node name validation regex was incorrectly copied from Kubernetes (https://github.com/kubermatic/dashboard-v2/pull/1783). JS/TS requires additional backslash to make it work the same as in i.e. Go. That is why words separated with space were accepted. I recommend using some IDE (IntelliJ) while copying those. They tend to fix it automatically during pasting.
- Form validation status was always overriden to true by the component that downloads sizes. Now it should correctly take node data form status into account.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1821

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
