### PR TITLE
Fixed documentation link

### DIFF
--- a/src/app/cluster/cluster-details/share-kubeconfig/share-kubeconfig.component.html
+++ b/src/app/cluster/cluster-details/share-kubeconfig/share-kubeconfig.component.html
@@ -6,7 +6,7 @@
       They can use it to authenticate with an OIDC provider and then generate a kubeconfig.
     </p>
     <p>
-      Please <a href="https://docs.kubermatic.io/advanced/oidc_auth"
+      Please <a href="https://docs.loodse.com/kubermatic/master/advanced/oidc_auth/"
          target="_blank"
          rel="noopener">visit our documentation</a>
       for more details.


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a link to the documentation.

```release-note
NONE
```
