### PR TITLE
Hide Operation Systems on VSphere if no template is available

### DIFF
--- a/src/app/node-data/node-data.component.html
+++ b/src/app/node-data/node-data.component.html
@@ -111,16 +111,17 @@
   <mat-button-toggle-group group="operatingSystemGroup"
                            formControlName="operatingSystem">
     <mat-button-toggle value="ubuntu"
-                       *ngIf="!isClusterOpenshift()">
+                       *ngIf="!isClusterOpenshift() && isAvailable('ubuntu')">
       <i class="km-os-image-ubuntu"></i>
       Ubuntu
     </mat-button-toggle>
-    <mat-button-toggle value="centos">
+    <mat-button-toggle value="centos"
+                       *ngIf="isAvailable('centos')">
       <i class="km-os-image-centos"></i>
       CentOS
     </mat-button-toggle>
     <mat-button-toggle value="containerLinux"
-                       *ngIf="!cluster.spec.cloud.hetzner && !isClusterOpenshift()">
+                       *ngIf="!cluster.spec.cloud.hetzner && !isClusterOpenshift() && isAvailable('coreos')">
       <i class="km-os-image-container-linux"></i>
       Container Linux
     </mat-button-toggle>


### PR DESCRIPTION
**What this PR does / why we need it**:
Hide Operation Systems on VSphere if no template is available

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1692

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Hide Operation Systems on VSphere for which no template is specified in datacenter file.
```
