### PR TITLE
Remove trailing slash from WebSocket host

### DIFF
--- a/src/app/core/services/settings/settings.service.ts
+++ b/src/app/core/services/settings/settings.service.ts
@@ -38,7 +38,8 @@ const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
 export class SettingsService {
   private readonly restRoot = environment.restRoot;
   private readonly wsProtocol = window.location.protocol.replace('http', 'ws');
-  private readonly wsRoot = `${this.wsProtocol}//${window.location.host}/${this.restRoot}/ws`;
+  private readonly wsHost = window.location.host.replace(/\/+$/, '');
+  private readonly wsRoot = `${this.wsProtocol}//${this.wsHost}/${this.restRoot}/ws`;
   private _userSettings$: Observable<UserSettings>;
   private _userSettingsRefresh$ = new Subject();
   private readonly _adminSettings$ = new BehaviorSubject(DEFAULT_ADMIN_SETTINGS);


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: It fixes issue existing on dev right now: `WebSocket connection to 'wss://dev.kubermatic.io//api/v1/ws/admin/settings' failed: Error during WebSocket handshake: Unexpected response code: 301`. The host part has its own trailing slash which may cause conflicts.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
