### PR TITLE
Fix WebSocket root path

### DIFF
--- a/src/app/core/services/settings/settings.service.ts
+++ b/src/app/core/services/settings/settings.service.ts
@@ -37,9 +37,7 @@ const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
 })
 export class SettingsService {
   private readonly restRoot = environment.restRoot;
-  private readonly wsProtocol = window.location.protocol.replace('http', 'ws');
-  private readonly wsHost = window.location.host.replace(/\/+$/, '');
-  private readonly wsRoot = `${this.wsProtocol}//${this.wsHost}/${this.restRoot}/ws`;
+  private readonly wsRoot = environment.wsRoot;
   private _userSettings$: Observable<UserSettings>;
   private _userSettingsRefresh$ = new Subject();
   private readonly _adminSettings$ = new BehaviorSubject(DEFAULT_ADMIN_SETTINGS);

--- a/src/environments/environment.e2e.local.ts
+++ b/src/environments/environment.e2e.local.ts
@@ -1,3 +1,7 @@
+const host = window.location.host.replace(/\/+$/, '');
+const protocol = window.location.protocol;
+const wsProtocol = protocol.replace('http', 'ws');
+
 export const environment = {
   name: 'dev',
   production: false,
@@ -6,6 +10,7 @@ export const environment = {
   customCSS: '../../assets/custom/style.css',
   refreshTimeBase: 1000,  // Unit: ms
   restRoot: 'api/v1',
+  wsRoot: `${wsProtocol}//${host}/api/v1/ws`,
   oidcProviderUrl: 'http://dex.oauth:5556/dex/auth',
   oidcConnectorId: 'local',
   animations: false,

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -1,3 +1,7 @@
+const host = window.location.host.replace(/\/+$/, '');
+const protocol = window.location.protocol;
+const wsProtocol = protocol.replace('http', 'ws');
+
 export const environment = {
   name: 'dev',
   production: false,
@@ -6,6 +10,7 @@ export const environment = {
   customCSS: '../../assets/custom/style.css',
   refreshTimeBase: 1000,  // Unit: ms
   restRoot: 'api/v1',
+  wsRoot: `${wsProtocol}//${host}/api/v1/ws`,
   oidcProviderUrl: 'https://dev.kubermatic.io/dex/auth',
   oidcConnectorId: 'local',
   animations: false,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,7 @@
+const host = window.location.host.replace(/\/+$/, '');
+const protocol = window.location.protocol;
+const wsProtocol = protocol.replace('http', 'ws');
+
 export const environment = {
   name: 'prod',
   production: true,
@@ -6,7 +10,8 @@ export const environment = {
   customCSS: '../assets/custom/style.css',
   refreshTimeBase: 1000,  // Unit: ms
   restRoot: '/api/v1',
-  oidcProviderUrl: window.location.protocol + '//' + window.location.host + '/dex/auth',
+  wsRoot: `${wsProtocol}//${host}/api/v1/ws`,
+  oidcProviderUrl: `${protocol}//${host}/dex/auth`,
   oidcConnectorId: null,
   animations: true,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,6 +3,10 @@
 // 'ng build --env=prod' then 'environment.prod.ts' will be used instead.
 // The list of which env maps to which file can be found in 'angular-cli.json'.
 
+const host = window.location.host.replace(/\/+$/, '');
+const protocol = window.location.protocol;
+const wsProtocol = protocol.replace('http', 'ws');
+
 export const environment = {
   name: 'dev',
   production: false,
@@ -11,6 +15,7 @@ export const environment = {
   customCSS: '../../assets/custom/style.css',
   refreshTimeBase: 1000,  // Unit: ms
   restRoot: 'api/v1',
+  wsRoot: `${wsProtocol}//${host}/api/v1/ws`,
   oidcProviderUrl: 'https://dev.kubermatic.io/dex/auth',
   oidcConnectorId: null,
   animations: true,


### PR DESCRIPTION
**What this PR does / why we need it**: Production environment file contains additional `/` that was used in WebSocket root path. This breaks the path and prevents Websockets from working as expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard-v2/issues/2029

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
