### PR TITLE
Use SameSite=Lax

### DIFF
--- a/src/app/core/services/auth/auth.service.ts
+++ b/src/app/core/services/auth/auth.service.ts
@@ -24,11 +24,11 @@ export class Auth {
       if (this.compareNonceWithToken(token, nonce)) {
         // remove URL fragment with token, so that users can't accidentally copy&paste it and send it to others
         this.removeFragment();
-        this._cookieService.set(Auth.Cookie.Token, token, 1, '/', null, true, 'Strict');
+        this._cookieService.set(Auth.Cookie.Token, token, 1, '/', null, true, 'Lax');
         // localhost is only served via http, though secure cookie is not possible
         // following line will only work when domain is localhost
-        this._cookieService.set(Auth.Cookie.Token, token, 1, '/', 'localhost', false, 'Strict');
-        this._cookieService.set(Auth.Cookie.Token, token, 1, '/', '127.0.0.1', false, 'Strict');
+        this._cookieService.set(Auth.Cookie.Token, token, 1, '/', 'localhost', false, 'Lax');
+        this._cookieService.set(Auth.Cookie.Token, token, 1, '/', '127.0.0.1', false, 'Lax');
       }
       this._previousRouteService.loadRouting();
     }

--- a/src/app/pages/frontpage/frontpage.component.ts
+++ b/src/app/pages/frontpage/frontpage.component.ts
@@ -28,11 +28,11 @@ export class FrontpageComponent implements OnInit {
     const nonceRegExp = /[\?&#]nonce=([^&]+)/;
     const nonceStr = nonceRegExp.exec(this._auth.getOIDCProviderURL());
     if (!!nonceStr && nonceStr.length >= 2 && !!nonceStr[1]) {
-      this._cookieService.set(Auth.Cookie.Nonce, nonceStr[1], null, '/', null, true, 'Strict');
+      this._cookieService.set(Auth.Cookie.Nonce, nonceStr[1], null, '/', null, true, 'Lax');
       // localhost is only served via http, though secure cookie is not possible
       // following line will only work when domain is localhost
-      this._cookieService.set(Auth.Cookie.Nonce, nonceStr[1], null, '/', 'localhost', false, 'Strict');
-      this._cookieService.set(Auth.Cookie.Nonce, nonceStr[1], null, '/', '127.0.0.1', false, 'Strict');
+      this._cookieService.set(Auth.Cookie.Nonce, nonceStr[1], null, '/', 'localhost', false, 'Lax');
+      this._cookieService.set(Auth.Cookie.Nonce, nonceStr[1], null, '/', '127.0.0.1', false, 'Lax');
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `SameSite=Lax` instead of `SameSite=Strict`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Use `SameSite=Lax`
```
