### PR TITLE
Add support for enable OIDC kubeconfig admin setting

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -15,7 +15,7 @@
               class="km-share-kubeconfig-btn"
               (click)="shareConfigDialog()"
               [disabled]="!isClusterRunning"
-              *ngIf="!!config.share_kubeconfig"
+              *ngIf="isShareConfigEnabled() | async"
               matTooltip="Share">
         <i class="km-icon-mask km-icon-share"></i>
       </button>
@@ -23,7 +23,7 @@
               mat-icon-button
               [disabled]="!isClusterRunning"
               matTooltip="Download config">
-        <a href="{{getDownloadURL()}}"
+        <a href="{{getDownloadURL() | async}}"
            target="_blank"
            rel="noopener">
           <i class="km-icon-mask km-icon-download"></i>

--- a/src/app/settings/admin/admin-settings.component.html
+++ b/src/app/settings/admin/admin-settings.component.html
@@ -113,6 +113,17 @@
                       (change)="onSettingsChange()"></mat-checkbox>
         <km-settings-status [isSaved]="isEqual(settings.enableDashboard, apiSettings.enableDashboard)"></km-settings-status>
       </div>
+
+      <div fxLayout="row">
+        <div class="km-admin-settings-label">
+          <span>Enable OIDC Kubeconfig</span>
+          <div class="km-icon-info"
+               matTooltip="Use OIDC provider as a proxy for kubeconfig download."></div>
+        </div>
+        <mat-checkbox [(ngModel)]="settings.enableOIDCKubeconfig"
+                      (change)="onSettingsChange()"></mat-checkbox>
+        <km-settings-status [isSaved]="isEqual(settings.enableOIDCKubeconfig, apiSettings.enableOIDCKubeconfig)"></km-settings-status>
+      </div>
     </div>
   </mat-card-content>
 </mat-card>


### PR DESCRIPTION
**What this PR does / why we need it**:
Added new field to the admin settings to enable/disable OIDC kubeconfig and updated share/download kubeconfig buttons logic on the cluster details as required.

**Which issue(s) this PR fixes**:
Fixes #2075 
Fixes #2074

**Special notes for your reviewer**:
Please check if the tooltip for new field in the admin settings is correct.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add the option to use an OIDC provider for the kubeconfig download.
```
