### PR TITLE
Fix settings update notification

### DIFF
--- a/src/app/settings/admin/admin-settings.component.ts
+++ b/src/app/settings/admin/admin-settings.component.ts
@@ -65,9 +65,12 @@ export class AdminSettingsComponent implements OnInit, OnChanges, OnDestroy {
       }
     });
 
-    this._settingsChange.pipe(debounceTime(500))
-        .pipe(takeUntil(this._unsubscribe))
-        .pipe(switchMap(() => this._settingsService.patchAdminSettings(this._getPatch())))
+    this._settingsChange
+        .pipe(
+            debounceTime(500),
+            switchMap(() => this._settingsService.patchAdminSettings(this._getPatch())),
+            takeUntil(this._unsubscribe),
+            )
         .subscribe(_ => {});
 
     this._settingsService.userSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes https://github.com/kubermatic/dashboard-v2/issues/2039

**Special notes for your reviewer**: Right now we have a race condition between patch response and the update that is coming from WebSocket. If WebSocket's response is first then we can see the external update notification. This change simplifies the process of patching the settings and makes sure that we display the updated notification on each change (excluding initial response).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
