### PR TITLE
update custom-dashboard image for Angular 9 compatibility

### DIFF
--- a/containers/custom-dashboard/Dockerfile
+++ b/containers/custom-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubermatic/go-node:1.12.9-11
+FROM quay.io/kubermatic/go-node:1.12.9-12
 
 LABEL maintainer="sebastian@loodse.com"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Using the custom-dashboard image does not work because the dependencies in it are not compatible with the currently used Angular version. This PR simply bumps the base image to fix that.

**Release note**:
```release-note
NONE
```
