### PR TITLE
[release/2.13] Fix selection of cleanup options in cluster delete dialog

### DIFF
--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.ts
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/cluster-delete-confirmation.component.ts
@@ -40,8 +40,12 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck, OnDe
 
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       this.settings = settings;
-      this.deleteForm.controls.clusterLBCleanupCheckbox.setValue(this.settings.cleanupOptions.Enabled);
-      this.deleteForm.controls.clusterVolumeCleanupCheckbox.setValue(this.settings.cleanupOptions.Enabled);
+      if (this.deleteForm.controls.clusterLBCleanupCheckbox.pristine) {
+        this.deleteForm.controls.clusterLBCleanupCheckbox.setValue(this.settings.cleanupOptions.Enabled);
+      }
+      if (this.deleteForm.controls.clusterVolumeCleanupCheckbox.pristine) {
+        this.deleteForm.controls.clusterVolumeCleanupCheckbox.setValue(this.settings.cleanupOptions.Enabled);
+      }
       if (this.settings.cleanupOptions.Enforced) {
         this.deleteForm.controls.clusterLBCleanupCheckbox.disable();
         this.deleteForm.controls.clusterVolumeCleanupCheckbox.disable();


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix selection of cleanup options in cluster delete dialog in release 2.13. as the fields automatically were resetted to the default admin setting.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix selection of cleanup options in cluster delete dialog
```
