### PR TITLE
Deactivate delete cluster button in cluster list for viewers

### DIFF
--- a/src/app/cluster/cluster-list/cluster-list.component.html
+++ b/src/app/cluster/cluster-list/cluster-list.component.html
@@ -115,7 +115,7 @@
                         [attr.id]="'km-delete-cluster-' + element.name"
                         matTooltip="Delete Cluster"
                         (click)="deleteClusterDialog(element, $event)"
-                        [disabled]="!!userGroup && !userGroupConfig[userGroup].clusters.delete">
+                        [disabled]="!!_currentGroupConfig && !_currentGroupConfig.clusters.delete">
                   <i class="km-icon-delete"></i>
                 </button>
               </ng-container>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the broken permission check for the "Delete Cluster" button in the cluster list for viewers.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
