### PR TITLE
Deactivate cluster upgrade dialog for viewers

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -94,7 +94,7 @@
         <km-version-picker [datacenter]="datacenter"
                            [cluster]="cluster"
                            [isClusterRunning]="isClusterAPIRunning"
-                           [upgrades]="upgrades"></km-version-picker>
+                           [upgrades]="isEditEnabled() ? upgrades : []"></km-version-picker>
 
         <km-property>
           <div key>Cluster ID</div>


### PR DESCRIPTION
Signed-off-by: Bastian Hofmann <b.hofmann@syseleven.de>

**What this PR does / why we need it**:
Deactivate cluster upgrade dialog for viewers. The API request won't work anyways for viewers.

**Special notes for your reviewer**:
Not sure, if there is a better way to easily deactivate that a viewer can open the update dialog. If yes, I will gladly change the PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
