### PR TITLE
Improve digitalocean size formatting

### DIFF
--- a/src/app/node-data-new/basic/provider/digitalocean/component.ts
+++ b/src/app/node-data-new/basic/provider/digitalocean/component.ts
@@ -2,8 +2,7 @@ import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import {Observable, of} from 'rxjs';
 import {catchError, takeUntil} from 'rxjs/operators';
-import {DigitaloceanSizes} from '../../../../shared/entity/provider/digitalocean/DropletSizeEntity';
-import {Type} from '../../../../shared/entity/provider/hetzner/TypeEntity';
+import {DigitaloceanSizes, Optimized, Standard} from '../../../../shared/entity/provider/digitalocean/DropletSizeEntity';
 import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
 import {NodeDataService} from '../../../service/service';
 
@@ -51,13 +50,20 @@ export class DigitalOceanBasicNodeDataComponent extends BaseFormValidator implem
     this._unsubscribe.complete();
   }
 
-  getTypes(group: SizeTypes): Type[] {
+  getTypes(group: SizeTypes): Optimized[]|Standard[] {
     const key = Object.keys(SizeTypes).find(key => SizeTypes[key] === group);
     return this.sizes[key.toLowerCase()];
   }
 
   onTypeChange(size: string): void {
     this._nodeDataService.nodeData.spec.cloud.digitalocean.size = size;
+  }
+
+  sizeDisplayName(slug: string): string {
+    const size = [...this.sizes.optimized, ...this.sizes.standard].find(size => size.slug === slug);
+    return size ? `${size.slug} (${size.memory / 1024} GB RAM, ${size.vcpus} CPU${(size.vcpus !== 1) ? 's' : ''}, $${
+                      size.price_monthly} per month)` :
+                  '';
   }
 
   private get _sizesObservable(): Observable<DigitaloceanSizes> {

--- a/src/app/node-data-new/basic/provider/digitalocean/template.html
+++ b/src/app/node-data-new/basic/provider/digitalocean/template.html
@@ -1,19 +1,19 @@
 <form [formGroup]="form"
       fxLayout="column"
       fxLayoutGap="16px">
-  <div fxFlex
-       class="mat-select-container">
-    <km-combobox [required]="true"
-                 [grouped]="true"
-                 [selected]="selectedSize"
-                 [groups]="sizeTypes"
-                 [optionsGetter]="getTypes.bind(this)"
-                 [formControlName]="Controls.Size"
-                 (changed)="onTypeChange($event)"
-                 label="Node Size"
-                 inputLabel="Select size..."
-                 filterBy="slug">
-      <div *option="let size">{{ size.memory / 1024 }} GB RAM, {{ size.vcpus }} CPU{{ (size.vcpus!=1) ? 's' : '' }}, ${{ size.price_monthly }} per month</div>
-    </km-combobox>
-  </div>
+  <km-combobox [required]="true"
+               [grouped]="true"
+               [selected]="selectedSize"
+               [valueFormatter]="sizeDisplayName.bind(this)"
+               [groups]="sizeTypes"
+               [optionsGetter]="getTypes.bind(this)"
+               [formControlName]="Controls.Size"
+               (changed)="onTypeChange($event)"
+               label="Node Size"
+               inputLabel="Select size..."
+               filterBy="slug">
+    <div *option="let size">
+      {{size.slug}} ({{ size.memory / 1024 }} GB RAM, {{ size.vcpus }} CPU{{ (size.vcpus != 1) ? 's' : '' }}, ${{ size.price_monthly }} per month)
+    </div>
+  </km-combobox>
 </form>

--- a/src/app/node-data/digitalocean-node-data/digitalocean-node-data.component.html
+++ b/src/app/node-data/digitalocean-node-data/digitalocean-node-data.component.html
@@ -14,14 +14,14 @@
                       label="Standard Droplets">
           <mat-option *ngFor="let size of filteredSizes.standard"
                       [value]="size.slug">
-            {{ size.memory / 1024 }} GB RAM, {{ size.vcpus }} CPU{{ (size.vcpus!=1) ? 's' : '' }}, ${{ size.price_monthly }} per month
+            {{size.slug}} ({{ size.memory / 1024 }} GB RAM, {{ size.vcpus }} CPU{{ (size.vcpus!=1) ? 's' : '' }}, ${{ size.price_monthly }} per month)
           </mat-option>
         </mat-optgroup>
         <mat-optgroup *ngIf="sizes.optimized.length > 0"
                       label="Optimized Droplets">
           <mat-option *ngFor="let size of filteredSizes.optimized"
                       [value]="size.slug">
-            {{ size.memory / 1024 }} GB RAM, {{ size.vcpus }} CPU{{ (size.vcpus!=1) ? 's' : '' }}, ${{ size.price_monthly }} per month
+            {{size.slug}} ({{ size.memory / 1024 }} GB RAM, {{ size.vcpus }} CPU{{ (size.vcpus!=1) ? 's' : '' }}, ${{ size.price_monthly }} per month)
           </mat-option>
         </mat-optgroup>
       </mat-autocomplete>

--- a/src/app/shared/components/combobox/component.ts
+++ b/src/app/shared/components/combobox/component.ts
@@ -1,6 +1,6 @@
 import {Component, ContentChild, ElementRef, EventEmitter, forwardRef, Input, OnChanges, OnDestroy, OnInit, Output, TemplateRef, ViewChild} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
-import {takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 import {BaseFormValidator} from '../../validators/base-form.validator';
 import {OptionDirective} from './directive';
 
@@ -28,6 +28,7 @@ export class FilteredComboboxComponent extends BaseFormValidator implements OnIn
   @Input('optionsGetter') getOptions: (group: string) => object[];
   @Input() selected: string;
   @Input() hint: string;
+  @Input() valueFormatter: (selected: string) => string;
 
   @Output() changed = new EventEmitter<string>();
 
@@ -48,7 +49,8 @@ export class FilteredComboboxComponent extends BaseFormValidator implements OnIn
     });
 
     this.form.get(Controls.Select)
-        .valueChanges.pipe(takeUntil(this._unsubscribe))
+        .valueChanges.pipe(distinctUntilChanged())
+        .pipe(takeUntil(this._unsubscribe))
         .subscribe(_ => this.changed.emit(this.form.get(Controls.Select).value));
   }
 

--- a/src/app/shared/components/combobox/template.html
+++ b/src/app/shared/components/combobox/template.html
@@ -37,7 +37,7 @@
                           fxLayout="row">
         <div fxFlex
              fxLayoutAlign="start">
-          {{ selected }}
+          {{ valueFormatter ? valueFormatter(selected) : selected }}
         </div>
 
         <div fxFlex


### PR DESCRIPTION
**What this PR does / why we need it**:
For the old wizard, it is tricky to update it properly, so I have only added slug names to the displayed autocomplete values. New wizard changes are easier to handle.

Old wizard change:
![Zrzut ekranu z 2020-04-07 14-40-01](https://user-images.githubusercontent.com/2285385/78672605-2f9cc780-78e1-11ea-8859-0bdd0e146cf6.png)

New wizard change:
![Zrzut ekranu z 2020-04-07 15-06-10](https://user-images.githubusercontent.com/2285385/78672752-5ce97580-78e1-11ea-8764-7ec08267d2b2.png)
![Zrzut ekranu z 2020-04-07 15-06-15](https://user-images.githubusercontent.com/2285385/78672759-5e1aa280-78e1-11ea-8185-c3fb28b42620.png)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2152

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
