### PR TITLE
Fix loading Openstack flavor in add/edit note data dialog

### DIFF
--- a/src/app/node-data/openstack-node-data/openstack-node-data.component.ts
+++ b/src/app/node-data/openstack-node-data/openstack-node-data.component.ts
@@ -221,7 +221,7 @@ export class OpenstackNodeDataComponent implements OnInit, OnDestroy {
   }
 
   private _loadFlavors(): void {
-    if (!this._hasCredentials() && !this._selectedPreset) {
+    if (this.isInWizard() && !this._hasCredentials() && !this._selectedPreset) {
       return;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On the cluster view when adding/editing node flavor were not loaded. As in the "dialog mode" we do not have any credentials nor presets, it just skipped loading them.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix loading Openstack flavors in add/edit node deployment dialog
```
