### PR TITLE
Fix node data dialog for vSphere clusters

### DIFF
--- a/src/app/node-data/node-data.component.ts
+++ b/src/app/node-data/node-data.component.ts
@@ -240,7 +240,8 @@ export class NodeDataComponent implements OnInit, OnDestroy {
 
   isAvailable(os: string): boolean {
     if (!!this.cluster.spec.cloud.vsphere) {
-      return !!this.seedDc && !!this.seedDc.spec.vsphere.templates[os] && this.seedDc.spec.vsphere.templates[os] !== '';
+      return !!this.seedDc && !!this.seedDc.spec && !!this.seedDc.spec.vsphere &&
+          !!this.seedDc.spec.vsphere.templates[os] && this.seedDc.spec.vsphere.templates[os] !== '';
     } else {
       return true;
     }


### PR DESCRIPTION
**What this PR does / why we need it**: The node data dialog doesn't load due to null pointer without it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: Fixes https://github.com/kubermatic/dashboard-v2/issues/2249.

**Special notes for your reviewer**: Null pointer is thrown because datacenters switch during the component lifetime. When it is loaded for the first time seed datacenter is used (i.e. `europe-west3-c`) and it doesn't contain the templates that are used in the component (that's why it rendering fails). Just after that the datacenter is loaded again but this time it's not seed datacenter but the one from the cluster specification (`this._dc.getDataCenter(this.cluster.spec.cloud.dc)`; i.e. `vsphere-hamburg`). This is an important issue that we have to address sooner than later. Overall, I can see that in few places seed datacenters are mixed with others.

cc @kgroschoff @floreks 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed node data dialog for vSphere clusters.
```
