### PR TITLE
Display creation time for clusters

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -140,6 +140,13 @@
           </div>
         </km-property>
 
+        <km-property>
+          <div key>Created</div>
+          <div value>
+            <km-relative-time [date]="cluster.creationTimestamp"></km-relative-time>
+          </div>
+        </km-property>
+
         <km-property *ngIf="cluster.labels">
           <div key>Labels</div>
           <div value>

--- a/src/app/cluster/cluster-list/cluster-list.component.html
+++ b/src/app/cluster/cluster-list/cluster-list.component.html
@@ -96,6 +96,16 @@
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="created">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell">Created</th>
+        <td mat-cell
+            *matCellDef="let element">
+          <km-relative-time [date]="element.creationTimestamp"></km-relative-time>
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="actions">
         <th mat-header-cell
             *matHeaderCellDef

--- a/src/app/cluster/cluster-list/cluster-list.component.ts
+++ b/src/app/cluster/cluster-list/cluster-list.component.ts
@@ -33,7 +33,7 @@ export class ClusterListComponent implements OnInit, OnChanges, OnDestroy {
   seedDC: DataCenterEntity[] = [];
   health: HealthEntity[] = [];
   provider = [];
-  displayedColumns: string[] = ['status', 'name', 'labels', 'provider', 'region', 'type', 'actions'];
+  displayedColumns: string[] = ['status', 'name', 'labels', 'provider', 'region', 'type', 'created', 'actions'];
   dataSource = new MatTableDataSource<ClusterEntity>();
   @ViewChild(MatSort, {static: true}) sort: MatSort;
   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard-v2/issues/2217

**Special notes for your reviewer**:
<img width="2001" alt="Zrzut ekranu 2020-05-4 o 11 59 33" src="https://user-images.githubusercontent.com/2823399/80955193-22e79280-8dff-11ea-9a90-ecd6f94343bb.png">
<img width="2001" alt="Zrzut ekranu 2020-05-4 o 11 59 25" src="https://user-images.githubusercontent.com/2823399/80955199-27ac4680-8dff-11ea-87bf-2fa0922d2dcc.png">

/cc @kgroschoff @cschieder 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Cluster creation time is now visible in the UI.
```
