### PR TITLE
[EE] Distinguish between CE/EE variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL=/bin/bash
-REPO=quay.io/kubermatic/dashboard
+KUBERMATIC_EDITION?=ce
+REPO=quay.io/kubermatic/dashboard$(shell [ "$(KUBERMATIC_EDITION)" != "ee" ] && echo "-$(KUBERMATIC_EDITION)" )
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')
 CC=npm
 export GOOS?=linux
@@ -40,7 +41,7 @@ dist: install
 	@$(CC) run build
 
 build:
-	CGO_ENABLED=0 go build -ldflags '-w -extldflags '-static'' -o dashboard .
+	CGO_ENABLED=0 go build -tags '$(KUBERMATIC_EDITION)' -ldflags '-w -extldflags '-static'' -o dashboard .
 
 docker-build: build dist
 	docker build -t $(REPO):$(IMAGE_TAG) .

--- a/containers/cypress/build-and-release.sh
+++ b/containers/cypress/build-and-release.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-IMG_REPO="quay.io/kubermatic"
-IMG_NAME="e2e-kind-cypress"
+IMG_REPO="quay.io/kubermatic/e2e-kind-cypress"
 IMG_VERSION="v1.1.1"
 
 # Preloaded images
@@ -12,7 +11,7 @@ IMG_KIND_NAME="kindest.tar"
 
 docker pull ${IMG_KIND}
 docker save -o ${IMG_KIND_NAME} ${IMG_KIND}
-docker build -t ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION} .
-docker push ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION}
+docker build -t ${IMG_REPO}:${IMG_VERSION} .
+docker push ${IMG_REPO}:${IMG_VERSION}
 
 rm ${IMG_KIND_NAME}

--- a/containers/e2e/build-and-release.sh
+++ b/containers/e2e/build-and-release.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-IMG_REPO="quay.io/kubermatic"
-IMG_NAME="e2e-kind"
+IMG_REPO="quay.io/kubermatic/e2e-kind"
 IMG_VERSION="v1.0.13"
 
 # Preloaded images
@@ -12,7 +11,7 @@ IMG_KIND_NAME="kindest.tar"
 
 docker pull ${IMG_KIND}
 docker save -o ${IMG_KIND_NAME} ${IMG_KIND}
-docker build -t ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION} .
-docker push ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION}
+docker build -t ${IMG_REPO}:${IMG_VERSION} .
+docker push ${IMG_REPO}:${IMG_VERSION}
 
 rm ${IMG_KIND_NAME}

--- a/containers/go-node/build-and-release.sh
+++ b/containers/go-node/build-and-release.sh
@@ -2,9 +2,8 @@
 
 set -e
 
-IMG_REPO="quay.io/kubermatic"
-IMG_NAME="go-node"
+IMG_REPO="quay.io/kubermatic/go-node"
 IMG_VERSION="1.12.9-12"
 
-docker build -t ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION} .
-docker push ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION}
+docker build -t ${IMG_REPO}:${IMG_VERSION} .
+docker push ${IMG_REPO}:${IMG_VERSION}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,8 @@ func main() {
 	rawLog, _ := config.Build()
 	log := rawLog.Sugar()
 
+	log.Infof("Kubermatic Dashboard %s", Edition)
+
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	mux.Handle("/", InstrumentHandler(http.HandlerFunc(handler)))

--- a/main_ce.go
+++ b/main_ce.go
@@ -1,0 +1,7 @@
+// +build !ee
+
+package main
+
+const (
+	Edition = "Community Edition"
+)

--- a/main_ee.go
+++ b/main_ee.go
@@ -1,0 +1,7 @@
+// +build ee
+
+package main
+
+const (
+	Edition = "Enterprise Edition"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
This introduces the same env variable we use in Kubermatic, `KUBEMATIC_EDITION`, to toggle between Community Edition (CE) and Enterprise Edition (EE). This has no effect yet, except for a friendly log line when the Go server starts up, and that Docker images for the CE are pushed to `quay.io/kubermatic/dashboard-ce`.

By default, running `make` will give you the CE version.

The postsubmit jobs have been updated to

* deploy the EE version to dev.
* push CE/EE versions for every tag in this repository.

So this PR would need to be merged together with https://github.com/kubermatic/infra/pull/1024.

This PR also contains a fix for a pet peeve of mine. `quay.io/kubermatic` is not a repository, it's an organization. `quay.io/kubermatic/dashboard` is a repository and `quay.io/kubermatic/dashboard:master` then denotes a single image in that repo.

**Release note**:
```release-note
NONE
```
