### PR TITLE
Add project name & cluster name to page title

### DIFF
--- a/src/app/core/services/params/params.service.ts
+++ b/src/app/core/services/params/params.service.ts
@@ -5,6 +5,8 @@ import {filter, switchMap} from 'rxjs/operators';
 
 export enum PathParam {
   ProjectID = 'projectID',
+  ClusterID = 'clusterName',
+  SeedDC = 'seedDc',
 }
 
 @Injectable()


### PR DESCRIPTION
**What this PR does / why we need it**:
Add project name & cluster name to page title. 
Each view will have the selected project name displayed in the title => `{project_name} - Kubermatic`. When opening the cluster detail view, the cluster name will also be added => `{cluster_name}/{project_name} - Kubermatic`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2062

**Special notes for your reviewer**:
Project "new", Cluster "elated-borg"
![page-title](https://user-images.githubusercontent.com/19547196/84275249-1c9cb280-ab31-11ea-9ce2-04d670cf4061.JPG)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
