### PR TITLE
Restructure Admission Plugins

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.html
+++ b/src/app/cluster/cluster-details/cluster-details.component.html
@@ -134,6 +134,13 @@
                              *ngIf="!!cluster.spec.usePodNodeSelectorAdmissionPlugin">
         </km-property-boolean>
 
+        <km-property *ngIf="cluster.spec.admissionPlugins">
+          <div key>Enabled Admission Plugins</div>
+          <div value>
+            {{getAdmissionPlugins()}}
+          </div>
+        </km-property>
+
         <km-property>
           <div value>
             <km-ssh-key-list [sshKeys]="sshKeys"></km-ssh-key-list>

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -27,6 +27,7 @@ import {Binding, ClusterBinding, SimpleBinding, SimpleClusterBinding} from '../.
 import {SSHKeyEntity} from '../../shared/entity/SSHKeyEntity';
 import {Config, GroupConfig} from '../../shared/model/Config';
 import {NodeProvider} from '../../shared/model/NodeProviderConstants';
+import {AdmissionPluginUtils} from '../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {ClusterHealthStatus} from '../../shared/utils/health-status/cluster-health-status';
 import {MemberUtils, Permission} from '../../shared/utils/member-utils/member-utils';
 import {NodeService} from '../services/node.service';
@@ -431,6 +432,6 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   getAdmissionPlugins(): string {
-    return this.cluster.spec.admissionPlugins.join(', ');
+    return AdmissionPluginUtils.getJoinedPluginNames(this.cluster.spec.admissionPlugins);
   }
 }

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -429,4 +429,8 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
       map(settings => !!this.config.share_kubeconfig && !settings.enableOIDCKubeconfig)
     );
   }
+
+  getAdmissionPlugins(): string {
+    return this.cluster.spec.admissionPlugins.join(', ');
+  }
 }

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
@@ -33,15 +33,15 @@
                       disableOptionCentering>
             <mat-option *ngFor="let admissionPlugin of admissionPlugins"
                         [value]="admissionPlugin"
-                        [disabled]="admissionPlugin === 'PodSecurityPolicy' && !!isPodSecurityPolicyEnforced()">
+                        [disabled]="admissionPlugin === admissionPlugin.PodSecurityPolicy && !!isPodSecurityPolicyEnforced()">
               {{getPluginName(admissionPlugin)}}
-              <i *ngIf="admissionPlugin === 'PodSecurityPolicy'"
+              <i *ngIf="admissionPlugin === admissionPlugin.PodSecurityPolicy"
                  class="km-icon-info"
                  matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
             </mat-option>
           </mat-select>
         </mat-form-field>
-        <span *ngIf="isPluginEnabled('PodSecurityPolicy')"
+        <span *ngIf="isPluginEnabled(admissionPlugin.PodSecurityPolicy)"
               class="km-admission-plugin-warning"
               fxLayout="row">
           <i class="km-icon-warning km-warning"></i>

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
@@ -22,6 +22,39 @@
           Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -).
         </mat-error>
       </mat-form-field>
+
+      <div fxFlex="100"
+           fxLayout="column">
+        <mat-form-field>
+          <mat-label>Admission Plugins</mat-label>
+          <mat-select formControlName="admissionPlugins"
+                      multiple
+                      panelClass="km-multiple-values-dropdown"
+                      disableOptionCentering>
+            <mat-option *ngFor="let admissionPlugin of admissionPlugins"
+                        [value]="admissionPlugin"
+                        [disabled]="admissionPlugin === 'PodSecurityPolicy' && !!isPodSecurityPolicyEnforced()">
+              {{getPluginName(admissionPlugin)}}
+              <i *ngIf="admissionPlugin === 'PodSecurityPolicy'"
+                 class="km-icon-info"
+                 matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <span *ngIf="isPluginEnabled('PodSecurityPolicy')"
+              class="km-admission-plugin-warning"
+              fxLayout="row">
+          <i class="km-icon-warning km-warning"></i>
+          <p fxFlex="95">Activating Pod Security Policy will mean that a lot of Pod specifications, Operators and Helm charts will not work out of the box. Make sure that you know the consequences of activating this feature.</p>
+        </span>
+        <span *ngIf="isPodSecurityPolicyEnforced()"
+              class="km-admission-plugin-warning"
+              fxLayout="row">
+          <i class="km-icon-info"></i>
+          <p fxFlex="95">Pod Security Policy is enforced by your admin in the chosen datacenter.</p>
+        </span>
+      </div>
+
       <div fxLayout="row"
            fxLayoutGap="16px">
         <div fxLayout="row"
@@ -33,22 +66,6 @@
              matTooltip="Audit Logging is enforced by your admin in the chosen datacenter.">
           </i>
         </div>
-        <div fxLayout="row"
-             fxLayoutGap="8px"
-             fxLayoutAlign=" center">
-          <mat-checkbox formControlName="usePodSecurityPolicyAdmissionPlugin">Pod Security Policy</mat-checkbox>
-          <i *ngIf="!!datacenter.spec.enforcePodSecurityPolicy"
-             class="km-icon-warning km-warning"
-             matTooltip="Pod Security Policy is enforced by your admin in the chosen datacenter.">
-          </i>
-          <i class="km-icon-info"
-             matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
-          <i *ngIf="form.controls.usePodSecurityPolicyAdmissionPlugin.value"
-             class="km-icon-warning km-warning"
-             matTooltip="Activating Pod Security Policy will mean that a lot of Pod specifications, Operators and Helm charts will not work out of the box. Make sure that you know the consequences of activating this feature.">
-          </i>
-        </div>
-        <mat-checkbox formControlName="usePodNodeSelectorAdmissionPlugin">Pod Node Selector</mat-checkbox>
       </div>
       <km-label-form title="Labels"
                      [(labels)]="labels"

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.scss
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.scss
@@ -4,10 +4,6 @@
   margin-bottom: 30px;
 }
 
-.km-icon-warning {
-  margin: (.5 * $baseline-grid) 0;
-}
-
 km-label-form {
   margin-top: 3.75 * $baseline-grid;
 }

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.spec.ts
@@ -6,13 +6,14 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {Subject} from 'rxjs';
 
 import {CoreModule} from '../../../core/core.module';
-import {ClusterService, ProviderSettingsPatch} from '../../../core/services/cluster/cluster.service';
+import {ApiService, ClusterService} from '../../../core/services';
+import {ProviderSettingsPatch} from '../../../core/services/cluster/cluster.service';
 import {SharedModule} from '../../../shared/shared.module';
 import {doPatchCloudSpecFake} from '../../../testing/fake-data/cloud-spec.fake';
 import {fakeDigitaloceanCluster} from '../../../testing/fake-data/cluster.fake';
 import {fakeDigitaloceanDatacenter} from '../../../testing/fake-data/datacenter.fake';
 import {fakeProject} from '../../../testing/fake-data/project.fake';
-import {asyncData} from '../../../testing/services/api-mock.service';
+import {ApiMockService, asyncData} from '../../../testing/services/api-mock.service';
 import {MatDialogRefMock} from '../../../testing/services/mat-dialog-ref-mock';
 import {AlibabaProviderSettingsComponent} from '../edit-provider-settings/alibaba-provider-settings/alibaba-provider-settings.component';
 import {AWSProviderSettingsComponent} from '../edit-provider-settings/aws-provider-settings/aws-provider-settings.component';
@@ -63,6 +64,7 @@ describe('EditClusterComponent', () => {
       providers: [
         {provide: MatDialogRef, useClass: MatDialogRefMock},
         {provide: ClusterService, useValue: clusterServiceMock},
+        {provide: ApiService, useClass: ApiMockService},
       ],
     }).compileComponents();
   }));

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
@@ -12,7 +12,10 @@ import {ClusterEntityPatch} from '../../../shared/entity/ClusterEntityPatch';
 import {DataCenterEntity} from '../../../shared/entity/DatacenterEntity';
 import {ResourceType} from '../../../shared/entity/LabelsEntity';
 import {AsyncValidators} from '../../../shared/validators/async-label-form.validator';
-import {AdmissionPluginUtils} from '../../../shared/utils/admission-plugin-utils/admission-plugin-utils';
+import {
+  AdmissionPlugin,
+  AdmissionPluginUtils,
+} from '../../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 
 @Component({
   selector: 'km-edit-cluster',
@@ -23,6 +26,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   @Input() cluster: ClusterEntity;
   @Input() datacenter: DataCenterEntity;
   @Input() projectID: string;
+  admissionPlugin = AdmissionPlugin;
   form: FormGroup;
   labels: object;
   admissionPlugins: string[] = [];
@@ -71,7 +75,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     if (this.cluster.spec.usePodNodeSelectorAdmissionPlugin) {
       const value = AdmissionPluginUtils.updateSelectedPluginArray(
         this.form.controls.admissionPlugins,
-        'PodNodeSelector'
+        AdmissionPlugin.PodNodeSelector
       );
       this.form.controls.admissionPlugins.setValue(value);
     }
@@ -79,7 +83,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     if (this.cluster.spec.usePodSecurityPolicyAdmissionPlugin) {
       const value = AdmissionPluginUtils.updateSelectedPluginArray(
         this.form.controls.admissionPlugins,
-        'PodSecurityPolicy'
+        AdmissionPlugin.PodSecurityPolicy
       );
       this.form.controls.admissionPlugins.setValue(value);
     }
@@ -96,7 +100,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     if (this.datacenter.spec.enforcePodSecurityPolicy) {
       const value = AdmissionPluginUtils.updateSelectedPluginArray(
         this.form.controls.admissionPlugins,
-        'PodSecurityPolicy'
+        AdmissionPlugin.PodSecurityPolicy
       );
       this.form.controls.admissionPlugins.setValue(value);
     }

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
@@ -12,6 +12,7 @@ import {ClusterEntityPatch} from '../../../shared/entity/ClusterEntityPatch';
 import {DataCenterEntity} from '../../../shared/entity/DatacenterEntity';
 import {ResourceType} from '../../../shared/entity/LabelsEntity';
 import {AsyncValidators} from '../../../shared/validators/async-label-form.validator';
+import {AdmissionPluginUtils} from '../../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 
 @Component({
   selector: 'km-edit-cluster',
@@ -68,12 +69,18 @@ export class EditClusterComponent implements OnInit, OnDestroy {
 
   checkForLegacyAdmissionPlugins(): void {
     if (this.cluster.spec.usePodNodeSelectorAdmissionPlugin) {
-      const value = this.updateSelectedPluginArray('PodNodeSelector');
+      const value = AdmissionPluginUtils.updateSelectedPluginArray(
+        this.form.controls.admissionPlugins,
+        'PodNodeSelector'
+      );
       this.form.controls.admissionPlugins.setValue(value);
     }
 
     if (this.cluster.spec.usePodSecurityPolicyAdmissionPlugin) {
-      const value = this.updateSelectedPluginArray('PodSecurityPolicy');
+      const value = AdmissionPluginUtils.updateSelectedPluginArray(
+        this.form.controls.admissionPlugins,
+        'PodSecurityPolicy'
+      );
       this.form.controls.admissionPlugins.setValue(value);
     }
 
@@ -87,33 +94,24 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     }
 
     if (this.datacenter.spec.enforcePodSecurityPolicy) {
-      const value = this.updateSelectedPluginArray('PodSecurityPolicy');
+      const value = AdmissionPluginUtils.updateSelectedPluginArray(
+        this.form.controls.admissionPlugins,
+        'PodSecurityPolicy'
+      );
       this.form.controls.admissionPlugins.setValue(value);
     }
   }
 
-  updateSelectedPluginArray(name: string): string[] {
-    const plugins: string[] = this.form.controls.admissionPlugins.value
-      ? this.form.controls.admissionPlugins.value
-      : [];
-    if (!plugins.some(x => x === name)) {
-      plugins.push(name);
-    }
-    return plugins;
-  }
-
   getPluginName(name: string): string {
-    return name.replace(/([A-Z])/g, ' $1').trim();
+    return AdmissionPluginUtils.getPluginName(name);
   }
 
   isPluginEnabled(name: string): boolean {
-    return (
-      !!this.form.controls.admissionPlugins.value && this.form.controls.admissionPlugins.value.some(x => x === name)
-    );
+    return AdmissionPluginUtils.isPluginEnabled(this.form.controls.admissionPlugins, name);
   }
 
   isPodSecurityPolicyEnforced(): boolean {
-    return !!this.datacenter && !!this.datacenter.spec && !!this.datacenter.spec.enforcePodSecurityPolicy;
+    return AdmissionPluginUtils.isPodSecurityPolicyEnforced(this.datacenter);
   }
 
   editCluster(): void {

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -254,6 +254,11 @@ export class ApiService {
     return this._http.get<MasterVersion[]>(url);
   }
 
+  getAdmissionPlugins(version: string): Observable<string[]> {
+    const url = `${this._restRoot}/admission/plugins/${version}`;
+    return this._http.get<string[]>(url);
+  }
+
   getAzureSizes(projectId: string, dc: string, cluster: string): Observable<AzureSizes[]> {
     const url = `${this._restRoot}/projects/${projectId}/dc/${dc}/clusters/${cluster}/providers/azure/sizes`;
     return this._http.get<AzureSizes[]>(url);

--- a/src/app/shared/entity/ClusterEntity.ts
+++ b/src/app/shared/entity/ClusterEntity.ts
@@ -207,6 +207,7 @@ export class ClusterSpec {
   version?: string;
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
+  admissionPlugins?: string[];
   openshift?: OpenShift;
 }
 

--- a/src/app/shared/entity/ClusterEntityPatch.ts
+++ b/src/app/shared/entity/ClusterEntityPatch.ts
@@ -15,6 +15,7 @@ export class ClusterSpecPatch {
   version?: string;
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
+  admissionPlugins?: string[];
   auditLogging?: AuditLoggingSettings;
   openshift?: OpenShiftPatch;
 }

--- a/src/app/shared/model/ClusterForm.ts
+++ b/src/app/shared/model/ClusterForm.ts
@@ -10,6 +10,7 @@ export class ClusterSpecForm {
   imagePullSecret?: string;
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
+  admissionPlugins?: string[];
   auditLogging?: AuditLoggingSettings;
   valid: boolean;
 }

--- a/src/app/shared/utils/admission-plugin-utils/admission-plugin-utils.ts
+++ b/src/app/shared/utils/admission-plugin-utils/admission-plugin-utils.ts
@@ -1,5 +1,11 @@
 import {AbstractControl} from '@angular/forms';
 import {DataCenterEntity} from '../../entity/DatacenterEntity';
+import {ClusterEntity} from '../../entity/ClusterEntity';
+
+export enum AdmissionPlugin {
+  PodSecurityPolicy = 'PodSecurityPolicy',
+  PodNodeSelector = 'PodNodeSelector',
+}
 
 export class AdmissionPluginUtils {
   static getPluginName(name: string): string {
@@ -7,9 +13,7 @@ export class AdmissionPluginUtils {
   }
 
   static getJoinedPluginNames(plugins: string[]): string {
-    const prettifiedNames: string[] = [];
-    plugins.forEach(plugin => prettifiedNames.push(this.getPluginName(plugin)));
-    return prettifiedNames.join(', ');
+    return plugins.map(plugin => this.getPluginName(plugin)).join(', ');
   }
 
   static isPluginEnabled(form: AbstractControl, name: string): boolean {
@@ -24,6 +28,14 @@ export class AdmissionPluginUtils {
     const plugins: string[] = form.value ? form.value : [];
     if (!plugins.some(x => x === name)) {
       plugins.push(name);
+    }
+    return plugins;
+  }
+
+  static updateSelectedPluginArrayIfPSPEnforced(cluster: ClusterEntity, datacenter: DataCenterEntity): string[] {
+    const plugins: string[] = cluster.spec.admissionPlugins ? cluster.spec.admissionPlugins : [];
+    if (!!this.isPodSecurityPolicyEnforced(datacenter) && !plugins.some(x => x === AdmissionPlugin.PodSecurityPolicy)) {
+      plugins.push(AdmissionPlugin.PodSecurityPolicy);
     }
     return plugins;
   }

--- a/src/app/shared/utils/admission-plugin-utils/admission-plugin-utils.ts
+++ b/src/app/shared/utils/admission-plugin-utils/admission-plugin-utils.ts
@@ -1,0 +1,30 @@
+import {AbstractControl} from '@angular/forms';
+import {DataCenterEntity} from '../../entity/DatacenterEntity';
+
+export class AdmissionPluginUtils {
+  static getPluginName(name: string): string {
+    return name.replace(/([A-Z])/g, ' $1').trim();
+  }
+
+  static getJoinedPluginNames(plugins: string[]): string {
+    const prettifiedNames: string[] = [];
+    plugins.forEach(plugin => prettifiedNames.push(this.getPluginName(plugin)));
+    return prettifiedNames.join(', ');
+  }
+
+  static isPluginEnabled(form: AbstractControl, name: string): boolean {
+    return !!form.value && form.value.some(x => x === name);
+  }
+
+  static isPodSecurityPolicyEnforced(datacenter: DataCenterEntity): boolean {
+    return !!datacenter && !!datacenter.spec && !!datacenter.spec.enforcePodSecurityPolicy;
+  }
+
+  static updateSelectedPluginArray(form: AbstractControl, name: string): string[] {
+    const plugins: string[] = form.value ? form.value : [];
+    if (!plugins.some(x => x === name)) {
+      plugins.push(name);
+    }
+    return plugins;
+  }
+}

--- a/src/app/testing/services/api-mock.service.ts
+++ b/src/app/testing/services/api-mock.service.ts
@@ -248,6 +248,10 @@ export class ApiMockService {
   getOpenshiftProxyURL(): string {
     return '';
   }
+
+  getAdmissionPlugins(version: string): Observable<string[]> {
+    return of(['PodNodeSecurity', 'PodSecurityPolicy']);
+  }
 }
 
 export function asyncData<T>(data: T): Observable<T> {

--- a/src/app/wizard-new/service/cluster.ts
+++ b/src/app/wizard-new/service/cluster.ts
@@ -9,11 +9,13 @@ export class ClusterService {
   readonly providerChanges = new EventEmitter<NodeProvider>();
   readonly datacenterChanges = new EventEmitter<string>();
   readonly sshKeyChanges = new EventEmitter<SSHKeyEntity[]>();
+  readonly admissionPluginsChanges = new EventEmitter<string[]>();
   readonly clusterChanges = new EventEmitter<ClusterEntity>();
   readonly clusterTypeChanges = new EventEmitter<ClusterType>();
 
   private _clusterEntity: ClusterEntity = ClusterEntity.newEmptyClusterEntity();
   private _sshKeysEntity: SSHKeyEntity[] = [];
+  private _admissionPluginsEntity: string[] = [];
 
   set cluster(cluster: ClusterEntity) {
     if (
@@ -89,6 +91,15 @@ export class ClusterService {
 
   get sshKeys(): SSHKeyEntity[] {
     return this._sshKeysEntity;
+  }
+
+  set admissionPlugins(plugins: string[]) {
+    this._admissionPluginsEntity = plugins;
+    this.admissionPluginsChanges.emit(this._admissionPluginsEntity);
+  }
+
+  get admissionPlugins(): string[] {
+    return this._admissionPluginsEntity;
   }
 
   set clusterType(type: ClusterType) {

--- a/src/app/wizard-new/step/cluster/component.ts
+++ b/src/app/wizard-new/step/cluster/component.ts
@@ -17,6 +17,7 @@ import {ClusterNameGenerator} from '../../../core/util/name-generator.service';
 import {ClusterEntity, ClusterSpec, ClusterType, MasterVersion} from '../../../shared/entity/ClusterEntity';
 import {DataCenterEntity} from '../../../shared/entity/DatacenterEntity';
 import {ResourceType} from '../../../shared/entity/LabelsEntity';
+import {AdmissionPluginUtils} from '../../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {AsyncValidators} from '../../../shared/validators/async-label-form.validator';
 import {ClusterService} from '../../service/cluster';
 import {WizardService} from '../../service/wizard';
@@ -157,18 +158,15 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   isPodSecurityPolicyEnforced(): boolean {
-    return !!this._datacenterSpec && !!this._datacenterSpec.spec.enforcePodSecurityPolicy;
+    return AdmissionPluginUtils.isPodSecurityPolicyEnforced(this._datacenterSpec);
   }
 
   getPluginName(name: string): string {
-    return name.replace(/([A-Z])/g, ' $1').trim();
+    return AdmissionPluginUtils.getPluginName(name);
   }
 
   isPluginEnabled(name: string): boolean {
-    return (
-      !!this.form.get(Controls.AdmissionPlugins).value &&
-      this.form.get(Controls.AdmissionPlugins).value.some(x => x === name)
-    );
+    return AdmissionPluginUtils.isPluginEnabled(this.form.get(Controls.AdmissionPlugins), name);
   }
 
   private _enforce(control: Controls, isEnforced: boolean): void {
@@ -180,7 +178,11 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
   private _enforcePodSecurityPolicy(isEnforced: boolean): void {
     if (isEnforced) {
-      this.form.get(Controls.AdmissionPlugins).patchValue(['PodSecurityPolicy']);
+      const value = AdmissionPluginUtils.updateSelectedPluginArray(
+        this.form.get(Controls.AdmissionPlugins),
+        'PodSecurityPolicy'
+      );
+      this.form.get(Controls.AdmissionPlugins).setValue(value);
     }
   }
 

--- a/src/app/wizard-new/step/cluster/component.ts
+++ b/src/app/wizard-new/step/cluster/component.ts
@@ -17,7 +17,10 @@ import {ClusterNameGenerator} from '../../../core/util/name-generator.service';
 import {ClusterEntity, ClusterSpec, ClusterType, MasterVersion} from '../../../shared/entity/ClusterEntity';
 import {DataCenterEntity} from '../../../shared/entity/DatacenterEntity';
 import {ResourceType} from '../../../shared/entity/LabelsEntity';
-import {AdmissionPluginUtils} from '../../../shared/utils/admission-plugin-utils/admission-plugin-utils';
+import {
+  AdmissionPlugin,
+  AdmissionPluginUtils,
+} from '../../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {AsyncValidators} from '../../../shared/validators/async-label-form.validator';
 import {ClusterService} from '../../service/cluster';
 import {WizardService} from '../../service/wizard';
@@ -51,6 +54,7 @@ enum Controls {
   ],
 })
 export class ClusterStepComponent extends StepBase implements OnInit, ControlValueAccessor, Validator, OnDestroy {
+  admissionPlugin = AdmissionPlugin;
   masterVersions: MasterVersion[] = [];
   admissionPlugins: string[] = [];
   labels: object;
@@ -180,7 +184,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     if (isEnforced) {
       const value = AdmissionPluginUtils.updateSelectedPluginArray(
         this.form.get(Controls.AdmissionPlugins),
-        'PodSecurityPolicy'
+        AdmissionPlugin.PodSecurityPolicy
       );
       this.form.get(Controls.AdmissionPlugins).setValue(value);
     }

--- a/src/app/wizard-new/step/cluster/component.ts
+++ b/src/app/wizard-new/step/cluster/component.ts
@@ -180,7 +180,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
   private _enforcePodSecurityPolicy(isEnforced: boolean): void {
     if (isEnforced) {
-      this.form.get(Controls.AdmissionPlugins).setValue(['PodSecurityPolicy']);
+      this.form.get(Controls.AdmissionPlugins).patchValue(['PodSecurityPolicy']);
     }
   }
 

--- a/src/app/wizard-new/step/cluster/style.scss
+++ b/src/app/wizard-new/step/cluster/style.scss
@@ -1,7 +1,6 @@
 @import "../../../../assets/css/variables";
 
 .km-icon-warning {
-  margin: (.5 * $baseline-grid) 0;
   cursor: pointer;
 }
 

--- a/src/app/wizard-new/step/cluster/template.html
+++ b/src/app/wizard-new/step/cluster/template.html
@@ -94,15 +94,15 @@
                           disableOptionCentering>
                 <mat-option *ngFor="let admissionPlugin of admissionPlugins"
                             [value]="admissionPlugin"
-                            [disabled]="admissionPlugin === 'PodSecurityPolicy' && !!isPodSecurityPolicyEnforced()">
+                            [disabled]="admissionPlugin === admissionPlugin.PodSecurityPolicy && !!isPodSecurityPolicyEnforced()">
                   {{getPluginName(admissionPlugin)}}
-                  <i *ngIf="admissionPlugin === 'PodSecurityPolicy'"
+                  <i *ngIf="admissionPlugin === admissionPlugin.PodSecurityPolicy"
                      class="km-icon-info"
                      matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
                 </mat-option>
               </mat-select>
             </mat-form-field>
-            <span *ngIf="isPluginEnabled('PodSecurityPolicy')"
+            <span *ngIf="isPluginEnabled(admissionPlugin.PodSecurityPolicy)"
                   class="km-admission-plugin-warning"
                   fxLayout="row">
               <i class="km-icon-warning km-warning"></i>

--- a/src/app/wizard-new/step/cluster/template.html
+++ b/src/app/wizard-new/step/cluster/template.html
@@ -84,6 +84,38 @@
             </mat-hint>
           </mat-form-field>
 
+          <div fxFlex="100"
+               fxLayout="column">
+            <mat-form-field>
+              <mat-label>Admission Plugins</mat-label>
+              <mat-select [formControlName]="Controls.AdmissionPlugins"
+                          multiple
+                          panelClass="km-multiple-values-dropdown"
+                          disableOptionCentering>
+                <mat-option *ngFor="let admissionPlugin of admissionPlugins"
+                            [value]="admissionPlugin"
+                            [disabled]="admissionPlugin === 'PodSecurityPolicy' && !!isPodSecurityPolicyEnforced()">
+                  {{getPluginName(admissionPlugin)}}
+                  <i *ngIf="admissionPlugin === 'PodSecurityPolicy'"
+                     class="km-icon-info"
+                     matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
+            <span *ngIf="isPluginEnabled('PodSecurityPolicy')"
+                  class="km-admission-plugin-warning"
+                  fxLayout="row">
+              <i class="km-icon-warning km-warning"></i>
+              <p fxFlex="95">Activating Pod Security Policy will mean that a lot of Pod specifications, Operators and Helm charts will not work out of the box. Make sure that you know the consequences of activating this feature.</p>
+            </span>
+            <span *ngIf="isPodSecurityPolicyEnforced()"
+                  class="km-admission-plugin-warning"
+                  fxLayout="row">
+              <i class="km-icon-info"></i>
+              <p fxFlex="95">Pod Security Policy is enforced by your admin in the chosen datacenter.</p>
+            </span>
+          </div>
+
           <div fxLayout="column"
                fxLayoutGap="16px"
                fxFlex>
@@ -95,23 +127,6 @@
                    class="km-icon-info"
                    matTooltip="Audit Logging is enforced by your admin in the chosen datacenter."></i>
               </mat-checkbox>
-              <div fxLayout="row"
-                   fxLayoutGap="8px"
-                   fxLayoutAlign=" center">
-                <mat-checkbox [formControlName]="Controls.PodSecurityPolicyAdmissionPlugin">
-                  Pod Security Policy
-                </mat-checkbox>
-                <i class="km-icon-info"
-                   matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
-                <i *ngIf="isEnforced(Controls.PodSecurityPolicyAdmissionPlugin)"
-                   class="km-icon-info"
-                   matTooltip="Pod Security Policy is enforced by your admin in the chosen datacenter."></i>
-                <i *ngIf="controlValue(Controls.PodSecurityPolicyAdmissionPlugin)"
-                   class="km-icon-warning km-warning"
-                   matTooltip="Activating Pod Security Policy will mean that a lot of Pod specifications, Operators and Helm charts will not work out of the box. Make sure that you know the consequences of activating this feature.">
-                </i>
-              </div>
-              <mat-checkbox [formControlName]="Controls.PodNodeSelectorAdmissionPlugin">Pod Node Selector</mat-checkbox>
             </div>
 
             <km-label-form title="Labels"

--- a/src/app/wizard-new/step/provider-settings/ssh-keys/template.html
+++ b/src/app/wizard-new/step/provider-settings/ssh-keys/template.html
@@ -5,7 +5,7 @@
     <mat-select [formControlName]="Controls.Keys"
                 multiple
                 disableOptionCentering
-                panelClass="km-sshkey-dropdown"
+                panelClass="km-multiple-values-dropdown"
                 [compareWith]="compareValues">
       <mat-option *ngFor="let key of keys"
                   [value]="key">{{key.name}}</mat-option>

--- a/src/app/wizard-new/step/summary/component.ts
+++ b/src/app/wizard-new/step/summary/component.ts
@@ -19,6 +19,7 @@ import {ClusterService} from '../../service/cluster';
 })
 export class SummaryStepComponent implements OnInit, OnDestroy {
   clusterSSHKeys: SSHKeyEntity[] = [];
+  clusterAdmissionPlugins: string[] = [];
   nodeData: NodeData;
   cluster: ClusterEntity;
   noMoreIpsLeft = false;
@@ -55,6 +56,10 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
     this._clusterService.sshKeyChanges
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(keys => (this.clusterSSHKeys = keys));
+
+    this._clusterService.admissionPluginsChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(plugins => (this.clusterAdmissionPlugins = plugins));
 
     this._clusterService.datacenterChanges
       .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc)))
@@ -122,6 +127,14 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
 
   getSSHKeyNames(): string {
     return this.clusterSSHKeys.map(key => key.name).join(', ');
+  }
+
+  hasAdminPlugins(): boolean {
+    return !!this.clusterAdmissionPlugins && this.clusterAdmissionPlugins.length > 0;
+  }
+
+  getAdmissionPlugins(): string {
+    return this.clusterAdmissionPlugins.join(', ');
   }
 
   private _hasProviderOptions(provider: NodeProvider): boolean {

--- a/src/app/wizard-new/step/summary/component.ts
+++ b/src/app/wizard-new/step/summary/component.ts
@@ -1,6 +1,8 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {Subject} from 'rxjs';
 import {switchMap, takeUntil} from 'rxjs/operators';
+import * as _ from 'lodash';
+
 import {DatacenterService} from '../../../core/services';
 import {NodeDataService} from '../../../node-data-new/service/service';
 import {LabelFormComponent} from '../../../shared/components/label-form/label-form.component';
@@ -131,7 +133,7 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
   }
 
   hasAdmissionPlugins(): boolean {
-    return !!this.clusterAdmissionPlugins && this.clusterAdmissionPlugins.length > 0;
+    return !_.isEmpty(this.clusterAdmissionPlugins);
   }
 
   getAdmissionPlugins(): string {

--- a/src/app/wizard-new/step/summary/component.ts
+++ b/src/app/wizard-new/step/summary/component.ts
@@ -9,6 +9,7 @@ import {SSHKeyEntity} from '../../../shared/entity/SSHKeyEntity';
 import {getIpCount} from '../../../shared/functions/get-ip-count';
 import {NodeProvider} from '../../../shared/model/NodeProviderConstants';
 import {NodeData} from '../../../shared/model/NodeSpecChange';
+import {AdmissionPluginUtils} from '../../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {NodeUtils} from '../../../shared/utils/node-utils/node-utils';
 import {ClusterService} from '../../service/cluster';
 
@@ -129,12 +130,12 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
     return this.clusterSSHKeys.map(key => key.name).join(', ');
   }
 
-  hasAdminPlugins(): boolean {
+  hasAdmissionPlugins(): boolean {
     return !!this.clusterAdmissionPlugins && this.clusterAdmissionPlugins.length > 0;
   }
 
   getAdmissionPlugins(): string {
-    return this.clusterAdmissionPlugins.join(', ');
+    return AdmissionPluginUtils.getJoinedPluginNames(this.clusterAdmissionPlugins);
   }
 
   private _hasProviderOptions(provider: NodeProvider): boolean {

--- a/src/app/wizard-new/step/summary/template.html
+++ b/src/app/wizard-new/step/summary/template.html
@@ -64,7 +64,7 @@
                                [value]="false">
           </km-property-boolean>
         </div>
-        <div [ngSwitch]="hasAdminPlugins()">
+        <div [ngSwitch]="hasAdmissionPlugins()">
           <km-property *ngSwitchCase="true">
             <div key>Enabled Admission Plugins</div>
             <div value>{{getAdmissionPlugins()}}</div>

--- a/src/app/wizard-new/step/summary/template.html
+++ b/src/app/wizard-new/step/summary/template.html
@@ -64,14 +64,18 @@
                                [value]="false">
           </km-property-boolean>
         </div>
+        <div [ngSwitch]="hasAdminPlugins()">
+          <km-property *ngSwitchCase="true">
+            <div key>Enabled Admission Plugins</div>
+            <div value>{{getAdmissionPlugins()}}</div>
+          </km-property>
+          <km-property-boolean *ngSwitchCase="false"
+                               label="Admission Plugins"
+                               [value]="false">
+          </km-property-boolean>
+        </div>
         <km-property-boolean label="Audit Logging"
                              [value]="cluster.spec.auditLogging?.enabled">
-        </km-property-boolean>
-        <km-property-boolean label="Pod Security Policy"
-                             [value]="cluster.spec.usePodSecurityPolicyAdmissionPlugin">
-        </km-property-boolean>
-        <km-property-boolean label="Pod Node Selector"
-                             [value]="cluster.spec.usePodNodeSelectorAdmissionPlugin">
         </km-property-boolean>
         <km-property-boolean *ngIf="nodeData.spec.operatingSystem.ubuntu"
                              label="Upgrade system on the first boot"

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
@@ -89,24 +89,37 @@
         </mat-form-field>
       </div>
 
+      <div fxFlex="100"
+           fxLayout="column">
+        <mat-form-field>
+          <mat-label>Admission Plugins</mat-label>
+          <mat-select formControlName="admissionPlugins"
+                      multiple
+                      panelClass="km-multiple-values-dropdown"
+                      disableOptionCentering>
+            <mat-option *ngFor="let admissionPlugin of admissionPlugins"
+                        [value]="admissionPlugin">
+              {{getPluginName(admissionPlugin)}}
+              <i *ngIf="admissionPlugin === 'PodSecurityPolicy'"
+                 class="km-icon-info"
+                 matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <span *ngIf="isPluginEnabled('PodSecurityPolicy')"
+              class="km-admission-plugin-warning"
+              fxLayout="row">
+          <i class="km-icon-warning km-warning"></i>
+          <p fxFlex="95">Activating Pod Security Policy will mean that a lot of Pod specifications, Operators and Helm charts will not work out of the box. Make sure that you know the consequences of activating this feature.</p>
+        </span>
+      </div>
+
       <div fxLayout="row"
            fxLayoutGap="16px">
         <mat-checkbox formControlName="auditLogging">Audit Logging</mat-checkbox>
-        <div fxLayout="row"
-             fxLayoutGap="8px"
-             fxLayoutAlign=" center">
-          <mat-checkbox formControlName="usePodSecurityPolicyAdmissionPlugin">
-            Pod Security Policy
-          </mat-checkbox>
-          <i class="km-icon-info"
-             matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
-          <i *ngIf="clusterSpecForm.controls.usePodSecurityPolicyAdmissionPlugin.value"
-             class="km-icon-warning km-warning"
-             matTooltip="Activating Pod Security Policy will mean that a lot of Pod specifications, Operators and Helm charts will not work out of the box. Make sure that you know the consequences of activating this feature.">
-          </i>
-        </div>
-        <mat-checkbox formControlName="usePodNodeSelectorAdmissionPlugin">Pod Node Selector</mat-checkbox>
       </div>
+
+
       <km-label-form title="Labels"
                      [(labels)]="labels"
                      [asyncKeyValidators]=asyncLabelValidators

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
@@ -100,13 +100,13 @@
             <mat-option *ngFor="let admissionPlugin of admissionPlugins"
                         [value]="admissionPlugin">
               {{getPluginName(admissionPlugin)}}
-              <i *ngIf="admissionPlugin === 'PodSecurityPolicy'"
+              <i *ngIf="admissionPlugin === admissionPlugin.PodSecurityPolicy"
                  class="km-icon-info"
                  matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
             </mat-option>
           </mat-select>
         </mat-form-field>
-        <span *ngIf="isPluginEnabled('PodSecurityPolicy')"
+        <span *ngIf="isPluginEnabled(admissionPlugin.PodSecurityPolicy)"
               class="km-admission-plugin-warning"
               fxLayout="row">
           <i class="km-icon-warning km-warning"></i>

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.scss
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.scss
@@ -1,9 +1,5 @@
 @import "../../../assets/css/variables";
 
-.km-icon-warning {
-  margin: (.5 * $baseline-grid) 0;
-}
-
 .km-randomize-btn {
   position: absolute;
   right: -0.625 * $baseline-grid;

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
@@ -8,6 +8,7 @@ import {ClusterNameGenerator} from '../../core/util/name-generator.service';
 import {AdminSettings, ClusterTypeOptions} from '../../shared/entity/AdminSettings';
 import {ClusterEntity, ClusterType, MasterVersion} from '../../shared/entity/ClusterEntity';
 import {ResourceType} from '../../shared/entity/LabelsEntity';
+import {AdmissionPluginUtils} from '../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {AsyncValidators} from '../../shared/validators/async-label-form.validator';
 
 @Component({
@@ -121,14 +122,11 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
   }
 
   getPluginName(name: string): string {
-    return name.replace(/([A-Z])/g, ' $1').trim();
+    return AdmissionPluginUtils.getPluginName(name);
   }
 
   isPluginEnabled(name: string): boolean {
-    return (
-      !!this.clusterSpecForm.controls.admissionPlugins.value &&
-      this.clusterSpecForm.controls.admissionPlugins.value.some(x => x === name)
-    );
+    return AdmissionPluginUtils.isPluginEnabled(this.clusterSpecForm.controls.admissionPlugins, name);
   }
 
   setClusterSpec(): void {

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
@@ -8,7 +8,7 @@ import {ClusterNameGenerator} from '../../core/util/name-generator.service';
 import {AdminSettings, ClusterTypeOptions} from '../../shared/entity/AdminSettings';
 import {ClusterEntity, ClusterType, MasterVersion} from '../../shared/entity/ClusterEntity';
 import {ResourceType} from '../../shared/entity/LabelsEntity';
-import {AdmissionPluginUtils} from '../../shared/utils/admission-plugin-utils/admission-plugin-utils';
+import {AdmissionPlugin, AdmissionPluginUtils} from '../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {AsyncValidators} from '../../shared/validators/async-label-form.validator';
 
 @Component({
@@ -19,6 +19,7 @@ import {AsyncValidators} from '../../shared/validators/async-label-form.validato
 export class SetClusterSpecComponent implements OnInit, OnDestroy {
   @Input() cluster: ClusterEntity;
   @Input() settings: AdminSettings;
+  admissionPlugin = AdmissionPlugin;
   labels: object;
   clusterSpecForm: FormGroup;
   masterVersions: MasterVersion[] = [];

--- a/src/app/wizard/set-datacenter/set-datacenter.component.ts
+++ b/src/app/wizard/set-datacenter/set-datacenter.component.ts
@@ -6,6 +6,7 @@ import {takeUntil} from 'rxjs/operators';
 import {DatacenterService, WizardService} from '../../core/services';
 import {AuditLoggingSettings, ClusterEntity, getClusterProvider} from '../../shared/entity/ClusterEntity';
 import {DataCenterEntity, getDatacenterProvider} from '../../shared/entity/DatacenterEntity';
+import {AdmissionPluginUtils} from '../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 
 @Component({
   selector: 'km-set-datacenter',
@@ -54,10 +55,8 @@ export class SetDatacenterComponent implements OnInit, OnDestroy {
 
         const auditLogging = dc.spec.enforceAuditLogging ? {enabled: true} : this.cluster.spec.auditLogging;
 
-        const admissionPlugins = this.cluster.spec.admissionPlugins ? this.cluster.spec.admissionPlugins : [];
-        if (!!dc.spec.enforcePodSecurityPolicy && !admissionPlugins.some(x => x === 'PodSecurityPolicy')) {
-          admissionPlugins.push('PodSecurityPolicy');
-        }
+        const admissionPlugins = AdmissionPluginUtils.updateSelectedPluginArrayIfPSPEnforced(this.cluster, dc);
+
         this.enforceClusterProperties(auditLogging, admissionPlugins);
       }
     }

--- a/src/app/wizard/set-datacenter/set-datacenter.component.ts
+++ b/src/app/wizard/set-datacenter/set-datacenter.component.ts
@@ -55,7 +55,7 @@ export class SetDatacenterComponent implements OnInit, OnDestroy {
         const auditLogging = dc.spec.enforceAuditLogging ? {enabled: true} : this.cluster.spec.auditLogging;
 
         const admissionPlugins = this.cluster.spec.admissionPlugins ? this.cluster.spec.admissionPlugins : [];
-        if (!!dc.spec.enforcePodSecurityPolicy && !!admissionPlugins.some(x => x === 'PodSecurityPolicy')) {
+        if (!!dc.spec.enforcePodSecurityPolicy && !admissionPlugins.some(x => x === 'PodSecurityPolicy')) {
           admissionPlugins.push('PodSecurityPolicy');
         }
         this.enforceClusterProperties(auditLogging, admissionPlugins);

--- a/src/app/wizard/set-settings/ssh-keys/cluster-ssh-keys.component.html
+++ b/src/app/wizard/set-settings/ssh-keys/cluster-ssh-keys.component.html
@@ -7,7 +7,7 @@
     <mat-select formControlName="keys"
                 multiple
                 disableOptionCentering
-                panelClass="km-sshkey-dropdown"
+                panelClass="km-multiple-values-dropdown"
                 [compareWith]="compareValues">
       <mat-option *ngFor="let key of keys"
                   [value]="key">{{key.name}}</mat-option>

--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -32,7 +32,7 @@
         </i>
       </div>
 
-      <div *ngIf="hasAdminPlugins">
+      <div *ngIf="hasAdmissionPlugins">
         <km-property class="km-admission-plugins">
           <div key>Enabled Admission Plugins</div>
           <div value>
@@ -43,7 +43,7 @@
           </div>
         </km-property>
       </div>
-      <div *ngIf="!hasAdminPlugins">
+      <div *ngIf="!hasAdmissionPlugins">
         <div class="km-summary-row">
           <span class="km-summary-left km-text">
             <i class="km-icon-disabled"></i>

--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -31,28 +31,27 @@
            matTooltip="Audit Logging is enforced by your admin in the chosen datacenter.">
         </i>
       </div>
-      <div class="km-summary-row">
-        <span class="km-summary-left km-text">
-          <i [ngClass]="{'km-icon-disabled': !cluster.spec.usePodSecurityPolicyAdmissionPlugin, 'km-icon-running': cluster.spec.usePodSecurityPolicyAdmissionPlugin}"></i>
-        </span>
-        <span>Pod Security Policy</span>
-        <i *ngIf="!!datacenterFormData.datacenter.spec.enforcePodSecurityPolicy"
-           class="km-icon-warning km-warning"
-           matTooltip="Pod Security Policy is enforced by your admin in the chosen datacenter.">
-        </i>
+
+      <div *ngIf="hasAdminPlugins">
+        <km-property class="km-admission-plugins">
+          <div key>Enabled Admission Plugins</div>
+          <div value>
+            {{getAdmissionPlugins()}}
+            <i *ngIf="!!datacenterFormData.datacenter.spec.enforcePodSecurityPolicy"
+               class="km-icon-warning km-warning"
+               matTooltip="Pod Security Policy is enforced by your admin in the chosen datacenter."></i>
+          </div>
+        </km-property>
       </div>
-      <div class="km-summary-row">
-        <span class="km-summary-left km-text">
-          <i [ngClass]="{'km-icon-disabled': !cluster.spec.usePodNodeSelectorAdmissionPlugin, 'km-icon-running': cluster.spec.usePodNodeSelectorAdmissionPlugin}"></i>
-        </span>
-        <span>Pod Node Selector</span>
+      <div *ngIf="!hasAdminPlugins">
+        <div class="km-summary-row">
+          <span class="km-summary-left km-text">
+            <i class="km-icon-disabled"></i>
+          </span>
+          <span>Admission Plugins</span>
+        </div>
       </div>
-      <div *ngIf="cluster.labels && displayTags(cluster.labels)"
-           class="km-summary-tags">
-        <div class="km-summary-row">Cluster Labels</div>
-        <km-labels [labels]="cluster.labels"
-                   emptyMessage="No assigned labels"></km-labels>
-      </div>
+
       <div *ngIf="!cluster.labels || !displayTags(cluster.labels)">
         <div class="km-summary-row">
           <span class="km-summary-left km-text">
@@ -61,6 +60,13 @@
           <span>Cluster Labels</span>
         </div>
       </div>
+      <div *ngIf="cluster.labels && displayTags(cluster.labels)"
+           class="km-summary-tags">
+        <div class="km-summary-row">Cluster Labels</div>
+        <km-labels [labels]="cluster.labels"
+                   emptyMessage="No assigned labels"></km-labels>
+      </div>
+
     </mat-card-content>
 
     <mat-card-header>

--- a/src/app/wizard/summary/summary.component.scss
+++ b/src/app/wizard/summary/summary.component.scss
@@ -54,3 +54,7 @@
 .km-icon-warning {
   margin-left: $baseline-grid;
 }
+
+.km-admission-plugins i {
+  margin: 0 $baseline-grid;
+}

--- a/src/app/wizard/summary/summary.component.ts
+++ b/src/app/wizard/summary/summary.component.ts
@@ -5,6 +5,7 @@ import {SSHKeyEntity} from '../../shared/entity/SSHKeyEntity';
 import {getIpCount} from '../../shared/functions/get-ip-count';
 import {ClusterDatacenterForm, ClusterProviderForm} from '../../shared/model/ClusterForm';
 import {NodeData} from '../../shared/model/NodeSpecChange';
+import {AdmissionPluginUtils} from '../../shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {NodeUtils} from '../../shared/utils/node-utils/node-utils';
 
 @Component({
@@ -109,11 +110,11 @@ export class SummaryComponent implements OnInit {
     return false;
   }
 
-  hasAdminPlugins(): boolean {
+  hasAdmissionPlugins(): boolean {
     return !!this.cluster.spec.admissionPlugins && this.cluster.spec.admissionPlugins.length > 0;
   }
 
   getAdmissionPlugins(): string {
-    return this.cluster.spec.admissionPlugins.join(', ');
+    return AdmissionPluginUtils.getJoinedPluginNames(this.cluster.spec.admissionPlugins);
   }
 }

--- a/src/app/wizard/summary/summary.component.ts
+++ b/src/app/wizard/summary/summary.component.ts
@@ -1,4 +1,6 @@
 import {Component, Input, OnInit} from '@angular/core';
+import * as _ from 'lodash';
+
 import {LabelFormComponent} from '../../shared/components/label-form/label-form.component';
 import {ClusterEntity} from '../../shared/entity/ClusterEntity';
 import {SSHKeyEntity} from '../../shared/entity/SSHKeyEntity';
@@ -111,7 +113,7 @@ export class SummaryComponent implements OnInit {
   }
 
   hasAdmissionPlugins(): boolean {
-    return !!this.cluster.spec.admissionPlugins && this.cluster.spec.admissionPlugins.length > 0;
+    return !_.isEmpty(this.cluster.spec.admissionPlugins);
   }
 
   getAdmissionPlugins(): string {

--- a/src/app/wizard/summary/summary.component.ts
+++ b/src/app/wizard/summary/summary.component.ts
@@ -108,4 +108,12 @@ export class SummaryComponent implements OnInit {
     }
     return false;
   }
+
+  hasAdminPlugins(): boolean {
+    return !!this.cluster.spec.admissionPlugins && this.cluster.spec.admissionPlugins.length > 0;
+  }
+
+  getAdmissionPlugins(): string {
+    return this.cluster.spec.admissionPlugins.join(', ');
+  }
 }

--- a/src/app/wizard/wizard.component.ts
+++ b/src/app/wizard/wizard.component.ts
@@ -41,6 +41,7 @@ export class WizardComponent implements OnInit, OnDestroy {
     name: '',
     type: ClusterType.Empty,
     version: '',
+    admissionPlugins: [],
     labels: {},
   };
   private _clusterProviderSettingsFormData: ClusterProviderSettingsForm = {
@@ -115,8 +116,7 @@ export class WizardComponent implements OnInit, OnDestroy {
         this.cluster.type = this._clusterSpecFormData.type;
         this.cluster.spec.auditLogging = this._clusterSpecFormData.auditLogging;
         this.cluster.labels = this._clusterSpecFormData.labels;
-        this.cluster.spec.usePodSecurityPolicyAdmissionPlugin = this._clusterSpecFormData.usePodSecurityPolicyAdmissionPlugin;
-        this.cluster.spec.usePodNodeSelectorAdmissionPlugin = this._clusterSpecFormData.usePodNodeSelectorAdmissionPlugin;
+        this.cluster.spec.admissionPlugins = this._clusterSpecFormData.admissionPlugins;
 
         if (this._clusterSpecFormData.type === ClusterType.OpenShift) {
           this.cluster.spec.openshift = {

--- a/src/assets/css/_theme.scss
+++ b/src/assets/css/_theme.scss
@@ -1516,7 +1516,7 @@
     margin-left: 2.75 * $baseline-grid !important;
   }
 
-  .km-sshkey-dropdown {
+  .km-multiple-values-dropdown {
     margin-left: 3.75 * $baseline-grid !important;
   }
 
@@ -1644,6 +1644,19 @@
   .km-user-settings-form-field {
     .mat-form-field-wrapper {
       padding-bottom: 0;
+    }
+  }
+
+  .km-admission-plugin-warning {
+    margin-bottom: 3 * $baseline-grid;
+
+    i {
+      margin: 0 $baseline-grid;
+    }
+
+    p {
+      margin: 0;
+      font-size: $font-size-body;
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Redesign Admission Plugin view: It is now a dropdown instead of seperate checkboxes.
Implement new struct: Instead of having multiple fields in the cluster spec, we now have one slice where all admission plugins are saved. The old fields will be transfered into the new slice once the cluster gets edited.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2011
Fixes #1987

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Use new field `AdmissionPlugins` in cluster struct, instead of `UsePodSecurityPolicyAdmissionPlugin` & `UsePodNodeSelectorAdmissionPlugin`
```
