### PR TITLE
Update README and add FOSS and KERO License

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# How to Contribute
+
+Kubermatic projects are [Apache 2.0 licensed](LICENSE) and accept contributions via
+GitHub pull requests. This document outlines some of the conventions on
+development workflow, commit message formatting, contact points and other
+resources to make it easier to get your contribution accepted.
+
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate of
+Origin (DCO). This document was created by the Linux Kernel community and is a
+simple statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
+
+Any copyright notices in this repo should specify the authors as "the  Kubermatic Kubernetes Platform contributors".
+
+To sign your work, just add a line like this at the end of your commit message:
+
+```
+Signed-off-by: Joe Example <joe@example.com>
+```
+
+This can easily be done with the `--signoff` option to `git commit`.
+
+Note that we're requiring all commits in a PR to be signed-off. If you already created a PR, you can sign-off all existing commits by rebasing with the `--signoff` flag.
+
+```
+git rebase --signoff origin/master
+```
+
+By doing this you state that you can certify the following (from https://developercertificate.org/):
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+## Email and Chat
+
+Kubermatic Kubernetes Platform currently uses the general Kubermatic email list and Slack channel:
+- Email: [kubermatic-dev](https://groups.google.com/forum/#!forum/kubermatic-dev)
+- Slack: #[Slack](http://slack.kubermatic.io/) on Slack
+
+Please avoid emailing maintainers found in the MAINTAINERS file directly. They
+are very busy and read the mailing lists.
+
+## Reporting a security vulnerability
+
+Due to their public nature, GitHub and mailing lists are not appropriate places for reporting vulnerabilities. If you suspect you have found a security vulnerability, please do not file a GitHub issue, but instead email security@kubermatic.com with the full details, including steps to reproduce the issue.
+
+## Getting Started
+
+- Fork the repository on GitHub
+- Read the [README](README.md) for build and test instructions
+- Play with the project, submit bugs, submit patches!
+
+### Contribution Flow
+
+This is a rough outline of what a contributor's workflow looks like:
+
+- Create a topic branch from where you want to base your work (usually master).
+- Make commits of logical units.
+- Make sure your commit messages are in the proper format (see below).
+- Push your changes to a topic branch in your fork of the repository.
+- Make sure the tests pass, and add any new tests as appropriate.
+- Submit a pull request to the original repository.
+
+Thanks for your contributions!

--- a/DCO
+++ b/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/Development.md
+++ b/Development.md
@@ -1,0 +1,59 @@
+# Development
+
+## Preparation
+Before you can start the application locally you should install the dependencies using `npm ci` command.
+
+## Starting the Application
+
+### Using Locally Installed NodeJS
+To start development server that will proxy API calls to the https://dev.kubermatic.io/ use 
+`npm start` command and navigate to http://localhost:8000/.
+
+If you would like to connect with your local API then you should use `npm run serve:local`.
+
+The application will automatically reload if you change any of the source files.
+
+### Using a Docker Container
+
+#### With dev.kubermatic.io API
+```bash
+./hack/run-dashboard.sh
+```
+
+#### With Local API
+```bash
+./hack/run-local-dashboard.sh
+```
+
+## Formatting the Code
+We are using [Google TypeScript Style](https://github.com/google/ts-style) and [Stylelint](https://github.com/stylelint/stylelint) to ensure consistent code formatting and linting.
+
+To check if files are formatted and linted use `npm run check` command.
+
+To automatically fix issues run `npm run fix` command.
+
+## Running the Unit Tests
+Run `npm test` to execute the unit tests via [Jest](https://jestjs.io/).
+
+## Running the End-to-end Tests
+End-to-end tests by default are executed against `dev.kubermatic.io` server. Before running tests set `CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME`, `CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME_2` and `CYPRESS_KUBERMATIC_DEX_DEV_E2E_PASSWORD` environment variables. To run tests, execute `npm run e2e`.
+
+**NOTE**: For the local tests `roxy@kubermatic.io` & `roxy2@kubermatic.io` users can be used. Password can be found in our vault inside `e2e-dex` secret.
+
+**NOTE**: `npm run e2e` command uses configuration from `src/environments/environment.e2e.ts`. You can modify it to match your setup.
+
+**NOTE**: End-to-end tests can be also run manually with `npm run cy` command. It requires app running at `http://localhost:8000`.
+
+## Building the Application
+Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory.
+
+Please check `package.json` for more information regarding the available commands and the project setup.
+
+## Running Commands Within the Docker Container
+
+This will run the below commands in a NodeJS Docker container with the source code mounted and set as working directory.
+```bash
+./hack/run-in-docker.sh npm install
+./hack/run-in-docker.sh npm foo
+./hack/run-in-docker.sh npm bar
+```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,219 @@
+   Kubermatic Kubernetes Platform (“Software”) is an open-core software. 
+   While the core of the Software is released under an open source licence,
+   other parts of the Software, are licensed under proprietary or other 
+   licences, subject to the following principles: 
+
+   1.	All files outside of the src/app/ee directory are licensed under the 
+      Apache License Version 2.0. The same applies to all files that 
+      reference the Apache License Version 2.0. 
+   2.	All other files contained in Software, in particular those in the 
+      src/app/ee directory, are licensed under the Kubermatic Enterprise 
+      Read-Only License v 1.0 ("KERO-1.0”). The same applies to all files 
+      that reference the KERO-1.0 license. Users who have acquired the Software 
+      by way of an individual agreement under an enterprise license 
+      (“Enterprise License”) may use the files and the Software in accordance 
+      with the terms of such Enterprise License. However, users that do not 
+      hold an Enterprise License may only view the files in accordance with 
+      the terms KERO-1.0 license.
+   3.	Unless otherwise stated, third-party components are licensed under the 
+      license specified in the respective subdirectory, in the respective 
+      source files or elsewhere within the third-party component.
+
+
+
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2020 Loodse GmbH
+
+   1.	You may only view, read and display for studying purposes the source 
+      code of the software licensed under this license, and, to the extent 
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including, 
+      without limitation, its execution, compilation, copying, modification 
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, 
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Kubermatic Kubernetes Platform
+Copyright 2020 Loodse GmbH
+
+This product includes software developed at Loodse GmbH.
+(http://www.kubermatic.com/).

--- a/README.md
+++ b/README.md
@@ -1,62 +1,55 @@
-# Kubermatic Dashboard
+# Dashboard for the Kubermatic Kubernetes Platform
 [![codecov](https://codecov.io/gh/kubermatic/dashboard/branch/master/graph/badge.svg?token=njXM3OrmAM)](https://codecov.io/gh/kubermatic/dashboard)
 
-## Development
 
-### Preparation
-Before you can start the application locally you should install the dependencies using `npm ci` command.
+## Overview & More information
 
-### Starting the Application
+This repo contains the Dashboard for the Kubermatic Kubernetes Platform. For more information regarding overview, installation and user guides check [Kubermatic Kubernetes Platform repo][4] & [Kubermatic Kubernetes Platform docs website][21].
 
-#### Using Locally Installed NodeJS
-To start development server that will proxy API calls to the https://dev.kubermatic.io/ use 
-`npm start` command and navigate to http://localhost:8000/.
+## Editions
+There are two editions of Kubermatic Kubernetes Platform:
 
-If you would like to connect with your local API then you should use `npm run serve:local`.
+Kubermatic Kubernetes Platform Community Edition (CE) is available freely under the Apache License, Version 2.0.
+Kubermatic Kubernetes Platform Enterprise Edition (EE) includes premium features that are most useful for organizations with large-scale Kubernetes installations with more than 50 clusters. To access the Enterprise Edition and get official support please become a subscriber.
 
-The application will automatically reload if you change any of the source files.
+## Licensing
+See the [LICENSE](LICENSE) file for licensing information as it pertains to files in this repository.
 
-#### Using a Docker Container
+## Troubleshooting
 
-##### With dev.kubermatic.io API
-```bash
-./hack/run-dashboard.sh
-```
+If you encounter issues [file an issue][1] or talk to us on the [#kubermatic channel][12] on the [Kubermatic Slack][15].
 
-##### With Local API
-```bash
-./hack/run-local-dashboard.sh
-```
+## Contributing
 
-### Formatting the Code
-We are using [Google TypeScript Style](https://github.com/google/ts-style) and [Stylelint](https://github.com/stylelint/stylelint) to ensure consistent code formatting and linting.
+Thanks for taking the time to join our community and start contributing!
 
-To check if files are formatted and linted use `npm run check` command.
+Feedback and discussion are available on [the mailing list][11].
 
-To automatically fix issues run `npm run fix` command.
+### Before you start
 
-### Running the Unit Tests
-Run `npm test` to execute the unit tests via [Jest](https://jestjs.io/).
+* Please familiarize yourself with the [Code of Conduct][4] before contributing.
+* See [CONTRIBUTING.md][2] and [Development.md][3] for instructions on the developer certificate of origin that we require.
+* Read how [we're using ZenHub][13] for project and roadmap planning
 
-### Running the End-to-end Tests
-End-to-end tests by default are executed against `dev.kubermatic.io` server. Before running tests set `CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME`, `CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME_2` and `CYPRESS_KUBERMATIC_DEX_DEV_E2E_PASSWORD` environment variables. To run tests, execute `npm run e2e`.
 
-**NOTE**: For the local tests `roxy@kubermatic.io` & `roxy2@kubermatic.io` users can be used. Password can be found in our vault inside `e2e-dex` secret.
+### Pull requests
 
-**NOTE**: `npm run e2e` command uses configuration from `src/environments/environment.e2e.ts`. You can modify it to match your setup.
+* We welcome pull requests. Feel free to dig through the [issues][1] and jump in.
 
-**NOTE**: End-to-end tests can be also run manually with `npm run cy` command. It requires app running at `http://localhost:8000`.
+## Changelog
 
-### Building the Application
-Run `npm run build` to build the project. The build artifacts will be stored in the `dist/` directory.
+See [the list of releases][3] to find out about feature changes.
 
-Please check `package.json` for more information regarding the available commands and the project setup.
+[1]: https://github.com/kubermatic/dashboard/issues
+[2]: https://github.com/kubermatic/dashboard/blob/master/CONTRIBUTING.md
+[3]: https://github.com/kubermatic/dashboard/blob/master/Development.md
+[3]: https://github.com/kubermatic/dashboard/releases
+[4]: https://github.com/kubermatic/dashboard/blob/master/CODE_OF_CONDUCT.md
+[5]: https://github.com/kubermatic/kubermatic/blob/master/README.md
 
-### Running Commands Within the Docker Container
+[11]: https://groups.google.com/forum/#!forum/kubermatic-dev
+[12]: https://kubermatic.slack.com/messages/kubermatic
+[13]: https://github.com/kubermatic/dashboard/blob/master/Zenhub.md
+[15]: http://slack.kubermatic.io/
 
-This will run the below commands in a NodeJS Docker container with the source code mounted and set as working directory.
-```bash
-./hack/run-in-docker.sh npm install
-./hack/run-in-docker.sh npm foo
-./hack/run-in-docker.sh npm bar
-```
+[21]: https://docs.kubermatic.com/kubermatic/

--- a/Zenhub.md
+++ b/Zenhub.md
@@ -1,0 +1,15 @@
+# ZenHub
+
+As an Open Source community, it is necessary for our work, communication, and collaboration to be done in the open.
+GitHub provides a central repository for code, pull requests, issues, and documentation. When applicable, we will use Google Docs for design reviews, proposals, and other working documents.
+
+While GitHub issues, milestones, and labels generally work pretty well, the Kubermatic team has found that product planning requires some additional tooling that GitHub projects do not offer.
+
+In our effort to minimize tooling while enabling product management insights, we have decided to use [ZenHub Open-Source](https://www.zenhub.com/blog/open-source/) to overlay product and project tracking on top of GitHub.
+ZenHub is a GitHub application that provides Kanban visualization, Epic tracking, fine-grained prioritization, and more. It's primary backing storage system is existing GitHub issues along with additional metadata stored in ZenHub's database.
+
+If you are an user or developer, you do not _need_ to use ZenHub for your regular workflow (e.g to see open bug reports or feature requests, work on pull requests). However, if you'd like to be able to visualize the high-level project goals and roadmap, you will need to use the free version of ZenHub.
+
+## Using ZenHub
+
+ZenHub can be integrated within the GitHub interface using their [Chrome or Firefox extensions](https://www.zenhub.com/extension). In addition, you can use their dedicated web application.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,37 @@
+# Kubermatic Community Code of Conduct
+
+## Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering
+an open and welcoming community, we pledge to respect all people who contribute
+through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing others' private information, such as physical or electronic addresses,
+  without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are not
+aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers
+commit themselves to fairly and consistently applying these principles to every aspect
+of managing this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Kubermatic Conduct Committee via coc@kubermatic.com.
+
+This Code of Conduct is adapted from the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) and [Contributor Covenant](http://contributor-covenant.org/version/1/2/0/), version 1.2.0.

--- a/src/app/ee/LICENSE
+++ b/src/app/ee/LICENSE
@@ -1,0 +1,19 @@
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2020 Loodse GmbH
+
+   1.	You may only view, read and display for studying purposes the source 
+      code of the software licensed under this license, and, to the extent 
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including, 
+      without limitation, its execution, compilation, copying, modification 
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, 
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS

--- a/src/app/ee/README.md
+++ b/src/app/ee/README.md
@@ -1,0 +1,3 @@
+# Kubermatic Kubernetes Platform Enterprise Edition (EE)
+
+This directory includes the source code of the Kubermatic Kubernetes Platform Enterprise Edition (EE) which includes premium features that are most useful for organizations with large-scale Kubernetes installations with more than 50 clusters. To access the Enterprise Edition and get official support please become a subscriber.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add all required license information for the open source of  Kubermatic Kubernetes Platform and updates the README


**Does this PR introduce a user-facing change?**:
```release-note
Open sourcing Kubermatic Kubernetes Platform
```