### PR TITLE
Fix build/push for the CE image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 KUBERMATIC_EDITION?=ee
-REPO=quay.io/kubermatic/dashboard$(if $(KUBERMATIC_EDITION:ce=),"-${KUBERMATIC_EDITION}")
+REPO=quay.io/kubermatic/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && echo "\-${KUBERMATIC_EDITION}" )
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')
 VERSION=$(shell git describe --tags --match "v[0-9]*")
 CC=npm


### PR DESCRIPTION
**What this PR does / why we need it**:
To be honest I am not entirely sure if this will work on the CI as previous way did work locally for me. This way is taken from the Kubermatic repo with the small change that is "escaping" the `\-${VERSION}` string. Locally echo does not allow to print `-ee` as `-e` is an argument that this command takes. Not sure why it behaves differently on the CI as CI uses `bash` also.

PS. That's why I never wanted to be a DevOps :slightly_smiling_face: 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
