### PR TITLE
Fix summary view for admission plugins

### DIFF
--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -32,7 +32,7 @@
         </i>
       </div>
 
-      <div *ngIf="hasAdmissionPlugins">
+      <div *ngIf="hasAdmissionPlugins()">
         <km-property class="km-admission-plugins">
           <div key>Enabled Admission Plugins</div>
           <div value>
@@ -43,7 +43,7 @@
           </div>
         </km-property>
       </div>
-      <div *ngIf="!hasAdmissionPlugins">
+      <div *ngIf="!hasAdmissionPlugins()">
         <div class="km-summary-row">
           <span class="km-summary-left km-text">
             <i class="km-icon-disabled"></i>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix summary view for admission plugins. This only happened in the current wizard and though it will be replaced soon, I wanted to have this one fixed, as it is attracts my attention every single time. 😅 

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
