### PR TITLE
[release/2.14] Add and use gcp subnetworks path

### DIFF
--- a/src/app/shared/entity/provider/gcp/GCP.ts
+++ b/src/app/shared/entity/provider/gcp/GCP.ts
@@ -33,4 +33,5 @@ export class GCPSubnetwork {
   selfLink: string;
   privateIpGoogleAccess: boolean;
   kind: string;
+  path: string;
 }

--- a/src/app/wizard-new/step/provider-settings/provider/extended/gcp/template.html
+++ b/src/app/wizard-new/step/provider-settings/provider/extended/gcp/template.html
@@ -26,7 +26,8 @@
                (changed)="onSubNetworkChange($event)"
                [label]="subNetworkLabel"
                inputLabel="Select subnetwork..."
-               filterBy="name">
+               filterBy="name"
+               selectBy="path">
     <div *option="let subnet">
       {{subnet.name}}
     </div>

--- a/src/app/wizard/set-settings/provider-settings/gcp/gcp-provider-options/gcp-provider-options.component.html
+++ b/src/app/wizard/set-settings/provider-settings/gcp/gcp-provider-options/gcp-provider-options.component.html
@@ -27,7 +27,7 @@
            [matAutocomplete]="autoSubnetwork">
     <mat-autocomplete #autoSubnetwork="matAutocomplete">
       <mat-option *ngFor="let subnetwork of subnetworks"
-                  [value]="subnetwork.name">
+                  [value]="subnetwork.path">
         {{subnetwork.name}}
       </mat-option>
     </mat-autocomplete>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add and use gcp subnetworks path
cherry picked from https://github.com/kubermatic/dashboard/pull/2483

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
