### PR TITLE
Add magic numbers lint rule and fix code

### DIFF
--- a/cypress/integration/stories/machine-deployments.spec.ts
+++ b/cypress/integration/stories/machine-deployments.spec.ts
@@ -79,13 +79,14 @@ describe('Machine Deployments Story', () => {
   });
 
   it('should wait for initial machine deployment to be created', () => {
+    const timeout = 900000;
     TrafficMonitor.newTrafficMonitor()
       .method(RequestType.GET)
       .url(Endpoint.NodeDeployments)
       .alias('getMachineDeployments')
-      .timeout(900000)
+      .timeout(timeout)
       .wait();
-    ClustersPage.getMachineDeploymentList(900000).should(Condition.Contain, initialMachineDeploymentName);
+    ClustersPage.getMachineDeploymentList(timeout).should(Condition.Contain, initialMachineDeploymentName);
   });
 
   it('should go to machine deployment details', () => {

--- a/cypress/pages/clusters.po.ts
+++ b/cypress/pages/clusters.po.ts
@@ -16,6 +16,8 @@ import {View} from '../utils/view';
 import {WizardPage} from './wizard.po';
 
 export class ClustersPage {
+  private static readonly _defaultTimeout = 5000;
+
   static getAddClusterBtn(): Cypress.Chainable<any> {
     return cy.get('#km-add-cluster-top-btn');
   }
@@ -56,7 +58,7 @@ export class ClustersPage {
     return cy.get('#km-confirmation-dialog-confirm-btn');
   }
 
-  static getMachineDeploymentList(timeout = 5000): Cypress.Chainable {
+  static getMachineDeploymentList(timeout = this._defaultTimeout): Cypress.Chainable {
     return cy.get('km-machine-deployment-list', {timeout: timeout});
   }
 

--- a/cypress/pages/projects.po.ts
+++ b/cypress/pages/projects.po.ts
@@ -63,11 +63,12 @@ export class ProjectsPage {
   }
 
   static waitForProject(projectName: string): void {
+    const retries = 5;
     TrafficMonitor.newTrafficMonitor()
       .method(RequestType.GET)
       .url(Endpoint.Projects)
       .alias('listProjects')
-      .retry(5)
+      .retry(retries)
       .expect(Response.newResponse(ResponseType.LIST).elements(1).property(Property.newProperty('name', projectName)));
   }
 
@@ -85,11 +86,12 @@ export class ProjectsPage {
   }
 
   static selectProject(projectName: string): void {
+    const waitTime = 500;
     cy.reload();
     this.getProjectItem(projectName).should(Condition.HaveLength, 1);
     this.getActiveProjects()
       .should(Condition.HaveLength, 1)
-      .wait(500)
+      .wait(waitTime)
       .click()
       .then(() => {
         ClustersPage.waitForRefresh();
@@ -110,6 +112,7 @@ export class ProjectsPage {
   }
 
   static deleteProject(projectName: string): void {
+    const retries = 5;
     this.getDeleteProjectBtn(projectName).should(Condition.NotBe, 'disabled').click();
     cy.get('#km-confirmation-dialog-input').type(projectName).should(Condition.HaveValue, projectName);
     cy.get('#km-confirmation-dialog-confirm-btn')
@@ -120,7 +123,7 @@ export class ProjectsPage {
           .method(RequestType.GET)
           .url(Endpoint.Projects)
           .alias('listProjects')
-          .retry(5)
+          .retry(retries)
           .expect(Response.newResponse(ResponseType.LIST).elements(0));
       });
   }

--- a/cypress/utils/random.ts
+++ b/cypress/utils/random.ts
@@ -10,7 +10,10 @@
 // limitations under the License.
 
 export function randomString(): string {
-  return Math.random().toString(36).substring(2, 15);
+  const radix = 36,
+    rangeStart = 2,
+    rangeEnd = 15;
+  return Math.random().toString(radix).substring(rangeStart, rangeEnd);
 }
 
 export function prefixedString(prefix: string): string {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,14 @@
       "@typescript-eslint/no-namespace": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-magic-numbers": [
+        "error", {
+          "ignore": [-1, 0, 1],
+          "ignoreArrayIndexes": true,
+          "ignoreReadonlyClassProperties": true,
+          "ignoreEnums": true
+        }
+      ],
       "node/no-unpublished-import": "off",
       "node/no-extraneous-require": "error",
       "node/no-unpublished-require": "error",
@@ -124,6 +132,7 @@
       "no-undef": "off",
       "no-inner-declarations": "off",
       "no-redeclare": "off",
+      "no-magic-numbers": "off",
       "eol-last": "error",
       "no-console": "error",
       "no-prototype-builtins": "error",

--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -189,7 +189,8 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
           this.bindings = this.createSimpleBinding(bindings);
         },
         error => {
-          if (error.status === 404) {
+          const errorCodeNotFound = 404;
+          if (error.status === errorCodeNotFound) {
             this._router.navigate(['404']);
           }
         }

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
@@ -44,9 +44,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     isValid: true,
     cloudSpecPatch: {},
   };
-
-  private _unsubscribe = new Subject<void>();
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
+
+  private readonly _nameMinLen = 3;
+  private _unsubscribe = new Subject<void>();
 
   constructor(
     private readonly _clusterService: ClusterService,
@@ -62,7 +63,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     this.form = new FormGroup({
       name: new FormControl(this.cluster.name, [
         Validators.required,
-        Validators.minLength(3),
+        Validators.minLength(this._nameMinLen),
         Validators.pattern('[a-zA-Z0-9-]*'),
       ]),
       auditLogging: new FormControl(!!this.cluster.spec.auditLogging && this.cluster.spec.auditLogging.enabled),

--- a/src/app/cluster/cluster-details/edit-provider-settings/alibaba-provider-settings/alibaba-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/alibaba-provider-settings/alibaba-provider-settings.component.ts
@@ -23,6 +23,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class AlibabaProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {accessKeyID: '', accessKeySecret: ''};
   private _unsubscribe = new Subject<void>();
 
@@ -35,7 +37,7 @@ export class AlibabaProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (

--- a/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/aws-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/aws-provider-settings.component.ts
@@ -23,6 +23,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class AWSProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {accessKeyId: '', secretAccessKey: ''};
   private _unsubscribe = new Subject<void>();
 
@@ -35,7 +37,7 @@ export class AWSProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (

--- a/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/azure-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/azure-provider-settings.component.ts
@@ -23,6 +23,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class AzureProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {
     clientID: '',
     clientSecret: '',
@@ -42,7 +44,7 @@ export class AzureProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (

--- a/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/digitalocean-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/digitalocean-provider-settings.component.ts
@@ -23,6 +23,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class DigitaloceanProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {token: ''};
   private _unsubscribe = new Subject<void>();
 
@@ -34,7 +36,7 @@ export class DigitaloceanProviderSettingsComponent implements OnInit, OnDestroy 
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (data.token !== this._formData.token) {
@@ -53,7 +55,8 @@ export class DigitaloceanProviderSettingsComponent implements OnInit, OnDestroy 
     if (!this.token.value) {
       this.token.clearValidators();
     } else {
-      this.token.setValidators([Validators.required, Validators.minLength(64), Validators.maxLength(64)]);
+      const tokenLen = 64;
+      this.token.setValidators([Validators.required, Validators.minLength(tokenLen), Validators.maxLength(tokenLen)]);
     }
 
     this.token.updateValueAndValidity();

--- a/src/app/cluster/cluster-details/edit-provider-settings/gcp-provider-settings/gcp-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/gcp-provider-settings/gcp-provider-settings.component.ts
@@ -22,6 +22,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class GCPProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {serviceAccount: ''};
   private _unsubscribe: Subject<any> = new Subject();
 
@@ -33,7 +35,7 @@ export class GCPProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (data.serviceAccount !== this._formData.serviceAccount) {

--- a/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/hetzner-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/hetzner-provider-settings.component.ts
@@ -23,6 +23,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class HetznerProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {token: ''};
   private _unsubscribe = new Subject<void>();
 
@@ -34,7 +36,7 @@ export class HetznerProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (data.token !== this._formData.token) {
@@ -53,7 +55,8 @@ export class HetznerProviderSettingsComponent implements OnInit, OnDestroy {
     if (!this.token.value) {
       this.token.clearValidators();
     } else {
-      this.token.setValidators([Validators.required, Validators.minLength(64), Validators.maxLength(64)]);
+      const tokenLen = 64;
+      this.token.setValidators([Validators.required, Validators.minLength(tokenLen), Validators.maxLength(tokenLen)]);
     }
 
     this.token.updateValueAndValidity();

--- a/src/app/cluster/cluster-details/edit-provider-settings/kubevirt-provider-settings/kubevirt-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/kubevirt-provider-settings/kubevirt-provider-settings.component.ts
@@ -23,6 +23,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class KubevirtProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {kubeconfig: ''};
   private _unsubscribe = new Subject<void>();
 
@@ -34,7 +36,7 @@ export class KubevirtProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (data.kubeconfig !== this._formData.kubeconfig) {

--- a/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/openstack-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/openstack-provider-settings.component.ts
@@ -23,6 +23,8 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 })
 export class OpenstackProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
+
+  private readonly _debounceTime = 1000;
   private _formData = {username: '', password: ''};
   private _unsubscribe = new Subject<void>();
 
@@ -35,7 +37,7 @@ export class OpenstackProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (data.username !== this._formData.username || data.password !== this._formData.password) {

--- a/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/packet-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/packet-provider-settings.component.ts
@@ -23,7 +23,13 @@ import {AVAILABLE_PACKET_BILLING_CYCLES, Cluster, ProviderSettingsPatch} from '.
 })
 export class PacketProviderSettingsComponent implements OnInit, OnDestroy {
   @Input() cluster: Cluster;
+
   form: FormGroup;
+
+  private readonly _billingCycleMaxLen = 64;
+  private readonly _apiKeyMaxLen = 64;
+  private readonly _projectIDMaxLen = 64;
+  private readonly _debounceTime = 1000;
   private _formData = {apiKey: '', projectID: '', billingCycle: ''};
   private _unsubscribe: Subject<any> = new Subject();
 
@@ -40,11 +46,11 @@ export class PacketProviderSettingsComponent implements OnInit, OnDestroy {
     this.form = new FormGroup({
       apiKey: new FormControl(''),
       projectID: new FormControl(''),
-      billingCycle: new FormControl(billingCycle, [Validators.maxLength(64)]),
+      billingCycle: new FormControl(billingCycle, [Validators.maxLength(this._billingCycleMaxLen)]),
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (
@@ -72,8 +78,8 @@ export class PacketProviderSettingsComponent implements OnInit, OnDestroy {
       this.apiKey.clearValidators();
       this.projectID.clearValidators();
     } else {
-      this.apiKey.setValidators([Validators.required, Validators.maxLength(256)]);
-      this.projectID.setValidators([Validators.required, Validators.maxLength(256)]);
+      this.apiKey.setValidators([Validators.required, Validators.maxLength(this._apiKeyMaxLen)]);
+      this.projectID.setValidators([Validators.required, Validators.maxLength(this._projectIDMaxLen)]);
     }
 
     this.apiKey.updateValueAndValidity();

--- a/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/vsphere-provider-settings.component.ts
@@ -23,6 +23,7 @@ import {ProviderSettingsPatch} from '../../../../shared/entity/cluster';
 export class VSphereProviderSettingsComponent implements OnInit, OnDestroy {
   form: FormGroup;
 
+  private readonly _debounceTime = 1000;
   private _formData = {
     infraManagementUsername: '',
     infraManagementPassword: '',
@@ -42,7 +43,7 @@ export class VSphereProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     this.form.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (

--- a/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys.component.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/edit-sshkeys.component.ts
@@ -40,11 +40,14 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
   @Input() seed: string;
   @Input() projectID: string;
 
+  @ViewChild(MatSort, {static: true}) sort: MatSort;
+
   loading = true;
   sshKeys: SSHKey[] = [];
   displayedColumns: string[] = ['name', 'actions'];
   dataSource = new MatTableDataSource<SSHKey>();
-  @ViewChild(MatSort, {static: true}) sort: MatSort;
+
+  private readonly _refreshTime = 5; // in seconds
   private _user: Member;
   private _currentGroupConfig: GroupConfig;
   private _unsubscribe: Subject<any> = new Subject();
@@ -70,7 +73,7 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
     this.sort.active = 'name';
     this.sort.direction = 'asc';
 
-    merge(timer(0, 5 * this._appConfig.getRefreshTimeBase()), this._sshKeysUpdate)
+    merge(timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase()), this._sshKeysUpdate)
       .pipe(
         switchMap(() =>
           this.projectID ? this._clusterService.sshKeys(this.projectID, this.cluster.id, this.seed) : EMPTY

--- a/src/app/cluster/cluster-details/machine-deployment-details/machine-deployment-details.component.ts
+++ b/src/app/cluster/cluster-details/machine-deployment-details/machine-deployment-details.component.ts
@@ -47,6 +47,8 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
   system: string;
   systemLogoClass: string;
   projectID: string;
+
+  private readonly _refreshTime = 10; // in seconds
   private _machineDeploymentID: string;
   private _isMachineDeploymentLoaded = false;
   private _areNodesLoaded = false;
@@ -83,7 +85,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(userGroup => (this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup)));
 
-    timer(0, 10 * this._appConfig.getRefreshTimeBase())
+    timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase())
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(() => {
         this.loadMachineDeployment();

--- a/src/app/cluster/cluster-details/node-list/node-list.component.ts
+++ b/src/app/cluster/cluster-details/node-list/node-list.component.ts
@@ -44,6 +44,10 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
   @Output() deleteNode = new EventEmitter<Node>();
   @Input() clusterHealthStatus: ClusterHealthStatus;
   @Input() isClusterRunning: boolean;
+
+  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+
   config: MatDialogConfig = {
     disableClose: false,
     hasBackdrop: true,
@@ -60,8 +64,7 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
   ];
   toggledColumns: string[] = ['nodeDetails'];
   dataSource = new MatTableDataSource<Node>();
-  @ViewChild(MatSort, {static: true}) sort: MatSort;
-  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+
   private _user: Member;
   private _currentGroupConfig: GroupConfig;
   private _unsubscribe = new Subject<void>();
@@ -146,18 +149,21 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
   getFormattedNodeMemory(memory: string): string {
     const memRE = /([0-9]+)([a-zA-Z])i/;
     const resRE = memory.match(memRE);
+    const base = 1024;
+    const radix = 10;
+    const fractionDigits = 2;
 
     let nodeCapacity;
     const prefixes = ['Ki', 'Mi', 'Gi', 'Ti'];
     let i = 0;
 
     if (resRE) {
-      let ki = parseInt(resRE[1], 10);
+      let ki = parseInt(resRE[1], radix);
       do {
-        ki /= 1024;
+        ki /= base;
         i++;
       } while (ki > 1);
-      nodeCapacity = (ki * 1024).toFixed(2);
+      nodeCapacity = (ki * base).toFixed(fractionDigits);
     }
 
     return nodeCapacity ? `${nodeCapacity} ${prefixes[i - 1]}` : 'unknown';

--- a/src/app/cluster/cluster-details/rbac/add-binding/add-binding.component.ts
+++ b/src/app/cluster/cluster-details/rbac/add-binding/add-binding.component.ts
@@ -37,12 +37,15 @@ export class AddBindingComponent implements OnInit, OnDestroy {
   @Input() cluster: Cluster;
   @Input() seed: string;
   @Input() projectID: string;
+
   readonly controls = Controls;
   form: FormGroup;
   bindingType = 'cluster';
   subjectType = 'user';
   clusterRoles: ClusterRoleName[];
   roles: RoleName[];
+
+  private readonly _debounceTime = 1000;
   private _unsubscribe = new Subject<void>();
 
   constructor(
@@ -87,7 +90,7 @@ export class AddBindingComponent implements OnInit, OnDestroy {
       });
 
     this.form.controls.role.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(data => {
         if (this.bindingType === 'namespace') {

--- a/src/app/core/components/sidenav/sidenav.component.spec.ts
+++ b/src/app/core/components/sidenav/sidenav.component.spec.ts
@@ -83,8 +83,9 @@ describe('SidenavComponent', () => {
   }));
 
   it('should get RouterLinks from template', () => {
+    const expectedLinks = 5;
     fixture.detectChanges();
-    expect(links.length).toBe(5);
+    expect(links.length).toBe(expectedLinks);
     expect(links[0].linkParams).toBe(`/projects/${fakeProjects()[0].id}/clusters`);
   });
 

--- a/src/app/core/components/sidenav/sidenav.component.ts
+++ b/src/app/core/components/sidenav/sidenav.component.ts
@@ -37,6 +37,7 @@ export class SidenavComponent implements OnInit, OnDestroy {
   settings: UserSettings;
   currentUser: Member;
   screenWidth = 0;
+
   private _selectedProject = {} as Project;
   private _currentGroupConfig: GroupConfig;
   private _isSidenavCollapsed = false;
@@ -90,7 +91,8 @@ export class SidenavComponent implements OnInit, OnDestroy {
   }
 
   isSidenavCollapsed(): boolean {
-    return this._isSidenavCollapsed || this.screenWidth < 767;
+    const maxScreenWidth = 767;
+    return this._isSidenavCollapsed || this.screenWidth < maxScreenWidth;
   }
 
   getLinkClass(url: string): string {

--- a/src/app/core/services/api/api.service.ts
+++ b/src/app/core/services/api/api.service.ts
@@ -47,11 +47,12 @@ import {AzureSizes, AzureZones} from '../../../shared/entity/provider/azure';
 
 @Injectable()
 export class ApiService {
+  private readonly _token: string;
+  private readonly _refreshTime = 30; // in seconds
   private _location: string = window.location.protocol + '//' + window.location.host;
   private _restRoot: string = environment.restRoot;
-  private readonly _token: string;
   private _addonConfigs$: Observable<any>;
-  private _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * 30);
+  private _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * this._refreshTime);
 
   constructor(
     private readonly _http: HttpClient,

--- a/src/app/core/services/auth/auth.service.ts
+++ b/src/app/core/services/auth/auth.service.ts
@@ -24,7 +24,8 @@ import {UserService} from '../user/user.service';
 
 @Injectable()
 export class Auth {
-  private readonly _nonce = RandomString(32);
+  private readonly _nonceLen = 32;
+  private readonly _nonce = RandomString(this._nonceLen);
   private readonly _responseType = 'id_token';
   private readonly _clientId = 'kubermatic';
   private readonly _defaultScope = 'openid email profile groups';
@@ -122,7 +123,8 @@ export class Auth {
   setNonce(): void {
     const nonceRegExp = /[?&#]nonce=([^&]+)/;
     const nonceStr = nonceRegExp.exec(this.getOIDCProviderURL());
-    if (!!nonceStr && nonceStr.length >= 2 && !!nonceStr[1]) {
+    const minLen = 2;
+    if (!!nonceStr && nonceStr.length >= minLen && !!nonceStr[1]) {
       this._cookieService.set(this._cookie.nonce, nonceStr[1], null, '/', null, true, 'Lax');
       // localhost is only served via http, though secure cookie is not possible
       // following line will only work when domain is localhost

--- a/src/app/core/services/cluster/cluster.service.ts
+++ b/src/app/core/services/cluster/cluster.service.ts
@@ -30,11 +30,12 @@ import {CreateClusterModel} from '../../../shared/model/CreateClusterModel';
 
 @Injectable()
 export class ClusterService {
+  private readonly _refreshTime = 10; // in seconds
   private _providerSettingsPatch = new Subject<ProviderSettingsPatch>();
   private _restRoot: string = environment.restRoot;
   private _headers: HttpHeaders = new HttpHeaders();
   private _clusters$ = new Map<string, Observable<Cluster[]>>();
-  private _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * 10);
+  private _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * this._refreshTime);
   private _onClustersUpdate = new Subject<void>();
 
   providerSettingsPatchChanges$ = this._providerSettingsPatch.asObservable();

--- a/src/app/core/services/datacenter/datacenter.service.ts
+++ b/src/app/core/services/datacenter/datacenter.service.ts
@@ -20,12 +20,13 @@ import {Auth} from '../auth/auth.service';
 
 @Injectable()
 export class DatacenterService {
+  private readonly _refreshTime = 60;
   private _restRoot: string = environment.restRoot;
   private _datacenters$: Observable<Datacenter[]>;
   private _datacentersRefresh$ = new Subject();
   private _seeds$: Observable<string[]>;
   private _seedsRefresh$ = new Subject();
-  private _refreshTimer$ = timer(0, this._appConfigService.getRefreshTimeBase() * 60);
+  private _refreshTimer$ = timer(0, this._appConfigService.getRefreshTimeBase() * this._refreshTime);
 
   constructor(
     private readonly _httpClient: HttpClient,

--- a/src/app/core/services/previous-route/previous-route.service.ts
+++ b/src/app/core/services/previous-route/previous-route.service.ts
@@ -24,7 +24,8 @@ export class PreviousRouteService {
       .pipe(filter(event => event instanceof NavigationEnd))
       .subscribe((urlAfterRedirects: NavigationEnd) => {
         this.history = [...this.history, urlAfterRedirects];
-        if (this.history.length > 10) {
+        const maxHistoryLen = 10;
+        if (this.history.length > maxHistoryLen) {
           this.history.splice(0, 1);
         }
       });
@@ -35,6 +36,7 @@ export class PreviousRouteService {
   }
 
   getPreviousUrl(): string {
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     return this.history[this.history.length - 2] || '/';
   }
 }

--- a/src/app/core/services/project/project.service.ts
+++ b/src/app/core/services/project/project.service.ts
@@ -28,7 +28,8 @@ export class ProjectService {
   onProjectsUpdate = new Subject<void>();
 
   private readonly _restRoot: string = environment.restRoot;
-  private readonly _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * 10);
+  private readonly _refreshTime = 10; // in seconds
+  private readonly _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * this._refreshTime);
 
   private _projects$: Observable<Project[]>;
   private _myProjects$: Observable<Project[]>;

--- a/src/app/core/services/token/token.service.ts
+++ b/src/app/core/services/token/token.service.ts
@@ -16,6 +16,8 @@ import {Cookie, COOKIE_DI_TOKEN} from '../../../app.config';
 
 @Injectable()
 export class TokenService {
+  private readonly _baseTime = 1000; // in ms
+
   constructor(
     private readonly _cookieService: CookieService,
     @Inject(COOKIE_DI_TOKEN) private readonly _cookie: Cookie
@@ -25,7 +27,7 @@ export class TokenService {
     const token = this._cookieService.get(this._cookie.token);
     if (token) {
       const tokenExp = this.decodeToken(token);
-      return moment().isBefore(moment(tokenExp.exp * 1000));
+      return moment().isBefore(moment(tokenExp.exp * this._baseTime));
     }
     return false;
   }
@@ -33,7 +35,8 @@ export class TokenService {
   decodeToken(token: string): any {
     if (token) {
       const parts = token.split('.');
-      if (parts.length !== 3) {
+      const expectedParts = 3;
+      if (parts.length !== expectedParts) {
         throw new Error('JWT must have 3 parts');
       }
       const decoded = this._urlBase64Decode(parts[1]);
@@ -44,6 +47,7 @@ export class TokenService {
     }
   }
 
+  /* eslint-disable @typescript-eslint/no-magic-numbers */
   private _urlBase64Decode(str: string): string {
     let output = str.replace(/-/g, '+').replace(/_/g, '/');
     switch (output.length % 4) {

--- a/src/app/core/services/user/user.service.ts
+++ b/src/app/core/services/user/user.service.ts
@@ -29,6 +29,7 @@ export class UserService {
   private readonly wsRoot = environment.wsRoot;
   private readonly _currentUser$ = new BehaviorSubject<Member>(undefined);
   private readonly _currentUserSettings$ = new BehaviorSubject<UserSettings>(DEFAULT_USER_SETTINGS);
+  private readonly _refreshTime = 3; // in seconds
 
   constructor(
     private readonly _httpClient: HttpClient,
@@ -44,7 +45,7 @@ export class UserService {
           errors.pipe(
             // eslint-disable-next-line no-console
             tap(console.debug),
-            delay(this._appConfigService.getRefreshTimeBase() * 3)
+            delay(this._appConfigService.getRefreshTimeBase() * this._refreshTime)
           )
         )
       );

--- a/src/app/dynamic/enterprise/theming/services/color-scheme.ts
+++ b/src/app/dynamic/enterprise/theming/services/color-scheme.ts
@@ -23,8 +23,8 @@ export enum ColorScheme {
 @Injectable()
 export class ColorSchemeService {
   private readonly _colorSchemeMediaQuery = colorScheme => `(prefers-color-scheme: ${colorScheme})`;
+  private readonly _timerInterval = 1000;
   private _selectedColorScheme = ColorScheme.NoPreference;
-  private _timerInterval = 1000;
 
   readonly onColorSchemeUpdate = new EventEmitter<ColorScheme>();
 

--- a/src/app/machine-networks/machine-networks.component.ts
+++ b/src/app/machine-networks/machine-networks.component.ts
@@ -11,6 +11,7 @@
 
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {FormArray, FormControl, FormGroup, Validators} from '@angular/forms';
+import * as _ from 'lodash';
 import {Subject} from 'rxjs';
 import {debounceTime, takeUntil} from 'rxjs/operators';
 import {WizardService} from '../core/services';
@@ -25,8 +26,11 @@ export class MachineNetworksComponent implements OnInit, OnDestroy {
   @Input() cluster: Cluster;
   @Input() width: number;
   @Input() isWizard: boolean;
+
   machineNetworksForm: FormGroup;
   machineNetworks: FormArray;
+
+  private readonly _debounceTime = 1000;
   private _unsubscribe = new Subject<void>();
 
   constructor(private wizardService: WizardService) {}
@@ -57,7 +61,7 @@ export class MachineNetworksComponent implements OnInit, OnDestroy {
       }
     }
 
-    if (machineNetworksList.length === 0) {
+    if (_.isEmpty(machineNetworksList)) {
       machineNetworksList.push(
         new FormGroup({
           cidr: new FormControl('', [
@@ -78,7 +82,7 @@ export class MachineNetworksComponent implements OnInit, OnDestroy {
     });
 
     this.machineNetworksForm.valueChanges
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(() => {
         this.setMachineNetworkSpec();

--- a/src/app/machine-networks/machine-networks.component.ts
+++ b/src/app/machine-networks/machine-networks.component.ts
@@ -61,7 +61,7 @@ export class MachineNetworksComponent implements OnInit, OnDestroy {
       }
     }
 
-    if (_.isEmpty(machineNetworksList)) {
+    if (machineNetworksList.length === 0) {
       machineNetworksList.push(
         new FormGroup({
           cidr: new FormControl('', [

--- a/src/app/member/member.component.spec.ts
+++ b/src/app/member/member.component.spec.ts
@@ -81,9 +81,10 @@ describe('MemberComponent', () => {
   });
 
   it('should open delete member confirmation dialog & call deleteMembers()', fakeAsync(() => {
+    const waitTime = 15000;
     component.deleteMember(fakeMembers()[0]);
     noop.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     const dialogTitle = document.body.querySelector('.mat-dialog-title');
     const deleteButton = document.body.querySelector('#km-confirmation-dialog-confirm-btn') as HTMLInputElement;
@@ -95,7 +96,7 @@ describe('MemberComponent', () => {
 
     noop.detectChanges();
     fixture.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     expect(deleteMembersSpy).toHaveBeenCalled();
     fixture.destroy();

--- a/src/app/member/member.component.ts
+++ b/src/app/member/member.component.ts
@@ -42,8 +42,11 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
   currentUser: Member;
   displayedColumns: string[] = ['name', 'email', 'group', 'actions'];
   dataSource = new MatTableDataSource<Member>();
+
   @ViewChild(MatSort, {static: true}) sort: MatSort;
   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+
+  private readonly _refreshTime = 10; // in seconds
   private _unsubscribe: Subject<any> = new Subject();
   private _membersUpdate: Subject<any> = new Subject();
   private _currentGroupConfig: GroupConfig;
@@ -83,7 +86,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(first())
       .subscribe(userGroup => (this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup)));
 
-    merge(timer(0, 10 * this._appConfig.getRefreshTimeBase()), this._membersUpdate)
+    merge(timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase()), this._membersUpdate)
       .pipe(switchMap(() => (this._selectedProject ? this._apiService.getMembers(this._selectedProject.id) : EMPTY)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(members => {

--- a/src/app/node-data/basic/provider/aws/component.ts
+++ b/src/app/node-data/basic/provider/aws/component.ts
@@ -69,6 +69,8 @@ enum SubnetState {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnInit, AfterViewChecked, OnDestroy {
+  private readonly _defaultDiskSize = 25;
+
   private _diskTypes: string[] = ['standard', 'gp2', 'io1', 'sc1', 'st1'];
   private _subnets: AWSSubnet[] = [];
   private _subnetMap: {[type: string]: AWSSubnet[]} = {};
@@ -114,7 +116,7 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.Size]: this._builder.control(''),
-      [Controls.DiskSize]: this._builder.control(25, Validators.required),
+      [Controls.DiskSize]: this._builder.control(this._defaultDiskSize, Validators.required),
       [Controls.DiskType]: this._builder.control('', Validators.required),
       [Controls.SubnetID]: this._builder.control(''),
       [Controls.AMI]: this._builder.control(''),

--- a/src/app/node-data/basic/provider/digitalocean/component.ts
+++ b/src/app/node-data/basic/provider/digitalocean/component.ts
@@ -98,8 +98,9 @@ export class DigitalOceanBasicNodeDataComponent extends BaseFormValidator implem
 
   sizeDisplayName(slug: string): string {
     const size = [...this._sizes.optimized, ...this._sizes.standard].find(size => size.slug === slug);
+    const memoryBase = 1024;
     return size
-      ? `${size.slug} (${size.memory / 1024} GB RAM, ${size.vcpus} CPU${size.vcpus !== 1 ? 's' : ''}, $${
+      ? `${size.slug} (${size.memory / memoryBase} GB RAM, ${size.vcpus} CPU${size.vcpus !== 1 ? 's' : ''}, $${
           size.price_monthly
         } per month)`
       : '';

--- a/src/app/node-data/basic/provider/gcp/component.ts
+++ b/src/app/node-data/basic/provider/gcp/component.ts
@@ -75,6 +75,7 @@ enum MachineTypeState {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GCPBasicNodeDataComponent extends BaseFormValidator implements OnInit, AfterViewInit, OnDestroy {
+  private readonly _defaultDiskSize = 25;
   private _zoneChanges = new EventEmitter<boolean>();
 
   @ViewChild('zonesCombobox')
@@ -124,7 +125,7 @@ export class GCPBasicNodeDataComponent extends BaseFormValidator implements OnIn
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.DiskSize]: this._builder.control(25, Validators.required),
+      [Controls.DiskSize]: this._builder.control(this._defaultDiskSize, Validators.required),
       [Controls.DiskType]: this._builder.control('', Validators.required),
       [Controls.Zone]: this._builder.control('', Validators.required),
       [Controls.MachineType]: this._builder.control('', Validators.required),

--- a/src/app/node-data/basic/provider/hetzner/component.ts
+++ b/src/app/node-data/basic/provider/hetzner/component.ts
@@ -11,6 +11,7 @@
 
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import * as _ from 'lodash';
 import {Observable} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {HetznerTypes, Type} from '../../../../shared/entity/provider/hetzner';
@@ -120,7 +121,7 @@ export class HetznerBasicNodeDataComponent extends BaseFormValidator implements 
       ? this._nodeDataService.nodeData.spec.cloud.hetzner.type
       : '';
 
-    if (!this.selectedType && this._types && this._types.standard && this._types.standard.length > 0) {
+    if (!this.selectedType && this._types && this._types.standard && !_.isEmpty(this._types.standard)) {
       this.selectedType = this._types.standard[0].name;
     }
 

--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -26,7 +26,6 @@ import {filter, first, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 import {DatacenterService} from '../../../../core/services';
 import {FilteredComboboxComponent} from '../../../../shared/components/combobox/component';
 import {ClusterType} from '../../../../shared/entity/cluster';
-
 import {DatacenterOperatingSystemOptions} from '../../../../shared/entity/datacenter';
 import {NodeCloudSpec, NodeSpec, OpenstackNodeSpec} from '../../../../shared/entity/node';
 import {OpenstackAvailabilityZone, OpenstackFlavor} from '../../../../shared/entity/provider/openstack';
@@ -197,8 +196,9 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
 
   flavorDisplayName(slug: string): string {
     const flavor = this.flavors.find(flavor => flavor.slug === slug);
+    const base = 1024;
     return flavor
-      ? `${flavor.slug} - ${flavor.memory / 1024} GB RAM, ${flavor.vcpus} CPU${flavor.vcpus !== 1 ? 's' : ''}, ${
+      ? `${flavor.slug} - ${flavor.memory / base} GB RAM, ${flavor.vcpus} CPU${flavor.vcpus !== 1 ? 's' : ''}, ${
           flavor.disk
         } GB Disk`
       : '';
@@ -240,7 +240,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
       this.selectedFlavor = this.flavors[0].slug;
     }
 
-    this.flavorsLabel = this.flavors.length > 0 ? FlavorState.Ready : FlavorState.Empty;
+    this.flavorsLabel = !_.isEmpty(this.flavors) ? FlavorState.Ready : FlavorState.Empty;
     this._cdr.detectChanges();
   }
 
@@ -260,8 +260,9 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
   private _setAvailabilityZone(availabilityZones: OpenstackAvailabilityZone[]): void {
     this.availabilityZones = availabilityZones;
     this.selectedAvailabilityZone = this._nodeDataService.nodeData.spec.cloud.openstack.availabilityZone;
-    this.availabilityZonesLabel =
-      this.availabilityZones.length > 0 ? AvailabilityZoneState.Ready : AvailabilityZoneState.Empty;
+    this.availabilityZonesLabel = !_.isEmpty(this.availabilityZones)
+      ? AvailabilityZoneState.Ready
+      : AvailabilityZoneState.Empty;
     this._cdr.detectChanges();
   }
 

--- a/src/app/node-data/basic/provider/vsphere/component.ts
+++ b/src/app/node-data/basic/provider/vsphere/component.ts
@@ -40,6 +40,9 @@ enum Controls {
   ],
 })
 export class VSphereBasicNodeDataComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  private readonly _defaultCPUCount = 2;
+  private readonly _defaultMemory = 4096;
+  private readonly _minMemory = 512;
   readonly Controls = Controls;
 
   constructor(private readonly _builder: FormBuilder, private readonly _nodeDataService: NodeDataService) {
@@ -48,8 +51,11 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.CPU]: this._builder.control(2, [Validators.required, Validators.min(1)]),
-      [Controls.Memory]: this._builder.control(4096, [Validators.required, Validators.min(512)]),
+      [Controls.CPU]: this._builder.control(this._defaultCPUCount, [Validators.required, Validators.min(1)]),
+      [Controls.Memory]: this._builder.control(this._defaultMemory, [
+        Validators.required,
+        Validators.min(this._minMemory),
+      ]),
     });
 
     this._init();

--- a/src/app/node-data/extended/provider/vsphere/component.ts
+++ b/src/app/node-data/extended/provider/vsphere/component.ts
@@ -45,6 +45,8 @@ enum Controls {
   ],
 })
 export class VSphereExtendedNodeDataComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  private readonly _defaultDiskSize = 10;
+
   private _defaultTemplate = '';
   private _templates: DatacenterOperatingSystemOptions;
 
@@ -65,7 +67,7 @@ export class VSphereExtendedNodeDataComponent extends BaseFormValidator implemen
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.DiskSizeGB]: this._builder.control(10),
+      [Controls.DiskSizeGB]: this._builder.control(this._defaultDiskSize),
       [Controls.Template]: this._builder.control(''),
     });
 

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -76,13 +76,14 @@ describe('ProjectComponent', () => {
   });
 
   it('should open delete project confirmation dialog & call deleteProject()', fakeAsync(() => {
+    const waitTime = 15000;
     const project = fakeProject();
     const event = new MouseEvent('click');
 
     component.deleteProject(project, event);
     noop.detectChanges();
     fixture.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     const dialogTitle = document.body.querySelector('.mat-dialog-title');
     const deleteButton = document.body.querySelector('#km-confirmation-dialog-confirm-btn') as HTMLInputElement;

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -51,9 +51,13 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
   isPaginatorVisible = false;
   showCards = true;
   settings: UserSettings;
+
+  private readonly _refreshTime = 10; // in seconds
+  private readonly _debounceTime = 500;
+  private readonly _maxOwnersLen = 30;
   private _settingsChange = new Subject<void>();
   private _unsubscribe: Subject<any> = new Subject();
-  private _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * 10);
+  private _refreshTimer$ = timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase());
 
   paginator: MatPaginator;
   @ViewChild(MatPaginator)
@@ -110,7 +114,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
       .subscribe(_ => this.selectDefaultProject());
 
     this._settingsChange
-      .pipe(debounceTime(500))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .pipe(
         switchMap(() =>
@@ -220,30 +224,33 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   getOwners(owners: ProjectOwners[]): string {
-    return this.isMoreOwners(owners) ? this.getOwnerString(owners).substring(0, 30) : this.getOwnerString(owners);
+    return this.isMoreOwners(owners)
+      ? this.getOwnerString(owners).substring(0, this._maxOwnersLen)
+      : this.getOwnerString(owners);
   }
 
   isMoreOwners(owners: ProjectOwners[]): boolean {
-    return this.getOwnerString(owners).length > 30;
+    return this.getOwnerString(owners).length > this._maxOwnersLen;
   }
 
   getMoreOwnersCount(owners: ProjectOwners[]): number {
     return this.isMoreOwners(owners)
-      ? owners.length - this.getOwnerString(owners).substring(0, 30).split(', ').length
+      ? owners.length - this.getOwnerString(owners).substring(0, this._maxOwnersLen).split(', ').length
       : 0;
   }
 
   getMoreOwners(owners: ProjectOwners[]): string {
     // truncatedLength = number of displayed owner names
-    const truncatedLength = this.getOwnerString(owners).substring(0, 30).split(', ').length;
+    const truncatedLength = this.getOwnerString(owners).substring(0, this._maxOwnersLen).split(', ').length;
     // count = length of original owner names that are displayed
-    // (truncatedLength - 1) * 2 = additional number of seperators (', ' = 2)
-    let count: number = (truncatedLength - 1) * 2;
+    // (truncatedLength - 1) * 2 = additional number of separators (', ' = 2)
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    let count = (truncatedLength - 1) * 2;
     for (let i = 0; i < truncatedLength; i++) {
       count += owners[i].name.length;
     }
     // if last displayed name is not complete, show it in tooltip
-    return count > 30
+    return count > this._maxOwnersLen
       ? this.getOwnerNameArray(owners)
           .slice(truncatedLength - 1, owners.length)
           .join(', ')
@@ -279,11 +286,14 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   getName(name: string): string {
-    return name.length > 18 ? `${name.substring(0, 15)}...` : `${name}`;
+    const maxNameLen = 18;
+    const truncatedNameLen = 15;
+    return name.length > maxNameLen ? `${name.substring(0, truncatedNameLen)}...` : `${name}`;
   }
 
   getProjectTooltip(name: string): string {
-    return name.length > 18 ? name : '';
+    const maxNameLen = 18;
+    return name.length > maxNameLen ? name : '';
   }
 
   isProjectActive(project: Project): boolean {

--- a/src/app/serviceaccount/serviceaccount-token/serviceaccount-token.component.spec.ts
+++ b/src/app/serviceaccount/serviceaccount-token/serviceaccount-token.component.spec.ts
@@ -86,9 +86,10 @@ describe('ServiceAccountTokenComponent', () => {
   });
 
   it('should open delete service account token dialog & call deleteServiceAccountToken()', fakeAsync(() => {
+    const waitTime = 15000;
     component.deleteServiceAccountToken(fakeServiceAccountTokens()[0]);
     noop.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     const dialogTitle = document.body.querySelector('.mat-dialog-title');
     const deleteButton = document.body.querySelector('#km-confirmation-dialog-confirm-btn') as HTMLInputElement;
@@ -101,7 +102,7 @@ describe('ServiceAccountTokenComponent', () => {
     noop.detectChanges();
     noopToken.detectChanges();
     fixture.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     expect(deleteServiceAccountTokenSpy).toHaveBeenCalled();
     fixture.destroy();

--- a/src/app/serviceaccount/serviceaccount.component.spec.ts
+++ b/src/app/serviceaccount/serviceaccount.component.spec.ts
@@ -87,10 +87,11 @@ describe('ServiceAccountComponent', () => {
   });
 
   it('should open delete service account confirmation dialog & call deleteServiceAccount()', fakeAsync(() => {
+    const waitTime = 15000;
     const event = new MouseEvent('click');
     component.deleteServiceAccount(fakeServiceAccounts()[0], event);
     noop.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     const dialogTitle = document.body.querySelector('.mat-dialog-title');
     const deleteButton = document.body.querySelector('#km-confirmation-dialog-confirm-btn') as HTMLInputElement;
@@ -102,7 +103,7 @@ describe('ServiceAccountComponent', () => {
 
     noop.detectChanges();
     fixture.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     expect(deleteServiceAccountSpy).toHaveBeenCalled();
     fixture.destroy();

--- a/src/app/serviceaccount/serviceaccount.component.ts
+++ b/src/app/serviceaccount/serviceaccount.component.ts
@@ -45,8 +45,11 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
   displayedColumns: string[] = ['stateArrow', 'status', 'name', 'group', 'creationDate', 'actions'];
   toggledColumns: string[] = ['token'];
   dataSource = new MatTableDataSource<ServiceAccount>();
+
   @ViewChild(MatSort, {static: true}) sort: MatSort;
   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+
+  private readonly _refreshTime = 10; // in seconds
   private _unsubscribe: Subject<any> = new Subject();
   private _serviceAccountUpdate: Subject<any> = new Subject();
   private _selectedProject = {} as Project;
@@ -127,7 +130,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
 
   getTokenList(serviceaccount: ServiceAccount): void {
     this.tokenList[serviceaccount.id] = [];
-    timer(0, 10 * this._appConfig.getRefreshTimeBase())
+    timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase())
       .pipe(takeUntil(this._unsubscribe))
       .pipe(
         switchMap(() =>

--- a/src/app/settings/admin/admin-settings.component.ts
+++ b/src/app/settings/admin/admin-settings.component.ts
@@ -35,6 +35,8 @@ export class AdminSettingsComponent implements OnInit, OnDestroy {
   selectedDistro = [];
   settings: AdminSettings; // Local settings copy. User can edit it.
   apiSettings: AdminSettings; // Original settings from the API. Cannot be edited by the user.
+
+  private readonly _debounceTime = 500;
   private _settingsChange = new Subject<void>();
   private _unsubscribe = new Subject<void>();
 
@@ -59,7 +61,7 @@ export class AdminSettingsComponent implements OnInit, OnDestroy {
 
     this._settingsChange
       .pipe(
-        debounceTime(500),
+        debounceTime(this._debounceTime),
         switchMap(() => this._settingsService.patchAdminSettings(this._getPatch())),
         takeUntil(this._unsubscribe)
       )

--- a/src/app/settings/user/user-settings.component.ts
+++ b/src/app/settings/user/user-settings.component.ts
@@ -17,8 +17,8 @@ import {NotificationService, ProjectService, UserService} from '../../core/servi
 import {HistoryService} from '../../core/services/history/history.service';
 import {Member} from '../../shared/entity/member';
 import {Project} from '../../shared/entity/project';
-import {objectDiff} from '../../shared/utils/common-utils';
 import {UserSettings} from '../../shared/entity/settings';
+import {objectDiff} from '../../shared/utils/common-utils';
 
 @Component({
   selector: 'km-user-settings',
@@ -26,11 +26,14 @@ import {UserSettings} from '../../shared/entity/settings';
   styleUrls: ['user-settings.component.scss'],
 })
 export class UserSettingsComponent implements OnInit, OnDestroy {
-  itemsPerPageOptions = [5, 10, 15, 20, 25];
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+  readonly itemsPerPageOptions = [5, 10, 15, 20, 25];
   projects: Project[] = [];
   user: Member;
   settings: UserSettings; // Local settings copy. User can edit it.
   apiSettings: UserSettings; // Original settings from the API. Cannot be edited by the user.
+
+  private readonly _debounceTime = 1000;
   private _settingsChange = new Subject<void>();
   private _unsubscribe = new Subject<void>();
 
@@ -55,7 +58,7 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
     });
 
     this._settingsChange
-      .pipe(debounceTime(1000))
+      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .pipe(switchMap(() => this._userService.patchCurrentUserSettings(objectDiff(this.settings, this.apiSettings))))
       .subscribe(settings => {

--- a/src/app/shared/components/machine-networks-new/component.ts
+++ b/src/app/shared/components/machine-networks-new/component.ts
@@ -64,7 +64,7 @@ class MachineNetworkSpec {
 export class MachineNetworkComponent extends BaseFormValidator implements OnInit, OnDestroy {
   readonly controls = Controls;
 
-  private _debounceTime = 250;
+  private readonly _debounceTime = 250;
 
   get networkControls(): AbstractControl[] {
     return this._networkArray.controls;

--- a/src/app/shared/components/property-usage/property-usage.component.ts
+++ b/src/app/shared/components/property-usage/property-usage.component.ts
@@ -17,6 +17,8 @@ import {Component, Input} from '@angular/core';
   styleUrls: ['./property-usage.component.scss'],
 })
 export class PropertyUsageComponent {
+  private readonly _maxUsage = 100;
+
   @Input() name: string;
   @Input() used: number;
   @Input() total: number;
@@ -24,7 +26,7 @@ export class PropertyUsageComponent {
 
   getPercentage(): number | undefined {
     return this.used && this.total
-      ? Math.round(((this.used / this.total) * 100 + Number.EPSILON) * 100) / 100
+      ? Math.round(((this.used / this.total) * this._maxUsage + Number.EPSILON) * this._maxUsage) / this._maxUsage
       : undefined;
   }
 

--- a/src/app/shared/components/settings-status/settings-status.component.ts
+++ b/src/app/shared/components/settings-status/settings-status.component.ts
@@ -19,8 +19,11 @@ import {fadeInOut} from '../../animations/fade';
   animations: [fadeInOut],
 })
 export class SettingsStatusComponent implements OnChanges {
+  private readonly _defaultTimeout = 3000;
+
   @Input() isSaved = true;
-  @Input() confirmationTimeout = 3000;
+  @Input() confirmationTimeout = this._defaultTimeout;
+
   isSaveConfirmationVisible = false;
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/src/app/shared/components/short-name-in-circle/short-name-in-circle.component.ts
+++ b/src/app/shared/components/short-name-in-circle/short-name-in-circle.component.ts
@@ -20,6 +20,7 @@ import {ProjectOwners} from '../../entity/project';
 export class ShortNameInCircleComponent implements OnInit, OnChanges {
   @Input() owners: ProjectOwners[];
   @Input() limit: number;
+
   shortNames: string[] = [];
 
   ngOnInit(): void {
@@ -45,8 +46,9 @@ export class ShortNameInCircleComponent implements OnInit, OnChanges {
 
     for (const owner in this.owners) {
       if (Object.prototype.hasOwnProperty.call(this.owners, owner)) {
+        const maxLength = 3;
         const capitalLetters = this.owners[owner].name.match(/\b(\w)/g);
-        const short = capitalLetters.slice(0, 3).join('').toUpperCase();
+        const short = capitalLetters.slice(0, maxLength).join('').toUpperCase();
         this.shortNames.push(short);
       }
     }

--- a/src/app/shared/components/ssh-key-list/ssh-key-list.component.ts
+++ b/src/app/shared/components/ssh-key-list/ssh-key-list.component.ts
@@ -18,8 +18,10 @@ import {SSHKey} from '../../entity/ssh-key';
   styleUrls: ['./ssh-key-list.component.scss'],
 })
 export class SSHKeyListComponent {
+  private readonly _defaultMaxDisplayed = 3;
+
   @Input() sshKeys: SSHKey[] = [];
-  @Input() maxDisplayed = 3;
+  @Input() maxDisplayed = this._defaultMaxDisplayed;
 
   getDisplayed(): string {
     return this.sshKeys

--- a/src/app/shared/functions/generate-random-string.ts
+++ b/src/app/shared/functions/generate-random-string.ts
@@ -14,7 +14,8 @@ export function RandomString(length): string {
   let result = '';
 
   while (length > 0) {
-    const bytes = new Uint8Array(16);
+    const arrLength = 16;
+    const bytes = new Uint8Array(arrLength);
     const random = window.crypto.getRandomValues(bytes);
 
     random.forEach(c => {

--- a/src/app/shared/functions/get-ip-count.ts
+++ b/src/app/shared/functions/get-ip-count.ts
@@ -11,6 +11,7 @@
 
 import {MachineNetwork} from '../entity/cluster';
 
+/* eslint-disable @typescript-eslint/no-magic-numbers */
 export function getIpCount(networks: MachineNetwork[]): number {
   const ip4ToInt = ip => ip.split('.').reduce((int, oct) => (int << 8) + parseInt(oct, 10), 0) >>> 0;
 

--- a/src/app/shared/validators/label-form.validators.ts
+++ b/src/app/shared/validators/label-form.validators.ts
@@ -23,7 +23,8 @@ export class LabelFormValidators {
     const value = control.value;
     const slashPosition = value.indexOf('/');
     const labelKeyName = slashPosition > -1 ? value.substring(slashPosition + 1) : value;
-    return labelKeyName.length <= 63 ? null : {validLabelKeyPrefixLength: {value: true}};
+    const maxLength = 63;
+    return labelKeyName.length <= maxLength ? null : {validLabelKeyPrefixLength: {value: true}};
   }
 
   /**
@@ -33,7 +34,8 @@ export class LabelFormValidators {
     const value = control.value;
     const slashPosition = value.indexOf('/');
     const labelKeyPrefix = slashPosition > -1 ? value.substring(0, slashPosition) : '';
-    return labelKeyPrefix.length <= 253 ? null : {validLabelKeyPrefixLength: {value: true}};
+    const maxLength = 253;
+    return labelKeyPrefix.length <= maxLength ? null : {validLabelKeyPrefixLength: {value: true}};
   }
 
   /**
@@ -63,7 +65,8 @@ export class LabelFormValidators {
    */
   static labelValueLength(control: FormControl): {[key: string]: object} {
     const value = control.value;
-    return value.length <= 63 ? null : {validLabelValueLength: {value: true}};
+    const maxLength = 63;
+    return value.length <= maxLength ? null : {validLabelValueLength: {value: true}};
   }
 
   /**

--- a/src/app/shared/validators/ssh-key-form.validator.ts
+++ b/src/app/shared/validators/ssh-key-form.validator.ts
@@ -18,8 +18,10 @@ import {FormControl, ValidatorFn} from '@angular/forms';
 export function SSHKeyFormValidator(): ValidatorFn {
   return (control: FormControl): any => {
     const splitForm = control.value.toString().trim().split(' ');
+    const rangeStart = 2;
+    const rangeEnd = 3;
 
-    if (splitForm.length < 2 || splitForm.length > 3) {
+    if (splitForm.length < rangeStart || splitForm.length > rangeEnd) {
       return {validSSHKey: true}; // Key type and encoded data are required. Comment part is optional.
     }
 

--- a/src/app/shared/validators/taint-form.validators.ts
+++ b/src/app/shared/validators/taint-form.validators.ts
@@ -18,7 +18,8 @@ export class TaintFormValidators {
    */
   static taintValueLength(control: FormControl): {[key: string]: object} {
     const value = control.value;
-    return value.length <= 63 ? null : {validLabelValueLength: {value: true}};
+    const maxLength = 63;
+    return value.length <= maxLength ? null : {validLabelValueLength: {value: true}};
   }
 
   /**

--- a/src/app/sshkey/sshkey.component.spec.ts
+++ b/src/app/sshkey/sshkey.component.spec.ts
@@ -88,6 +88,7 @@ describe('SSHKeyComponent', () => {
   });
 
   it('should open delete ssh key confirmation dialog & call deleteSshKey()', fakeAsync(() => {
+    const waitTime = 15000;
     component.projectID = fakeProject().id;
     component.sshKeys = fakeSSHKeys();
     const event = new MouseEvent('click');
@@ -96,7 +97,7 @@ describe('SSHKeyComponent', () => {
 
     fixture.detectChanges();
     noop.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     const dialogTitle = document.body.querySelector('.mat-dialog-title');
     const deleteButton = document.body.querySelector('#km-confirmation-dialog-confirm-btn') as HTMLInputElement;
@@ -108,7 +109,7 @@ describe('SSHKeyComponent', () => {
 
     noop.detectChanges();
     fixture.detectChanges();
-    tick(15000);
+    tick(waitTime);
 
     expect(deleteSSHKeySpy).toHaveBeenCalled();
     fixture.destroy();

--- a/src/app/testing/services/app-config-mock.service.ts
+++ b/src/app/testing/services/app-config-mock.service.ts
@@ -20,6 +20,8 @@ import {CustomLink} from '../../shared/entity/settings';
 
 @Injectable()
 export class AppConfigMockService {
+  private readonly _refreshTimeBase = 1000;
+
   getConfig(): Config {
     return fakeAppConfig();
   }
@@ -37,6 +39,6 @@ export class AppConfigMockService {
   }
 
   getRefreshTimeBase(): number {
-    return 1000;
+    return this._refreshTimeBase;
   }
 }

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -72,6 +72,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
 
   private _datacenterSpec: Datacenter;
+  private readonly _minNameLength = 5;
   readonly Controls = Controls;
 
   constructor(
@@ -90,7 +91,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     this.form = this._builder.group({
       [Controls.Name]: new FormControl('', [
         Validators.required,
-        Validators.minLength(5),
+        Validators.minLength(this._minNameLength),
         Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),
       ]),
       [Controls.Version]: new FormControl('', [Validators.required]),

--- a/src/app/wizard/step/provider-settings/preset/component.ts
+++ b/src/app/wizard/step/provider-settings/preset/component.ts
@@ -11,13 +11,14 @@
 
 import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import * as _ from 'lodash';
 import {switchMap, takeUntil} from 'rxjs/operators';
 
 import {PresetsService} from '../../../../core/services';
 import {Cluster} from '../../../../shared/entity/cluster';
-import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
 import {PresetList} from '../../../../shared/entity/preset';
 import {ClusterService} from '../../../../shared/services/cluster.service';
+import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
 
 export enum Controls {
   Preset = 'name',
@@ -88,7 +89,7 @@ export class PresetsComponent extends BaseFormValidator implements OnInit, OnDes
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(presetList => {
         this.reset();
-        this.presetsLoaded = presetList.names ? presetList.names.length > 0 : false;
+        this.presetsLoaded = presetList.names ? !_.isEmpty(presetList.names) : false;
         this._state = this.presetsLoaded ? PresetsState.Ready : PresetsState.Empty;
         this.presetList = presetList;
         this._enable(this._state !== PresetsState.Empty, Controls.Preset);

--- a/src/app/wizard/step/provider-settings/provider/basic/aws/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/aws/component.ts
@@ -19,15 +19,16 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import * as _ from 'lodash';
 import {EMPTY, merge, Observable, onErrorResumeNext} from 'rxjs';
 import {catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 import {PresetsService} from '../../../../../../core/services';
 import {FilteredComboboxComponent} from '../../../../../../shared/components/combobox/component';
 import {AWSCloudSpec, CloudSpec, Cluster, ClusterSpec} from '../../../../../../shared/entity/cluster';
-import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
-import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 import {AWSVPC} from '../../../../../../shared/entity/provider/aws';
+import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
 import {ClusterService} from '../../../../../../shared/services/cluster.service';
+import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 
 export enum Controls {
   AccessKeyID = 'accessKeyID',
@@ -184,7 +185,7 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
     this.vpcIds = vpcs;
     const defaultVPC = this.vpcIds.find(vpc => vpc.isDefault);
     this.selectedVPC = defaultVPC ? defaultVPC.vpcId : undefined;
-    this.vpcLabel = this.vpcIds.length > 0 ? VPCState.Ready : VPCState.Empty;
+    this.vpcLabel = !_.isEmpty(this.vpcIds) ? VPCState.Ready : VPCState.Empty;
     this._cdr.detectChanges();
   }
 

--- a/src/app/wizard/step/provider-settings/provider/basic/hetzner/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/hetzner/component.ts
@@ -41,6 +41,9 @@ export enum Controls {
   ],
 })
 export class HetznerProviderBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  private readonly _minTokenLength = 64;
+  private readonly _maxTokenLength = 64;
+
   readonly Controls = Controls;
 
   constructor(
@@ -55,8 +58,8 @@ export class HetznerProviderBasicComponent extends BaseFormValidator implements 
     this.form = this._builder.group({
       [Controls.Token]: this._builder.control('', [
         Validators.required,
-        Validators.minLength(64),
-        Validators.maxLength(64),
+        Validators.minLength(this._minTokenLength),
+        Validators.maxLength(this._maxTokenLength),
       ]),
     });
 

--- a/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
@@ -19,6 +19,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import * as _ from 'lodash';
 import {EMPTY, merge, Observable, onErrorResumeNext} from 'rxjs';
 import {
   catchError,
@@ -31,14 +32,13 @@ import {
   takeUntil,
   tap,
 } from 'rxjs/operators';
-
-import {PresetsService, DatacenterService} from '../../../../../../core/services';
+import {DatacenterService, PresetsService} from '../../../../../../core/services';
 import {FilteredComboboxComponent} from '../../../../../../shared/components/combobox/component';
 import {CloudSpec, Cluster, ClusterSpec, OpenstackCloudSpec} from '../../../../../../shared/entity/cluster';
-import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
-import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 import {OpenstackFloatingIpPool, OpenstackTenant} from '../../../../../../shared/entity/provider/openstack';
+import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
 import {ClusterService} from '../../../../../../shared/services/cluster.service';
+import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 
 enum Controls {
   Domain = 'domain',
@@ -79,9 +79,10 @@ enum ProjectState {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OpenstackProviderBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
-  private _isFloatingPoolIPEnforced = false;
   private readonly _debounceTime = 250;
   private readonly _domains: string[] = ['Default'];
+
+  private _isFloatingPoolIPEnforced = false;
 
   @ViewChild('floatingIPPoolCombobox')
   private readonly _floatingIPPoolCombobox: FilteredComboboxComponent;
@@ -156,7 +157,7 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .subscribe((projects: OpenstackTenant[]) => {
         this.projects = projects;
 
-        if (this.projects.length > 0) {
+        if (!_.isEmpty(this.projects)) {
           this.projectsLabel = ProjectState.Ready;
           this._cdr.detectChanges();
         }
@@ -169,7 +170,7 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .subscribe((floatingIPPools: OpenstackFloatingIpPool[]) => {
         this.floatingIPPools = floatingIPPools;
 
-        if (this.floatingIPPools.length > 0) {
+        if (!_.isEmpty(this.floatingIPPools)) {
           this.floatingIPPoolsLabel = FloatingIPPoolState.Ready;
           this._cdr.detectChanges();
         }

--- a/src/app/wizard/step/provider-settings/provider/basic/packet/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/packet/component.ts
@@ -49,6 +49,10 @@ export enum Controls {
   ],
 })
 export class PacketProviderBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  private readonly _apiKeyLength = 256;
+  private readonly _projectIDLength = 256;
+  private readonly _billingCycleLength = 64;
+
   readonly Controls = Controls;
 
   constructor(
@@ -61,11 +65,14 @@ export class PacketProviderBasicComponent extends BaseFormValidator implements O
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.APIKey]: this._builder.control('', [Validators.required, Validators.maxLength(256)]),
-      [Controls.ProjectID]: this._builder.control('', [Validators.required, Validators.maxLength(256)]),
+      [Controls.APIKey]: this._builder.control('', [Validators.required, Validators.maxLength(this._apiKeyLength)]),
+      [Controls.ProjectID]: this._builder.control('', [
+        Validators.required,
+        Validators.maxLength(this._projectIDLength),
+      ]),
       [Controls.BillingCycle]: this._builder.control(this.getAvailableBillingCycles()[0], [
         Validators.required,
-        Validators.maxLength(64),
+        Validators.maxLength(this._billingCycleLength),
       ]),
     });
 

--- a/src/app/wizard/step/provider-settings/provider/extended/gcp/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/gcp/component.ts
@@ -20,15 +20,16 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
+import * as _ from 'lodash';
 import {EMPTY, Observable, onErrorResumeNext} from 'rxjs';
 import {catchError, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {PresetsService} from '../../../../../../core/services';
 import {FilteredComboboxComponent} from '../../../../../../shared/components/combobox/component';
-import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
-import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 import {GCPNetwork, GCPSubnetwork} from '../../../../../../shared/entity/provider/gcp';
+import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
 import {ClusterService} from '../../../../../../shared/services/cluster.service';
+import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 
 enum Controls {
   Network = 'network',
@@ -157,7 +158,7 @@ export class GCPProviderExtendedComponent extends BaseFormValidator implements O
   }
 
   private _loadNetworks(networks: GCPNetwork[]): void {
-    this.networkLabel = networks.length > 0 ? NetworkState.Ready : NetworkState.Empty;
+    this.networkLabel = !_.isEmpty(networks) ? NetworkState.Ready : NetworkState.Empty;
     this.networks = networks;
     this._cdr.detectChanges();
   }
@@ -219,7 +220,7 @@ export class GCPProviderExtendedComponent extends BaseFormValidator implements O
   }
 
   private _loadSubNetworks(subNetworks: GCPSubnetwork[]): void {
-    this.subNetworkLabel = subNetworks.length > 0 ? SubNetworkState.Ready : SubNetworkState.Empty;
+    this.subNetworkLabel = !_.isEmpty(subNetworks) ? SubNetworkState.Ready : SubNetworkState.Empty;
     this.subNetworks = subNetworks;
     this._cdr.detectChanges();
   }

--- a/src/app/wizard/step/provider-settings/provider/extended/openstack/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/openstack/component.ts
@@ -19,6 +19,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
+import * as _ from 'lodash';
 import {EMPTY, Observable, onErrorResumeNext} from 'rxjs';
 import {catchError, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 
@@ -30,8 +31,8 @@ import {
   OpenstackSubnet,
 } from '../../../../../../shared/entity/provider/openstack';
 import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
-import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 import {ClusterService} from '../../../../../../shared/services/cluster.service';
+import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
 
 enum Controls {
   SecurityGroup = 'securityGroup',
@@ -177,19 +178,19 @@ export class OpenstackProviderExtendedComponent extends BaseFormValidator implem
 
   private _loadSecurityGroups(securityGroups: OpenstackSecurityGroup[]): void {
     this.securityGroups = securityGroups;
-    this.securityGroupsLabel = this.securityGroups.length > 0 ? SecurityGroupState.Ready : SecurityGroupState.Empty;
+    this.securityGroupsLabel = !_.isEmpty(this.securityGroups) ? SecurityGroupState.Ready : SecurityGroupState.Empty;
     this._cdr.detectChanges();
   }
 
   private _loadNetworks(networks: OpenstackNetwork[]): void {
     this.networks = networks;
-    this.networksLabel = this.networks.length > 0 ? NetworkState.Ready : NetworkState.Empty;
+    this.networksLabel = !_.isEmpty(this.networks) ? NetworkState.Ready : NetworkState.Empty;
     this._cdr.detectChanges();
   }
 
   private _loadSubnetIDs(subnetIDs: OpenstackSubnet[]): void {
     this.subnetIDs = subnetIDs;
-    this.subnetIDsLabel = this.subnetIDs.length > 0 ? SubnetIDState.Ready : SubnetIDState.Empty;
+    this.subnetIDsLabel = !_.isEmpty(this.subnetIDs) ? SubnetIDState.Ready : SubnetIDState.Empty;
     this._cdr.detectChanges();
   }
 

--- a/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
@@ -20,17 +20,19 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
+
+import * as _ from 'lodash';
 import {EMPTY, Observable, onErrorResumeNext} from 'rxjs';
 import {catchError, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {PresetsService} from '../../../../../../core/services';
 import {FilteredComboboxComponent} from '../../../../../../shared/components/combobox/component';
 import {Cluster} from '../../../../../../shared/entity/cluster';
+import {VSphereFolder, VSphereNetwork} from '../../../../../../shared/entity/provider/vsphere';
 import {NodeProvider} from '../../../../../../shared/model/NodeProviderConstants';
+import {ClusterService} from '../../../../../../shared/services/cluster.service';
 import {isObjectEmpty} from '../../../../../../shared/utils/common-utils';
 import {BaseFormValidator} from '../../../../../../shared/validators/base-form.validator';
-import {VSphereFolder, VSphereNetwork} from '../../../../../../shared/entity/provider/vsphere';
-import {ClusterService} from '../../../../../../shared/services/cluster.service';
 
 enum Controls {
   VMNetName = 'vmNetName',
@@ -182,7 +184,7 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
       this._networkMap[network.type].push(network);
     });
 
-    if (networks.length > 0) {
+    if (!_.isEmpty(networks)) {
       this.networkLabel = NetworkState.Ready;
       this._cdr.detectChanges();
     }
@@ -191,7 +193,7 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
   private _loadFolders(folders: VSphereFolder[]): void {
     this.folders = folders;
 
-    if (this.folders.length > 0) {
+    if (!_.isEmpty(this.folders)) {
       this.folderLabel = FolderState.Ready;
       this._cdr.detectChanges();
     }

--- a/src/app/wizard/step/provider-settings/ssh-keys/component.ts
+++ b/src/app/wizard/step/provider-settings/ssh-keys/component.ts
@@ -12,6 +12,7 @@
 import {ChangeDetectorRef, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {MatDialog} from '@angular/material/dialog';
+import * as _ from 'lodash';
 import {filter, first, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 import {ApiService, ProjectService, UserService} from '../../../../core/services';
@@ -21,9 +22,9 @@ import {Member} from '../../../../shared/entity/member';
 import {Project} from '../../../../shared/entity/project';
 import {SSHKey} from '../../../../shared/entity/ssh-key';
 import {GroupConfig} from '../../../../shared/model/Config';
+import {ClusterService} from '../../../../shared/services/cluster.service';
 import {MemberUtils, Permission} from '../../../../shared/utils/member-utils/member-utils';
 import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
-import {ClusterService} from '../../../../shared/services/cluster.service';
 
 enum Controls {
   Keys = 'keys',
@@ -125,7 +126,7 @@ export class ClusterSSHKeysComponent extends BaseFormValidator implements OnInit
   }
 
   hasKeys(): boolean {
-    return this._keys.length > 0;
+    return !_.isEmpty(this.keys);
   }
 
   private _getSelectedKeys(): SSHKey[] {

--- a/src/app/wizard/step/summary/component.ts
+++ b/src/app/wizard/step/summary/component.ts
@@ -160,6 +160,7 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
   }
 
   private _noIpsLeft(cluster: Cluster, nodeCount: number): boolean {
-    return getIpCount(cluster.spec.machineNetworks) >= nodeCount;
+    const ipCount = getIpCount(cluster.spec.machineNetworks);
+    return ipCount > 0 ? ipCount < nodeCount : false;
   }
 }

--- a/src/app/wizard/step/summary/component.ts
+++ b/src/app/wizard/step/summary/component.ts
@@ -110,7 +110,7 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
   }
 
   displayTags(tags: object): boolean {
-    return !!tags && Object.keys(LabelFormComponent.filterNullifiedKeys(tags)).length > 0;
+    return !!tags && !_.isEmpty(Object.keys(LabelFormComponent.filterNullifiedKeys(tags)));
   }
 
   displayNoProviderTags(): boolean {
@@ -128,7 +128,7 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
         return (
           this.nodeData.spec.cloud[provider] &&
           this.nodeData.spec.cloud[provider].tags &&
-          this.nodeData.spec.cloud[provider].tags.length === 0
+          _.isEmpty(this.nodeData.spec.cloud[provider].tags)
         );
     }
 
@@ -160,11 +160,6 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
   }
 
   private _noIpsLeft(cluster: Cluster, nodeCount: number): boolean {
-    const ipCount = getIpCount(cluster.spec.machineNetworks);
-
-    if (!!ipCount && ipCount > 0) {
-      return !(ipCount - nodeCount >= 0);
-    }
-    return false;
+    return getIpCount(cluster.spec.machineNetworks) >= nodeCount;
   }
 }

--- a/src/test.base.mocks.ts
+++ b/src/test.base.mocks.ts
@@ -26,6 +26,7 @@ Object.defineProperty(document.body.style, 'transform', {
 
 Object.defineProperties(window, {
   crypto: {
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     value: {getRandomValues: () => [2, 4, 8, 16]},
   },
   URL: {value: {createObjectURL: () => {}}},

--- a/src/test.base.ts
+++ b/src/test.base.ts
@@ -16,4 +16,5 @@ import 'jest-preset-angular';
 import './test.base.mocks';
 
 // Async operations timeout
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
 jest.setTimeout(15000);


### PR DESCRIPTION
**What this PR does / why we need it**:
Using magic numbers is allowed only in a few cases:
- Array indexes
- `-1, 0, -1` - usually used for sorting or empty array check
- In enums

In all other cases, it is required to use const or readonly properties. On rare occasions, it makes sense to also disable this check for the next line or method (as I have done in a few places).

**Which issue(s) this PR fixes**:
Fixes #2491

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
