### PR TITLE
Choose smallest/cheapest instance as the default one

### DIFF
--- a/src/app/node-data/basic/provider/alibaba/component.ts
+++ b/src/app/node-data/basic/provider/alibaba/component.ts
@@ -28,6 +28,7 @@ import {FilteredComboboxComponent} from '../../../../shared/components/combobox/
 import {NodeCloudSpec, NodeSpec} from '../../../../shared/entity/node';
 import {AlibabaInstanceType, AlibabaZone} from '../../../../shared/entity/provider/alibaba';
 import {NodeData} from '../../../../shared/model/NodeSpecChange';
+import {compare} from '../../../../shared/utils/common-utils';
 import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
 import {NodeDataService} from '../../../service/service';
 
@@ -162,6 +163,15 @@ export class AlibabaBasicNodeDataComponent extends BaseFormValidator implements 
     this._nodeDataService.nodeDataChanges.next();
   }
 
+  instanceDisplayName(instanceID: string): string {
+    const instance = this.instanceTypes.find(instance => instance.id === instanceID);
+    if (!instance) {
+      return instanceID;
+    }
+
+    return `${instance.id} (${instance.cpuCoreCount} CPU, ${instance.memorySize} GB RAM)`;
+  }
+
   private _init(): void {
     if (this._nodeDataService.nodeData.spec.cloud.alibaba) {
       this.form.get(Controls.DiskSize).setValue(this._nodeDataService.nodeData.spec.cloud.alibaba.diskSize);
@@ -207,7 +217,7 @@ export class AlibabaBasicNodeDataComponent extends BaseFormValidator implements 
     this.selectedInstanceType = this._nodeDataService.nodeData.spec.cloud.alibaba.instanceType;
 
     if (!this.selectedInstanceType && this.instanceTypes.length > 0) {
-      this.selectedInstanceType = this.instanceTypes[0].id;
+      this.selectedInstanceType = this._findCheapestInstance(instanceTypes).id;
     }
 
     this.instanceTypeLabel = this.selectedInstanceType ? InstanceTypeState.Ready : InstanceTypeState.Empty;
@@ -234,6 +244,13 @@ export class AlibabaBasicNodeDataComponent extends BaseFormValidator implements 
     }
 
     this._cdr.detectChanges();
+  }
+
+  private _findCheapestInstance(instanceTypes: AlibabaInstanceType[]): AlibabaInstanceType {
+    // Avoid mutating original array
+    return [...instanceTypes]
+      .sort((a, b) => compare(a.memorySize, b.memorySize))
+      .sort((a, b) => compare(a.cpuCoreCount, b.cpuCoreCount))[0];
   }
 
   private _getNodeData(): NodeData {

--- a/src/app/node-data/basic/provider/alibaba/template.html
+++ b/src/app/node-data/basic/provider/alibaba/template.html
@@ -19,6 +19,7 @@ limitations under the License.
                [selected]="selectedInstanceType"
                [options]="instanceTypes"
                [formControlName]="Controls.InstanceType"
+               [valueFormatter]="instanceDisplayName.bind(this)"
                (changed)="onInstanceTypeChange($event)"
                [label]="instanceTypeLabel"
                inputLabel="Select instance type..."

--- a/src/app/node-data/basic/provider/aws/component.ts
+++ b/src/app/node-data/basic/provider/aws/component.ts
@@ -171,6 +171,15 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
     this._nodeDataService.nodeDataChanges.next();
   }
 
+  sizeDisplayName(sizeName: string): string {
+    const size = this.sizes.find(size => size.name === sizeName);
+    if (!size) {
+      return sizeName;
+    }
+
+    return `${size.name} (${size.vcpus} vCPU, ${size.memory} GB RAM, ${size.price} USD per hour)`;
+  }
+
   private _init(): void {
     if (this._nodeDataService.nodeData.spec.cloud.aws) {
       this.form.get(Controls.DiskSize).setValue(this._nodeDataService.nodeData.spec.cloud.aws.diskSize);

--- a/src/app/node-data/basic/provider/aws/template.html
+++ b/src/app/node-data/basic/provider/aws/template.html
@@ -19,6 +19,7 @@ limitations under the License.
                [selected]="selectedSize"
                [options]="sizes"
                [formControlName]="Controls.Size"
+               [valueFormatter]="sizeDisplayName.bind(this)"
                (changed)="onSizeChange($event)"
                [label]="sizeLabel"
                inputLabel="Select size..."

--- a/src/app/node-data/basic/provider/azure/component.ts
+++ b/src/app/node-data/basic/provider/azure/component.ts
@@ -26,6 +26,7 @@ import {PresetsService} from '../../../../core/services';
 import {AzureNodeSpec, NodeCloudSpec, NodeSpec} from '../../../../shared/entity/node';
 import {AzureSizes, AzureZones} from '../../../../shared/entity/provider/azure';
 import {NodeData} from '../../../../shared/model/NodeSpecChange';
+import {compare} from '../../../../shared/utils/common-utils';
 import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
 import {NodeDataService} from '../../../service/service';
 
@@ -142,6 +143,15 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
     }
   }
 
+  sizeDisplayName(sizeName: string): string {
+    const size = this.sizes.find(size => size.name === sizeName);
+    if (!size) {
+      return sizeName;
+    }
+
+    return `${size.name} (${size.numberOfCores} vCPU, ${size.memoryInMB} MB RAM)`;
+  }
+
   private _init(): void {
     if (this._nodeDataService.nodeData.spec.cloud.azure) {
       this.selectedZone = this._nodeDataService.nodeData.spec.cloud.azure.zone;
@@ -182,7 +192,7 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
     this.selectedSize = this._nodeDataService.nodeData.spec.cloud.azure.size;
 
     if (!this.selectedSize && this.sizes.length > 0) {
-      this.selectedSize = this.sizes[0].name;
+      this.selectedSize = this._findCheapestInstance(sizes).name;
     }
 
     this.sizeLabel = this.selectedSize ? SizeState.Ready : SizeState.Empty;
@@ -200,6 +210,13 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
 
     this.zoneLabel = this.zones && this.zones.length > 0 ? ZoneState.Ready : ZoneState.Empty;
     this._cdr.detectChanges();
+  }
+
+  private _findCheapestInstance(instanceTypes: AzureSizes[]): AzureSizes {
+    // Avoid mutating original array
+    return [...instanceTypes]
+      .sort((a, b) => compare(a.memoryInMB, b.memoryInMB))
+      .sort((a, b) => compare(a.numberOfCores, b.numberOfCores))[0];
   }
 
   private _getNodeData(): NodeData {

--- a/src/app/node-data/basic/provider/azure/template.html
+++ b/src/app/node-data/basic/provider/azure/template.html
@@ -18,6 +18,7 @@ limitations under the License.
                [selected]="selectedSize"
                [options]="sizes"
                [formControlName]="Controls.Size"
+               [valueFormatter]="sizeDisplayName.bind(this)"
                (changed)="onSizeChange($event)"
                [label]="sizeLabel"
                inputLabel="Select size..."

--- a/src/app/node-data/basic/provider/gcp/component.ts
+++ b/src/app/node-data/basic/provider/gcp/component.ts
@@ -28,6 +28,7 @@ import {FilteredComboboxComponent} from '../../../../shared/components/combobox/
 import {GCPNodeSpec, NodeCloudSpec, NodeSpec} from '../../../../shared/entity/node';
 import {GCPDiskType, GCPMachineSize, GCPZone} from '../../../../shared/entity/provider/gcp';
 import {NodeData} from '../../../../shared/model/NodeSpecChange';
+import {compare} from '../../../../shared/utils/common-utils';
 import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
 import {NodeDataService} from '../../../service/service';
 
@@ -174,6 +175,15 @@ export class GCPBasicNodeDataComponent extends BaseFormValidator implements OnIn
     this._nodeDataService.nodeDataChanges.next();
   }
 
+  sizeDisplayName(machineName: string): string {
+    const machine = this.machineTypes.find(size => size.name === machineName);
+    if (!machine) {
+      return machineName;
+    }
+
+    return `${machine.name} (${machine.description})`;
+  }
+
   private _init(): void {
     if (this._nodeDataService.nodeData.spec.cloud.gcp) {
       this.form.get(Controls.DiskSize).setValue(this._nodeDataService.nodeData.spec.cloud.gcp.diskSize);
@@ -253,11 +263,16 @@ export class GCPBasicNodeDataComponent extends BaseFormValidator implements OnIn
     this.selectedMachineType = this._nodeDataService.nodeData.spec.cloud.gcp.machineType;
 
     if (!this.selectedMachineType && !_.isEmpty(this.machineTypes)) {
-      this.selectedMachineType = this.machineTypes[0].name;
+      this.selectedMachineType = this._findCheapestInstance(machineTypes).name;
     }
 
     this.machineTypeLabel = this.selectedMachineType ? MachineTypeState.Ready : MachineTypeState.Empty;
     this._cdr.detectChanges();
+  }
+
+  private _findCheapestInstance(instanceTypes: GCPMachineSize[]): GCPMachineSize {
+    // Avoid mutating original array
+    return [...instanceTypes].sort((a, b) => compare(a.memory, b.memory)).sort((a, b) => compare(a.vcpus, b.vcpus))[0];
   }
 
   private _getNodeData(): NodeData {

--- a/src/app/node-data/basic/provider/gcp/template.html
+++ b/src/app/node-data/basic/provider/gcp/template.html
@@ -58,6 +58,7 @@ limitations under the License.
                [selected]="selectedMachineType"
                [options]="machineTypes"
                [formControlName]="Controls.MachineType"
+               [valueFormatter]="sizeDisplayName.bind(this)"
                (changed)="onMachineTypeChange($event)"
                [label]="machineTypeLabel"
                inputLabel="Select machine type..."

--- a/src/app/node-data/basic/provider/packet/template.html
+++ b/src/app/node-data/basic/provider/packet/template.html
@@ -18,6 +18,7 @@ limitations under the License.
                [selected]="selectedSize"
                [options]="sizes"
                [formControlName]="Controls.InstanceType"
+               [valueFormatter]="sizeDisplayName.bind(this)"
                (changed)="onSizeChange($event)"
                [label]="sizeLabel"
                inputLabel="Select plan..."

--- a/src/app/node-data/service/provider/alibaba.ts
+++ b/src/app/node-data/service/provider/alibaba.ts
@@ -45,7 +45,7 @@ export class NodeDataAlibabaProvider {
         return this._clusterService.clusterChanges
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.ALIBABA))
           .pipe(tap(c => (cluster = c)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc)))
+          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(first())))
           .pipe(tap(dc => (region = dc.spec.alibaba.region)))
           .pipe(
             switchMap(_ =>
@@ -71,7 +71,11 @@ export class NodeDataAlibabaProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>
@@ -106,7 +110,7 @@ export class NodeDataAlibabaProvider {
         return this._clusterService.clusterChanges
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.ALIBABA))
           .pipe(tap(c => (cluster = c)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc)))
+          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(first())))
           .pipe(tap(dc => (region = dc.spec.alibaba.region)))
           .pipe(
             switchMap(_ =>

--- a/src/app/node-data/service/provider/aws.ts
+++ b/src/app/node-data/service/provider/aws.ts
@@ -37,7 +37,7 @@ export class NodeDataAWSProvider {
     switch (this._nodeDataService.mode) {
       case NodeDataMode.Wizard:
         return this._clusterService.datacenterChanges
-          .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc)))
+          .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
           .pipe(
             switchMap(dc =>
               this._presetService
@@ -59,7 +59,11 @@ export class NodeDataAWSProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>
@@ -109,7 +113,11 @@ export class NodeDataAWSProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>

--- a/src/app/node-data/service/provider/azure.ts
+++ b/src/app/node-data/service/provider/azure.ts
@@ -43,7 +43,7 @@ export class NodeDataAzureProvider {
         return this._clusterService.clusterChanges
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE))
           .pipe(tap(c => (cluster = c)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc)))
+          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(first())))
           .pipe(tap(dc => (location = dc.spec.azure.location)))
           .pipe(
             switchMap(_ =>
@@ -71,7 +71,11 @@ export class NodeDataAzureProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>
@@ -99,6 +103,7 @@ export class NodeDataAzureProvider {
       case NodeDataMode.Wizard:
         return this._datacenterService
           .getDatacenter(this._clusterService.cluster.spec.cloud.dc)
+          .pipe(first())
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE))
           .pipe(tap(dc => (location = dc.spec.azure.location)))
           .pipe(
@@ -128,7 +133,11 @@ export class NodeDataAzureProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>

--- a/src/app/node-data/service/provider/digitalocean.ts
+++ b/src/app/node-data/service/provider/digitalocean.ts
@@ -62,7 +62,11 @@ export class NodeDataDigitalOceanProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>

--- a/src/app/node-data/service/provider/gcp.ts
+++ b/src/app/node-data/service/provider/gcp.ts
@@ -72,7 +72,11 @@ export class NodeDataGCPProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>
@@ -115,7 +119,11 @@ export class NodeDataGCPProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>
@@ -163,7 +171,11 @@ export class NodeDataGCPProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>

--- a/src/app/node-data/service/provider/hetzner.ts
+++ b/src/app/node-data/service/provider/hetzner.ts
@@ -56,7 +56,11 @@ export class NodeDataHetznerProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>

--- a/src/app/node-data/service/provider/openstack.ts
+++ b/src/app/node-data/service/provider/openstack.ts
@@ -71,7 +71,11 @@ export class NodeDataOpenstackProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>
@@ -97,7 +101,11 @@ export class NodeDataOpenstackProvider {
       case NodeDataMode.Wizard:
         return merge(this._nodeDataService.operatingSystemChanges, this._clusterService.datacenterChanges)
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.OPENSTACK))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)));
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          );
     }
   }
 
@@ -137,7 +145,11 @@ export class NodeDataOpenstackProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>

--- a/src/app/node-data/service/provider/packet.ts
+++ b/src/app/node-data/service/provider/packet.ts
@@ -63,7 +63,11 @@ export class NodeDataPacketProvider {
         let selectedProject: string;
         return this._projectService.selectedProject
           .pipe(tap(project => (selectedProject = project.id)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc)))
+          .pipe(
+            switchMap(_ =>
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+            )
+          )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(
             switchMap(dc =>

--- a/src/app/shared/utils/common-utils.ts
+++ b/src/app/shared/utils/common-utils.ts
@@ -34,3 +34,7 @@ export function isObjectEmpty(obj: object): boolean {
 
   return !obj;
 }
+
+export function compare(a: number, b: number): -1 | 0 | 1 {
+  return a < b ? -1 : a !== b ? 1 : 0;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updated providers logic in the wizard to choose the smallest/cheapest instance by default
- Updated display name format to show all information after selecting an instance
- Fixed an issue with triggering refresh of sizes and related endpoints when datacenters are refreshed


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Cheapest/smallest provider instance will be chosen by default in the wizard
```
