### PR TITLE
Skip ND test case

### DIFF
--- a/cypress/integration/stories/machine-deployments.spec.ts
+++ b/cypress/integration/stories/machine-deployments.spec.ts
@@ -23,7 +23,8 @@ import {prefixedString} from '../../utils/random';
 import {View} from '../../utils/view';
 import {WizardStep} from '../../utils/wizard';
 
-describe('Machine Deployments Story', () => {
+// TODO: remove skip once networking issues are fixed
+describe.skip('Machine Deployments Story', () => {
   const email = Cypress.env('KUBERMATIC_DEX_DEV_E2E_USERNAME');
   const password = Cypress.env('KUBERMATIC_DEX_DEV_E2E_PASSWORD');
   const projectName = prefixedString('e2e-test-project');


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable node deployment test case until e2e networking issue is fixed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
