### PR TITLE
Add option to restrict project creation to admins

### DIFF
--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -34,6 +34,7 @@ limitations under the License.
     <button id="km-add-project-top-btn"
             mat-flat-button
             type="button"
+            [disabled]="isProjectCreationRestricted()"
             (click)="addProject()">
       Add Project
     </button>

--- a/src/app/settings/admin/admin-settings.component.html
+++ b/src/app/settings/admin/admin-settings.component.html
@@ -178,6 +178,9 @@ limitations under the License.
           <div class="km-pointer"
                matTooltip="Set limit to zero to allow unlimited project creation for users. It does not affect administrators."></div>
         </div>
+        <mat-checkbox fxLayoutAlign=" center"
+                      [(ngModel)]="settings.restrictProjectCreation"
+                      (change)="onSettingsChange()">Restrict Project Creation to Adminstrators</mat-checkbox>
         <mat-form-field class="km-admin-settings-field-md km-no-padding">
           <mat-label>User Projects Limit</mat-label>
           <input matInput
@@ -185,6 +188,7 @@ limitations under the License.
                  type="number"
                  min="0"
                  autocomplete="off"
+                 [disabled]="settings.restrictProjectCreation"
                  [(ngModel)]="settings.userProjectsLimit"
                  (change)="onSettingsChange()">
         </mat-form-field>

--- a/src/app/shared/entity/settings.ts
+++ b/src/app/shared/entity/settings.ts
@@ -31,6 +31,7 @@ export class AdminSettings {
   enableDashboard: boolean;
   enableOIDCKubeconfig: boolean;
   userProjectsLimit: number;
+  restrictProjectCreation: boolean;
 }
 
 export class CleanupOptions {
@@ -128,4 +129,5 @@ export const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
   displayTermsOfService: false,
   enableDashboard: true,
   enableOIDCKubeconfig: false,
+  restrictProjectCreation: false,
 };

--- a/src/app/testing/services/settings-mock.service.ts
+++ b/src/app/testing/services/settings-mock.service.ts
@@ -33,6 +33,7 @@ export const DEFAULT_ADMIN_SETTINGS_MOCK: AdminSettings = {
   enableDashboard: true,
   enableOIDCKubeconfig: false,
   userProjectsLimit: 0,
+  restrictProjectCreation: false,
 };
 
 @Injectable()


### PR DESCRIPTION
**What this PR does / why we need it**:
Add option to restrict project creation to admins

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2603

**Special notes for your reviewer**:
/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added option to restrict project creation to admins via the Admin Settings
```
