### PR TITLE
Fix project selector jumping to selected value on refresh

### DIFF
--- a/src/app/core/components/navigation/project/component.ts
+++ b/src/app/core/components/navigation/project/component.ts
@@ -68,6 +68,10 @@ export class ProjectSelectorComponent implements OnInit, OnDestroy {
     return !!a && !!b && a.id === b.id;
   }
 
+  trackByProject(_: number, project: Project): string {
+    return project.id;
+  }
+
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();

--- a/src/app/core/components/navigation/project/template.html
+++ b/src/app/core/components/navigation/project/template.html
@@ -24,7 +24,7 @@ limitations under the License.
                 disableOptionCentering>
       <mat-optgroup *ngIf="externalProjects.length > 0">
         <div>External projects</div>
-        <mat-option *ngFor="let project of externalProjects"
+        <mat-option *ngFor="let project of externalProjects; trackBy: trackByProject"
                     [value]="project"
                     [disabled]="project.status !== 'Active'"
                     [matTooltip]="project.status !== 'Active' ? project.status + ' Project' : ''">
@@ -33,7 +33,7 @@ limitations under the License.
       </mat-optgroup>
       <mat-optgroup *ngIf="myProjects">
         <div>My projects</div>
-        <mat-option *ngFor="let project of myProjects"
+        <mat-option *ngFor="let project of myProjects; trackBy: trackByProject"
                     [value]="project"
                     [disabled]="project.status !== 'Active'"
                     [matTooltip]="project.status !== 'Active' ? project.status + ' Project' : ''">


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #2626 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fix project selector auto-scroll to selected value on refresh
```
