### PR TITLE
Add option to enable/disable external cluster import from admin settings

### DIFF
--- a/src/app/cluster/cluster-list/cluster-list.component.html
+++ b/src/app/cluster/cluster-list/cluster-list.component.html
@@ -16,6 +16,7 @@ limitations under the License.
        fxLayoutAlign="end center">
     <button mat-flat-button
             color="alternative"
+            *ngIf="(adminSettings$ | async).enableExternalClusterImport"
             [disabled]="!canAdd()"
             (click)="connectCluster()">
       Connect Cluster

--- a/src/app/cluster/cluster-list/cluster-list.component.spec.ts
+++ b/src/app/cluster/cluster-list/cluster-list.component.spec.ts
@@ -39,7 +39,7 @@ describe('ClusterListComponent', () => {
   let activatedRoute: ActivatedRouteStub;
 
   beforeEach(async(() => {
-    const clusterServiceMock = {clusters: jest.fn(), health: jest.fn()};
+    const clusterServiceMock = {clusters: jest.fn(), health: jest.fn(), refreshClusters: () => {}};
     getClustersSpy = clusterServiceMock.clusters.mockReturnValue(asyncData([fakeAWSCluster()]));
     clusterServiceMock.health.mockReturnValue(asyncData([fakeHealth()]));
 

--- a/src/app/core/interceptors/error-notifications/error-notifications.service.ts
+++ b/src/app/core/interceptors/error-notifications/error-notifications.service.ts
@@ -19,7 +19,7 @@ import {NotificationService} from '../../services';
 export class ErrorNotificationsInterceptor implements HttpInterceptor {
   private readonly _notificationService: NotificationService;
   // Array of partial error messages that should be silenced in the UI.
-  private readonly _silenceErrArr = ['external cluster'];
+  private readonly _silenceErrArr = ['external cluster functionality'];
 
   constructor(private readonly _inj: Injector) {
     this._notificationService = this._inj.get(NotificationService);

--- a/src/app/core/interceptors/error-notifications/error-notifications.service.ts
+++ b/src/app/core/interceptors/error-notifications/error-notifications.service.ts
@@ -19,7 +19,7 @@ import {NotificationService} from '../../services';
 export class ErrorNotificationsInterceptor implements HttpInterceptor {
   private readonly _notificationService: NotificationService;
   // Array of partial error messages that should be silenced in the UI.
-  private readonly _silenceErrArr = [];
+  private readonly _silenceErrArr = ['external cluster'];
 
   constructor(private readonly _inj: Injector) {
     this._notificationService = this._inj.get(NotificationService);
@@ -34,20 +34,32 @@ export class ErrorNotificationsInterceptor implements HttpInterceptor {
             return;
           }
 
-          if (!!errorInstance.error && !!errorInstance.error.error) {
-            this._notificationService.error(
-              `Error ${errorInstance.status}: ${
-                errorInstance.error.error.message || errorInstance.message || errorInstance.statusText
-              }`
-            );
-          } else if (
-            errorInstance.message &&
-            this._silenceErrArr.every(partial => !errorInstance.message.includes(partial))
-          ) {
-            this._notificationService.error(`${errorInstance.message}`);
+          if (this._shouldSilenceError(errorInstance)) {
+            return;
           }
+
+          let errorMsg = '';
+
+          if (errorInstance.status) {
+            errorMsg += `Error ${errorInstance.status}`;
+          }
+
+          errorMsg += errorInstance.error.error.message || errorInstance.message || errorInstance.statusText;
+          this._notificationService.error(errorMsg);
         }
       )
+    );
+  }
+
+  private _isAPIError(instance: any): boolean {
+    return !!instance.error && !!instance.error.error;
+  }
+
+  private _shouldSilenceError(instance: any): boolean {
+    return (
+      (this._isAPIError(instance) &&
+        this._silenceErrArr.some(partial => instance.error.error.message.includes(partial))) ||
+      this._silenceErrArr.some(partial => instance.message.includes(partial))
     );
   }
 }

--- a/src/app/core/services/cluster/cluster.service.ts
+++ b/src/app/core/services/cluster/cluster.service.ts
@@ -11,12 +11,13 @@
 
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {combineLatest, merge, Observable, of, timer} from 'rxjs';
-import {catchError, filter, map, shareReplay, switchMap, switchMapTo, take} from 'rxjs/operators';
-import {Subject} from 'rxjs';
+import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
+import {combineLatest, merge, Observable, of, Subject, timer} from 'rxjs';
+import {catchError, filter, map, shareReplay, startWith, switchMap, switchMapTo, take} from 'rxjs/operators';
 
 import {environment} from '../../../../environments/environment';
 import {AppConfigService} from '../../../app-config.service';
+import {ConfirmationDialogComponent} from '../../../shared/components/confirmation-dialog/confirmation-dialog.component';
 import {LabelFormComponent} from '../../../shared/components/label-form/label-form.component';
 import {TaintFormComponent} from '../../../shared/components/taint-form/taint-form.component';
 import {Addon} from '../../../shared/entity/addon';
@@ -24,12 +25,10 @@ import {Cluster, ClusterPatch, Finalizer, MasterVersion, ProviderSettingsPatch} 
 import {Event} from '../../../shared/entity/event';
 import {Health} from '../../../shared/entity/health';
 import {ClusterMetrics, NodeMetrics} from '../../../shared/entity/metrics';
-import {SSHKey} from '../../../shared/entity/ssh-key';
 import {Node} from '../../../shared/entity/node';
+import {SSHKey} from '../../../shared/entity/ssh-key';
 import {CreateClusterModel} from '../../../shared/model/CreateClusterModel';
 import {ExternalClusterModel} from '../../../shared/model/ExternalClusterModel';
-import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
-import {ConfirmationDialogComponent} from '../../../shared/components/confirmation-dialog/confirmation-dialog.component';
 
 @Injectable()
 export class ClusterService {
@@ -261,7 +260,10 @@ export class ClusterService {
 
   private _getExternalClusters(projectID: string): Observable<Cluster[]> {
     const url = `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters`;
-    return this._http.get<Cluster[]>(url).pipe(catchError(() => of<Cluster[]>()));
+    return this._http
+      .get<Cluster[]>(url)
+      .pipe(catchError(() => of<Cluster[]>()))
+      .pipe(startWith([]));
   }
 
   private _getCluster(projectID: string, clusterID: string, seed: string): Observable<Cluster> {

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -22,6 +22,10 @@ import {DatacenterService, ProjectService, UserService} from '../core/services';
 import {SettingsService} from '../core/services/settings/settings.service';
 import {GoogleAnalyticsService} from '../google-analytics.service';
 import {SharedModule} from '../shared/shared.module';
+import {
+  DialogTestModule,
+  NoopProjectDeleteDialogComponent,
+} from '../testing/components/noop-project-delete-dialog.component';
 import {fakeProject} from '../testing/fake-data/project.fake';
 import {RouterStub, RouterTestingModule} from '../testing/router-stubs';
 import {AppConfigMockService} from '../testing/services/app-config-mock.service';
@@ -31,11 +35,7 @@ import {SettingsMockService} from '../testing/services/settings-mock.service';
 import {UserMockService} from '../testing/services/user-mock.service';
 
 import {ProjectComponent} from './project.component';
-import {DeleteProjectConfirmationComponent} from './delete-project/delete-project.component';
-import {
-  DialogTestModule,
-  NoopProjectDeleteDialogComponent,
-} from '../testing/components/noop-project-delete-dialog.component';
+import {ProjectModule} from './project.module';
 
 describe('ProjectComponent', () => {
   let fixture: ComponentFixture<ProjectComponent>;
@@ -48,11 +48,11 @@ describe('ProjectComponent', () => {
         BrowserModule,
         BrowserAnimationsModule,
         RouterTestingModule,
+        ProjectModule,
         SharedModule,
         CoreModule,
         DialogTestModule,
       ],
-      declarations: [ProjectComponent, DeleteProjectConfirmationComponent],
       providers: [
         {provide: Router, useClass: RouterStub},
         {provide: ProjectService, useClass: ProjectMockService},

--- a/src/app/project/project.module.ts
+++ b/src/app/project/project.module.ts
@@ -22,6 +22,5 @@ const components: any[] = [ProjectComponent, EditProjectComponent, DeleteProject
   imports: [SharedModule, ProjectRoutingModule],
   declarations: [...components],
   exports: [...components],
-  entryComponents: [EditProjectComponent, DeleteProjectConfirmationComponent],
 })
 export class ProjectModule {}

--- a/src/app/settings/admin/admin-settings.component.html
+++ b/src/app/settings/admin/admin-settings.component.html
@@ -174,13 +174,26 @@ limitations under the License.
         <div fxFlex="16%"
              fxLayoutAlign=" center"
              class="entry-label">
+          <span>Enable External Cluster Import</span>
+          <div class="km-icon-info km-pointer"
+               matTooltip="Enable/Disable &quot;Connect Cluster&quot; button on the cluster list and allow/block access to the import cluster feature through the API."></div>
+        </div>
+        <mat-checkbox [(ngModel)]="settings.enableExternalClusterImport"
+                      (change)="onSettingsChange()"></mat-checkbox>
+        <km-settings-status [isSaved]="isEqual(settings.enableExternalClusterImport, apiSettings.enableExternalClusterImport)"></km-settings-status>
+      </div>
+
+      <div fxLayout="row">
+        <div fxFlex="16%"
+             fxLayoutAlign=" center"
+             class="entry-label">
           <span>User Projects Limit</span>
           <div class="km-icon-info km-pointer"
                matTooltip="Set limit to zero to allow unlimited project creation for users. It does not affect administrators."></div>
         </div>
         <mat-checkbox fxLayoutAlign=" center"
                       [(ngModel)]="settings.restrictProjectCreation"
-                      (change)="onSettingsChange()">Restrict Project Creation to Adminstrators</mat-checkbox>
+                      (change)="onSettingsChange()">Restrict Project Creation to Administrators</mat-checkbox>
         <mat-form-field class="km-admin-settings-field-md km-no-padding">
           <mat-label>User Projects Limit</mat-label>
           <input matInput

--- a/src/app/settings/admin/admin-settings.component.html
+++ b/src/app/settings/admin/admin-settings.component.html
@@ -174,7 +174,7 @@ limitations under the License.
         <div fxFlex="16%"
              fxLayoutAlign=" center"
              class="entry-label">
-          <span>Enable External Cluster Connection</span>
+          <span>Enable External Clusters</span>
           <div class="km-icon-info km-pointer"
                matTooltip="Enable/Disable &quot;Connect Cluster&quot; button on the cluster list and allow/block access to the connect cluster feature through the API."></div>
         </div>

--- a/src/app/settings/admin/admin-settings.component.html
+++ b/src/app/settings/admin/admin-settings.component.html
@@ -174,9 +174,9 @@ limitations under the License.
         <div fxFlex="16%"
              fxLayoutAlign=" center"
              class="entry-label">
-          <span>Enable External Cluster Import</span>
+          <span>Enable External Cluster Connection</span>
           <div class="km-icon-info km-pointer"
-               matTooltip="Enable/Disable &quot;Connect Cluster&quot; button on the cluster list and allow/block access to the import cluster feature through the API."></div>
+               matTooltip="Enable/Disable &quot;Connect Cluster&quot; button on the cluster list and allow/block access to the connect cluster feature through the API."></div>
         </div>
         <mat-checkbox [(ngModel)]="settings.enableExternalClusterImport"
                       (change)="onSettingsChange()"></mat-checkbox>

--- a/src/app/shared/entity/settings.ts
+++ b/src/app/shared/entity/settings.ts
@@ -32,6 +32,7 @@ export class AdminSettings {
   enableOIDCKubeconfig: boolean;
   userProjectsLimit: number;
   restrictProjectCreation: boolean;
+  enableExternalClusterImport: boolean;
 }
 
 export class CleanupOptions {
@@ -130,4 +131,5 @@ export const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
   enableDashboard: true,
   enableOIDCKubeconfig: false,
   restrictProjectCreation: false,
+  enableExternalClusterImport: true,
 };

--- a/src/app/testing/services/settings-mock.service.ts
+++ b/src/app/testing/services/settings-mock.service.ts
@@ -34,6 +34,7 @@ export const DEFAULT_ADMIN_SETTINGS_MOCK: AdminSettings = {
   enableOIDCKubeconfig: false,
   userProjectsLimit: 0,
   restrictProjectCreation: false,
+  enableExternalClusterImport: true,
 };
 
 @Injectable()


### PR DESCRIPTION
**What this PR does / why we need it**:
API error with information about the disabled external cluster import feature is silenced and `Connect Cluster` button is hidden after disabling the feature. We could think about improving the error behavior of handling the GET of a single cluster in case someone uses a direct link? Not sure what should be done in this case though.

**Which issue(s) this PR fixes**:
Fixes #2642

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add option to enable/disable external cluster import feature from admin settings.
```
