### PR TITLE
Make vsphere VM template a required parameter

### DIFF
--- a/src/app/node-data/basic/provider/vsphere/template.html
+++ b/src/app/node-data/basic/provider/vsphere/template.html
@@ -44,4 +44,13 @@ limitations under the License.
       Memory have to be at least 512.
     </mat-error>
   </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>VM Template</mat-label>
+    <input matInput
+           [formControlName]="Controls.Template"
+           type="text"
+           autocomplete="off"
+           required>
+  </mat-form-field>
 </form>

--- a/src/app/node-data/extended/provider/vsphere/component.ts
+++ b/src/app/node-data/extended/provider/vsphere/component.ts
@@ -11,22 +11,16 @@
 
 import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {merge, of} from 'rxjs';
-import {filter, first, switchMap, takeUntil, tap} from 'rxjs/operators';
-import {DatacenterService} from '../../../../core/services';
-import {ClusterType} from '../../../../shared/entity/cluster';
-import {DatacenterOperatingSystemOptions} from '../../../../shared/entity/datacenter';
+import {merge} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 import {NodeCloudSpec, NodeSpec, VSphereNodeSpec} from '../../../../shared/entity/node';
-import {OperatingSystem} from '../../../../shared/model/NodeProviderConstants';
 import {NodeData} from '../../../../shared/model/NodeSpecChange';
-import {ClusterService} from '../../../../shared/services/cluster.service';
 import {BaseFormValidator} from '../../../../shared/validators/base-form.validator';
 import {NodeDataMode} from '../../../config';
 import {NodeDataService} from '../../../service/service';
 
 enum Controls {
   DiskSizeGB = 'diskSizeGB',
-  Template = 'template',
 }
 
 @Component({
@@ -48,55 +42,21 @@ enum Controls {
 export class VSphereExtendedNodeDataComponent extends BaseFormValidator implements OnInit, OnDestroy {
   private readonly _defaultDiskSize = 10;
 
-  private _defaultTemplate = '';
-  private _templates: DatacenterOperatingSystemOptions;
-
   readonly Controls = Controls;
 
-  get template(): string {
-    return this.form.get(Controls.Template).value ? this.form.get(Controls.Template).value : this._defaultTemplate;
-  }
-
-  constructor(
-    private readonly _builder: FormBuilder,
-    private readonly _nodeDataService: NodeDataService,
-    private readonly _datacenterService: DatacenterService,
-    private readonly _clusterService: ClusterService
-  ) {
+  constructor(private readonly _builder: FormBuilder, private readonly _nodeDataService: NodeDataService) {
     super();
   }
 
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.DiskSizeGB]: this._builder.control(this._defaultDiskSize),
-      [Controls.Template]: this._builder.control(''),
     });
 
     this._init();
     this._nodeDataService.nodeData = this._getNodeData();
 
-    merge<string>(this._clusterService.datacenterChanges, of(this._clusterService.datacenter))
-      .pipe(filter(dc => !!dc))
-      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
-      .pipe(tap(dc => (this._templates = dc.spec.vsphere.templates)))
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(_ => this._setDefaultTemplate(OperatingSystem.Ubuntu));
-
-    this._clusterService.clusterTypeChanges
-      .pipe(filter(_ => !!this._templates))
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(_ =>
-        this._isOpenshiftCluster()
-          ? this._setDefaultTemplate(OperatingSystem.CentOS)
-          : this._setDefaultTemplate(OperatingSystem.Ubuntu)
-      );
-
-    this._nodeDataService.operatingSystemChanges
-      .pipe(filter(_ => !!this._templates))
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(this._setDefaultTemplate.bind(this));
-
-    merge(this.form.get(Controls.DiskSizeGB).valueChanges, this.form.get(Controls.Template).valueChanges)
+    merge(this.form.get(Controls.DiskSizeGB).valueChanges)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._nodeDataService.nodeData = this._getNodeData()));
   }
@@ -116,40 +76,11 @@ export class VSphereExtendedNodeDataComponent extends BaseFormValidator implemen
     }
   }
 
-  private _isOpenshiftCluster(): boolean {
-    return this._clusterService.clusterType === ClusterType.OpenShift;
-  }
-
-  private _setDefaultTemplate(os: OperatingSystem): void {
-    switch (os) {
-      case OperatingSystem.CentOS:
-        this._defaultTemplate = this._templates.centos;
-        break;
-      case OperatingSystem.Ubuntu:
-        this._defaultTemplate = this._templates.ubuntu;
-        break;
-      case OperatingSystem.SLES:
-        this._defaultTemplate = this._templates.sles;
-        break;
-      case OperatingSystem.ContainerLinux:
-        this._defaultTemplate = this._templates.coreos;
-        break;
-      case OperatingSystem.Flatcar:
-        this._defaultTemplate = this._templates.flatcar;
-        break;
-      default:
-        this._defaultTemplate = this._templates.ubuntu;
-    }
-
-    this.form.get(Controls.Template).setValue(this._defaultTemplate);
-  }
-
   private _getNodeData(): NodeData {
     return {
       spec: {
         cloud: {
           vsphere: {
-            template: this.template,
             diskSizeGB: this.form.get(Controls.DiskSizeGB).value,
           } as VSphereNodeSpec,
         } as NodeCloudSpec,

--- a/src/app/node-data/extended/provider/vsphere/template.html
+++ b/src/app/node-data/extended/provider/vsphere/template.html
@@ -20,13 +20,4 @@ limitations under the License.
            type="number"
            autocomplete="off">
   </mat-form-field>
-
-  <mat-form-field fxFlex>
-    <mat-label>VM Template</mat-label>
-    <input matInput
-           [formControlName]="Controls.Template"
-           type="text"
-           autocomplete="off">
-    <mat-hint>Optional. If not set, a template called {{template}} will be used.</mat-hint>
-  </mat-form-field>
 </form>


### PR DESCRIPTION
**What this PR does / why we need it**:
Since VM template is not really an optional parameter I have made it a required one. Optional parameters are allowed to be empty and only then they can be a part of extended options.

**Which issue(s) this PR fixes**:
Fixes #2682

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
