### PR TITLE
Add datastore support to vsphere provider

### DIFF
--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -178,6 +178,8 @@ export class VSphereCloudSpec {
   vmNetName: string;
   folder?: string;
   infraManagementUser: VSphereInfraManagementUser;
+  datastore?: string;
+  datastoreCluster?: string;
 }
 
 export class VSphereInfraManagementUser {

--- a/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
@@ -22,7 +22,7 @@ import {
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {PresetsService} from '@core/services/wizard/presets.service';
 import {FilteredComboboxComponent} from '@shared/components/combobox/component';
-import {Cluster} from '@shared/entity/cluster';
+import {CloudSpec, Cluster, ClusterSpec, VSphereCloudSpec} from '@shared/entity/cluster';
 import {VSphereFolder, VSphereNetwork} from '@shared/entity/provider/vsphere';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
@@ -30,12 +30,14 @@ import {isObjectEmpty} from '@shared/utils/common-utils';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 
 import * as _ from 'lodash';
-import {EMPTY, Observable, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {forkJoin, merge, Observable, of} from 'rxjs';
+import {catchError, distinctUntilChanged, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 
 enum Controls {
   VMNetName = 'vmNetName',
   Folder = 'folder',
+  Datastore = 'datastore',
+  DatastoreCluster = 'datastoreCluster',
 }
 
 enum NetworkState {
@@ -101,6 +103,8 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
     this.form = this._builder.group({
       [Controls.VMNetName]: this._builder.control({value: '', disabled: true}),
       [Controls.Folder]: this._builder.control({value: '', disabled: true}),
+      [Controls.Datastore]: this._builder.control({value: '', disabled: false}),
+      [Controls.DatastoreCluster]: this._builder.control({value: '', disabled: false}),
     });
 
     this.form.valueChanges
@@ -119,15 +123,31 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
 
     this._credentialsChanged
       .pipe(tap(_ => this._clearFolders()))
-      .pipe(switchMap(_ => this._folderListObservable()))
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(this._loadFolders.bind(this));
-
-    this._credentialsChanged
       .pipe(tap(_ => this._clearNetworks()))
-      .pipe(switchMap(_ => this._networkListObservable()))
+      .pipe(switchMap(_ => forkJoin([this._folderListObservable(), this._networkListObservable()])))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(this._loadNetworks.bind(this));
+      .subscribe(([folders, networks]) => {
+        this._loadFolders(folders);
+        this._loadNetworks(networks);
+      });
+
+    // Mutually exclusive fields
+    this.form
+      .get(Controls.Datastore)
+      .valueChanges.pipe(filter(_ => !this._presets.preset))
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(val => this._enable(!val, Controls.DatastoreCluster));
+
+    this.form
+      .get(Controls.DatastoreCluster)
+      .valueChanges.pipe(filter(_ => !this._presets.preset))
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(val => this._enable(!val, Controls.Datastore));
+
+    merge(this.form.get(Controls.Datastore).valueChanges, this.form.get(Controls.DatastoreCluster).valueChanges)
+      .pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => (this._clusterService.cluster = this._getCluster()));
   }
 
   getNetworks(type: string): VSphereNetwork[] {
@@ -148,6 +168,8 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
       case Controls.Folder:
         return this._hasRequiredCredentials() ? '' : 'Please enter your credentials first.';
     }
+
+    return '';
   }
 
   ngOnDestroy(): void {
@@ -215,9 +237,9 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
       .networks(this._onNetworksLoading.bind(this))
       .pipe(map(networks => _.sortBy(networks, n => n.name.toLowerCase())))
       .pipe(
-        catchError(() => {
+        catchError(_ => {
           this._clearNetworks();
-          return onErrorResumeNext(EMPTY);
+          return of([]);
         })
       );
   }
@@ -243,9 +265,9 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
       .datacenter(this._clusterService.datacenter)
       .folders(this._onFoldersLoading.bind(this))
       .pipe(
-        catchError(() => {
+        catchError(_ => {
           this._clearFolders();
-          return onErrorResumeNext(EMPTY);
+          return of([]);
         })
       );
   }
@@ -271,5 +293,18 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
     if (!enable && this.form.get(name).enabled) {
       this.form.get(name).disable();
     }
+  }
+
+  private _getCluster(): Cluster {
+    return {
+      spec: {
+        cloud: {
+          vsphere: {
+            datastore: this.form.get(Controls.Datastore).value,
+            datastoreCluster: this.form.get(Controls.DatastoreCluster).value,
+          } as VSphereCloudSpec,
+        } as CloudSpec,
+      } as ClusterSpec,
+    } as Cluster;
   }
 }

--- a/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
@@ -41,4 +41,24 @@ limitations under the License.
       {{folder.path}}
     </div>
   </km-combobox>
+
+  <mat-form-field fxFlex>
+    <mat-label>Datastore</mat-label>
+    <input matInput
+           [formControlName]="Controls.Datastore"
+           [name]="Controls.Datastore"
+           type="text"
+           autocomplete="off">
+    <mat-hint>Datastore to be used for the virtual machines. It is mutually exclusive with Datastore Cluster field.</mat-hint>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Datastore Cluster</mat-label>
+    <input matInput
+           [formControlName]="Controls.DatastoreCluster"
+           [name]="Controls.DatastoreCluster"
+           type="text"
+           autocomplete="off">
+    <mat-hint>Datastore to be used for the virtual machines. It is mutually exclusive with Datastore field.</mat-hint>
+  </mat-form-field>
 </form>

--- a/src/app/wizard/step/summary/template.html
+++ b/src/app/wizard/step/summary/template.html
@@ -10,20 +10,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<div fxLayout="row"
-     fxLayout.md="column"
-     fxLayout.sm="column"
-     fxLayout.xs="column"
-     fxLayoutGap="20px"
-     fxLayoutGap.md="0"
-     fxLayoutGap.sm="0"
-     fxLayoutGap.xs="0"
-     fxLayoutAlign="start start"
-     class="km-wizard-summary">
-  <div fxFlex="50%"
-       fxLayout="column"
-       fxLayoutAlign="start start">
+<div class="km-wizard-summary">
+  <div fxFlex
+       fxLayoutAlign="start start"
+       fxLayout="row wrap"
+       fxLayout.sm="column"
+       fxLayout.xs="column">
     <div class="section"
+         fxFlex="50%"
          fxLayout="column"
          fxLayoutAlign="start start">
       <div class="header">Provider</div>
@@ -40,6 +34,7 @@ limitations under the License.
     </div>
 
     <div class="section"
+         fxFlex="50%"
          fxLayout="column"
          fxLayoutAlign="start start">
       <div class="header">Cluster</div>
@@ -136,6 +131,7 @@ limitations under the License.
 
     <div *ngIf="cluster.credential || displaySettings()"
          class="section"
+         fxFlex="50%"
          fxLayout="column"
          fxLayoutAlign="start start">
       <div class="header">Settings</div>
@@ -273,6 +269,14 @@ limitations under the License.
               <div key>Folder</div>
               <div value>{{cluster.spec.cloud.vsphere.folder}}</div>
             </km-property>
+            <km-property *ngIf="cluster.spec.cloud.vsphere.datastore">
+              <div key>Datastore</div>
+              <div value>{{cluster.spec.cloud.vsphere.datastore}}</div>
+            </km-property>
+            <km-property *ngIf="cluster.spec.cloud.vsphere.datastoreCluster">
+              <div key>Datastore Cluster</div>
+              <div value>{{cluster.spec.cloud.vsphere.datastoreCluster}}</div>
+            </km-property>
           </ng-container>
         </ng-container>
       </div>
@@ -282,6 +286,7 @@ limitations under the License.
          fxLayout="column"
          fxLayoutAlign="start start">
       <div class="section"
+           fxFlex="50%"
            fxLayout="column"
            fxLayoutAlign="start start"
            *ngIf="!cluster.spec.cloud.bringyourown">
@@ -645,6 +650,7 @@ limitations under the License.
 
 
       <div class="section"
+           fxFlex="50%"
            fxLayout="column"
            fxLayoutAlign="start start"
            *ngIf="cluster.spec.cloud.vsphere && cluster.spec.machineNetworks && cluster.spec.machineNetworks?.length > 0">
@@ -679,3 +685,4 @@ limitations under the License.
       </p>
     </div>
   </div>
+</div>


### PR DESCRIPTION
**What this PR does / why we need it**:
- Added `Datastore` and `Datastore Cluster` support to vsphere provider in wizard
- Fix summary view layout

**Which issue(s) this PR fixes**:
Fixes #2611

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add Datastore/Datastore Cluster support to the VSphere provider in the wizard.
```
