### PR TITLE
Restore list of cluster nodes

### DIFF
--- a/src/app/cluster/cluster-details/component.spec.ts
+++ b/src/app/cluster/cluster-details/component.spec.ts
@@ -55,6 +55,7 @@ import {MachineNetworksDisplayComponent} from './machine-networks-display/compon
 import {NodeListComponent} from './node-list/component';
 import {RBACComponent} from './rbac/component';
 import {VersionPickerComponent} from './version-picker/component';
+import {nodesFake} from '@app/testing/fake-data/node.fake';
 
 describe('ClusterDetailsComponent', () => {
   let fixture: ComponentFixture<ClusterDetailsComponent>;
@@ -133,6 +134,17 @@ describe('ClusterDetailsComponent', () => {
 
     tick();
     expect(component.cluster).toEqual(expectedCluster);
+  }));
+
+  it('should get nodes', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const expectedNodes = nodesFake();
+    expectedNodes[0].creationTimestamp = expect.any(Date);
+    expectedNodes[1].creationTimestamp = expect.any(Date);
+
+    tick();
+    expect(component.nodes).toEqual(expectedNodes);
   }));
 
   it('should create simple cluster binding for rbac', () => {

--- a/src/app/cluster/cluster-details/component.ts
+++ b/src/app/cluster/cluster-details/component.ts
@@ -57,6 +57,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   nodeDc: Datacenter;
   seed: string;
   sshKeys: SSHKey[] = [];
+  nodes: Node[] = [];
   machineDeployments: MachineDeployment[];
   isClusterRunning = false;
   isClusterAPIRunning = false;
@@ -145,6 +146,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
               this._canReloadNodes()
                 ? [
                     this._clusterService.addons(this.projectID, this.cluster.id, this.seed),
+                    this._clusterService.nodes(this.projectID, this.cluster.id),
                     this._api.getMachineDeployments(this.cluster.id, this.projectID),
                     this._clusterService.metrics(this.projectID, this.cluster.id),
                   ]
@@ -156,15 +158,17 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
       )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(
-        ([upgrades, clusterBindings, bindings, addons, machineDeployments, metrics]: [
+        ([upgrades, clusterBindings, bindings, addons, nodes, machineDeployments, metrics]: [
           MasterVersion[],
           ClusterBinding[],
           Binding[],
           Addon[],
+          Node[],
           MachineDeployment[],
           ClusterMetrics
         ]) => {
           this.addons = addons;
+          this.nodes = nodes;
           this.machineDeployments = machineDeployments;
           this.metrics = metrics;
           this.upgrades = _.isEmpty(upgrades) ? [] : upgrades;

--- a/src/app/cluster/cluster-details/template.html
+++ b/src/app/cluster/cluster-details/template.html
@@ -215,6 +215,15 @@ limitations under the License.
                               [projectID]="projectID"
                               [isClusterRunning]="isClusterRunning"></km-machine-deployment-list>
 
+  <div *ngIf="nodes.length > 0">
+    <km-node-list [cluster]="cluster"
+                  [nodes]="nodes"
+                  [seed]="seed"
+                  [projectID]="projectID"
+                  [clusterHealthStatus]="clusterHealthStatus"
+                  [isClusterRunning]="isClusterAPIRunning"></km-node-list>
+  </div>
+
   <km-rbac *ngIf="isRBACEnabled()"
            [cluster]="cluster"
            [seed]="seed"

--- a/src/app/core/services/cluster/service.ts
+++ b/src/app/core/services/cluster/service.ts
@@ -199,6 +199,11 @@ export class ClusterService {
     return this._http.put(url, {version} as MasterVersion);
   }
 
+  nodes(projectID: string, clusterID: string): Observable<Node[]> {
+    const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/nodes?hideInitialConditions=true`;
+    return this._http.get<Node[]>(url).pipe(catchError(() => of<Node[]>()));
+  }
+
   deleteNode(projectID: string, clusterID: string, nodeID: string): Observable<any> {
     const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/machinedeployments/nodes/${nodeID}`;
     return this._http.delete(url);


### PR DESCRIPTION
**What this PR does / why we need it**: It basically reverts https://github.com/kubermatic/dashboard/pull/2574 but this time uses new endpoint from https://github.com/kubermatic/kubermatic/pull/6130.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard/issues/2771

**Special notes for your reviewer**:

/hold

Wait for https://github.com/kubermatic/kubermatic/pull/6130 to be merged.

/cherry-pick release/v2.15

/assign @floreks 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Restore list of cluster nodes.
```
