### PR TITLE
Add support for new Openstack variables

### DIFF
--- a/src/app/cluster/cluster-details/node-list/template.html
+++ b/src/app/cluster/cluster-details/node-list/template.html
@@ -245,6 +245,14 @@ limitations under the License.
               <div key>Availability Zone</div>
               <div value>{{element.spec.cloud.openstack.availabilityZone}}</div>
             </km-property>
+            <km-property *ngIf="element.spec.cloud.openstack?.instanceReadyCheckPeriod">
+              <div key>Instance Ready Check Period</div>
+              <div value>{{element.spec.cloud.openstack.instanceReadyCheckPeriod}}</div>
+            </km-property>
+            <km-property *ngIf="element.spec.cloud.openstack?.instanceReadyCheckTimeout">
+              <div key>Instance Ready Check Timeout</div>
+              <div value>{{element.spec.cloud.openstack.instanceReadyCheckTimeout}}</div>
+            </km-property>
 
             <km-property *ngIf="element.spec.cloud.kubevirt">
               <div key>Number of CPUs</div>

--- a/src/app/node-data/basic/provider/openstack/template.html
+++ b/src/app/node-data/basic/provider/openstack/template.html
@@ -90,7 +90,7 @@ limitations under the License.
     <mat-label>Instance Ready Check Period</mat-label>
     <input [formControlName]="Controls.InstanceReadyCheckPeriod"
            matInput
-           min="5"
+           min="1"
            type="number"
            autocomplete="off"
            required>
@@ -101,7 +101,7 @@ limitations under the License.
     <mat-label>Instance Ready Check Timeout</mat-label>
     <input [formControlName]="Controls.InstanceReadyCheckTimeout"
            matInput
-           min="10"
+           min="1"
            type="number"
            autocomplete="off"
            required>

--- a/src/app/node-data/basic/provider/openstack/template.html
+++ b/src/app/node-data/basic/provider/openstack/template.html
@@ -85,4 +85,26 @@ limitations under the License.
        class="km-icon-info km-pointer"
        matTooltip="Floating IP usage is enforced by selected datacenter"></i>
   </mat-checkbox>
+
+  <mat-form-field fxFlex>
+    <mat-label>Instance Ready Check Period</mat-label>
+    <input [formControlName]="Controls.InstanceReadyCheckPeriod"
+           matInput
+           min="5"
+           type="number"
+           autocomplete="off"
+           required>
+    <mat-hint>Time in seconds between running a check for instance ready status.</mat-hint>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Instance Ready Check Timeout</mat-label>
+    <input [formControlName]="Controls.InstanceReadyCheckTimeout"
+           matInput
+           min="10"
+           type="number"
+           autocomplete="off"
+           required>
+    <mat-hint>Time in seconds to wait for instance to be in ready status before timing out.</mat-hint>
+  </mat-form-field>
 </form>

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -205,6 +205,8 @@ export class OpenstackNodeSpec {
   tags: object;
   diskSize?: number;
   availabilityZone?: string;
+  instanceReadyCheckPeriod: string;
+  instanceReadyCheckTimeout: string;
 }
 
 export class PacketNodeSpec {

--- a/src/app/testing/fake-data/node.fake.ts
+++ b/src/app/testing/fake-data/node.fake.ts
@@ -348,6 +348,8 @@ export function nodeDataFake(): NodeData {
           image: '',
           useFloatingIP: false,
           tags: {},
+          instanceReadyCheckPeriod: '10',
+          instanceReadyCheckTimeout: '120',
         },
         hetzner: {
           type: 'cx31',

--- a/src/app/testing/fake-data/node.fake.ts
+++ b/src/app/testing/fake-data/node.fake.ts
@@ -429,6 +429,8 @@ export function nodeDataCentOsFake(): NodeData {
           image: '',
           useFloatingIP: false,
           tags: {},
+          instanceReadyCheckPeriod: '10',
+          instanceReadyCheckTimeout: '120',
         },
         hetzner: {
           type: 'cx31',
@@ -494,6 +496,8 @@ export function nodeDataContainerLinuxFake(): NodeData {
           image: '',
           useFloatingIP: false,
           tags: {},
+          instanceReadyCheckPeriod: '10',
+          instanceReadyCheckTimeout: '120',
         },
         hetzner: {
           type: 'cx31',
@@ -558,6 +562,8 @@ export function nodeDataSLESFake(): NodeData {
           image: '',
           useFloatingIP: false,
           tags: {},
+          instanceReadyCheckPeriod: '10',
+          instanceReadyCheckTimeout: '120',
         },
         hetzner: {
           type: 'cx31',

--- a/src/app/wizard/step/summary/template.html
+++ b/src/app/wizard/step/summary/template.html
@@ -458,6 +458,14 @@ limitations under the License.
               <div key>Image</div>
               <div value>{{nodeData.spec.cloud.openstack.image}}</div>
             </km-property>
+            <km-property>
+              <div key>Instance Ready Check Period</div>
+              <div value>{{nodeData.spec.cloud.openstack.instanceReadyCheckPeriod}}</div>
+            </km-property>
+            <km-property>
+              <div key>Instance Ready Check Timeout</div>
+              <div value>{{nodeData.spec.cloud.openstack.instanceReadyCheckTimeout}}</div>
+            </km-property>
             <km-property-boolean *ngIf="nodeData.spec.operatingSystem.centos"
                                  label="Allocate Floating IP"
                                  [value]="nodeData.spec.cloud.openstack?.useFloatingIP">
@@ -492,33 +500,33 @@ limitations under the License.
             </km-property>
           </ng-container>
 
-        <!-- Anexia Nodes -->
-        <ng-container *ngIf="cluster.spec.cloud.anexia">
-          <km-property>
-            <div key>Number of CPUs</div>
-            <div value>{{nodeData.spec.cloud.anexia?.cpus}}</div>
-          </km-property>
-          <km-property>
-            <div key>Memory in MB</div>
-            <div value>{{nodeData.spec.cloud.anexia?.memory}}</div>
-          </km-property>
-          <km-property>
-            <div key>Disk Size in GB</div>
-            <div value>{{nodeData.spec.cloud.anexia?.diskSize}}</div>
-          </km-property>
-          <km-property>
-            <div key>Template ID</div>
-            <div value>{{nodeData.spec.cloud.anexia?.templateID}}</div>
-          </km-property>
-          <km-property>
-            <div key>VLAN ID</div>
-            <div value>{{nodeData.spec.cloud.anexia?.vlanID}}</div>
-          </km-property>
-        </ng-container>
+          <!-- Anexia Nodes -->
+          <ng-container *ngIf="cluster.spec.cloud.anexia">
+            <km-property>
+              <div key>Number of CPUs</div>
+              <div value>{{nodeData.spec.cloud.anexia?.cpus}}</div>
+            </km-property>
+            <km-property>
+              <div key>Memory in MB</div>
+              <div value>{{nodeData.spec.cloud.anexia?.memory}}</div>
+            </km-property>
+            <km-property>
+              <div key>Disk Size in GB</div>
+              <div value>{{nodeData.spec.cloud.anexia?.diskSize}}</div>
+            </km-property>
+            <km-property>
+              <div key>Template ID</div>
+              <div value>{{nodeData.spec.cloud.anexia?.templateID}}</div>
+            </km-property>
+            <km-property>
+              <div key>VLAN ID</div>
+              <div value>{{nodeData.spec.cloud.anexia?.vlanID}}</div>
+            </km-property>
+          </ng-container>
 
-        <km-property-boolean label="Dynamic kubelet Config"
-                             [value]="nodeData.dynamicConfig">
-        </km-property-boolean>
+          <km-property-boolean label="Dynamic kubelet Config"
+                               [value]="nodeData.dynamicConfig">
+          </km-property-boolean>
 
           <!-- AWS Node Options -->
           <ng-container *ngIf="cluster.spec.cloud.aws">


### PR DESCRIPTION
**What this PR does / why we need it**:
Added support for 2 new Openstack fields.
- `instanceReadyCheckPeriod`
- `instanceReadyCheckTimeout`

Related to https://github.com/kubermatic/kubermatic/pull/6139.

![Zrzut ekranu z 2020-11-10 11-55-46](https://user-images.githubusercontent.com/2285385/98665233-b15b4480-234b-11eb-9ac2-a766b5feaa68.png)

![Zrzut ekranu z 2020-11-10 11-32-54](https://user-images.githubusercontent.com/2285385/98665026-67725e80-234b-11eb-91c8-360749aa9890.png)

![Zrzut ekranu z 2020-11-10 11-35-11](https://user-images.githubusercontent.com/2285385/98665032-68a38b80-234b-11eb-94aa-275b72817ec1.png)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add support for 'instanceReadyCheckPeriod' and 'instanceReadyCheckTimeout' to the Openstack provider.
```
