### PR TITLE
Provide a better version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,36 @@ SHELL=/bin/bash
 KUBERMATIC_EDITION?=ee
 REPO=quay.io/kubermatic/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && echo "\-${KUBERMATIC_EDITION}" )
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')
-VERSION=$(shell git describe --tags --match "v[0-9]*")
+HUMAN_VERSION=$(shell git tag --points-at HEAD)
 CC=npm
 export GOOS?=linux
+
+# This determines the version that is printed at the footer in the
+# dashboard. It does not influence the tags used for the Docker images
+# for each revision.
+# As we only tag revisions in the release branches, a simple `git describe`
+# in the master branch yields not usable result. This is why the master
+# branch is manually set to the next minor version. When using a version
+# stamp like "v2.16.0-dev-gXXXX", Git only cares for the hash at the end,
+# thankfully.
+ifeq (${HUMAN_VERSION},)
+	CURRENT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+	TARGET_BRANCH=$(or ${PULL_BASE_REF},${PULL_BASE_REF},${CURRENT_BRANCH})
+
+	ifeq (${TARGET_BRANCH},master)
+	HUMAN_VERSION=v2.16.0-dev-g$(shell git rev-parse --short HEAD)
+	else
+	HUMAN_VERSION=$(shell git describe --tags --match "v[0-9]*")
+	endif
+endif
 
 # TODO: Old images config. Remove once deprecation period ends.
 REPO_OLD=quay.io/kubermatic/ui-v2
 
 all: install run
+
+version:
+	@echo $(HUMAN_VERSION)
 
 install:
 	@$(CC) ci --unsafe-perm
@@ -39,7 +61,7 @@ dist: install
 	@KUBERMATIC_EDITION=${KUBERMATIC_EDITION} $(CC) run build
 
 build:
-	CGO_ENABLED=0 go build -a -ldflags '-w -extldflags -static -X 'main.Edition=${KUBERMATIC_EDITION}' -X 'main.Version=${VERSION}'' -o dashboard .
+	CGO_ENABLED=0 go build -a -ldflags '-w -extldflags -static -X 'main.Edition=${KUBERMATIC_EDITION}' -X 'main.Version=${HUMAN_VERSION}'' -o dashboard .
 
 docker-build: build dist
 	docker build -t $(REPO):$(IMAGE_TAG) .

--- a/src/app/core/components/footer/template.html
+++ b/src/app/core/components/footer/template.html
@@ -23,9 +23,7 @@ limitations under the License.
          rel="noopener">powered by Kubermatic</a>
     </div>
 
-    <div *ngIf="!!version && !version.distance">{{version.tag}}</div>
-
-    <div *ngIf="!!version && !!version.distance">v{{version.semverString}}</div>
+    <div *ngIf="!!version">{{version.ui}}</div>
 
     <div id="km-edition">{{version.edition}}</div>
 

--- a/src/app/core/components/footer/template.html
+++ b/src/app/core/components/footer/template.html
@@ -23,7 +23,7 @@ limitations under the License.
          rel="noopener">powered by Kubermatic</a>
     </div>
 
-    <div *ngIf="!!version">{{version.ui}}</div>
+    <div *ngIf="!!version">{{version.humanReadable}}</div>
 
     <div id="km-edition">{{version.edition}}</div>
 

--- a/src/app/shared/entity/version-info.ts
+++ b/src/app/shared/entity/version-info.ts
@@ -19,6 +19,7 @@ export class VersionInfo {
   suffix: string;
   tag: string;
   edition: string;
+  ui: string;
 }
 
 export class Semver {

--- a/src/app/shared/entity/version-info.ts
+++ b/src/app/shared/entity/version-info.ts
@@ -19,7 +19,7 @@ export class VersionInfo {
   suffix: string;
   tag: string;
   edition: string;
-  ui: string;
+  humanReadable: string;
 }
 
 export class Semver {

--- a/src/app/testing/fake-data/versionInfo.fake.ts
+++ b/src/app/testing/fake-data/versionInfo.fake.ts
@@ -18,7 +18,7 @@ export function fakeVersionInfo(): VersionInfo {
     hash: '1234abcd',
     raw: 'v1.0.0',
     semverString: 'v1.0.0',
-    ui: 'v1.0.0',
+    humanReadable: 'v1.0.0',
     suffix: '',
     tag: 'v1.0.0',
   } as VersionInfo;

--- a/src/app/testing/fake-data/versionInfo.fake.ts
+++ b/src/app/testing/fake-data/versionInfo.fake.ts
@@ -18,6 +18,7 @@ export function fakeVersionInfo(): VersionInfo {
     hash: '1234abcd',
     raw: 'v1.0.0',
     semverString: 'v1.0.0',
+    ui: 'v1.0.0',
     suffix: '',
     tag: 'v1.0.0',
   } as VersionInfo;

--- a/version.js
+++ b/version.js
@@ -18,7 +18,7 @@ const gitInfo = gitDescribeSync({
 gitInfo.edition = getEditionDisplayName();
 
 // Re-use the version logic from our Makefile
-gitInfo.ui = execSync("make version").toString().trim();
+gitInfo.ui = execSync("make version --no-print-directory").toString().trim();
 
 const versionInfoJson = JSON.stringify(gitInfo, null, 2);
 

--- a/version.js
+++ b/version.js
@@ -1,6 +1,7 @@
 const {gitDescribeSync} = require('git-describe');
 const {resolve} = require('path');
 const {writeFileSync} = require('fs');
+const {execSync} = require('child_process');
 
 function getEditionDisplayName() {
   return process.env.KUBERMATIC_EDITION === 'ce'
@@ -15,6 +16,9 @@ const gitInfo = gitDescribeSync({
 
 // Append edition information
 gitInfo.edition = getEditionDisplayName();
+
+// Re-use the version logic from our Makefile
+gitInfo.ui = execSync("make version").toString().trim();
 
 const versionInfoJson = JSON.stringify(gitInfo, null, 2);
 

--- a/version.js
+++ b/version.js
@@ -18,7 +18,7 @@ const gitInfo = gitDescribeSync({
 gitInfo.edition = getEditionDisplayName();
 
 // Re-use the version logic from our Makefile
-gitInfo.ui = execSync("make version --no-print-directory").toString().trim();
+gitInfo.humanReadable = execSync("make version --no-print-directory").toString().trim();
 
 const versionInfoJson = JSON.stringify(gitInfo, null, 2);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As we tag releases on the release/XXX branches, a `git describe` on the master branch does not yield useful information. Currently it says something like `v2.14.0+255.g24fa837d`, because we more or less accidentally tagged that version on the exact moment we split the release branch away.

This PR changes the behaviour to treat master as 2.16.0. It was easier to hardcode the version into the Makefile than trying to do arithmetic and trying to calculate it based on the latest release branch.

I couldn't see where all the fields from the VersionInfo type are actually used, so maybe we can now skip the git-describe dependency alltogether?

**Release note**:
```release-note
NONE
```
