### PR TITLE
Replace first() with take(1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,12 @@
       "rxjs/no-nested-subscribe": "error",
       "rxjs/no-unbound-methods": "error",
       "rxjs/no-unsafe-takeuntil": "error",
+      "rxjs/ban-operators": [
+        "error",
+        {
+          "first": "use take(1) instead"
+        }
+      ],
       "no-undef": "off",
       "no-inner-declarations": "off",
       "no-redeclare": "off",

--- a/src/app/cluster/cluster-details/add-machine-network/component.ts
+++ b/src/app/cluster/cluster-details/add-machine-network/component.ts
@@ -15,7 +15,7 @@ import {ClusterService} from '@core/services/cluster/service';
 import {NotificationService} from '@core/services/notification/service';
 import {Cluster, ClusterPatch, MachineNetwork} from '@shared/entity/cluster';
 import * as _ from 'lodash';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-add-machine-network',
@@ -45,7 +45,7 @@ export class AddMachineNetworkComponent {
           machineNetworks: this.machineNetworks,
         },
       } as ClusterPatch)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(res => {
         this._notificationService.success(
           `The machine network(s) for the <strong>${this.cluster.name}</strong> cluster were added`

--- a/src/app/cluster/cluster-details/change-cluster-version/component.ts
+++ b/src/app/cluster/cluster-details/change-cluster-version/component.ts
@@ -19,7 +19,7 @@ import {Cluster, ClusterPatch} from '@shared/entity/cluster';
 import {Project} from '@shared/entity/project';
 import {EndOfLifeService} from '@shared/services/eol.service';
 import {Subject} from 'rxjs';
-import {first, takeUntil} from 'rxjs/operators';
+import {take, takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'km-change-cluster-version',
@@ -78,7 +78,7 @@ export class ChangeClusterVersionComponent implements OnInit, OnDestroy {
   upgradeMachineDeployments(): void {
     this._clusterService
       .upgradeMachineDeployments(this.project.id, this.cluster.id, this.selectedVersion)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
           `The machine deployments from the <strong>${this.cluster.name}</strong> cluster are being updated to the ${this.selectedVersion} version`

--- a/src/app/cluster/cluster-details/component.ts
+++ b/src/app/cluster/cluster-details/component.ts
@@ -39,7 +39,7 @@ import {ClusterHealthStatus} from '@shared/utils/health-status/cluster-health-st
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import * as _ from 'lodash';
 import {combineLatest, iif, Observable, of, Subject} from 'rxjs';
-import {filter, first, map, switchMap, take, takeUntil} from 'rxjs/operators';
+import {filter, map, switchMap, take, takeUntil} from 'rxjs/operators';
 import {NodeService} from '../services/node.service';
 import {ClusterDeleteConfirmationComponent} from './cluster-delete-confirmation/component';
 import {EditClusterComponent} from './edit-cluster/component';
@@ -96,7 +96,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     const clusterID = this._route.snapshot.paramMap.get(PathParam.ClusterID);
     this.seed = this._route.snapshot.paramMap.get(PathParam.SeedDC);
 
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
 
     this._userService
       .getCurrentUserGroup(this.projectID)
@@ -332,7 +332,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     modal.componentInstance.projectID = this.projectID;
     modal
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(isChanged => {
         if (isChanged) {
           this._clusterService.onClusterUpdate.next();
@@ -354,7 +354,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   handleAddonCreation(addon: Addon): void {
     this._clusterService
       .createAddon(addon, this.projectID, this.cluster.id, this.seed)
-      .pipe(first())
+      .pipe(take(1))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(() => {
         this.reloadAddons();
@@ -367,7 +367,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   handleAddonEdition(addon: Addon): void {
     this._clusterService
       .editAddon(addon, this.projectID, this.cluster.id, this.seed)
-      .pipe(first())
+      .pipe(take(1))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(() => {
         this.reloadAddons();
@@ -378,7 +378,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   handleAddonDeletion(addon: Addon): void {
     this._clusterService
       .deleteAddon(addon.id, this.projectID, this.cluster.id, this.seed)
-      .pipe(first())
+      .pipe(take(1))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(() => {
         this.reloadAddons();
@@ -392,7 +392,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     if (this.projectID && this.cluster && this.seed) {
       this._clusterService
         .addons(this.projectID, this.cluster.id, this.seed)
-        .pipe(first())
+        .pipe(take(1))
         .subscribe(addons => {
           this.addons = addons;
         });

--- a/src/app/cluster/cluster-details/edit-sshkeys/add-cluster-sshkeys/component.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/add-cluster-sshkeys/component.ts
@@ -25,7 +25,7 @@ import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import * as _ from 'lodash';
 import {Subscription} from 'rxjs';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-add-cluster-sshkeys',
@@ -56,7 +56,7 @@ export class AddClusterSSHKeysComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
     this._userService
       .getCurrentUserGroup(this.projectID)
       .subscribe(userGroup => (this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup)));

--- a/src/app/cluster/cluster-details/edit-sshkeys/component.ts
+++ b/src/app/cluster/cluster-details/edit-sshkeys/component.ts
@@ -27,7 +27,7 @@ import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import * as _ from 'lodash';
 import {EMPTY, merge, Subject, timer} from 'rxjs';
-import {filter, first, switchMap, takeUntil} from 'rxjs/operators';
+import {filter, take, switchMap, takeUntil} from 'rxjs/operators';
 import {AddClusterSSHKeysComponent} from './add-cluster-sshkeys/component';
 
 @Component({
@@ -63,7 +63,7 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
 
     this._userService
       .getCurrentUserGroup(this.projectID)
@@ -109,7 +109,7 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
 
     dialogRef
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe((sshkey: SSHKey) => {
         if (sshkey) {
           this.sshKeys.push(sshkey);
@@ -141,7 +141,7 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
       .afterClosed()
       .pipe(filter(isConfirmed => isConfirmed))
       .pipe(switchMap(_ => this._clusterService.deleteSSHKey(this.projectID, this.cluster.id, sshKey.id)))
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
           `The <strong>${sshKey.name}</strong> SSH key was removed from the <strong>${this.cluster.name}</strong> cluster`

--- a/src/app/cluster/cluster-details/machine-deployment-details/component.ts
+++ b/src/app/cluster/cluster-details/machine-deployment-details/component.ts
@@ -30,7 +30,7 @@ import {GroupConfig} from '@shared/model/Config';
 import {MachineDeploymentHealthStatus} from '@shared/utils/health-status/machine-deployment-health-status';
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import {Subject, timer} from 'rxjs';
-import {first, take, takeUntil} from 'rxjs/operators';
+import {take, takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'km-machine-deployment-details',
@@ -81,7 +81,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
     this.projectID = this._activatedRoute.snapshot.paramMap.get('projectID');
     this.seed = this._activatedRoute.snapshot.paramMap.get(PathParam.SeedDC);
 
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
 
     this._userService
       .getCurrentUserGroup(this.projectID)
@@ -103,7 +103,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
   loadMachineDeployment(): void {
     this._apiService
       .getMachineDeployment(this._machineDeploymentID, this._clusterName, this.seed, this.projectID)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe((md: MachineDeployment) => {
         this.machineDeployment = md;
         this.system = getOperatingSystem(this.machineDeployment.spec.template);
@@ -116,7 +116,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
   loadNodes(): void {
     this._apiService
       .getMachineDeploymentNodes(this._machineDeploymentID, this._clusterName, this.seed, this.projectID)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(n => {
         this.nodes = n;
         this._areNodesLoaded = true;
@@ -126,7 +126,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
   loadNodesEvents(): void {
     this._apiService
       .getMachineDeploymentNodesEvents(this._machineDeploymentID, this._clusterName, this.seed, this.projectID)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(e => {
         this.events = e;
         this._areNodesEventsLoaded = true;
@@ -136,7 +136,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
   loadNodesMetrics(): void {
     this._apiService
       .getMachineDeploymentNodesMetrics(this._machineDeploymentID, this._clusterName, this.seed, this.projectID)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(metrics => {
         this._storeNodeMetrics(metrics);
       });
@@ -145,7 +145,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
   loadCluster(): void {
     this._clusterService
       .cluster(this.projectID, this._clusterName)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(c => {
         this.cluster = c;
         this.clusterProvider = Cluster.getProvider(this.cluster.spec.cloud);
@@ -157,7 +157,7 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
   loadDatacenter(): void {
     this._datacenterService
       .getDatacenter(this.cluster.spec.cloud.dc)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(d => {
         this.datacenter = d;
         this._isDatacenterLoaded = true;

--- a/src/app/cluster/cluster-details/node-list/component.ts
+++ b/src/app/cluster/cluster-details/node-list/component.ts
@@ -30,7 +30,7 @@ import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import {NodeUtils} from '@shared/utils/node-utils/node-utils';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {filter, first, switchMap, takeUntil} from 'rxjs/operators';
+import {filter, switchMap, take, takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'km-node-list',
@@ -86,7 +86,7 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
     this.sort.active = 'name';
     this.sort.direction = 'asc';
 
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
 
     this._userService
       .getCurrentUserGroup(this.projectID)
@@ -134,7 +134,7 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
       .afterClosed()
       .pipe(filter(isConfirmed => isConfirmed))
       .pipe(switchMap(_ => this._clusterService.deleteNode(this.projectID, this.cluster.id, node.id)))
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
           `The <strong>${node.name}</strong> node was removed from the <strong>${this.cluster.name}</strong> cluster`

--- a/src/app/cluster/cluster-details/rbac/component.ts
+++ b/src/app/cluster/cluster-details/rbac/component.ts
@@ -19,7 +19,7 @@ import {Cluster} from '@shared/entity/cluster';
 import {SimpleBinding, SimpleClusterBinding} from '@shared/entity/rbac';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {filter, first, switchMap} from 'rxjs/operators';
+import {filter, switchMap, take} from 'rxjs/operators';
 import {AddBindingComponent} from './add-binding/component';
 
 @Component({
@@ -120,7 +120,7 @@ export class RBACComponent implements OnInit, OnDestroy {
           )
         )
       )
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
           `The <strong>${element.name}</strong> ${element.kind} was removed from the binding`
@@ -161,7 +161,7 @@ export class RBACComponent implements OnInit, OnDestroy {
           )
         )
       )
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
           `The <strong>${element.name}</strong> ${element.kind} was removed from the binding`

--- a/src/app/cluster/cluster-details/revoke-token/component.ts
+++ b/src/app/cluster/cluster-details/revoke-token/component.ts
@@ -19,7 +19,7 @@ import {View} from '@shared/entity/common';
 import {Member} from '@shared/entity/member';
 import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-revoke-token',
@@ -43,7 +43,7 @@ export class RevokeTokenComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
 
     this._userService.getCurrentUserGroup(this.projectID).subscribe(userGroup => {
       this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup);

--- a/src/app/cluster/cluster-details/share-kubeconfig/component.ts
+++ b/src/app/cluster/cluster-details/share-kubeconfig/component.ts
@@ -14,7 +14,7 @@ import {ApiService} from '@core/services/api/service';
 import {Auth} from '@core/services/auth/service';
 import {UserService} from '@core/services/user/service';
 import {Cluster} from '@shared/entity/cluster';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-share-kubeconfig',
@@ -36,7 +36,7 @@ export class ShareKubeconfigComponent implements OnInit {
 
   ngOnInit(): void {
     if (this._auth.authenticated()) {
-      this._userService.currentUser.pipe(first()).subscribe(user => {
+      this._userService.currentUser.pipe(take(1)).subscribe(user => {
         this.userID = user.id;
         this.kubeconfigLink = this._api.getShareKubeconfigURL(this.projectID, this.seed, this.cluster.id, this.userID);
       });

--- a/src/app/cluster/cluster-details/version-picker/component.ts
+++ b/src/app/cluster/cluster-details/version-picker/component.ts
@@ -14,9 +14,9 @@ import {MatDialog} from '@angular/material/dialog';
 import {ClusterService} from '@core/services/cluster/service';
 import {Cluster, MasterVersion} from '@shared/entity/cluster';
 import {EndOfLifeService} from '@shared/services/eol.service';
-import {first} from 'rxjs/operators';
 import {gt, lt} from 'semver';
 import {ChangeClusterVersionComponent} from '../change-cluster-version/component';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-version-picker',
@@ -102,7 +102,7 @@ export class VersionPickerComponent implements OnInit, OnChanges {
       modal.componentInstance.controlPlaneVersions = this.versionsList;
       modal
         .afterClosed()
-        .pipe(first())
+        .pipe(take(1))
         .subscribe(isChanged => {
           if (isChanged) {
             this._clusterService.onClusterUpdate.next();

--- a/src/app/cluster/cluster-list/component.ts
+++ b/src/app/cluster/cluster-list/component.ts
@@ -36,7 +36,7 @@ import {ClusterHealthStatus} from '@shared/utils/health-status/cluster-health-st
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import * as _ from 'lodash';
 import {EMPTY, forkJoin, Observable, of, onErrorResumeNext, Subject} from 'rxjs';
-import {catchError, distinctUntilChanged, filter, first, switchMap, take, takeUntil, tap} from 'rxjs/operators';
+import {catchError, distinctUntilChanged, filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {ClusterDeleteConfirmationComponent} from '../cluster-details/cluster-delete-confirmation/component';
 
 @Component({
@@ -88,7 +88,7 @@ export class ClusterListComponent implements OnInit, OnChanges, OnDestroy {
     this.sort.active = 'name';
     this.sort.direction = 'asc';
 
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
 
     this._userService.currentUserSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       this.paginator.pageSize = settings.itemsPerPage;

--- a/src/app/cluster/services/node.service.ts
+++ b/src/app/cluster/services/node.service.ts
@@ -19,7 +19,7 @@ import {Cluster} from '@shared/entity/cluster';
 import {MachineDeployment, MachineDeploymentPatch} from '@shared/entity/machine-deployment';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {Observable, of} from 'rxjs';
-import {catchError, filter, first, mergeMap, switchMap} from 'rxjs/operators';
+import {catchError, filter, mergeMap, switchMap, take} from 'rxjs/operators';
 
 @Injectable()
 export class NodeService {
@@ -145,7 +145,7 @@ export class NodeService {
             if (isConfirmed) {
               return this._apiService
                 .deleteMachineDeployment(clusterID, md, dcName, projectID)
-                .pipe(first())
+                .pipe(take(1))
                 .pipe(
                   catchError(() => {
                     this._notificationService.error('Could not remove the <strong>${md.name}</strong> node deployment');
@@ -171,6 +171,6 @@ export class NodeService {
           }
         )
       )
-      .pipe(first());
+      .pipe(take(1));
   }
 }

--- a/src/app/core/services/auth/service.ts
+++ b/src/app/core/services/auth/service.ts
@@ -16,7 +16,7 @@ import {environment} from '@environments/environment';
 import {RandomString} from '@shared/functions/generate-random-string';
 import {CookieService} from 'ngx-cookie-service';
 import {Observable} from 'rxjs';
-import {first, tap} from 'rxjs/operators';
+import {take, tap} from 'rxjs/operators';
 import {PreviousRouteService} from '../previous-route/service';
 import {TokenService} from '../token/service';
 import {UserService} from '../user/service';
@@ -116,7 +116,7 @@ export class Auth {
           this._cookieService.delete(this._cookie.nonce, '/');
         })
       )
-      .pipe(first());
+      .pipe(take(1));
   }
 
   setNonce(): void {

--- a/src/app/core/services/datacenter/service.ts
+++ b/src/app/core/services/datacenter/service.ts
@@ -12,7 +12,7 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {iif, merge, Observable, of, Subject, timer} from 'rxjs';
-import {first, map, shareReplay, switchMap} from 'rxjs/operators';
+import {map, shareReplay, switchMap, take} from 'rxjs/operators';
 import {environment} from '@environments/environment';
 import {CreateDatacenterModel, Datacenter} from '@shared/entity/datacenter';
 import {AppConfigService} from '@app/config.service';
@@ -40,13 +40,13 @@ export class DatacenterService {
       .pipe(switchMap(() => iif(() => this._auth.authenticated(), this._getDatacenters(), of([]))))
       .pipe(map(datacenters => _.sortBy(datacenters, d => d.metadata.name.toLowerCase())))
       .pipe(shareReplay(1));
-    this._datacenters$.pipe(first()).subscribe(_ => {});
+    this._datacenters$.pipe(take(1)).subscribe(_ => {});
 
     this._seeds$ = merge(this._seedsRefresh$, this._refreshTimer$)
       .pipe(switchMap(() => iif(() => this._auth.authenticated(), this._getSeeds(), of([]))))
       .pipe(map((seeds: string[]) => _.sortBy(seeds, s => s.toLowerCase())))
       .pipe(shareReplay(1));
-    this._seeds$.pipe(first()).subscribe(_ => {});
+    this._seeds$.pipe(take(1)).subscribe(_ => {});
   }
 
   get datacenters(): Observable<Datacenter[]> {

--- a/src/app/core/services/project/service.ts
+++ b/src/app/core/services/project/service.ts
@@ -19,7 +19,7 @@ import {environment} from '@environments/environment';
 import {Project} from '@shared/entity/project';
 import {ProjectUtils} from '@shared/utils/project-utils/project-utils';
 import {EMPTY, merge, Observable, of, Subject, timer} from 'rxjs';
-import {catchError, first, map, shareReplay, switchMap, switchMapTo} from 'rxjs/operators';
+import {catchError, map, shareReplay, switchMap, switchMapTo, take} from 'rxjs/operators';
 
 @Injectable()
 export class ProjectService {
@@ -66,7 +66,7 @@ export class ProjectService {
 
   get selectedProject(): Observable<Project> {
     if (!this._project$) {
-      this._project$ = merge(this._params.onParamChange, this.projects.pipe(first()))
+      this._project$ = merge(this._params.onParamChange, this.projects.pipe(take(1)))
         .pipe(switchMapTo(this.projects))
         .pipe(map(projects => projects.find(project => project.id === this._selectedProjectID)))
         .pipe(switchMap(project => (project ? of(project) : this._getProject(this._selectedProjectID))))

--- a/src/app/core/services/user/service.ts
+++ b/src/app/core/services/user/service.ts
@@ -12,7 +12,7 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {BehaviorSubject, EMPTY, iif, Observable, of} from 'rxjs';
-import {catchError, delay, filter, first, map, retryWhen, switchMap, tap} from 'rxjs/operators';
+import {catchError, delay, filter, take, map, retryWhen, switchMap, tap} from 'rxjs/operators';
 import {environment} from '@environments/environment';
 import {AppConfigService} from '@app/config.service';
 import {Member} from '@shared/entity/member';
@@ -101,6 +101,6 @@ export class UserService {
       .pipe(switchMap(user => this._httpClient.post(url, user)))
       .pipe(map(_ => true))
       .pipe(catchError(_ => of(false)))
-      .pipe(first());
+      .pipe(take(1));
   }
 }

--- a/src/app/dynamic/enterprise/theming/picker/component.ts
+++ b/src/app/dynamic/enterprise/theming/picker/component.ts
@@ -19,7 +19,7 @@ import {Theme} from '@shared/model/Config';
 import {objectDiff} from '@shared/utils/common-utils';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {debounceTime, first, switchMap, takeUntil} from 'rxjs/operators';
+import {debounceTime, take, switchMap, takeUntil} from 'rxjs/operators';
 
 @Component({
   templateUrl: 'template.html',
@@ -69,7 +69,7 @@ export class StylePickerComponent implements OnInit {
   ngOnInit(): void {
     this.themes = this._themeService.themes;
 
-    this._userService.currentUserSettings.pipe(first()).subscribe(this._selectDefaultTheme.bind(this));
+    this._userService.currentUserSettings.pipe(take(1)).subscribe(this._selectDefaultTheme.bind(this));
 
     this._userService.currentUserSettings
       .pipe(takeUntil(this._unsubscribe))

--- a/src/app/member/member.component.ts
+++ b/src/app/member/member.component.ts
@@ -28,7 +28,7 @@ import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import * as _ from 'lodash';
 import {EMPTY, merge, Subject, timer} from 'rxjs';
-import {filter, first, switchMap, takeUntil} from 'rxjs/operators';
+import {filter, switchMap, take, takeUntil} from 'rxjs/operators';
 import {AddMemberComponent} from './add-member/add-member.component';
 import {EditMemberComponent} from './edit-member/edit-member.component';
 
@@ -74,7 +74,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
       this.dataSource.paginator = this.paginator; // Force refresh.
     });
 
-    this._userService.currentUser.pipe(first()).subscribe(user => (this.currentUser = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this.currentUser = user));
 
     this._projectService.selectedProject
       .pipe(
@@ -83,7 +83,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
           return this._userService.getCurrentUserGroup(project.id);
         })
       )
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(userGroup => (this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup)));
 
     merge(timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase()), this._membersUpdate)
@@ -120,7 +120,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
     modal.componentInstance.project = this._selectedProject;
     modal
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe((member: Member) => {
         if (member) {
           this.members.push(member);
@@ -150,7 +150,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
     modal.componentInstance.member = member;
     modal
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(isEdited => {
         if (isEdited) {
           this._membersUpdate.next();
@@ -191,7 +191,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
       .afterClosed()
       .pipe(filter(isConfirmed => isConfirmed))
       .pipe(switchMap(_ => this._apiService.deleteMembers(this._selectedProject.id, member)))
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
           `The <strong>${member.name}</strong> member was removed from the <strong>${this._selectedProject.name}</strong> project`

--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -33,7 +33,7 @@ import {ClusterService} from '@shared/services/cluster.service';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import * as _ from 'lodash';
 import {merge, Observable, of} from 'rxjs';
-import {filter, first, map, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {filter, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import moment = require('moment');
 
 enum Controls {
@@ -153,7 +153,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
 
     merge<string>(this._clusterService.datacenterChanges, of(this._clusterService.datacenter))
       .pipe(filter(dc => !!dc))
-      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
+      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(take(1))))
       .pipe(tap(dc => (this._images = dc.spec.openstack.images)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(dc => {

--- a/src/app/node-data/basic/provider/vsphere/component.ts
+++ b/src/app/node-data/basic/provider/vsphere/component.ts
@@ -21,7 +21,7 @@ import {NodeData} from '@shared/model/NodeSpecChange';
 import {ClusterService} from '@shared/services/cluster.service';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import {merge, of} from 'rxjs';
-import {filter, first, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
 enum Controls {
   CPU = 'cpu',
@@ -89,7 +89,7 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
 
     merge<string>(this._clusterService.datacenterChanges, of(this._clusterService.datacenter))
       .pipe(filter(dc => !!dc))
-      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
+      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(take(1))))
       .pipe(tap(dc => (this._templates = dc.spec.vsphere.templates)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._setDefaultTemplate(OperatingSystem.Ubuntu));

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -30,7 +30,7 @@ import {ClusterService} from '@shared/services/cluster.service';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import {NoIpsLeftValidator} from '@shared/validators/no-ips-left.validator';
 import {merge, of} from 'rxjs';
-import {filter, first, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {filter, take, switchMap, takeUntil, tap} from 'rxjs/operators';
 import {NodeDataService} from './service/service';
 
 enum Controls {
@@ -141,7 +141,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
 
     merge<string>(this._clusterService.datacenterChanges, of(this._clusterService.datacenter))
       .pipe(filter(dc => !!dc))
-      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
+      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(take(1))))
       .pipe(takeUntil(this._unsubscribe))
       .pipe(tap(dc => (this._datacenterSpec = dc)))
       .subscribe(_ => this.form.get(Controls.OperatingSystem).setValue(this._getDefaultOS()));

--- a/src/app/node-data/kubelet-version/component.ts
+++ b/src/app/node-data/kubelet-version/component.ts
@@ -18,7 +18,7 @@ import {NodeSpec} from '@shared/entity/node';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {ClusterService as ClusterDataService} from '@shared/services/cluster.service';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
-import {first, switchMap, takeUntil} from 'rxjs/operators';
+import {take, switchMap, takeUntil} from 'rxjs/operators';
 import {NodeDataService} from '../service/service';
 
 enum Controls {
@@ -82,7 +82,7 @@ export class KubeletVersionNodeDataComponent extends BaseFormValidator implement
           )
         )
       )
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(this._setDefaultVersion.bind(this));
 
     this.form

--- a/src/app/node-data/service/provider/alibaba.ts
+++ b/src/app/node-data/service/provider/alibaba.ts
@@ -18,7 +18,7 @@ import {AlibabaInstanceType, AlibabaZone} from '@shared/entity/provider/alibaba'
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, filter, take, switchMap, tap} from 'rxjs/operators';
 import {NodeDataMode} from '../../config';
 import {NodeDataService} from '../service';
 
@@ -47,7 +47,7 @@ export class NodeDataAlibabaProvider {
         return this._clusterService.clusterChanges
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.ALIBABA))
           .pipe(tap(c => (cluster = c)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(first())))
+          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(take(1))))
           .pipe(tap(dc => (region = dc.spec.alibaba.region)))
           .pipe(
             switchMap(_ =>
@@ -75,7 +75,7 @@ export class NodeDataAlibabaProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -98,7 +98,7 @@ export class NodeDataAlibabaProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }
@@ -112,7 +112,7 @@ export class NodeDataAlibabaProvider {
         return this._clusterService.clusterChanges
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.ALIBABA))
           .pipe(tap(c => (cluster = c)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(first())))
+          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(take(1))))
           .pipe(tap(dc => (region = dc.spec.alibaba.region)))
           .pipe(
             switchMap(_ =>
@@ -159,7 +159,7 @@ export class NodeDataAlibabaProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/node-data/service/provider/aws.ts
+++ b/src/app/node-data/service/provider/aws.ts
@@ -17,7 +17,7 @@ import {AWSSize, AWSSubnet} from '@shared/entity/provider/aws';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, filter, take, switchMap, tap} from 'rxjs/operators';
 import {NodeDataMode} from '../../config';
 import {NodeDataService} from '../service';
 
@@ -40,7 +40,7 @@ export class NodeDataAWSProvider {
     switch (this._nodeDataService.mode) {
       case NodeDataMode.Wizard:
         return this._clusterService.datacenterChanges
-          .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
+          .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(take(1))))
           .pipe(
             switchMap(dc =>
               this._presetService
@@ -64,7 +64,7 @@ export class NodeDataAWSProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -82,7 +82,7 @@ export class NodeDataAWSProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }
@@ -118,7 +118,7 @@ export class NodeDataAWSProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -136,7 +136,7 @@ export class NodeDataAWSProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/node-data/service/provider/azure.ts
+++ b/src/app/node-data/service/provider/azure.ts
@@ -20,7 +20,7 @@ import {AzureSizes, AzureZones} from '@shared/entity/provider/azure';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, filter, take, switchMap, tap} from 'rxjs/operators';
 
 export class NodeDataAzureProvider {
   constructor(
@@ -46,7 +46,7 @@ export class NodeDataAzureProvider {
         return this._clusterService.clusterChanges
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE))
           .pipe(tap(c => (cluster = c)))
-          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(first())))
+          .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(take(1))))
           .pipe(tap(dc => (location = dc.spec.azure.location)))
           .pipe(
             switchMap(_ =>
@@ -76,7 +76,7 @@ export class NodeDataAzureProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -94,7 +94,7 @@ export class NodeDataAzureProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }
@@ -106,7 +106,7 @@ export class NodeDataAzureProvider {
       case NodeDataMode.Wizard:
         return this._datacenterService
           .getDatacenter(this._clusterService.cluster.spec.cloud.dc)
-          .pipe(first())
+          .pipe(take(1))
           .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE))
           .pipe(tap(dc => (location = dc.spec.azure.location)))
           .pipe(
@@ -138,7 +138,7 @@ export class NodeDataAzureProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -161,7 +161,7 @@ export class NodeDataAzureProvider {
               return onErrorResumeNext(of({} as AzureZones));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/node-data/service/provider/digitalocean.ts
+++ b/src/app/node-data/service/provider/digitalocean.ts
@@ -17,7 +17,7 @@ import {DigitaloceanSizes} from '@shared/entity/provider/digitalocean';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, filter, take, switchMap, tap} from 'rxjs/operators';
 import {NodeDataMode} from '../../config';
 import {NodeDataService} from '../service';
 
@@ -66,7 +66,7 @@ export class NodeDataDigitalOceanProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -84,7 +84,7 @@ export class NodeDataDigitalOceanProvider {
               return onErrorResumeNext(of(DigitaloceanSizes.newDigitalOceanSizes()));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/node-data/service/provider/gcp.ts
+++ b/src/app/node-data/service/provider/gcp.ts
@@ -18,7 +18,7 @@ import {GCPDiskType, GCPMachineSize, GCPZone} from '@shared/entity/provider/gcp'
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, filter, take, switchMap, tap} from 'rxjs/operators';
 import {NodeDataMode} from '../../config';
 import {NodeDataService} from '../service';
 
@@ -76,7 +76,7 @@ export class NodeDataGCPProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -94,7 +94,7 @@ export class NodeDataGCPProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }
@@ -123,7 +123,7 @@ export class NodeDataGCPProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -146,7 +146,7 @@ export class NodeDataGCPProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }
@@ -175,7 +175,7 @@ export class NodeDataGCPProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -198,7 +198,7 @@ export class NodeDataGCPProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/node-data/service/provider/hetzner.ts
+++ b/src/app/node-data/service/provider/hetzner.ts
@@ -18,7 +18,7 @@ import {HetznerTypes} from '@shared/entity/provider/hetzner';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, filter, take, switchMap, tap} from 'rxjs/operators';
 import {NodeDataService} from '../service';
 
 export class NodeDataHetznerProvider {
@@ -60,7 +60,7 @@ export class NodeDataHetznerProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -78,7 +78,7 @@ export class NodeDataHetznerProvider {
               return onErrorResumeNext(of(HetznerTypes.newHetznerTypes()));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/node-data/service/provider/openstack.ts
+++ b/src/app/node-data/service/provider/openstack.ts
@@ -17,7 +17,7 @@ import {OpenstackAvailabilityZone, OpenstackFlavor} from '@shared/entity/provide
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, debounceTime, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, debounceTime, filter, take, switchMap, tap} from 'rxjs/operators';
 import {NodeDataMode} from '../../config';
 import {NodeDataService} from '../service';
 
@@ -74,7 +74,7 @@ export class NodeDataOpenstackProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -92,7 +92,7 @@ export class NodeDataOpenstackProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }
@@ -135,7 +135,7 @@ export class NodeDataOpenstackProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -157,7 +157,7 @@ export class NodeDataOpenstackProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/node-data/service/provider/packet.ts
+++ b/src/app/node-data/service/provider/packet.ts
@@ -17,7 +17,7 @@ import {PacketSize} from '@shared/entity/provider/packet';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, first, switchMap, tap} from 'rxjs/operators';
+import {catchError, filter, switchMap, take, tap} from 'rxjs/operators';
 import {NodeDataMode} from '../../config';
 import {NodeDataService} from '../service';
 
@@ -67,7 +67,7 @@ export class NodeDataPacketProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(
             switchMap(_ =>
-              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(first())
+              this._datacenterService.getDatacenter(this._clusterService.cluster.spec.cloud.dc).pipe(take(1))
             )
           )
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
@@ -85,7 +85,7 @@ export class NodeDataPacketProvider {
               return onErrorResumeNext(of([]));
             })
           )
-          .pipe(first());
+          .pipe(take(1));
       }
     }
   }

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -43,7 +43,7 @@ import {ProjectUtils} from '@shared/utils/project-utils/project-utils';
 import * as _ from 'lodash';
 import {CookieService} from 'ngx-cookie-service';
 import {Subject} from 'rxjs';
-import {filter, first, switchMap, take, takeUntil, tap} from 'rxjs/operators';
+import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {DeleteProjectConfirmationComponent} from './delete-project/delete-project.component';
 import {EditProjectComponent} from './edit-project/edit-project.component';
 
@@ -348,7 +348,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
     this._matDialog
       .open(AddProjectDialogComponent)
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(isAdded => {
         if (isAdded) {
           this._projectService.onProjectsUpdate.next();
@@ -372,7 +372,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
     modal.componentInstance.project = project;
     modal
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(editedProject => {
         if (editedProject) {
           this._projectService.onProjectsUpdate.next();

--- a/src/app/serviceaccount/add-serviceaccount/add-serviceaccount.component.ts
+++ b/src/app/serviceaccount/add-serviceaccount/add-serviceaccount.component.ts
@@ -16,7 +16,7 @@ import {ApiService} from '@core/services/api/service';
 import {NotificationService} from '@core/services/notification/service';
 import {Project} from '@shared/entity/project';
 import {ServiceAccountModel} from '@shared/entity/service-account';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-add-serviceaccount',
@@ -47,7 +47,7 @@ export class AddServiceAccountComponent implements OnInit {
 
     this._apiService
       .createServiceAccount(this.project.id, createServiceAccount)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._matDialogRef.close(true);
         this._notificationService.success(

--- a/src/app/serviceaccount/edit-serviceaccount/edit-serviceaccount.component.ts
+++ b/src/app/serviceaccount/edit-serviceaccount/edit-serviceaccount.component.ts
@@ -16,7 +16,7 @@ import {ApiService} from '@core/services/api/service';
 import {NotificationService} from '@core/services/notification/service';
 import {Project} from '@shared/entity/project';
 import {ServiceAccount} from '@shared/entity/service-account';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-edit-serviceaccount',
@@ -52,7 +52,7 @@ export class EditServiceAccountComponent implements OnInit {
 
     this._apiService
       .editServiceAccount(this.project.id, editServiceAccount)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._matDialogRef.close(true);
         this._notificationService.success(

--- a/src/app/serviceaccount/serviceaccount-token/add-serviceaccount-token/add-serviceaccount-token.component.ts
+++ b/src/app/serviceaccount/serviceaccount-token/add-serviceaccount-token/add-serviceaccount-token.component.ts
@@ -17,8 +17,8 @@ import {NotificationService} from '@core/services/notification/service';
 
 import {Project} from '@shared/entity/project';
 import {CreateTokenEntity, ServiceAccount, ServiceAccountToken} from '@shared/entity/service-account';
-import {first} from 'rxjs/operators';
 import {TokenDialogComponent} from '../token-dialog/token-dialog.component';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-add-serviceaccount-token',
@@ -49,7 +49,7 @@ export class AddServiceAccountTokenComponent implements OnInit {
 
     this._apiService
       .createServiceAccountToken(this.project.id, this.serviceaccount, createServiceAccountToken)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(token => {
         this._matDialogRef.close(true);
         this._notificationService.success(

--- a/src/app/serviceaccount/serviceaccount-token/edit-serviceaccount-token/edit-serviceaccount-token.component.ts
+++ b/src/app/serviceaccount/serviceaccount-token/edit-serviceaccount-token/edit-serviceaccount-token.component.ts
@@ -16,7 +16,7 @@ import {ApiService} from '@core/services/api/service';
 import {NotificationService} from '@core/services/notification/service';
 import {Project} from '@shared/entity/project';
 import {ServiceAccount, ServiceAccountToken, ServiceAccountTokenPatch} from '@shared/entity/service-account';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 @Component({
   selector: 'km-edit-serviceaccount-token',
@@ -47,7 +47,7 @@ export class EditServiceAccountTokenComponent implements OnInit {
 
     this._apiService
       .patchServiceAccountToken(this.project.id, this.serviceaccount, this.token, patchServiceAccountToken)
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._matDialogRef.close(true);
         this._notificationService.success(`The <strong>${this.token.name}</strong> token was updated`);

--- a/src/app/serviceaccount/serviceaccount-token/serviceaccount-token.component.ts
+++ b/src/app/serviceaccount/serviceaccount-token/serviceaccount-token.component.ts
@@ -22,7 +22,7 @@ import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialo
 import {Project} from '@shared/entity/project';
 import {ServiceAccount, ServiceAccountToken} from '@shared/entity/service-account';
 import {GroupConfig} from '@shared/model/Config';
-import {filter, first, switchMap} from 'rxjs/operators';
+import {filter, switchMap, take} from 'rxjs/operators';
 import {AddServiceAccountTokenComponent} from './add-serviceaccount-token/add-serviceaccount-token.component';
 import {EditServiceAccountTokenComponent} from './edit-serviceaccount-token/edit-serviceaccount-token.component';
 import {TokenDialogComponent} from './token-dialog/token-dialog.component';
@@ -63,7 +63,7 @@ export class ServiceAccountTokenComponent implements OnInit {
           return this._userService.getCurrentUserGroup(project.id);
         })
       )
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(userGroup => (this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup)));
   }
 
@@ -104,7 +104,7 @@ export class ServiceAccountTokenComponent implements OnInit {
           this._apiService.regenerateServiceAccountToken(this._selectedProject.id, this.serviceaccount, token)
         )
       )
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(token => {
         this.openTokenDialog(token);
         this._notificationService.success(`The <strong>${token.name}</strong> was regenerated`);
@@ -139,7 +139,7 @@ export class ServiceAccountTokenComponent implements OnInit {
       .pipe(
         switchMap(_ => this._apiService.deleteServiceAccountToken(this._selectedProject.id, this.serviceaccount, token))
       )
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
           `The <strong>${token.name}</strong> token was removed from the <strong>${this.serviceaccount.name}</strong> service account`

--- a/src/app/serviceaccount/serviceaccount.component.ts
+++ b/src/app/serviceaccount/serviceaccount.component.ts
@@ -28,7 +28,7 @@ import {MemberUtils} from '@shared/utils/member-utils/member-utils';
 import {ProjectUtils} from '@shared/utils/project-utils/project-utils';
 import * as _ from 'lodash';
 import {EMPTY, merge, Subject, timer} from 'rxjs';
-import {filter, first, switchMap, switchMapTo, takeUntil} from 'rxjs/operators';
+import {filter, switchMap, switchMapTo, take, takeUntil} from 'rxjs/operators';
 import {AddServiceAccountComponent} from './add-serviceaccount/add-serviceaccount.component';
 import {EditServiceAccountComponent} from './edit-serviceaccount/edit-serviceaccount.component';
 
@@ -78,7 +78,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
       this.dataSource.paginator = this.paginator; // Force refresh.
     });
 
-    merge(this._serviceAccountUpdate, this._projectService.selectedProject.pipe(first()))
+    merge(this._serviceAccountUpdate, this._projectService.selectedProject.pipe(take(1)))
       .pipe(switchMapTo(this._projectService.selectedProject))
       .pipe(
         switchMap(project => {
@@ -152,7 +152,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
 
     modal
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(isAdded => {
         if (isAdded) {
           this._serviceAccountUpdate.next();
@@ -167,7 +167,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
     modal.componentInstance.serviceaccount = serviceAccount;
     modal
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(isEdited => {
         if (isEdited) {
           this._serviceAccountUpdate.next();
@@ -194,7 +194,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
       .afterClosed()
       .pipe(filter(isConfirmed => isConfirmed))
       .pipe(switchMap(_ => this._apiService.deleteServiceAccount(this._selectedProject.id, serviceAccount)))
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(() => {
         delete this.tokenList[serviceAccount.id];
         this._serviceAccountUpdate.next();

--- a/src/app/settings/admin/component.ts
+++ b/src/app/settings/admin/component.ts
@@ -21,7 +21,7 @@ import {AdminSettings, ClusterTypeOptions} from '@shared/entity/settings';
 import {objectDiff} from '@shared/utils/common-utils';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {debounceTime, first, switchMap, takeUntil} from 'rxjs/operators';
+import {debounceTime, switchMap, take, takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'km-admin-settings',
@@ -47,7 +47,7 @@ export class AdminSettingsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this._userService.currentUser.pipe(first()).subscribe(user => (this.user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this.user = user));
 
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {

--- a/src/app/settings/user/user-settings.component.ts
+++ b/src/app/settings/user/user-settings.component.ts
@@ -20,7 +20,7 @@ import {UserSettings} from '@shared/entity/settings';
 import {objectDiff} from '@shared/utils/common-utils';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {debounceTime, first, switchMap, takeUntil} from 'rxjs/operators';
+import {debounceTime, switchMap, take, takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'km-user-settings',
@@ -48,7 +48,7 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this._userService.currentUser.pipe(first()).subscribe(user => (this.user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this.user = user));
 
     this._userService.currentUserSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {

--- a/src/app/shared/components/addon-list/addon-list.component.ts
+++ b/src/app/shared/components/addon-list/addon-list.component.ts
@@ -15,7 +15,7 @@ import {DomSanitizer, SafeUrl} from '@angular/platform-browser';
 import {ApiService} from '@core/services/api/service';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {first, takeUntil} from 'rxjs/operators';
+import {take, takeUntil} from 'rxjs/operators';
 import {Addon, AddonConfig, getAddonLogoData, hasAddonLogoData} from '../../entity/addon';
 import {ConfirmationDialogComponent} from '../confirmation-dialog/confirmation-dialog.component';
 import {EditAddonDialogComponent} from './edit-addon-dialog/edit-addon-dialog.component';
@@ -127,7 +127,7 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
       dialog.componentInstance.addonConfigs = this.addonConfigs;
       dialog
         .afterClosed()
-        .pipe(first())
+        .pipe(take(1))
         .subscribe(addedAddon => {
           if (addedAddon) {
             this.addAddon.emit(addedAddon);
@@ -142,7 +142,7 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
     dialog.componentInstance.addonConfig = this.addonConfigs.get(addon.name);
     dialog
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(editedAddon => {
         if (editedAddon) {
           this.editAddon.emit(editedAddon);
@@ -166,7 +166,7 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
     const dialog = this._matDialog.open(ConfirmationDialogComponent, config);
     dialog
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(isConfirmed => {
         if (isConfirmed) {
           this.deleteAddon.emit(addon);

--- a/src/app/shared/components/addon-list/select-addon-dialog/select-addon-dialog.component.ts
+++ b/src/app/shared/components/addon-list/select-addon-dialog/select-addon-dialog.component.ts
@@ -12,7 +12,7 @@
 import {Component, Input} from '@angular/core';
 import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {DomSanitizer, SafeUrl} from '@angular/platform-browser';
-import {first} from 'rxjs/operators';
+import {take} from 'rxjs/operators';
 
 import {AddonConfig, getAddonLogoData, getAddonShortDescription, hasAddonLogoData} from '../../../entity/addon';
 import {InstallAddonDialogComponent} from '../install-addon-dialog/install-addon-dialog.component';
@@ -51,7 +51,7 @@ export class SelectAddonDialogComponent {
     dialog.componentInstance.addonConfig = this.addonConfigs.get(name);
     dialog
       .afterClosed()
-      .pipe(first())
+      .pipe(take(1))
       .subscribe(addedAddon => {
         this.dialogRef.close(addedAddon);
       });

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -30,7 +30,7 @@ import {ClusterService} from '@shared/services/cluster.service';
 import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plugin-utils/admission-plugin-utils';
 import {AsyncValidators} from '@shared/validators/async-label-form.validator';
 import {merge} from 'rxjs';
-import {filter, first, switchMap, takeUntil} from 'rxjs/operators';
+import {filter, take, switchMap, takeUntil} from 'rxjs/operators';
 import {WizardService} from '../../service/wizard';
 import {StepBase} from '../base';
 
@@ -102,7 +102,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     });
 
     this._clusterService.datacenterChanges
-      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
+      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(take(1))))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe((dc: Datacenter) => {
         this._datacenterSpec = dc;

--- a/src/app/wizard/step/cluster/ssh-keys/component.ts
+++ b/src/app/wizard/step/cluster/ssh-keys/component.ts
@@ -26,7 +26,7 @@ import {ClusterService} from '@shared/services/cluster.service';
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import * as _ from 'lodash';
-import {filter, first, switchMap, take, takeUntil, tap} from 'rxjs/operators';
+import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
 enum Controls {
   Keys = 'keys',
@@ -82,14 +82,14 @@ export class ClusterSSHKeysComponent extends BaseFormValidator implements OnInit
       [Controls.Keys]: this._builder.control([]),
     });
 
-    this._userService.currentUser.pipe(first()).subscribe(user => (this._user = user));
+    this._userService.currentUser.pipe(take(1)).subscribe(user => (this._user = user));
 
     this._projectService.selectedProject
       .pipe(tap(project => (this._project = project)))
       .pipe(switchMap(_ => this._userService.getCurrentUserGroup(this._project.id)))
       .pipe(tap(group => (this._groupConfig = this._userService.getCurrentUserGroupConfig(group))))
       .pipe(switchMap(_ => this._apiService.getSSHKeys(this._project.id)))
-      .pipe(first())
+      .pipe(take(1))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(sshKeys => (this.keys = sshKeys));
 

--- a/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
@@ -34,7 +34,7 @@ import {
   debounceTime,
   distinctUntilChanged,
   filter,
-  first,
+  take,
   map,
   switchMap,
   takeUntil,
@@ -131,7 +131,7 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
 
     merge(this._clusterService.providerChanges, this._clusterService.datacenterChanges)
       .pipe(filter(_ => this._clusterService.provider === NodeProvider.OPENSTACK))
-      .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.datacenter).pipe(first())))
+      .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterService.datacenter).pipe(take(1))))
       .pipe(tap(dc => (this._isFloatingPoolIPEnforced = dc.spec.openstack.enforce_floating_ip)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this.form.reset());

--- a/src/app/wizard/step/summary/component.ts
+++ b/src/app/wizard/step/summary/component.ts
@@ -23,7 +23,7 @@ import {ClusterService} from '@shared/services/cluster.service';
 import {AdmissionPluginUtils} from '@shared/utils/admission-plugin-utils/admission-plugin-utils';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {first, switchMap, takeUntil} from 'rxjs/operators';
+import {take, switchMap, takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'km-wizard-summary-step',
@@ -75,7 +75,7 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
       .subscribe(plugins => (this.clusterAdmissionPlugins = plugins));
 
     this._clusterService.datacenterChanges
-      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(first())))
+      .pipe(switchMap(dc => this._datacenterService.getDatacenter(dc).pipe(take(1))))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(dc => {
         this._location = dc.spec.location;


### PR DESCRIPTION
**What this PR does / why we need it**: `EmptyErrorImpl {message: "no elements in sequence", name: "EmptyError"}` was shown after closing some dialogs etc. It was caused by filtering observable before it was passed through `first()` pipe. `first()` always require at least one object in the observable and if the requirement is not met then error will be produced. `take(1)` doesn't have this requirement and that is why I think we should use it in most of the cases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard/issues/2828

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
