### PR TITLE
Do not remove labels when pressing enter key in the label form

### DIFF
--- a/src/app/shared/components/label-form/label-form.component.html
+++ b/src/app/shared/components/label-form/label-form.component.html
@@ -66,6 +66,7 @@ limitations under the License.
         </mat-error>
       </mat-form-field>
       <button mat-icon-button
+              type="button"
               class="delete-button"
               [disabled]="!isRemovable(i)"
               (click)="deleteLabel(i)">


### PR DESCRIPTION
**What this PR does / why we need it**: The behavior was invalid because the delete button was by default acting like submit button. Adding type "button" to it fixes the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard/issues/2891

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Fixed the bug with labels that were removed from form after pressing enter key.
```
