### PR TITLE
openstack wizard: pre-fill username and domain fields

### DIFF
--- a/src/app/shared/model/Config.ts
+++ b/src/app/shared/model/Config.ts
@@ -19,7 +19,10 @@ export type EndOfLife = {[version: string]: string};
 
 export interface Config {
   share_kubeconfig?: boolean;
-  openstack?: {wizard_use_default_user?: boolean};
+  openstack?: {
+    wizard_use_default_user?: boolean;
+    wizard_default_domain_name?: string;
+  };
   google_analytics_code?: string;
   google_analytics_config?: object;
   oidc_provider_url?: string;

--- a/src/assets/config/config.json
+++ b/src/assets/config/config.json
@@ -1,6 +1,7 @@
 {
   "openstack": {
-    "wizard_use_default_user": false
+    "wizard_use_default_user": false,
+    "wizard_default_domain_name": "Default"
   },
   "share_kubeconfig": false
 }


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

This pre-fills the username and domain name fields in the cluster creation wizard / openstack settings with the user's login name (for the username) and a default domain name (configurable in a new option in the dashboard config file).

I think these things were there in 2.14. (at least the username thing)

What I'd also like (and was also there in 2.14 I think) would be after the project is selected and the floating IP pool list loaded, to pre-select the first floating ip pool if there's only one. But I couldn't get that to work, so maybe later in a separate PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Wizard/Openstack: Fill the form with defaults for username and domain name
```