### PR TITLE
Use endpoints to get Azure resource groups, security groups and route tables

### DIFF
--- a/src/app/core/services/wizard/provider/azure.ts
+++ b/src/app/core/services/wizard/provider/azure.ts
@@ -15,6 +15,7 @@ import {NodeProvider} from '../../../../shared/model/NodeProviderConstants';
 import {Provider} from './provider';
 import {
   AzureResourceGroups,
+  AzureRouteTables,
   AzureSecurityGroups,
   AzureSizes,
   AzureZones,
@@ -144,6 +145,30 @@ export class Azure extends Provider {
     return this._http
       .get<AzureSecurityGroups>(url, {headers: this._headers})
       .pipe(map(securityGroups => securityGroups.securityGroups));
+  }
+
+  routeTables(onLoadingCb: () => void = null): Observable<string[]> {
+    this._setRequiredHeaders(
+      Azure.Header.SubscriptionID,
+      Azure.Header.TenantID,
+      Azure.Header.ClientID,
+      Azure.Header.ClientSecret,
+      Azure.Header.ResourceGroup,
+      Azure.Header.Location
+    );
+
+    if (!this._hasRequiredHeaders()) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._newRestRoot}/providers/${this._provider}/routetables`;
+    return this._http
+      .get<AzureRouteTables>(url, {headers: this._headers})
+      .pipe(map(routeTables => routeTables.routeTables));
   }
 
   availabilityZones(onLoadingCb: () => void = null): Observable<AzureZones> {

--- a/src/app/core/services/wizard/provider/azure.ts
+++ b/src/app/core/services/wizard/provider/azure.ts
@@ -11,15 +11,17 @@
 
 import {HttpClient} from '@angular/common/http';
 import {EMPTY, Observable} from 'rxjs';
-import {NodeProvider} from '../../../../shared/model/NodeProviderConstants';
+import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {Provider} from './provider';
 import {
   AzureResourceGroups,
   AzureRouteTables,
   AzureSecurityGroups,
   AzureSizes,
+  AzureSubnets,
+  AzureVNets,
   AzureZones,
-} from '../../../../shared/entity/provider/azure';
+} from '@shared/entity/provider/azure';
 import {map} from 'rxjs/operators';
 
 export class Azure extends Provider {
@@ -79,6 +81,13 @@ export class Azure extends Provider {
   resourceGroup(resourceGroup: string): Azure {
     if (resourceGroup) {
       this._headers = this._headers.set(Azure.Header.ResourceGroup, resourceGroup);
+    }
+    return this;
+  }
+
+  vnet(vnet: string): Azure {
+    if (vnet) {
+      this._headers = this._headers.set(Azure.Header.VNet, vnet);
     }
     return this;
   }
@@ -171,6 +180,54 @@ export class Azure extends Provider {
       .pipe(map(routeTables => routeTables.routeTables));
   }
 
+  vnets(onLoadingCb: () => void = null): Observable<string[]> {
+    this._setRequiredHeaders(
+      Azure.Header.SubscriptionID,
+      Azure.Header.TenantID,
+      Azure.Header.ClientID,
+      Azure.Header.ClientSecret,
+      Azure.Header.ResourceGroup,
+      Azure.Header.Location
+    );
+
+    if (!this._hasRequiredHeaders()) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._newRestRoot}/providers/${this._provider}/vnets`;
+    return this._http
+      .get<AzureVNets>(url, {headers: this._headers})
+      .pipe(map(vnets => vnets.vnets));
+  }
+
+  subnets(onLoadingCb: () => void = null): Observable<string[]> {
+    this._setRequiredHeaders(
+      Azure.Header.SubscriptionID,
+      Azure.Header.TenantID,
+      Azure.Header.ClientID,
+      Azure.Header.ClientSecret,
+      Azure.Header.ResourceGroup,
+      Azure.Header.VNet
+    );
+
+    if (!this._hasRequiredHeaders()) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._newRestRoot}/providers/${this._provider}/subnets`;
+    return this._http
+      .get<AzureSubnets>(url, {headers: this._headers})
+      .pipe(map(subnets => subnets.subnets));
+  }
+
   availabilityZones(onLoadingCb: () => void = null): Observable<AzureZones> {
     this._setRequiredHeaders(
       Azure.Header.ClientID,
@@ -202,6 +259,7 @@ export namespace Azure {
     TenantID = 'TenantID',
     Location = 'Location',
     ResourceGroup = 'ResourceGroup',
+    VNet = 'VirtualNetwork',
     SKUName = 'SKUName',
   }
 }

--- a/src/app/core/services/wizard/provider/azure.ts
+++ b/src/app/core/services/wizard/provider/azure.ts
@@ -116,7 +116,7 @@ export class Azure extends Provider {
       onLoadingCb();
     }
 
-    const url = `${this._restRoot}/providers/${this._provider}/resourcegroups`;
+    const url = `${this._newRestRoot}/providers/${this._provider}/resourcegroups`;
     return this._http
       .get<AzureResourceGroups>(url, {headers: this._headers})
       .pipe(map(resourceGroups => resourceGroups.resourceGroups));

--- a/src/app/core/services/wizard/provider/azure.ts
+++ b/src/app/core/services/wizard/provider/azure.ts
@@ -140,7 +140,7 @@ export class Azure extends Provider {
       onLoadingCb();
     }
 
-    const url = `${this._restRoot}/providers/${this._provider}/securitygroups`;
+    const url = `${this._newRestRoot}/providers/${this._provider}/securitygroups`;
     return this._http
       .get<AzureSecurityGroups>(url, {headers: this._headers})
       .pipe(map(securityGroups => securityGroups.securityGroups));

--- a/src/app/core/services/wizard/provider/azure.ts
+++ b/src/app/core/services/wizard/provider/azure.ts
@@ -13,7 +13,13 @@ import {HttpClient} from '@angular/common/http';
 import {EMPTY, Observable} from 'rxjs';
 import {NodeProvider} from '../../../../shared/model/NodeProviderConstants';
 import {Provider} from './provider';
-import {AzureSizes, AzureZones} from '../../../../shared/entity/provider/azure';
+import {
+  AzureResourceGroups,
+  AzureSecurityGroups,
+  AzureSizes,
+  AzureZones,
+} from '../../../../shared/entity/provider/azure';
+import {map} from 'rxjs/operators';
 
 export class Azure extends Provider {
   constructor(http: HttpClient, provider: NodeProvider) {
@@ -69,6 +75,13 @@ export class Azure extends Provider {
     return this;
   }
 
+  resourceGroup(resourceGroup: string): Azure {
+    if (resourceGroup) {
+      this._headers = this._headers.set(Azure.Header.ResourceGroup, resourceGroup);
+    }
+    return this;
+  }
+
   credential(credential: string): Azure {
     super._credential(credential);
     return this;
@@ -86,7 +99,7 @@ export class Azure extends Provider {
     return this._http.get<AzureSizes[]>(this._url, {headers: this._headers});
   }
 
-  resourceGroups(onLoadingCb: () => void = null): Observable<AzureSizes[]> {
+  resourceGroups(onLoadingCb: () => void = null): Observable<string[]> {
     this._setRequiredHeaders(
       Azure.Header.SubscriptionID,
       Azure.Header.TenantID,
@@ -104,10 +117,12 @@ export class Azure extends Provider {
     }
 
     const url = `${this._restRoot}/providers/${this._provider}/resourcegroups`;
-    return this._http.get<AzureSizes[]>(url, {headers: this._headers});
+    return this._http
+      .get<AzureResourceGroups>(url, {headers: this._headers})
+      .pipe(map(resourceGroups => resourceGroups.resourceGroups));
   }
 
-  securityGroups(onLoadingCb: () => void = null): Observable<AzureSizes[]> {
+  securityGroups(onLoadingCb: () => void = null): Observable<string[]> {
     this._setRequiredHeaders(
       Azure.Header.SubscriptionID,
       Azure.Header.TenantID,
@@ -126,7 +141,9 @@ export class Azure extends Provider {
     }
 
     const url = `${this._restRoot}/providers/${this._provider}/securitygroups`;
-    return this._http.get<AzureSizes[]>(url, {headers: this._headers});
+    return this._http
+      .get<AzureSecurityGroups>(url, {headers: this._headers})
+      .pipe(map(securityGroups => securityGroups.securityGroups));
   }
 
   availabilityZones(onLoadingCb: () => void = null): Observable<AzureZones> {

--- a/src/app/core/services/wizard/provider/azure.ts
+++ b/src/app/core/services/wizard/provider/azure.ts
@@ -86,6 +86,49 @@ export class Azure extends Provider {
     return this._http.get<AzureSizes[]>(this._url, {headers: this._headers});
   }
 
+  resourceGroups(onLoadingCb: () => void = null): Observable<AzureSizes[]> {
+    this._setRequiredHeaders(
+      Azure.Header.SubscriptionID,
+      Azure.Header.TenantID,
+      Azure.Header.ClientID,
+      Azure.Header.ClientSecret,
+      Azure.Header.Location
+    );
+
+    if (!this._hasRequiredHeaders()) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._restRoot}/providers/${this._provider}/resourcegroups`;
+    return this._http.get<AzureSizes[]>(url, {headers: this._headers});
+  }
+
+  securityGroups(onLoadingCb: () => void = null): Observable<AzureSizes[]> {
+    this._setRequiredHeaders(
+      Azure.Header.SubscriptionID,
+      Azure.Header.TenantID,
+      Azure.Header.ClientID,
+      Azure.Header.ClientSecret,
+      Azure.Header.ResourceGroup,
+      Azure.Header.Location
+    );
+
+    if (!this._hasRequiredHeaders()) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._restRoot}/providers/${this._provider}/securitygroups`;
+    return this._http.get<AzureSizes[]>(url, {headers: this._headers});
+  }
+
   availabilityZones(onLoadingCb: () => void = null): Observable<AzureZones> {
     this._setRequiredHeaders(
       Azure.Header.ClientID,
@@ -116,6 +159,7 @@ export namespace Azure {
     SubscriptionID = 'SubscriptionID',
     TenantID = 'TenantID',
     Location = 'Location',
+    ResourceGroup = 'ResourceGroup',
     SKUName = 'SKUName',
   }
 }

--- a/src/app/core/services/wizard/provider/provider.ts
+++ b/src/app/core/services/wizard/provider/provider.ts
@@ -18,6 +18,7 @@ export abstract class Provider {
 
   protected _headers = new HttpHeaders();
   protected _restRoot = environment.restRoot;
+  protected _newRestRoot = environment.newRestRoot;
   protected readonly _url = `${this._restRoot}/providers/${this._provider}/sizes`;
 
   protected constructor(protected _http: HttpClient, protected readonly _provider: NodeProvider) {}

--- a/src/app/shared/entity/provider/azure.ts
+++ b/src/app/shared/entity/provider/azure.ts
@@ -22,6 +22,10 @@ export class AzureZones {
   zones: string[];
 }
 
+export class AzureRouteTables {
+  routeTables: string[];
+}
+
 export class AzureSecurityGroups {
   securityGroups: string[];
 }

--- a/src/app/shared/entity/provider/azure.ts
+++ b/src/app/shared/entity/provider/azure.ts
@@ -22,6 +22,14 @@ export class AzureZones {
   zones: string[];
 }
 
+export class AzureVNets {
+  vnets: string[];
+}
+
+export class AzureSubnets {
+  subnets: string[];
+}
+
 export class AzureRouteTables {
   routeTables: string[];
 }

--- a/src/app/shared/entity/provider/azure.ts
+++ b/src/app/shared/entity/provider/azure.ts
@@ -21,3 +21,11 @@ export class AzureSizes {
 export class AzureZones {
   zones: string[];
 }
+
+export class AzureSecurityGroups {
+  securityGroups: string[];
+}
+
+export class AzureResourceGroups {
+  resourceGroups: string[];
+}

--- a/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
@@ -45,9 +45,7 @@ enum Controls {
 })
 export class AWSProviderExtendedComponent extends BaseFormValidator implements OnInit, OnDestroy {
   readonly Controls = Controls;
-
   securityGroups: string[] = [];
-  filteredSecurityGroups: Observable<string[]>;
 
   constructor(
     private readonly _builder: FormBuilder,
@@ -81,7 +79,7 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
       .pipe(tap(_ => (!this.hasRequiredCredentials() ? this._clearSecurityGroup() : null)))
       .pipe(switchMap(_ => this._securityGroupObservable()))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(this._loadSecurityGroups.bind(this));
+      .subscribe(securityGroups => (this.securityGroups = securityGroups));
 
     merge(
       this.form.get(Controls.RouteTableID).valueChanges,
@@ -94,8 +92,8 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
     this.form
       .get(Controls.SecurityGroup)
       .valueChanges.pipe(takeUntil(this._unsubscribe))
-      .subscribe(change => {
-        this._clusterService.cluster.spec.cloud.aws.securityGroupID = change;
+      .subscribe(sg => {
+        this._clusterService.cluster.spec.cloud.aws.securityGroupID = sg;
       });
   }
 
@@ -129,10 +127,6 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
   private _clearSecurityGroup(): void {
     this.securityGroups = [];
     this.form.get(Controls.SecurityGroup).setValue('');
-  }
-
-  private _loadSecurityGroups(securityGroups: string[]): void {
-    this.securityGroups = securityGroups;
   }
 
   private _enable(enable: boolean, name: string): void {

--- a/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
@@ -17,7 +17,7 @@ import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import {EMPTY, merge, Observable, onErrorResumeNext} from 'rxjs';
-import {catchError, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {catchError, debounceTime, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 import * as _ from 'lodash';
 
 enum Controls {
@@ -44,6 +44,7 @@ enum Controls {
   ],
 })
 export class AWSProviderExtendedComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  private readonly _debounceTime = 1000;
   readonly Controls = Controls;
   securityGroups: string[] = [];
 
@@ -75,6 +76,7 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
       });
 
     this._clusterService.clusterChanges
+      .pipe(debounceTime(this._debounceTime))
       .pipe(filter(_ => this._clusterService.provider === NodeProvider.AWS))
       .pipe(tap(_ => (!this.hasRequiredCredentials() ? this._clearSecurityGroup() : null)))
       .pipe(switchMap(_ => this._securityGroupObservable()))

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
@@ -20,6 +20,7 @@ import {EMPTY, merge, Observable, of, onErrorResumeNext} from 'rxjs';
 import {catchError, debounceTime, filter, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import * as _ from 'lodash';
 import {DatacenterService} from '@core/services/datacenter/service';
+import {Datacenter} from '@shared/entity/datacenter';
 
 enum Controls {
   ResourceGroup = 'resourceGroup',
@@ -199,10 +200,7 @@ export class AzureProviderExtendedComponent extends BaseFormValidator implements
 
   private _routeTableObservable(): Observable<string[]> {
     let location = '';
-    return this._datacenterService
-      .getDatacenter(this._clusterService.cluster.spec.cloud.dc)
-      .pipe(take(1))
-      .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE))
+    return this._getDatacenter()
       .pipe(tap(dc => (location = dc.spec.azure.location)))
       .pipe(
         switchMap(_dc =>
@@ -234,10 +232,7 @@ export class AzureProviderExtendedComponent extends BaseFormValidator implements
 
   private _securityGroupObservable(): Observable<string[]> {
     let location = '';
-    return this._datacenterService
-      .getDatacenter(this._clusterService.cluster.spec.cloud.dc)
-      .pipe(take(1))
-      .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE))
+    return this._getDatacenter()
       .pipe(tap(dc => (location = dc.spec.azure.location)))
       .pipe(
         switchMap(_dc =>
@@ -265,6 +260,13 @@ export class AzureProviderExtendedComponent extends BaseFormValidator implements
   private _clearSecurityGroup(): void {
     this.securityGroups = [];
     this.form.get(Controls.SecurityGroup).setValue('');
+  }
+
+  private _getDatacenter(): Observable<Datacenter> {
+    return this._datacenterService
+      .getDatacenter(this._clusterService.cluster.spec.cloud.dc)
+      .pipe(take(1))
+      .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE));
   }
 
   private _enable(enable: boolean, name: string): void {

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
@@ -92,7 +92,7 @@ export class AzureProviderExtendedComponent extends BaseFormValidator implements
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(resourceGroups => (this.resourceGroups = resourceGroups));
 
-    this._clusterService.clusterChanges
+    merge(this._clusterService.clusterChanges, this.form.get(Controls.ResourceGroup).valueChanges)
       .pipe(filter(_ => this._clusterService.provider === NodeProvider.AZURE))
       .pipe(
         tap(_ =>

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
@@ -191,7 +191,7 @@ export class AzureProviderExtendedComponent extends BaseFormValidator implements
             .clientSecret(this._clusterService.cluster.spec.cloud.azure.clientSecret)
             .subscriptionID(this._clusterService.cluster.spec.cloud.azure.subscriptionID)
             .tenantID(this._clusterService.cluster.spec.cloud.azure.tenantID)
-            .resourceGroup(this._clusterService.cluster.spec.cloud.azure.resourceGroup)
+            .resourceGroup(this.form.get(Controls.ResourceGroup).value)
             .location(location)
             .credential(this._presets.preset)
             .securityGroups()

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
@@ -47,7 +47,7 @@ enum Controls {
   ],
 })
 export class AzureProviderExtendedComponent extends BaseFormValidator implements OnInit, OnDestroy {
-  private readonly _debounceTime = 1000;
+  private readonly _debounceTime = 500;
   readonly Controls = Controls;
   resourceGroups: string[] = [];
   routeTables: string[] = [];

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
@@ -16,7 +16,7 @@ import {AzureCloudSpec, CloudSpec, Cluster, ClusterSpec} from '@shared/entity/cl
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterService} from '@shared/services/cluster.service';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
-import {EMPTY, merge, Observable, onErrorResumeNext} from 'rxjs';
+import {EMPTY, merge, Observable, of, onErrorResumeNext} from 'rxjs';
 import {catchError, debounceTime, filter, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import * as _ from 'lodash';
 import {DatacenterService} from '@core/services/datacenter/service';
@@ -104,7 +104,7 @@ export class AzureProviderExtendedComponent extends BaseFormValidator implements
             : null
         )
       )
-      .pipe(switchMap(_ => this._securityGroupObservable()))
+      .pipe(switchMap(_ => (this.form.get(Controls.ResourceGroup).value ? this._securityGroupObservable() : of([]))))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(securityGroups => (this.securityGroups = securityGroups));
 

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
@@ -40,11 +40,20 @@ limitations under the License.
 
   <mat-form-field fxFlex>
     <mat-label>Security Group</mat-label>
-    <input matInput
+    <input type="text"
+           matInput
            [formControlName]="Controls.SecurityGroup"
-           [name]="Controls.SecurityGroup"
-           type="text"
-           autocomplete="off">
+           [matAutocomplete]="auto">
+    <mat-autocomplete autoActiveFirstOption
+                      #auto="matAutocomplete">
+      <mat-option *ngFor="let securityGroup of securityGroups | filterBy: form.get(Controls.SecurityGroup).value"
+                  [value]="securityGroup">
+        {{securityGroup}}
+      </mat-option>
+    </mat-autocomplete>
+    <mat-hint *ngIf="!hasRequiredCredentials() || !form.get(Controls.ResourceGroup).value">
+      Enter your credentials and resource group to load autocompletions.
+    </mat-hint>
   </mat-form-field>
 
   <mat-form-field fxFlex>

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
@@ -29,13 +29,23 @@ limitations under the License.
     <mat-hint *ngIf="!hasRequiredCredentials()">Enter your credentials to load autocompletions.</mat-hint>
   </mat-form-field>
 
+
   <mat-form-field fxFlex>
     <mat-label>Route Table</mat-label>
-    <input matInput
+    <input type="text"
+           matInput
            [formControlName]="Controls.RouteTable"
-           [name]="Controls.RouteTable"
-           type="text"
-           autocomplete="off">
+           [matAutocomplete]="autoRouteTable">
+    <mat-autocomplete autoActiveFirstOption
+                      #autoRouteTable="matAutocomplete">
+      <mat-option *ngFor="let routeTable of routeTables | filterBy: form.get(Controls.RouteTable).value"
+                  [value]="routeTable">
+        {{routeTable}}
+      </mat-option>
+    </mat-autocomplete>
+    <mat-hint *ngIf="!hasRequiredCredentials() || !form.get(Controls.ResourceGroup).value">
+      Enter your credentials and resource group to load autocompletions.
+    </mat-hint>
   </mat-form-field>
 
   <mat-form-field fxFlex>

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
@@ -18,9 +18,9 @@ limitations under the License.
     <input type="text"
            matInput
            [formControlName]="Controls.ResourceGroup"
-           [matAutocomplete]="auto">
+           [matAutocomplete]="autoResourceGroup">
     <mat-autocomplete autoActiveFirstOption
-                      #auto="matAutocomplete">
+                      #autoResourceGroup="matAutocomplete">
       <mat-option *ngFor="let resourceGroup of resourceGroups | filterBy: form.get(Controls.ResourceGroup).value"
                   [value]="resourceGroup">
         {{resourceGroup}}
@@ -43,9 +43,9 @@ limitations under the License.
     <input type="text"
            matInput
            [formControlName]="Controls.SecurityGroup"
-           [matAutocomplete]="auto">
+           [matAutocomplete]="autoSecurityGroup">
     <mat-autocomplete autoActiveFirstOption
-                      #auto="matAutocomplete">
+                      #autoSecurityGroup="matAutocomplete">
       <mat-option *ngFor="let securityGroup of securityGroups | filterBy: form.get(Controls.SecurityGroup).value"
                   [value]="securityGroup">
         {{securityGroup}}

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
@@ -15,11 +15,18 @@ limitations under the License.
       fxLayoutGap="16px">
   <mat-form-field fxFlex>
     <mat-label>Resource Group</mat-label>
-    <input matInput
+    <input type="text"
+           matInput
            [formControlName]="Controls.ResourceGroup"
-           [name]="Controls.ResourceGroup"
-           type="text"
-           autocomplete="off">
+           [matAutocomplete]="auto">
+    <mat-autocomplete autoActiveFirstOption
+                      #auto="matAutocomplete">
+      <mat-option *ngFor="let resourceGroup of resourceGroups | filterBy: form.get(Controls.ResourceGroup).value"
+                  [value]="resourceGroup">
+        {{resourceGroup}}
+      </mat-option>
+    </mat-autocomplete>
+    <mat-hint *ngIf="!hasRequiredCredentials()">Enter your credentials to load autocompletions.</mat-hint>
   </mat-form-field>
 
   <mat-form-field fxFlex>

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/template.html
@@ -67,19 +67,28 @@ limitations under the License.
   </mat-form-field>
 
   <mat-form-field fxFlex>
+    <mat-label>VNet</mat-label>
+    <input type="text"
+           matInput
+           [formControlName]="Controls.VNet"
+           [matAutocomplete]="autoVNet">
+    <mat-autocomplete autoActiveFirstOption
+                      #autoVNet="matAutocomplete">
+      <mat-option *ngFor="let vnet of vnets | filterBy: form.get(Controls.VNet).value"
+                  [value]="vnet">
+        {{vnet}}
+      </mat-option>
+    </mat-autocomplete>
+    <mat-hint *ngIf="!hasRequiredCredentials() || !form.get(Controls.ResourceGroup).value">
+      Enter your credentials and resource group to load autocompletions.
+    </mat-hint>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
     <mat-label>Subnet</mat-label>
     <input matInput
            [formControlName]="Controls.Subnet"
            [name]="Controls.Subnet"
-           type="text"
-           autocomplete="off">
-  </mat-form-field>
-
-  <mat-form-field fxFlex>
-    <mat-label>VNet</mat-label>
-    <input matInput
-           [formControlName]="Controls.VNet"
-           [name]="Controls.VNet"
            type="text"
            autocomplete="off">
   </mat-form-field>


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubermatic/dashboard/issues/2921
Fixes https://github.com/kubermatic/dashboard/issues/2920
Fixes https://github.com/kubermatic/dashboard/issues/2918

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Azure resource groups, security groups and route tables will be now loaded from the API to provide autocompletion.
```
