### PR TITLE
[release/v2.15] Pod Node Selector Config

### DIFF
--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
@@ -65,6 +65,15 @@ limitations under the License.
           <i class="km-icon-info km-pointer"></i>
           <p fxFlex="95">Pod Security Policy is enforced by your admin in the chosen datacenter.</p>
         </span>
+        <km-label-form *ngIf="isPluginEnabled(admissionPlugin.PodNodeSelector)"
+                       class="pod-node-selector-config"
+                       title="Pod Node Selector Configuration"
+                       keyName="Namespace"
+                       valueName="Label Selector"
+                       noValidators="true"
+                       [(labels)]="podNodeSelectorAdmissionPluginConfig"
+                       formControlName="podNodeSelectorAdmissionPluginConfig"
+                       fxFlex="100"></km-label-form>
       </div>
 
       <div fxLayout="row"

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.scss
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.scss
@@ -15,6 +15,6 @@
   margin-bottom: 30px;
 }
 
-km-label-form {
+km-label-form:not(.pod-node-selector-config) {
   margin-top: 30px;
 }

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
@@ -39,6 +39,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   admissionPlugin = AdmissionPlugin;
   form: FormGroup;
   labels: object;
+  podNodeSelectorAdmissionPluginConfig: object;
   admissionPlugins: string[] = [];
   providerSettingsPatch: ProviderSettingsPatch = {
     isValid: true,
@@ -59,6 +60,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.labels = _.cloneDeep(this.cluster.labels);
+    this.podNodeSelectorAdmissionPluginConfig = _.cloneDeep(this.cluster.spec.podNodeSelectorAdmissionPluginConfig);
 
     this.form = new FormGroup({
       name: new FormControl(this.cluster.name, [
@@ -68,6 +70,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       ]),
       auditLogging: new FormControl(!!this.cluster.spec.auditLogging && this.cluster.spec.auditLogging.enabled),
       admissionPlugins: new FormControl(this.cluster.spec.admissionPlugins),
+      podNodeSelectorAdmissionPluginConfig: new FormControl(''),
       labels: new FormControl(''),
     });
 
@@ -147,6 +150,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         usePodNodeSelectorAdmissionPlugin: null,
         usePodSecurityPolicyAdmissionPlugin: null,
         admissionPlugins: this.form.controls.admissionPlugins.value,
+        podNodeSelectorAdmissionPluginConfig: this.podNodeSelectorAdmissionPluginConfig,
       },
     };
 

--- a/src/app/shared/components/label-form/label-form.component.html
+++ b/src/app/shared/components/label-form/label-form.component.html
@@ -21,14 +21,14 @@ limitations under the License.
          fxLayout="row"
          fxLayoutGap="10px">
       <mat-form-field fxFlex="45">
-        <mat-label>Key</mat-label>
+        <mat-label>{{keyName}}</mat-label>
         <input matInput
                (keyup)="check(i)"
                name="key"
                formControlName="key">
         <mat-error *ngIf="label.get('key').errors?.validLabelKeyUniqueness"
                    i18n>
-          Key is not unique.
+          {{keyName}} is not unique.
         </mat-error>
         <mat-error *ngIf="label.get('key').errors?.validLabelKeyPrefixPattern"
                    i18n>
@@ -51,18 +51,18 @@ limitations under the License.
         </mat-error>
       </mat-form-field>
       <mat-form-field fxFlex="45">
-        <mat-label>Value</mat-label>
+        <mat-label>{{valueName}}</mat-label>
         <input matInput
                (keyup)="check(i)"
                name="value"
                formControlName="value">
         <mat-error *ngIf="label.get('value').errors?.validLabelValuePattern"
                    i18n>
-          Value not allowed.
+          {{valueName}} not allowed.
         </mat-error>
         <mat-error *ngIf="label.get('value').errors?.validLabelValueLength"
                    i18n>
-          Value is too long.
+          {{valueName}} is too long.
         </mat-error>
       </mat-form-field>
       <button mat-icon-button

--- a/src/app/shared/components/label-form/label-form.component.ts
+++ b/src/app/shared/components/label-form/label-form.component.ts
@@ -47,8 +47,11 @@ import {LabelFormValidators} from '../../validators/label-form.validators';
 })
 export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccessor, AsyncValidator, DoCheck {
   @Input() title = 'Labels';
+  @Input() keyName = 'Key';
+  @Input() valueName = 'Value';
   @Input() labels: object;
   @Input() inheritedLabels: object = {};
+  @Input() noValidators = false;
   @Input() asyncKeyValidators: AsyncValidatorFn[] = [];
   @Output() labelsChange = new EventEmitter<object>();
   form: FormGroup;
@@ -164,24 +167,33 @@ export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccess
   }
 
   private _addLabel(key = '', value = ''): void {
-    this.labelArray.push(
-      this._formBuilder.group({
-        key: [
-          {value: key, disabled: this._isInherited(key)},
-          Validators.compose([
-            LabelFormValidators.labelKeyNameLength,
-            LabelFormValidators.labelKeyPrefixLength,
-            LabelFormValidators.labelKeyNamePattern,
-            LabelFormValidators.labelKeyPrefixPattern,
-          ]),
-          Validators.composeAsync(this.asyncKeyValidators),
-        ],
-        value: [
-          {value, disabled: this._isInherited(key)},
-          Validators.compose([LabelFormValidators.labelValueLength, LabelFormValidators.labelValuePattern]),
-        ],
-      })
-    );
+    if (this.noValidators) {
+      this.labelArray.push(
+        this._formBuilder.group({
+          key: [{value: key, disabled: this._isInherited(key)}],
+          value: [{value, disabled: this._isInherited(key)}],
+        })
+      );
+    } else {
+      this.labelArray.push(
+        this._formBuilder.group({
+          key: [
+            {value: key, disabled: this._isInherited(key)},
+            Validators.compose([
+              LabelFormValidators.labelKeyNameLength,
+              LabelFormValidators.labelKeyPrefixLength,
+              LabelFormValidators.labelKeyNamePattern,
+              LabelFormValidators.labelKeyPrefixPattern,
+            ]),
+            Validators.composeAsync(this.asyncKeyValidators),
+          ],
+          value: [
+            {value, disabled: this._isInherited(key)},
+            Validators.compose([LabelFormValidators.labelValueLength, LabelFormValidators.labelValuePattern]),
+          ],
+        })
+      );
+    }
   }
 
   private _validateKey(index: number): void {

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -212,6 +212,7 @@ export class ClusterSpec {
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
   admissionPlugins?: string[];
+  podNodeSelectorAdmissionPluginConfig?: object;
   openshift?: OpenShift;
 }
 
@@ -257,6 +258,7 @@ export class ClusterSpecPatch {
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
   admissionPlugins?: string[];
+  podNodeSelectorAdmissionPluginConfig?: object;
   auditLogging?: AuditLoggingSettings;
   openshift?: OpenShiftPatch;
 }

--- a/src/app/shared/model/ClusterForm.ts
+++ b/src/app/shared/model/ClusterForm.ts
@@ -22,6 +22,7 @@ export class ClusterSpecForm {
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
   admissionPlugins?: string[];
+  podNodeSelectorAdmissionPluginConfig?: object;
   auditLogging?: AuditLoggingSettings;
   valid: boolean;
 }

--- a/src/app/shared/services/cluster.service.ts
+++ b/src/app/shared/services/cluster.service.ts
@@ -95,6 +95,10 @@ export class ClusterService {
     this._cluster.labels = labels;
   }
 
+  set podNodeSelectorAdmissionPluginConfig(config: object) {
+    this._cluster.spec.podNodeSelectorAdmissionPluginConfig = config;
+  }
+
   set sshKeys(keys: SSHKey[]) {
     this._sshKeys = keys;
     this.sshKeyChanges.emit(this._sshKeys);

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -46,6 +46,7 @@ enum Controls {
   Labels = 'labels',
   AdmissionPlugins = 'admissionPlugins',
   SSHKeys = 'sshKeys',
+  PodNodeSelectorAdmissionPluginConfig = 'podNodeSelectorAdmissionPluginConfig',
 }
 
 @Component({
@@ -70,6 +71,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   masterVersions: MasterVersion[] = [];
   admissionPlugins: AdmissionPlugin[] = [];
   labels: object;
+  podNodeSelectorAdmissionPluginConfig: object;
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
 
   private _datacenterSpec: Datacenter;
@@ -100,6 +102,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.ImagePullSecret]: new FormControl(''),
       [Controls.AuditLogging]: new FormControl(false),
       [Controls.AdmissionPlugins]: new FormControl([]),
+      [Controls.PodNodeSelectorAdmissionPluginConfig]: new FormControl(''),
       [Controls.Labels]: new FormControl(''),
       [Controls.SSHKeys]: this._builder.control(''),
     });
@@ -164,6 +167,11 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   onLabelsChange(labels: object): void {
     this.labels = labels;
     this._clusterService.labels = this.labels;
+  }
+
+  onPodNodeSelectorAdmissionPluginConfigChange(config: object): void {
+    this.podNodeSelectorAdmissionPluginConfig = config;
+    this._clusterService.podNodeSelectorAdmissionPluginConfig = this.podNodeSelectorAdmissionPluginConfig;
   }
 
   isEnforced(control: Controls): boolean {

--- a/src/app/wizard/step/cluster/style.scss
+++ b/src/app/wizard/step/cluster/style.scss
@@ -81,6 +81,6 @@ $toggle-height: 56px;
   width: auto;
 }
 
-km-label-form {
+km-label-form:not(.pod-node-selector-config) {
   margin-top: 30px;
 }

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -137,6 +137,16 @@ limitations under the License.
               <i class="km-icon-info km-pointer"></i>
               <p fxFlex="95">Pod Security Policy is enforced by your admin in the chosen datacenter.</p>
             </span>
+            <km-label-form *ngIf="isPluginEnabled(admissionPlugin.PodNodeSelector)"
+                           class="pod-node-selector-config"
+                           title="Pod Node Selector Configuration"
+                           keyName="Namespace"
+                           valueName="Label Selector"
+                           noValidators="true"
+                           [labels]="podNodeSelectorAdmissionPluginConfig"
+                           [formControlName]="Controls.PodNodeSelectorAdmissionPluginConfig"
+                           (labelsChange)="onPodNodeSelectorAdmissionPluginConfigChange($event)"
+                           fxFlex="100"></km-label-form>
           </div>
 
           <div fxLayout="column"

--- a/src/app/wizard/step/summary/template.html
+++ b/src/app/wizard/step/summary/template.html
@@ -97,6 +97,12 @@ limitations under the License.
                                [value]="false">
           </km-property-boolean>
         </div>
+        <km-property *ngIf="cluster.spec.podNodeSelectorAdmissionPluginConfig">
+          <div key>Pod Node Selector Config</div>
+          <div value>
+            <km-labels [labels]="cluster.spec.podNodeSelectorAdmissionPluginConfig"></km-labels>
+          </div>
+        </km-property>
         <km-property-boolean label="Audit Logging"
                              [value]="cluster.spec.auditLogging?.enabled">
         </km-property-boolean>


### PR DESCRIPTION
**What this PR does / why we need it**:
Added option to specify a Pod Node Selector Configuration during cluster creation or cluster edit. It will only be visible, when Pod Node Selector is enabled as Admission Plugin.

cherry picked from https://github.com/kubermatic/dashboard/pull/2929

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add option to specify Pod Node Selector Configuration
```
