### PR TITLE
[release/v2.14] Pod Node Selector Config

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -86,7 +86,7 @@ presubmits:
   # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
   - org: kubermatic
     repo: kubermatic
-    base_ref: master
+    base_ref: release/v2.14
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
   labels:
     preset-digitalocean: "true"
@@ -127,7 +127,7 @@ presubmits:
     # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
     - org: kubermatic
       repo: kubermatic
-      base_ref: master
+      base_ref: release/v2.14
       clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
   labels:
     preset-digitalocean: "true"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -99,7 +99,7 @@ presubmits:
     preset-vault: "true"
   spec:
     containers:
-    - image: quay.io/kubermatic/e2e-kind-cypress:v1.1.1
+    - image: quay.io/kubermatic/e2e-kind-cypress:v1.1.2
       command:
       - make
       - run-e2e-ci
@@ -140,7 +140,7 @@ presubmits:
     preset-vault: "true"
   spec:
     containers:
-      - image: quay.io/kubermatic/e2e-kind-cypress:v1.1.1
+      - image: quay.io/kubermatic/e2e-kind-cypress:v1.1.2
         command:
           - /bin/bash
           - -c

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.html
@@ -50,6 +50,14 @@
         </div>
         <mat-checkbox formControlName="usePodNodeSelectorAdmissionPlugin">Pod Node Selector</mat-checkbox>
       </div>
+      <km-label-form *ngIf="form.controls.usePodNodeSelectorAdmissionPlugin.value"
+                     title="Pod Node Selector Configuration"
+                     keyName="Namespace"
+                     valueName="Label Selector"
+                     noValidators="true"
+                     [(labels)]="podNodeSelectorAdmissionPluginConfig"
+                     formControlName="podNodeSelectorAdmissionPluginConfig"
+                     fxFlex="100"></km-label-form>
       <km-label-form title="Labels"
                      [(labels)]="labels"
                      [inheritedLabels]="cluster.inheritedLabels"

--- a/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/edit-cluster.component.ts
@@ -24,6 +24,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   @Input() projectID: string;
   form: FormGroup;
   labels: object;
+  podNodeSelectorAdmissionPluginConfig: object;
   providerSettingsPatch: ProviderSettingsPatch = {
     isValid: true,
     cloudSpecPatch: {},
@@ -40,6 +41,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.labels = _.cloneDeep(this.cluster.labels);
+    this.podNodeSelectorAdmissionPluginConfig = _.cloneDeep(this.cluster.spec.podNodeSelectorAdmissionPluginConfig);
 
     this.form = new FormGroup({
       name: new FormControl(this.cluster.name, [
@@ -50,6 +52,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       auditLogging: new FormControl(!!this.cluster.spec.auditLogging && this.cluster.spec.auditLogging.enabled),
       usePodSecurityPolicyAdmissionPlugin: new FormControl(this.cluster.spec.usePodSecurityPolicyAdmissionPlugin),
       usePodNodeSelectorAdmissionPlugin: new FormControl(this.cluster.spec.usePodNodeSelectorAdmissionPlugin),
+      podNodeSelectorAdmissionPluginConfig: new FormControl(''),
       labels: new FormControl(''),
     });
 
@@ -83,6 +86,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         },
         usePodSecurityPolicyAdmissionPlugin: this.form.controls.usePodSecurityPolicyAdmissionPlugin.value,
         usePodNodeSelectorAdmissionPlugin: this.form.controls.usePodNodeSelectorAdmissionPlugin.value,
+        podNodeSelectorAdmissionPluginConfig: this.podNodeSelectorAdmissionPluginConfig,
       },
     };
 

--- a/src/app/shared/components/label-form/label-form.component.html
+++ b/src/app/shared/components/label-form/label-form.component.html
@@ -9,14 +9,14 @@
          fxLayout="row"
          fxLayoutGap="10px">
       <mat-form-field fxFlex="45">
-        <mat-label>Key</mat-label>
+        <mat-label>{{keyName}}</mat-label>
         <input matInput
                (keyup)="check(i)"
                name="key"
                formControlName="key">
         <mat-error *ngIf="label.get('key').errors?.validLabelKeyUniqueness"
                    i18n>
-          Key is not unique.
+          {{keyName}} is not unique.
         </mat-error>
         <mat-error *ngIf="label.get('key').errors?.validLabelKeyPrefixPattern"
                    i18n>
@@ -39,18 +39,18 @@
         </mat-error>
       </mat-form-field>
       <mat-form-field fxFlex="45">
-        <mat-label>Value</mat-label>
+        <mat-label>{{valueName}}</mat-label>
         <input matInput
                (keyup)="check(i)"
                name="value"
                formControlName="value">
         <mat-error *ngIf="label.get('value').errors?.validLabelValuePattern"
                    i18n>
-          Value not allowed.
+          {{valueName}} not allowed.
         </mat-error>
         <mat-error *ngIf="label.get('value').errors?.validLabelValueLength"
                    i18n>
-          Value is too long.
+          {{valueName}} is too long.
         </mat-error>
       </mat-form-field>
       <button mat-icon-button

--- a/src/app/shared/components/label-form/label-form.component.ts
+++ b/src/app/shared/components/label-form/label-form.component.ts
@@ -36,8 +36,11 @@ import {LabelFormValidators} from '../../validators/label-form.validators';
 })
 export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccessor, AsyncValidator, DoCheck {
   @Input() title = 'Labels';
+  @Input() keyName = 'Key';
+  @Input() valueName = 'Value';
   @Input() labels: object;
   @Input() inheritedLabels: object = {};
+  @Input() noValidators = false;
   @Input() asyncKeyValidators: AsyncValidatorFn[] = [];
   @Output() labelsChange = new EventEmitter<object>();
   form: FormGroup;
@@ -153,24 +156,33 @@ export class LabelFormComponent implements OnInit, OnDestroy, ControlValueAccess
   }
 
   private _addLabel(key = '', value = ''): void {
-    this.labelArray.push(
-      this._formBuilder.group({
-        key: [
-          {value: key, disabled: this._isInherited(key)},
-          Validators.compose([
-            LabelFormValidators.labelKeyNameLength,
-            LabelFormValidators.labelKeyPrefixLength,
-            LabelFormValidators.labelKeyNamePattern,
-            LabelFormValidators.labelKeyPrefixPattern,
-          ]),
-          Validators.composeAsync(this.asyncKeyValidators),
-        ],
-        value: [
-          {value, disabled: this._isInherited(key)},
-          Validators.compose([LabelFormValidators.labelValueLength, LabelFormValidators.labelValuePattern]),
-        ],
-      })
-    );
+    if (this.noValidators) {
+      this.labelArray.push(
+        this._formBuilder.group({
+          key: [{value: key, disabled: this._isInherited(key)}],
+          value: [{value, disabled: this._isInherited(key)}],
+        })
+      );
+    } else {
+      this.labelArray.push(
+        this._formBuilder.group({
+          key: [
+            {value: key, disabled: this._isInherited(key)},
+            Validators.compose([
+              LabelFormValidators.labelKeyNameLength,
+              LabelFormValidators.labelKeyPrefixLength,
+              LabelFormValidators.labelKeyNamePattern,
+              LabelFormValidators.labelKeyPrefixPattern,
+            ]),
+            Validators.composeAsync(this.asyncKeyValidators),
+          ],
+          value: [
+            {value, disabled: this._isInherited(key)},
+            Validators.compose([LabelFormValidators.labelValueLength, LabelFormValidators.labelValuePattern]),
+          ],
+        })
+      );
+    }
   }
 
   private _validateKey(index: number): void {

--- a/src/app/shared/entity/ClusterEntity.ts
+++ b/src/app/shared/entity/ClusterEntity.ts
@@ -207,6 +207,7 @@ export class ClusterSpec {
   version?: string;
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
+  podNodeSelectorAdmissionPluginConfig?: object;
   openshift?: OpenShift;
 }
 

--- a/src/app/shared/entity/ClusterEntityPatch.ts
+++ b/src/app/shared/entity/ClusterEntityPatch.ts
@@ -15,6 +15,7 @@ export class ClusterSpecPatch {
   version?: string;
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
+  podNodeSelectorAdmissionPluginConfig?: object;
   auditLogging?: AuditLoggingSettings;
   openshift?: OpenShiftPatch;
 }

--- a/src/app/shared/model/ClusterForm.ts
+++ b/src/app/shared/model/ClusterForm.ts
@@ -10,6 +10,7 @@ export class ClusterSpecForm {
   imagePullSecret?: string;
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
+  podNodeSelectorAdmissionPluginConfig?: object;
   auditLogging?: AuditLoggingSettings;
   valid: boolean;
 }

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.html
@@ -108,6 +108,14 @@
         </div>
         <mat-checkbox formControlName="usePodNodeSelectorAdmissionPlugin">Pod Node Selector</mat-checkbox>
       </div>
+      <km-label-form *ngIf="clusterSpecForm.controls.usePodNodeSelectorAdmissionPlugin.value"
+                     title="Pod Node Selector Configuration"
+                     keyName="Namespace"
+                     valueName="Label Selector"
+                     noValidators="true"
+                     [(labels)]="podNodeSelectorAdmissionPluginConfig"
+                     formControlName="podNodeSelectorAdmissionPluginConfig"
+                     fxFlex="100"></km-label-form>
       <km-label-form title="Labels"
                      [(labels)]="labels"
                      [asyncKeyValidators]=asyncLabelValidators

--- a/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
+++ b/src/app/wizard/set-cluster-spec/set-cluster-spec.component.ts
@@ -19,6 +19,7 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
   @Input() cluster: ClusterEntity;
   @Input() settings: AdminSettings;
   labels: object;
+  podNodeSelectorAdmissionPluginConfig: object;
   clusterSpecForm: FormGroup;
   masterVersions: MasterVersion[] = [];
   defaultVersion: string;
@@ -44,6 +45,7 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
       usePodSecurityPolicyAdmissionPlugin: new FormControl(this.cluster.spec.usePodSecurityPolicyAdmissionPlugin),
       usePodNodeSelectorAdmissionPlugin: new FormControl(this.cluster.spec.usePodNodeSelectorAdmissionPlugin),
       auditLogging: new FormControl(!!this.cluster.spec.auditLogging && this.cluster.spec.auditLogging.enabled),
+      podNodeSelectorAdmissionPluginConfig: new FormControl(''),
       labels: new FormControl(''),
     });
 
@@ -124,6 +126,7 @@ export class SetClusterSpecComponent implements OnInit, OnDestroy {
       imagePullSecret: this.clusterSpecForm.controls.imagePullSecret.value,
       usePodSecurityPolicyAdmissionPlugin: this.clusterSpecForm.controls.usePodSecurityPolicyAdmissionPlugin.value,
       usePodNodeSelectorAdmissionPlugin: this.clusterSpecForm.controls.usePodNodeSelectorAdmissionPlugin.value,
+      podNodeSelectorAdmissionPluginConfig: this.podNodeSelectorAdmissionPluginConfig,
       auditLogging: {
         enabled: this.clusterSpecForm.controls.auditLogging.value,
       },

--- a/src/app/wizard/set-datacenter/set-datacenter.component.ts
+++ b/src/app/wizard/set-datacenter/set-datacenter.component.ts
@@ -96,6 +96,7 @@ export class SetDatacenterComponent implements OnInit, OnDestroy {
       imagePullSecret: this.cluster.spec.openshift ? this.cluster.spec.openshift.imagePullSecret : '',
       usePodSecurityPolicyAdmissionPlugin,
       usePodNodeSelectorAdmissionPlugin: this.cluster.spec.usePodNodeSelectorAdmissionPlugin,
+      podNodeSelectorAdmissionPluginConfig: this.cluster.spec.podNodeSelectorAdmissionPluginConfig,
       auditLogging,
       valid: true,
     });

--- a/src/app/wizard/summary/summary.component.html
+++ b/src/app/wizard/summary/summary.component.html
@@ -47,6 +47,12 @@
         </span>
         <span>Pod Node Selector</span>
       </div>
+      <div *ngIf="cluster.spec.usePodNodeSelectorAdmissionPlugin && cluster.spec.podNodeSelectorAdmissionPluginConfig && displayTags(cluster.spec.podNodeSelectorAdmissionPluginConfig)"
+           class="km-summary-tags">
+        <div class="km-summary-row">Pod Node Selector Config</div>
+        <km-labels [labels]="cluster.spec.podNodeSelectorAdmissionPluginConfig"
+                   emptyMessage="No assigned config"></km-labels>
+      </div>
       <div *ngIf="cluster.labels && displayTags(cluster.labels)"
            class="km-summary-tags">
         <div class="km-summary-row">Cluster Labels</div>

--- a/src/app/wizard/wizard.component.ts
+++ b/src/app/wizard/wizard.component.ts
@@ -42,6 +42,7 @@ export class WizardComponent implements OnInit, OnDestroy {
     type: ClusterType.Empty,
     version: '',
     labels: {},
+    podNodeSelectorAdmissionPluginConfig: {},
   };
   private _clusterProviderSettingsFormData: ClusterProviderSettingsForm = {
     valid: false,
@@ -81,7 +82,7 @@ export class WizardComponent implements OnInit, OnDestroy {
   ) {
     this.cluster = {
       name: '',
-      spec: {version: '', cloud: {dc: ''}, machineNetworks: []},
+      spec: {version: '', cloud: {dc: ''}, machineNetworks: [], podNodeSelectorAdmissionPluginConfig: {}},
       type: ClusterType.Empty,
     };
     this.addNodeData = {
@@ -117,6 +118,7 @@ export class WizardComponent implements OnInit, OnDestroy {
         this.cluster.labels = this._clusterSpecFormData.labels;
         this.cluster.spec.usePodSecurityPolicyAdmissionPlugin = this._clusterSpecFormData.usePodSecurityPolicyAdmissionPlugin;
         this.cluster.spec.usePodNodeSelectorAdmissionPlugin = this._clusterSpecFormData.usePodNodeSelectorAdmissionPlugin;
+        this.cluster.spec.podNodeSelectorAdmissionPluginConfig = this._clusterSpecFormData.podNodeSelectorAdmissionPluginConfig;
 
         if (this._clusterSpecFormData.type === ClusterType.OpenShift) {
           this.cluster.spec.openshift = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added option to specify a Pod Node Selector Configuration during cluster creation or cluster edit. It will only be visible, when Pod Node Selector is enabled as Admission Plugin.

"cherry picked" from #2929

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Add option to specify Pod Node Selector Configuration
```
