### PR TITLE
update Go dependencies, cleanup .prow.yaml

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,24 +1,4 @@
 presubmits:
-- name: pre-dashboard-validate-prow
-  always_run: true
-  decorate: true
-  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-  extra_refs:
-    - org: kubermatic
-      repo: infra
-      base_ref: master
-      clone_uri: git@github.com:kubermatic/infra.git
-  spec:
-    containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20200203-711d3732b
-        command:
-          - /app/prow/cmd/checkconfig/app.binary
-        args:
-          - --plugin-config=/home/prow/go/src/github.com/kubermatic/infra/prow/plugins.yaml
-          - --config-path=/home/prow/go/src/github.com/kubermatic/infra/prow/config.yaml
-          - --job-config-path=/home/prow/go/src/github.com/kubermatic/infra/prow/jobs
-          - --prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
-
 - name: pre-dashboard-go-mod-verify
   always_run: true
   decorate: true
@@ -30,7 +10,6 @@ presubmits:
       - image: golang:1.15.2
         command:
           - make
-        args:
           - verify-go
         resources:
           requests:
@@ -45,7 +24,6 @@ presubmits:
       - image: node:14.11.0
         command:
           - make
-        args:
           - check
         resources:
           requests:
@@ -64,7 +42,6 @@ presubmits:
       - image: quay.io/kubermatic/chrome-headless:v0.6
         command:
           - make
-        args:
           - test-headless
         resources:
           requests:
@@ -85,11 +62,11 @@ presubmits:
   decorate: true
   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
   extra_refs:
-  # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
-  - org: kubermatic
-    repo: kubermatic
-    base_ref: master
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
+    - org: kubermatic
+      repo: kubermatic
+      base_ref: master
+      clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
   labels:
     preset-digitalocean: "true"
     preset-openstack: "true"
@@ -102,25 +79,25 @@ presubmits:
     preset-goproxy: "true"
   spec:
     containers:
-    - image: quay.io/kubermatic/e2e-kind-cypress:v1.2.1
-      command:
-      - make
-      - run-e2e-ci
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: 6Gi
-          cpu: 4
-        limits:
-          memory: 6Gi
-          cpu: 4
-      env:
-      - name: SERVICE_ACCOUNT_KEY
-        valueFrom:
-          secretKeyRef:
-            name: e2e-ci
-            key: serviceAccountSigningKey
+      - image: quay.io/kubermatic/e2e-kind-cypress:v1.2.1
+        command:
+          - make
+          - run-e2e-ci
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 6Gi
+            cpu: 4
+          limits:
+            memory: 6Gi
+            cpu: 4
+        env:
+          - name: SERVICE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: e2e-ci
+                key: serviceAccountSigningKey
 
 - name: pre-dashboard-test-e2e-ce
   always_run: true
@@ -146,12 +123,8 @@ presubmits:
     containers:
       - image: quay.io/kubermatic/e2e-kind-cypress:v1.2.1
         command:
-          - /bin/bash
-          - -c
-          - >-
-            set -eo pipefail &&
-            export KUBERMATIC_EDITION=ce &&
-            make run-e2e-ci
+          - make
+          - run-e2e-ci
         securityContext:
           privileged: true
         resources:
@@ -162,6 +135,8 @@ presubmits:
             memory: 6Gi
             cpu: 4
         env:
+          - name: KUBERMATIC_EDITION
+            value: ce
           - name: SERVICE_ACCOUNT_KEY
             valueFrom:
               secretKeyRef:
@@ -177,7 +152,7 @@ presubmits:
     preset-goproxy: "true"
   spec:
     containers:
-      - image: quay.io/kubermatic/go-docker-node:v1.3.0
+      - image: quay.io/kubermatic/go-docker-node:v1.3.1
         command:
           - /bin/bash
           - -c

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module k8c.io/dashboard/v2
 go 1.14
 
 require (
-	github.com/prometheus/client_golang v1.8.0
+	github.com/prometheus/client_golang v1.9.0
 	go.uber.org/zap v1.16.0
 	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.8.0 h1:zvJNkoCFAnYFNC24FV8nW4JdRJ3GIFcLbg65lL/JDcw=
-github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
+github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
+github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
@@ -233,8 +233,8 @@ github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
-github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
-github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
+github.com/prometheus/common v0.15.0 h1:4fgOnadei3EZvgRwxJ7RMpG1k1pOZth5Pc13tyspaKM=
+github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -356,8 +356,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
+golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
**What this PR does / why we need it**:
* the validate-prow-yaml job is always maintained in the infra repo, never the project repos (for easier Prow upgrades and because certalized jobs have slightly different semantics that in-repo jobs)
* the Prometheus dependency has been bumped to have an actual reason to make a PR in the first place
* the prow.yaml has been reformatted while I was at it

**Release note**:
```release-note
NONE
```
