### PR TITLE
Migrate from Helm to Kubermatic Installer in e2e tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,61 +1,61 @@
 presubmits:
-# - name: pre-dashboard-go-mod-verify
-#   always_run: true
-#   decorate: true
-#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-#   labels:
-#     preset-goproxy: "true"
-#   spec:
-#     containers:
-#       - image: golang:1.15.2
-#         command:
-#           - make
-#           - verify-go
-#         resources:
-#           requests:
-#             cpu: 100m
+- name: pre-dashboard-go-mod-verify
+  always_run: true
+  decorate: true
+  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+  labels:
+    preset-goproxy: "true"
+  spec:
+    containers:
+      - image: golang:1.15.2
+        command:
+          - make
+          - verify-go
+        resources:
+          requests:
+            cpu: 100m
 
-# - name: pre-dashboard-check-static
-#   always_run: true
-#   decorate: true
-#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-#   spec:
-#     containers:
-#       - image: node:14.11.0
-#         command:
-#           - make
-#           - check
-#         resources:
-#           requests:
-#             cpu: 1
-#             memory: 3Gi
-#           limits:
-#             cpu: 2
-#             memory: 5Gi
+- name: pre-dashboard-check-static
+  always_run: true
+  decorate: true
+  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+  spec:
+    containers:
+      - image: node:14.11.0
+        command:
+          - make
+          - check
+        resources:
+          requests:
+            cpu: 1
+            memory: 3Gi
+          limits:
+            cpu: 2
+            memory: 5Gi
 
-# - name: pre-dashboard-test-unit
-#   always_run: true
-#   decorate: true
-#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-#   spec:
-#     containers:
-#       - image: quay.io/kubermatic/chrome-headless:v0.6
-#         command:
-#           - make
-#           - test-headless
-#         resources:
-#           requests:
-#             cpu: 1
-#             memory: 3Gi
-#           limits:
-#             cpu: 2
-#             memory: 5Gi
-#         env:
-#           - name: CODECOV_TOKEN
-#             valueFrom:
-#               secretKeyRef:
-#                 name: kubermatic-codecov
-#                 key: token
+- name: pre-dashboard-test-unit
+  always_run: true
+  decorate: true
+  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+  spec:
+    containers:
+      - image: quay.io/kubermatic/chrome-headless:v0.6
+        command:
+          - make
+          - test-headless
+        resources:
+          requests:
+            cpu: 1
+            memory: 3Gi
+          limits:
+            cpu: 2
+            memory: 5Gi
+        env:
+          - name: CODECOV_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: kubermatic-codecov
+                key: token
 
 - name: pre-dashboard-test-e2e
   always_run: true
@@ -75,7 +75,6 @@ presubmits:
     preset-kubeconfig-ci: "true"
     preset-docker-pull: "true"
     preset-kind-volume-mounts: "true"
-    preset-vault: "true"
     preset-goproxy: "true"
   spec:
     containers:
@@ -99,78 +98,77 @@ presubmits:
                 name: e2e-ci
                 key: serviceAccountSigningKey
 
-# - name: pre-dashboard-test-e2e-ce
-#   always_run: true
-#   decorate: true
-#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-#   extra_refs:
-#     # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
-#     - org: kubermatic
-#       repo: kubermatic
-#       base_ref: master
-#       clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-#   labels:
-#     preset-digitalocean: "true"
-#     preset-openstack: "true"
-#     preset-azure: "true"
-#     preset-gce: "true"
-#     preset-kubeconfig-ci: "true"
-#     preset-docker-pull: "true"
-#     preset-kind-volume-mounts: "true"
-#     preset-vault: "true"
-#     preset-goproxy: "true"
-#   spec:
-#     containers:
-#       - image: quay.io/kubermatic/e2e-kind-cypress:v1.2.1
-#         command:
-#           - make
-#           - run-e2e-ci
-#         securityContext:
-#           privileged: true
-#         resources:
-#           requests:
-#             memory: 6Gi
-#             cpu: 4
-#           limits:
-#             memory: 6Gi
-#             cpu: 4
-#         env:
-#           - name: KUBERMATIC_EDITION
-#             value: ce
-#           - name: SERVICE_ACCOUNT_KEY
-#             valueFrom:
-#               secretKeyRef:
-#                 name: e2e-ci
-#                 key: serviceAccountSigningKey
+- name: pre-dashboard-test-e2e-ce
+  always_run: true
+  decorate: true
+  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+  extra_refs:
+    # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
+    - org: kubermatic
+      repo: kubermatic
+      base_ref: master
+      clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+  labels:
+    preset-digitalocean: "true"
+    preset-openstack: "true"
+    preset-azure: "true"
+    preset-gce: "true"
+    preset-kubeconfig-ci: "true"
+    preset-docker-pull: "true"
+    preset-kind-volume-mounts: "true"
+    preset-goproxy: "true"
+  spec:
+    containers:
+      - image: quay.io/kubermatic/e2e-kind-cypress:v1.3.0
+        command:
+          - make
+          - run-e2e-ci
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 6Gi
+            cpu: 4
+          limits:
+            memory: 6Gi
+            cpu: 4
+        env:
+          - name: KUBERMATIC_EDITION
+            value: ce
+          - name: SERVICE_ACCOUNT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: e2e-ci
+                key: serviceAccountSigningKey
 
-# - name: pre-dashboard-build-image
-#   always_run: true
-#   decorate: true
-#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-#   labels:
-#     preset-docker-push: "true"
-#     preset-goproxy: "true"
-#   spec:
-#     containers:
-#       - image: quay.io/kubermatic/go-docker-node:v1.3.1
-#         command:
-#           - /bin/bash
-#           - -c
-#           - >-
-#             set -euo pipefail &&
-#             /usr/local/bin/entrypoint.sh &&
-#             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD &&
-#             docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
-#             make docker-build
-#         # docker-in-docker needs privileged mode
-#         securityContext:
-#           privileged: true
-#         resources:
-#           requests:
-#             cpu: 250m
-#             memory: 2.5Gi
-#           limits:
-#             cpu: 1
-#             memory: 3Gi
-#     imagePullSecrets:
-#       - name: quay
+- name: pre-dashboard-build-image
+  always_run: true
+  decorate: true
+  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+  labels:
+    preset-docker-push: "true"
+    preset-goproxy: "true"
+  spec:
+    containers:
+      - image: quay.io/kubermatic/go-docker-node:v1.3.1
+        command:
+          - /bin/bash
+          - -c
+          - >-
+            set -euo pipefail &&
+            /usr/local/bin/entrypoint.sh &&
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD &&
+            docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
+            make docker-build
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 250m
+            memory: 2.5Gi
+          limits:
+            cpu: 1
+            memory: 3Gi
+    imagePullSecrets:
+      - name: quay

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -79,7 +79,7 @@ presubmits:
     preset-goproxy: "true"
   spec:
     containers:
-      - image: quay.io/kubermatic/e2e-kind-cypress:v1.2.1
+      - image: quay.io/kubermatic/e2e-kind-cypress:v1.3.0
         command:
           - make
           - run-e2e-ci

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,61 +1,61 @@
 presubmits:
-- name: pre-dashboard-go-mod-verify
-  always_run: true
-  decorate: true
-  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-  labels:
-    preset-goproxy: "true"
-  spec:
-    containers:
-      - image: golang:1.15.2
-        command:
-          - make
-          - verify-go
-        resources:
-          requests:
-            cpu: 100m
+# - name: pre-dashboard-go-mod-verify
+#   always_run: true
+#   decorate: true
+#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+#   labels:
+#     preset-goproxy: "true"
+#   spec:
+#     containers:
+#       - image: golang:1.15.2
+#         command:
+#           - make
+#           - verify-go
+#         resources:
+#           requests:
+#             cpu: 100m
 
-- name: pre-dashboard-check-static
-  always_run: true
-  decorate: true
-  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-  spec:
-    containers:
-      - image: node:14.11.0
-        command:
-          - make
-          - check
-        resources:
-          requests:
-            cpu: 1
-            memory: 3Gi
-          limits:
-            cpu: 2
-            memory: 5Gi
+# - name: pre-dashboard-check-static
+#   always_run: true
+#   decorate: true
+#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+#   spec:
+#     containers:
+#       - image: node:14.11.0
+#         command:
+#           - make
+#           - check
+#         resources:
+#           requests:
+#             cpu: 1
+#             memory: 3Gi
+#           limits:
+#             cpu: 2
+#             memory: 5Gi
 
-- name: pre-dashboard-test-unit
-  always_run: true
-  decorate: true
-  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-  spec:
-    containers:
-      - image: quay.io/kubermatic/chrome-headless:v0.6
-        command:
-          - make
-          - test-headless
-        resources:
-          requests:
-            cpu: 1
-            memory: 3Gi
-          limits:
-            cpu: 2
-            memory: 5Gi
-        env:
-          - name: CODECOV_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: kubermatic-codecov
-                key: token
+# - name: pre-dashboard-test-unit
+#   always_run: true
+#   decorate: true
+#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+#   spec:
+#     containers:
+#       - image: quay.io/kubermatic/chrome-headless:v0.6
+#         command:
+#           - make
+#           - test-headless
+#         resources:
+#           requests:
+#             cpu: 1
+#             memory: 3Gi
+#           limits:
+#             cpu: 2
+#             memory: 5Gi
+#         env:
+#           - name: CODECOV_TOKEN
+#             valueFrom:
+#               secretKeyRef:
+#                 name: kubermatic-codecov
+#                 key: token
 
 - name: pre-dashboard-test-e2e
   always_run: true
@@ -99,78 +99,78 @@ presubmits:
                 name: e2e-ci
                 key: serviceAccountSigningKey
 
-- name: pre-dashboard-test-e2e-ce
-  always_run: true
-  decorate: true
-  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-  extra_refs:
-    # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
-    - org: kubermatic
-      repo: kubermatic
-      base_ref: master
-      clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-  labels:
-    preset-digitalocean: "true"
-    preset-openstack: "true"
-    preset-azure: "true"
-    preset-gce: "true"
-    preset-kubeconfig-ci: "true"
-    preset-docker-pull: "true"
-    preset-kind-volume-mounts: "true"
-    preset-vault: "true"
-    preset-goproxy: "true"
-  spec:
-    containers:
-      - image: quay.io/kubermatic/e2e-kind-cypress:v1.2.1
-        command:
-          - make
-          - run-e2e-ci
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: 6Gi
-            cpu: 4
-          limits:
-            memory: 6Gi
-            cpu: 4
-        env:
-          - name: KUBERMATIC_EDITION
-            value: ce
-          - name: SERVICE_ACCOUNT_KEY
-            valueFrom:
-              secretKeyRef:
-                name: e2e-ci
-                key: serviceAccountSigningKey
+# - name: pre-dashboard-test-e2e-ce
+#   always_run: true
+#   decorate: true
+#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+#   extra_refs:
+#     # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
+#     - org: kubermatic
+#       repo: kubermatic
+#       base_ref: master
+#       clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+#   labels:
+#     preset-digitalocean: "true"
+#     preset-openstack: "true"
+#     preset-azure: "true"
+#     preset-gce: "true"
+#     preset-kubeconfig-ci: "true"
+#     preset-docker-pull: "true"
+#     preset-kind-volume-mounts: "true"
+#     preset-vault: "true"
+#     preset-goproxy: "true"
+#   spec:
+#     containers:
+#       - image: quay.io/kubermatic/e2e-kind-cypress:v1.2.1
+#         command:
+#           - make
+#           - run-e2e-ci
+#         securityContext:
+#           privileged: true
+#         resources:
+#           requests:
+#             memory: 6Gi
+#             cpu: 4
+#           limits:
+#             memory: 6Gi
+#             cpu: 4
+#         env:
+#           - name: KUBERMATIC_EDITION
+#             value: ce
+#           - name: SERVICE_ACCOUNT_KEY
+#             valueFrom:
+#               secretKeyRef:
+#                 name: e2e-ci
+#                 key: serviceAccountSigningKey
 
-- name: pre-dashboard-build-image
-  always_run: true
-  decorate: true
-  clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
-  labels:
-    preset-docker-push: "true"
-    preset-goproxy: "true"
-  spec:
-    containers:
-      - image: quay.io/kubermatic/go-docker-node:v1.3.1
-        command:
-          - /bin/bash
-          - -c
-          - >-
-            set -euo pipefail &&
-            /usr/local/bin/entrypoint.sh &&
-            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD &&
-            docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
-            make docker-build
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 250m
-            memory: 2.5Gi
-          limits:
-            cpu: 1
-            memory: 3Gi
-    imagePullSecrets:
-      - name: quay
+# - name: pre-dashboard-build-image
+#   always_run: true
+#   decorate: true
+#   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+#   labels:
+#     preset-docker-push: "true"
+#     preset-goproxy: "true"
+#   spec:
+#     containers:
+#       - image: quay.io/kubermatic/go-docker-node:v1.3.1
+#         command:
+#           - /bin/bash
+#           - -c
+#           - >-
+#             set -euo pipefail &&
+#             /usr/local/bin/entrypoint.sh &&
+#             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD &&
+#             docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
+#             make docker-build
+#         # docker-in-docker needs privileged mode
+#         securityContext:
+#           privileged: true
+#         resources:
+#           requests:
+#             cpu: 250m
+#             memory: 2.5Gi
+#           limits:
+#             cpu: 1
+#             memory: 3Gi
+#     imagePullSecrets:
+#       - name: quay

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-headless: install
 	./hack/upload-coverage.sh
 
 run-e2e-ci: install
-	./hack/e2e/ci-e2e.sh
+	./hack/e2e/run-tests.sh
 
 dist: install
 	@KUBERMATIC_EDITION=${KUBERMATIC_EDITION} $(CC) run build

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ test-headless: install
 	@$(CC) run test:ci
 	./hack/upload-coverage.sh
 
-run-e2e-ci: install
+#run-e2e-ci: install
+run-e2e-ci:
 	./hack/e2e/run-tests.sh
 
 dist: install

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,7 @@ test-headless: install
 	@$(CC) run test:ci
 	./hack/upload-coverage.sh
 
-#run-e2e-ci: install
-run-e2e-ci:
+run-e2e-ci: install
 	./hack/e2e/run-tests.sh
 
 dist: install

--- a/containers/cypress/Dockerfile
+++ b/containers/cypress/Dockerfile
@@ -11,15 +11,15 @@
 
 FROM ubuntu:16.04 AS download
 
-ENV HELM2_VERSION="v2.16.6"
-ENV HELM3_VERSION="v3.1.2"
-ENV VAULT_VERSION="1.4.1"
-ENV KIND_VERSION="v0.6.1"
-ENV YQ_VERSION="3.3.0"
-ENV KUBECTL_VERSION="v1.18.2"
+ENV HELM2_VERSION="v2.17.0"
+ENV HELM3_VERSION="v3.4.2"
+ENV VAULT_VERSION="1.6.1"
+ENV KIND_VERSION="v0.8.1"
+ENV YQ_VERSION="3.3.2"
+ENV KUBECTL_VERSION="v1.19.7"
 
-RUN apt update && \
-    apt install -y unzip curl && \
+RUN apt-get update && \
+    apt-get install -y unzip curl && \
     curl --fail -L https://get.helm.sh/helm-${HELM2_VERSION}-linux-amd64.tar.gz | tar -xzO linux-amd64/helm > helm2 && \
     curl --fail -L https://get.helm.sh/helm-${HELM3_VERSION}-linux-amd64.tar.gz | tar -xzO linux-amd64/helm > helm3 && \
     curl --fail -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
@@ -59,7 +59,9 @@ RUN apt-get update -qq && \
     apt-get install -y \
     curl \
     bash \
+    bash-completion \
     jq \
+    gettext \
     git && \
     rm -rf /var/lib/apt/lists/* && \
     curl --fail -L https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz|tar -C /usr/local -xvz && \

--- a/containers/cypress/build-and-release.sh
+++ b/containers/cypress/build-and-release.sh
@@ -14,10 +14,11 @@ set -e
 
 IMG_REPO="quay.io/kubermatic"
 IMG_NAME="e2e-kind-cypress"
-IMG_VERSION="v1.2.1"
+IMG_VERSION="v1.3.0"
 
-# Preloaded images
-IMG_KIND="kindest/node:v1.18.8"
+# preload node image (this has to match the kind version;
+# each kind release specifies the default node image)
+IMG_KIND="kindest/node:v1.18.2"
 IMG_KIND_NAME="kindest.tar"
 
 docker pull ${IMG_KIND}

--- a/hack/e2e/fixtures/kubermatic.yaml
+++ b/hack/e2e/fixtures/kubermatic.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operator.kubermatic.io/v1alpha1
+kind: KubermaticConfiguration
+metadata:
+  name: e2e
+  namespace: kubermatic
+spec:
+  ingress:
+    domain: ci.kubermatic.io
+    disable: true
+  imagePullSecret: '__IMAGE_PULL_SECRET__'
+  userCluster:
+    apiserverReplicas: 1
+  api:
+    replicas: 1
+    debugLog: true
+  ui:
+    replicas: 0
+  # Dex integration
+  auth:
+    tokenIssuer: "http://dex.oauth:5556/dex"
+    issuerRedirectURL: "http://localhost:8000"
+    serviceAccountKey: "__SERVICE_ACCOUNT_KEY__"

--- a/hack/e2e/fixtures/oauth_values.yaml
+++ b/hack/e2e/fixtures/oauth_values.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dex:
+  replicas: 1
+  ingress:
+    scheme: http
+    # this the the service name inside the kind cluster, so that the Kubermatic pods can find Dex to validate our token
+    host: dex.oauth:5556
+    path: "/dex"
+    class: non-existent
+  clients:
+  - id: kubermatic
+    name: Kubermatic
+    secret: BDZleMTgqON5kiJybIBZM4Si
+    RedirectURIs:
+    - http://localhost:8000
+    - http://localhost:8000/projects
+  staticPasswords:
+  - email: "roxy@loodse.com"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "roxy"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+  - email: "roxy2@loodse.com"
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "roxy2"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5467"

--- a/hack/e2e/fixtures/seed.yaml
+++ b/hack/e2e/fixtures/seed.yaml
@@ -1,0 +1,119 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: "__SEED_NAME__-kubeconfig"
+  namespace: kubermatic
+data:
+  kubeconfig: "__KUBECONFIG__"
+
+---
+kind: Seed
+apiVersion: kubermatic.k8s.io/v1
+metadata:
+  name: __SEED_NAME__
+  namespace: kubermatic
+  labels:
+    worker-name: "__BUILD_ID__"
+spec:
+  country: Germany
+  location: Hamburg
+  kubeconfig:
+    name: __SEED_NAME__-kubeconfig
+    namespace: kubermatic
+    fieldPath: kubeconfig
+  datacenters:
+    byo-kubernetes:
+      location: Frankfurt
+      country: DE
+      spec:
+         bringyourown: {}
+    alibaba-eu-central-1a:
+      location: Frankfurt
+      country: DE
+      spec:
+        alibaba:
+          region: eu-central-1
+    aws-eu-central-1a:
+      location: EU (Frankfurt)
+      country: DE
+      spec:
+        aws:
+          region: eu-central-1
+    hetzner-nbg1:
+      location: Nuremberg 1 DC 3
+      country: DE
+      spec:
+        hetzner:
+          datacenter: nbg1-dc3
+    vsphere-ger:
+      location: Hamburg
+      country: DE
+      spec:
+        vsphere:
+          endpoint: "https://vcenter.loodse.io"
+          datacenter: "dc-1"
+          datastore: "exsi-nas"
+          cluster: "cl-1"
+          root_path: "/dc-1/vm/e2e-tests"
+          templates:
+            ubuntu: "machine-controller-e2e-ubuntu"
+            centos: "machine-controller-e2e-centos"
+            coreos: "machine-controller-e2e-coreos"
+    azure-westeurope:
+      location: "Azure West europe"
+      country: NL
+      spec:
+        azure:
+          location: "westeurope"
+    gcp-westeurope:
+      location: "Europe West (Germany)"
+      country: DE
+      spec:
+        gcp:
+          region: europe-west3
+          zone_suffixes:
+          - c
+    packet-ewr1:
+      location: "Packet EWR1 (New York)"
+      country: US
+      spec:
+        packet:
+          facilities:
+          - ewr1
+    do-ams3:
+      location: Amsterdam
+      country: NL
+      spec:
+        digitalocean:
+          region: ams3
+    do-fra1:
+      location: Frankfurt
+      country: DE
+      spec:
+        digitalocean:
+          region: fra1
+    kubevirt-europe-west3-c:
+      location: Frankfurt
+      country: DE
+      spec:
+        kubevirt: {}
+    syseleven-dbl1:
+      country: DE
+      location: Syseleven - dbl1
+      spec:
+        openstack:
+          auth_url: https://api.cbk.cloud.syseleven.net:5000/v3
+          availability_zone: dbl1
+          dns_servers:
+          - 37.123.105.116
+          - 37.123.105.117
+          enforce_floating_ip: true
+          ignore_volume_az: false
+          images:
+            centos: kubermatic-e2e-centos
+            coreos: kubermatic-e2e-coreos
+            ubuntu: kubermatic-e2e-ubuntu
+          node_size_requirements:
+            minimum_memory: 0
+            minimum_vcpus: 0
+          region: dbl

--- a/hack/e2e/run-tests.sh
+++ b/hack/e2e/run-tests.sh
@@ -19,6 +19,7 @@ if [ -z "${JOB_NAME:-}" ] || [ -z "${PROW_JOB_ID:-}" ]; then
   exit 1
 fi
 
+export PATH="$PATH:/usr/local/go/bin"
 export KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ee}"
 export CYPRESS_KUBERMATIC_EDITION="${KUBERMATIC_EDITION}"
 export SEED_NAME="kubermatic"
@@ -27,8 +28,6 @@ export CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME="roxy@loodse.com"
 export CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME_2="roxy2@loodse.com"
 export CYPRESS_KUBERMATIC_DEX_DEV_E2E_PASSWORD="password"
 export CYPRESS_RECORD_KEY=7859bcb8-1d2a-4d56-b7f5-ca70b93f944c
-
-apt install -y gettext bash-completion
 
 source hack/e2e/setup-kind-cluster.sh
 source hack/e2e/setup-kubermatic-in-kind.sh

--- a/hack/e2e/run-tests.sh
+++ b/hack/e2e/run-tests.sh
@@ -10,15 +10,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eo pipefail
+set -euo pipefail
 
-shopt -s nocasematch
-if [[ ${KUBERMATIC_EDITION} = ce ]]; then
-  export CYPRESS_KUBERMATIC_EDITION=ce
-else
-  export CYPRESS_KUBERMATIC_EDITION=ee
+source "${GOPATH}/src/github.com/kubermatic/kubermatic/hack/lib.sh"
+
+if [ -z "${JOB_NAME:-}" ] || [ -z "${PROW_JOB_ID:-}" ]; then
+  echodate "This script should only be running in a CI environment."
+  exit 1
 fi
 
+export KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ee}"
+export CYPRESS_KUBERMATIC_EDITION="${KUBERMATIC_EDITION}"
+export SEED_NAME="kubermatic"
+export KIND_CLUSTER_NAME="${SEED_NAME}"
 export CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME="roxy@loodse.com"
 export CYPRESS_KUBERMATIC_DEX_DEV_E2E_USERNAME_2="roxy2@loodse.com"
 export CYPRESS_KUBERMATIC_DEX_DEV_E2E_PASSWORD="password"
@@ -26,6 +30,7 @@ export CYPRESS_RECORD_KEY=7859bcb8-1d2a-4d56-b7f5-ca70b93f944c
 
 apt install -y gettext bash-completion
 
-source hack/e2e/ci-setup-kubermatic-in-kind.sh
+source hack/e2e/setup-kind-cluster.sh
+source hack/e2e/setup-kubermatic-in-kind.sh
 
 WAIT_ON_TIMEOUT=600000 npm run e2e:local

--- a/hack/e2e/setup-kind-cluster.sh
+++ b/hack/e2e/setup-kind-cluster.sh
@@ -1,0 +1,105 @@
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REPO_ROOT="$(realpath .)"
+
+echodate "Setting up kind cluster..."
+
+export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
+export KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
+
+start_docker_daemon
+
+# Prevent mtu-related timeouts
+echodate "Setting iptables rule to clamp mss to path mtu"
+iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+
+# Make debugging a bit better
+echodate "Configuring bash"
+cat <<EOF >>~/.bashrc
+# Gets set to the CI cluster's kubeconfig by a Prow preset
+unset KUBECONFIG
+
+cn() {
+  kubectl config set-context --current --namespace=\$1
+}
+
+kubeconfig() {
+  TMP_KUBECONFIG=\$(mktemp);
+  kubectl get secret admin-kubeconfig -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > \$TMP_KUBECONFIG;
+  export KUBECONFIG=\$TMP_KUBECONFIG;
+  cn kube-system
+}
+
+# this alias makes it so that watch can be used with other aliases, like "watch k get pods"
+alias watch='watch '
+alias k=kubectl
+alias ll='ls -lh --file-type --group-directories-first'
+alias lll='ls -lahF --group-directories-first'
+source <(k completion bash )
+source <(k completion bash | sed s/kubectl/k/g)
+EOF
+
+# Load kind image
+echodate "Loading kindest image"
+docker load --input /kindest.tar
+echodate "Loaded kindest image"
+
+# Create kind cluster
+TEST_NAME="Create kind cluster"
+echodate "Creating the kind cluster"
+export KUBECONFIG=~/.kube/config
+
+beforeKindCreate=$(nowms)
+export KIND_NODE_VERSION=v1.18.2
+kind create cluster --name "$KIND_CLUSTER_NAME" --image=kindest/node:$KIND_NODE_VERSION
+pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$KIND_NODE_VERSION\""
+
+# Start cluster exposer, which will expose services from within kind as
+# a NodePort service on the host
+echodate "Starting cluster exposer"
+
+CGO_ENABLED=0 go build --tags "$KUBERMATIC_EDITION" -v -o /tmp/clusterexposer ./pkg/test/clusterexposer/cmd
+/tmp/clusterexposer \
+  --kubeconfig-inner "$KUBECONFIG" \
+  --kubeconfig-outer "/etc/kubeconfig/kubeconfig" \
+  --build-id "$PROW_JOB_ID" &> /var/log/clusterexposer.log &
+
+function print_cluster_exposer_logs {
+  if [[ $? -ne 0 ]]; then
+    # Tolerate errors and just continue
+    set +e
+    echodate "Printing cluster exposer logs"
+    cat /var/log/clusterexposer.log
+    echodate "Done printing cluster exposer logs"
+    set -e
+  fi
+}
+appendTrap print_cluster_exposer_logs EXIT
+
+TEST_NAME="Wait for cluster exposer"
+echodate "Waiting for cluster exposer to be running"
+
+retry 5 curl -s --fail http://127.0.0.1:2047/metrics -o /dev/null
+echodate "Cluster exposer is running"
+
+echodate "Setting up iptables rules for to make nodeports available"
+KIND_NETWORK_IF=$(ip -br addr | grep -- 'br-' | cut -d' ' -f1)
+
+iptables -t nat -A PREROUTING -i eth0 -p tcp -m multiport --dports=30000:33000 -j DNAT --to-destination 172.18.0.2
+# By default all traffic gets dropped unless specified (tested with docker server 18.09.1)
+iptables -t filter -I DOCKER-USER -d 172.18.0.2/32 ! -i $KIND_NETWORK_IF -o $KIND_NETWORK_IF -p tcp -m multiport --dports=30000:33000 -j ACCEPT
+# Docker sets up a MASQUERADE rule for postrouting, so nothing to do for us
+
+echodate "Successfully set up iptables rules for nodeports"
+echodate "Kind cluster $KIND_CLUSTER_NAME using Kubernetes $KIND_NODE_VERSION is up and running."
+
+cd "$REPO_ROOT"

--- a/hack/e2e/setup-kind-cluster.sh
+++ b/hack/e2e/setup-kind-cluster.sh
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 REPO_ROOT="$(realpath .)"
+cd "${GOPATH}/src/github.com/kubermatic/kubermatic"
 
 echodate "Setting up kind cluster..."
 

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export PATH="$PATH:/usr/local/go/bin"
 export KUBERMATIC_VERSION=latest
 export TARGET_BRANCH="${PULL_BASE_REF:-master}"
 export KUBERMATIC_OIDC_LOGIN="roxy@loodse.com"

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -43,7 +43,16 @@ kubermaticOperator:
 EOF
 
 # append custom Dex configuration
-cat hack/ci/testdata/oauth_values.yaml >> $HELM_VALUES_FILE
+cat $REPO_ROOT/hack/e2e/fixtures/oauth_values.yaml >> $HELM_VALUES_FILE
+
+# prepare to run kubermatic-installer
+KUBERMATIC_CONFIG="$(mktemp)"
+IMAGE_PULL_SECRET_INLINE="$(echo "$IMAGE_PULL_SECRET_DATA" | base64 --decode | jq --compact-output --monochrome-output '.')"
+
+cp $REPO_ROOT/hack/e2e/fixtures/kubermatic.yaml $KUBERMATIC_CONFIG
+
+sed -i "s;__SERVICE_ACCOUNT_KEY__;$SERVICE_ACCOUNT_KEY;g" $KUBERMATIC_CONFIG
+sed -i "s;__IMAGE_PULL_SECRET__;$IMAGE_PULL_SECRET_INLINE;g" $KUBERMATIC_CONFIG
 
 # The alias makes it easier to access the port-forwarded Dex inside the Kind cluster;
 # the token issuer cannot be localhost:5556, because pods inside the cluster would not
@@ -59,218 +68,52 @@ if ! grep oauth /etc/hosts > /dev/null; then
   echodate "Set dex.oauth alias in /etc/hosts"
 fi
 
-export KUBERMATIC_DEX_VALUES_FILE=$(realpath hack/ci/testdata/oauth_values.yaml)
-
 # Build binaries and load the Docker images into the kind cluster
 echodate "Building binaries for $KUBERMATIC_VERSION"
 TEST_NAME="Build Kubermatic binaries"
-make kubermatic-installer
-
-echo "OK"
-exit 0
+KUBERMATICDOCKERTAG=latest UIDOCKERTAG=latest make kubermatic-installer
 
 TEST_NAME="Deploy Kubermatic"
-echodate "Deploying Kubermatic [${KUBERMATIC_VERSION}] using Helm..."
+echodate "Deploying Kubermatic [${KUBERMATIC_VERSION}]..."
 
-# --force is needed in case the first attempt at installing didn't succeed
-# see https://github.com/helm/helm/pull/3597
-retry 3 helm upgrade --install --force --wait --timeout 300 \
-  --set=kubermatic.isMaster=true \
-  --set=kubermatic.imagePullSecretData=$IMAGE_PULL_SECRET_DATA \
-  --set-string=kubermatic.controller.addons.kubernetes.image.tag="$KUBERMATIC_VERSION" \
-  --set-string=kubermatic.controller.image.tag="$KUBERMATIC_VERSION" \
-  --set-string=kubermatic.controller.addons.openshift.image.tag="$KUBERMATIC_VERSION" \
-  --set-string=kubermatic.api.image.tag="$KUBERMATIC_VERSION" \
-  --set=kubermatic.controller.datacenterName=${SEED_NAME} \
-  --set=kubermatic.controller.workerCount=100 \
-  --set=kubermatic.api.replicas=1 \
-  --set-string=kubermatic.masterController.image.tag="$KUBERMATIC_VERSION" \
-  --set-string=kubermatic.ui.image.tag=latest \
-  --set=kubermatic.ui.replicas=0 \
-  --set=kubermatic.ingressClass=non-existent \
-  --set=kubermatic.checks.crd.disable=true \
-  --set=kubermatic.datacenters='' \
-  --set=kubermatic.dynamicDatacenters=true \
-  --set=kubermatic.dynamicPresets=true \
-  --set=kubermatic.kubeconfig="$(cat $KUBECONFIG|sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./'|base64 -w0)" \
-  --set=kubermatic.auth.tokenIssuer=http://dex.oauth:5556/dex \
-  --set=kubermatic.auth.clientID=kubermatic \
-  --set=kubermatic.auth.serviceAccountKey=$SERVICE_ACCOUNT_KEY \
-  --set=kubermatic.apiserverDefaultReplicas=1 \
-  --set=kubermatic.deployVPA=false \
-  --namespace=kubermatic \
-  --values ${VALUES_FILE} \
-  kubermatic \
-  charts/kubermatic/
+./_build/kubermatic-installer deploy \
+  --storageclass copy-default \
+  --config "$KUBERMATIC_CONFIG" \
+  --helm-values "$HELM_VALUES_FILE" \
+  --helm-binary "helm3"
 
 echodate "Finished installing Kubermatic"
+cd $REPO_ROOT
 
 echodate "Installing Seed..."
 SEED_MANIFEST="$(mktemp)"
-cat <<EOF >$SEED_MANIFEST
-kind: Secret
-apiVersion: v1
-metadata:
-  name: ${SEED_NAME}-kubeconfig
-  namespace: kubermatic
-data:
-  kubeconfig: "$(cat $KUBECONFIG|sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./'|base64 -w0)"
+SEED_KUBECONFIG="$(cat $KUBECONFIG | sed 's/127.0.0.1.*/kubernetes.default.svc.cluster.local./' | base64 -w0)"
 
----
-kind: Seed
-apiVersion: kubermatic.k8s.io/v1
-metadata:
-  name: ${SEED_NAME}
-  namespace: kubermatic
-  labels:
-    worker-name: "$BUILD_ID"
-spec:
-  country: Germany
-  location: Hamburg
-  kubeconfig:
-    name: ${SEED_NAME}-kubeconfig
-    namespace: kubermatic
-    fieldPath: kubeconfig
-  datacenters:
-    byo-kubernetes:
-      location: Frankfurt
-      country: DE
-      spec:
-         bringyourown: {}
-    alibaba-eu-central-1a:
-      location: Frankfurt
-      country: DE
-      spec:
-        alibaba:
-          region: eu-central-1
-    aws-eu-central-1a:
-      location: EU (Frankfurt)
-      country: DE
-      spec:
-        aws:
-          region: eu-central-1
-    hetzner-nbg1:
-      location: Nuremberg 1 DC 3
-      country: DE
-      spec:
-        hetzner:
-          datacenter: nbg1-dc3
-    vsphere-ger:
-      location: Hamburg
-      country: DE
-      spec:
-        vsphere:
-          endpoint: "https://vcenter.loodse.io"
-          datacenter: "dc-1"
-          datastore: "exsi-nas"
-          cluster: "cl-1"
-          root_path: "/dc-1/vm/e2e-tests"
-          templates:
-            ubuntu: "machine-controller-e2e-ubuntu"
-            centos: "machine-controller-e2e-centos"
-            coreos: "machine-controller-e2e-coreos"
-    azure-westeurope:
-      location: "Azure West europe"
-      country: NL
-      spec:
-        azure:
-          location: "westeurope"
-    gcp-westeurope:
-      location: "Europe West (Germany)"
-      country: DE
-      spec:
-        gcp:
-          region: europe-west3
-          zone_suffixes:
-          - c
-    packet-ewr1:
-      location: "Packet EWR1 (New York)"
-      country: US
-      spec:
-        packet:
-          facilities:
-          - ewr1
-    do-ams3:
-      location: Amsterdam
-      country: NL
-      spec:
-        digitalocean:
-          region: ams3
-    do-fra1:
-      location: Frankfurt
-      country: DE
-      spec:
-        digitalocean:
-          region: fra1
-    kubevirt-europe-west3-c:
-      location: Frankfurt
-      country: DE
-      spec:
-        kubevirt: {}
-    syseleven-dbl1:
-      country: DE
-      location: Syseleven - dbl1
-      spec:
-        openstack:
-          auth_url: https://api.cbk.cloud.syseleven.net:5000/v3
-          availability_zone: dbl1
-          dns_servers:
-          - 37.123.105.116
-          - 37.123.105.117
-          enforce_floating_ip: true
-          ignore_volume_az: false
-          images:
-            centos: kubermatic-e2e-centos
-            coreos: kubermatic-e2e-coreos
-            ubuntu: kubermatic-e2e-ubuntu
-          node_size_requirements:
-            minimum_memory: 0
-            minimum_vcpus: 0
-          region: dbl
-EOF
+cp hack/e2e/fixtures/seed.yaml $SEED_MANIFEST
+
+sed -i "s/__SEED_NAME__/$SEED_NAME/g" $SEED_MANIFEST
+sed -i "s/__BUILD_ID__/$BUILD_ID/g" $SEED_MANIFEST
+sed -i "s/__KUBECONFIG__/$SEED_KUBECONFIG/g" $SEED_MANIFEST
+
 retry 8 kubectl apply -f $SEED_MANIFEST
 echodate "Finished installing Seed"
 
-function kill_port_forwardings() {
-  echodate "Stopping any previous port-forwardings to port $1..."
-  ss -tlpn "sport = :$1" | (grep -oP "(?<=pid=)[0-9]+" || true) | uniq | tee | xargs -r kill
-}
+sleep 5
+echodate "Waiting for Kubermatic Operator to deploy Seed components..."
+retry 8 check_all_deployments_ready kubermatic
+echodate "Kubermatic Seed is ready."
 
-function cleanup_kubermatic_clusters_in_kind {
-  originalRC=$?
+echodate "Waiting for VPA to be ready..."
+retry 8 check_all_deployments_ready kube-system
+echodate "VPA is ready."
 
-  # Tolerate errors and just continue
-  set +e
-  # Clean up clusters
-  echodate "Cleaning up clusters..."
-  kubectl delete cluster --all --ignore-not-found=true
-  echodate "Done cleaning up clusters"
-
-  # Kill all descendant processes
-  pkill -P $$
-  set -e
-
-  return $originalRC
-}
 appendTrap cleanup_kubermatic_clusters_in_kind EXIT
 
 TEST_NAME="Expose Dex and Kubermatic API"
 echodate "Exposing Dex and Kubermatic API to localhost..."
-kill_port_forwardings 5556
-kill_port_forwardings 8080
-kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 &
-kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 &
+kubectl port-forward --address 0.0.0.0 -n oauth svc/dex 5556 >/dev/null &
+kubectl port-forward --address 0.0.0.0 -n kubermatic svc/kubermatic-api 8080:80 >/dev/null &
 echodate "Finished exposing components"
-
-echodate "Waiting for Dex to be ready"
-retry 5 curl -sSf  http://127.0.0.1:5556/dex/healthz
-echodate "Dex became ready"
-
-echodate "Waiting for Kubermatic API to be ready"
-retry 5 curl -sSf  http://127.0.0.1:8080/api/v1/healthz
-echodate "API became ready"
-
-cd -
 
 echodate "Creating UI Azure preset..."
 cat <<EOF > preset-azure.yaml
@@ -331,4 +174,4 @@ EOF
 retry 2 kubectl apply -f preset-openstack.yaml
 
 echodate "Applying user..."
-retry 2 kubectl apply -f $(dirname $0)/fixtures/user.yaml
+retry 2 kubectl apply -f hack/e2e/fixtures/user.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
The Helm chart is deprecated and soon to be removed. It's high time this repo switches to the KKP Installer.

This PR effectively brings the e2e setup code in-sync with what KKP does. Instead of using the Helm chart from the KKP repo, we now compile the installer and use that to install KKP (i.e. as before, the jobs clone the KKP repo and reuse some of its code).

Noteworthy is that the setup process is now split into 2 scripts:

* setup-kind-cluster.sh just sets up a kind cluster
* setup-kubermatic-in-kind.sh then follows and takes care of installing KKP

This has been done because

* it keeps the dashboard mostly in-sync with how KKP does it and
* KKP does it because separating kind from KKP makes it easier to run upgrade tests (i.e. tests where KKP is installed multiple times into the same kind cluster)

**Release note**:
```release-note
NONE
```
