### PR TITLE
declare master branch as 2.17-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifeq (${HUMAN_VERSION},)
 	TARGET_BRANCH=$(or ${PULL_BASE_REF},${PULL_BASE_REF},${CURRENT_BRANCH})
 
 	ifeq (${TARGET_BRANCH},master)
-	HUMAN_VERSION=v2.16.0-dev-g$(shell git rev-parse --short HEAD)
+	HUMAN_VERSION=v2.17.0-dev-g$(shell git rev-parse --short HEAD)
 	else
 	HUMAN_VERSION=$(shell git describe --tags --match "v[0-9]*")
 	endif


### PR DESCRIPTION
**What this PR does / why we need it**:
Time to get the 2.16 release on its way. Part of https://github.com/kubermatic/kubermatic/issues/6439

**Release note**:
```release-note
NONE
```
