### PR TITLE
revert ngx-monaco-editor to v9.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17354,12 +17354,9 @@
       }
     },
     "ngx-monaco-editor": {
-      "version": "10.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/ngx-monaco-editor/-/ngx-monaco-editor-10.0.0-beta.1.tgz",
-      "integrity": "sha512-U5p7YLhQB9yRnbQ8a/gq97PvAokwfot69In7wc4rkItD4ocTY/xvfaJXSAm2zQdm9MWRuwiis3iWb+CbVSaSLA==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-monaco-editor/-/ngx-monaco-editor-9.0.0.tgz",
+      "integrity": "sha512-fPXT3M8W920Vs0KPMX6iA7GJYjBRnl9naug9A7D2inPPzxQGtgPZrSEatIPf37a6ir9Ts+8fwt1bTkFzfTgIpQ=="
     },
     "ngx-window-token": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ngx-cookie-service": "11.0.2",
     "ngx-custom-validators": "8.0.0",
     "ngx-filter-pipe": "2.1.2",
-    "ngx-monaco-editor": "^9.0.0",
+    "ngx-monaco-editor": "9.0.0",
     "rxjs": "6.6.3",
     "rxjs-compat": "6.6.3",
     "semver": "7.3.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ngx-cookie-service": "11.0.2",
     "ngx-custom-validators": "8.0.0",
     "ngx-filter-pipe": "2.1.2",
-    "ngx-monaco-editor": "10.0.0-beta.1",
+    "ngx-monaco-editor": "^9.0.0",
     "rxjs": "6.6.3",
     "rxjs-compat": "6.6.3",
     "semver": "7.3.4",


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverted ngx-monaco-editor to v9.0.0 as v10.0.0-beta.1 was breaking the editor with 
- locally: `ngx-monaco-editor.js:48 GET http://localhost:8000/assets/vs/loader.js net::ERR_ABORTED 404 (Not Found)`
- dev: `Uncaught SyntaxError: Unexpected numbermain.a5fb73c17db805ba8809.js:1` & `ERROR TypeError: window.require is not a function`

**Special notes for your reviewer**:
See https://github.com/atularen/ngx-monaco-editor/issues/122 or https://github.com/atularen/ngx-monaco-editor/issues/189 as a reference

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
