### PR TITLE
Add resource quota settings to admin panel

### DIFF
--- a/src/app/settings/admin/template.html
+++ b/src/app/settings/admin/template.html
@@ -207,6 +207,66 @@ limitations under the License.
         </mat-form-field>
         <km-settings-status [isSaved]="isEqual(settings.userProjectsLimit, apiSettings.userProjectsLimit)"></km-settings-status>
       </div>
+
+      <div fxLayout="row">
+        <div fxFlex="16%"
+             fxLayoutAlign=" center"
+             class="entry-label">
+          <span>Resource quota</span>
+          <div class="km-icon-info km-pointer"
+               matTooltip=""></div>
+        </div>
+
+        <mat-form-field class="input km-no-padding">
+          <mat-label>Min CPU</mat-label>
+          <input matInput
+                 required
+                 type="number"
+                 min="0"
+                 autocomplete="off"
+                 [(ngModel)]="settings.machineDeploymentVMResourceQuota.minCPU"
+                 (change)="onSettingsChange()">
+        </mat-form-field>
+
+        <mat-form-field class="input km-no-padding">
+          <mat-label>Max CPU</mat-label>
+          <input matInput
+                 required
+                 type="number"
+                 min="0"
+                 autocomplete="off"
+                 [(ngModel)]="settings.machineDeploymentVMResourceQuota.maxCPU"
+                 (change)="onSettingsChange()">
+        </mat-form-field>
+
+        <mat-form-field class="input km-no-padding">
+          <mat-label>Min RAM</mat-label>
+          <input matInput
+                 required
+                 type="number"
+                 min="0"
+                 autocomplete="off"
+                 [(ngModel)]="settings.machineDeploymentVMResourceQuota.minRAM"
+                 (change)="onSettingsChange()">
+        </mat-form-field>
+
+        <mat-form-field class="input km-no-padding">
+          <mat-label>Max RAM</mat-label>
+          <input matInput
+                 required
+                 type="number"
+                 min="0"
+                 autocomplete="off"
+                 [(ngModel)]="settings.machineDeploymentVMResourceQuota.maxRAM"
+                 (change)="onSettingsChange()">
+        </mat-form-field>
+
+        <mat-checkbox fxLayoutAlign=" center"
+                      [(ngModel)]="settings.machineDeploymentVMResourceQuota.enableGPU"
+                      (change)="onSettingsChange()">Enable GPU</mat-checkbox>
+
+        <km-settings-status [isSaved]="isEqual(settings.machineDeploymentVMResourceQuota, apiSettings.machineDeploymentVMResourceQuota)"></km-settings-status>
+      </div>
     </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/shared/entity/settings.ts
+++ b/src/app/shared/entity/settings.ts
@@ -33,6 +33,15 @@ export class AdminSettings {
   userProjectsLimit: number;
   restrictProjectCreation: boolean;
   enableExternalClusterImport: boolean;
+  machineDeploymentVMResourceQuota: MachineDeploymentVMResourceQuota;
+}
+
+export class MachineDeploymentVMResourceQuota {
+  minCPU: number;
+  maxCPU: number;
+  minRAM: number;
+  maxRAM: number;
+  enableGPU: boolean;
 }
 
 export class CleanupOptions {
@@ -132,4 +141,11 @@ export const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
   enableOIDCKubeconfig: false,
   restrictProjectCreation: false,
   enableExternalClusterImport: true,
+  machineDeploymentVMResourceQuota: {
+    minRAM: 0,
+    maxRAM: 0,
+    minCPU: 0,
+    maxCPU: 0,
+    enableGPU: false,
+  },
 };

--- a/src/app/testing/services/settings-mock.service.ts
+++ b/src/app/testing/services/settings-mock.service.ts
@@ -35,6 +35,13 @@ export const DEFAULT_ADMIN_SETTINGS_MOCK: AdminSettings = {
   userProjectsLimit: 0,
   restrictProjectCreation: false,
   enableExternalClusterImport: true,
+  machineDeploymentVMResourceQuota: {
+    minRAM: 0,
+    maxRAM: 0,
+    minCPU: 0,
+    maxCPU: 0,
+    enableGPU: false,
+  },
 };
 
 @Injectable()


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds new resource quota related fields to the admin panel

![Zrzut ekranu z 2021-01-29 13-47-38](https://user-images.githubusercontent.com/2285385/106276943-986e7b00-6238-11eb-9892-1b0644942ef0.png)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3010

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Added resource quota settings to the admin panel.
```
