### PR TITLE
Add GPU information to AWS node sizes

### DIFF
--- a/src/app/node-data/basic/provider/aws/component.ts
+++ b/src/app/node-data/basic/provider/aws/component.ts
@@ -26,6 +26,7 @@ import {FilteredComboboxComponent} from '@shared/components/combobox/component';
 import {NodeCloudSpec, NodeSpec} from '@shared/entity/node';
 import {AWSSize, AWSSubnet} from '@shared/entity/provider/aws';
 import {NodeData} from '@shared/model/NodeSpecChange';
+import {compare} from '@shared/utils/common-utils';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import * as _ from 'lodash';
 import {merge, Observable} from 'rxjs';
@@ -175,7 +176,12 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
       return sizeName;
     }
 
-    return `${size.name} (${size.vcpus} vCPU, ${size.memory} GB RAM, ${size.price} USD per hour)`;
+    let result = `${size.pretty_name} (${size.vcpus} vCPU`;
+    if (size.gpus) {
+      result = `${result}, ${size.gpus} GPU`;
+    }
+
+    return `${result}, ${size.memory} GB RAM, ${size.price} USD per hour)`;
   }
 
   private _init(): void {
@@ -197,7 +203,7 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
   }
 
   private _setDefaultSize(sizes: AWSSize[]): void {
-    this.sizes = sizes;
+    this.sizes = sizes.sort((a, b) => compare(a.price, b.price));
     this.selectedSize = this._nodeDataService.nodeData.spec.cloud.aws.instanceType;
 
     if (!this.selectedSize && this.sizes.length > 0) {

--- a/src/app/node-data/basic/provider/aws/template.html
+++ b/src/app/node-data/basic/provider/aws/template.html
@@ -25,7 +25,7 @@ limitations under the License.
                inputLabel="Select size..."
                filterBy="name">
     <div *option="let size">
-      {{size.name}} ({{size.vcpus}} vCPU, {{size.memory}} GB RAM, {{size.price | number: '1.2-5'}} USD per hour)
+      {{sizeDisplayName(size.name)}}
     </div>
   </km-combobox>
 

--- a/src/app/shared/entity/provider/aws.ts
+++ b/src/app/shared/entity/provider/aws.ts
@@ -63,4 +63,5 @@ export class AWSSize {
   memory: number;
   vcpus: number;
   price: number;
+  gpus: number;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Used `pretty_name` instead of `name`
- Added GPU count information if available to the description
- Sorted instances by their price (cheapest to the most expensive)

![Zrzut ekranu z 2021-02-03 13-09-43](https://user-images.githubusercontent.com/2285385/106745247-1cea4080-6621-11eb-9b14-01bd3b530358.png)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3037

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
AWS node sizes in the wizard now provide GPU information.
```
