### PR TITLE
Cluster health state should only be checked for known statuses

### DIFF
--- a/src/app/shared/entity/health.ts
+++ b/src/app/shared/entity/health.ts
@@ -19,9 +19,17 @@ export class Health {
   userClusterControllerManager: HealthState;
 
   static allHealthy(health: Health): boolean {
-    return Object.keys(Health)
-      .map(key => health[key])
-      .every(status => HealthState.isUp(status));
+    const supported = [
+      health.apiserver,
+      health.controller,
+      health.etcd,
+      health.machineController,
+      health.scheduler,
+      health.cloudProviderInfrastructure,
+      health.userClusterControllerManager,
+    ];
+
+    return supported.every(status => HealthState.isUp(status));
   }
 }
 

--- a/src/app/shared/entity/health.ts
+++ b/src/app/shared/entity/health.ts
@@ -19,7 +19,9 @@ export class Health {
   userClusterControllerManager: HealthState;
 
   static allHealthy(health: Health): boolean {
-    return Object.values(health).every(status => HealthState.isUp(status));
+    return Object.keys(Health)
+      .map(key => health[key])
+      .every(status => HealthState.isUp(status));
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issue with additional health checks being provided by the API and checked by the frontend when they are not relevant to us. It was blocking i.e. machines from being loaded.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
