### PR TITLE
Filter external networks in openstack wizard

### DIFF
--- a/src/app/wizard/step/provider-settings/provider/extended/openstack/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/openstack/component.ts
@@ -178,7 +178,7 @@ export class OpenstackProviderExtendedComponent extends BaseFormValidator implem
   }
 
   private _loadNetworks(networks: OpenstackNetwork[]): void {
-    this.networks = networks;
+    this.networks = networks.filter(network => !network.external);
     this.networksLabel = !_.isEmpty(this.networks) ? NetworkState.Ready : NetworkState.Empty;
     this._cdr.detectChanges();
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
External networks cannot be used as cluster networks and will result in
a failure during cluster creation when selected.
Filter external networks in the cluster creation wizard for openstack to
prevent users from selecting those options.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
Filter external openstack networks during cluster creation
```
