### PR TITLE
Validate name during cluster creation with the same pattern as on edit

### DIFF
--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -95,7 +95,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.Name]: new FormControl('', [
         Validators.required,
         Validators.minLength(this._minNameLength),
-        Validators.pattern('[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),
+        Validators.pattern('[a-zA-Z0-9-]*'),
       ]),
       [Controls.Version]: new FormControl('', [Validators.required]),
       [Controls.Type]: new FormControl(''),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the pattern used to validate cluster names during cluster creation to the [same one](https://github.com/kubermatic/dashboard/blob/b062244f8645f14f9cdb015fa63d236141fde013/src/app/cluster/cluster-details/edit-cluster/component.ts#L67) that is used when editing the cluster.

**Which issue(s) this PR fixes** 
This fixes a bug where it is possible to create a cluster that can't be edited later.

```release-note
NONE
```
