### PR TITLE
Assign correct label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug encountered while operating Kubermatic Dashboard
-labels: kind/bug, team/ui
+labels: kind/bug, sig/ui
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/cleanup.md
+++ b/.github/ISSUE_TEMPLATE/cleanup.md
@@ -1,7 +1,7 @@
 ---
 name: Cleanup Request
 about: Suggest code cleanups (refactorings, removal of unused code,...) to the Kubermatic Dashboard project
-labels: kind/cleanup, team/ui
+labels: kind/cleanup, sig/ui
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/design-change.md
+++ b/.github/ISSUE_TEMPLATE/design-change.md
@@ -1,7 +1,7 @@
 ---
 name: UI/UX Change Suggestion
 about: Suggest changes and fixes to the UI 
-labels: kind/design, team/ui
+labels: kind/design, sig/ui
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -1,7 +1,7 @@
 ---
 name: Design Draft Request
 about: Request an UI draft for Kubermatic Kubernetes Platform 
-labels: kind/design, team/ui
+labels: kind/design, sig/ui
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,7 +1,7 @@
 ---
 name: Failing Test
 about: Report test failures in Kubermatic Dashboard CI jobs
-labels: kind/bug, testing, team/ui
+labels: kind/bug, testing, sig/ui
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Suggest an feature to the Kubermatic Dashboard project
-labels: kind/feature, team/ui
+labels: kind/feature, sig/ui
 
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of team/ui assign correct label sig/ui to new issues

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
