### PR TITLE
Update to Go 1.16.1

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
     preset-goproxy: "true"
   spec:
     containers:
-      - image: golang:1.15.2
+      - image: golang:1.16.1
         command:
           - make
           - verify-go
@@ -39,7 +39,7 @@ presubmits:
   clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
   spec:
     containers:
-      - image: quay.io/kubermatic/chrome-headless:v0.6
+      - image: quay.io/kubermatic/chrome-headless:v0.7
         command:
           - make
           - test-headless
@@ -79,7 +79,7 @@ presubmits:
     preset-kubeconfig-ci: "true"
   spec:
     containers:
-      - image: quay.io/kubermatic/e2e-kind-cypress:v1.3.0
+      - image: quay.io/kubermatic/e2e-kind-cypress:v1.4.0
         command:
           - make
           - run-e2e-ci
@@ -121,7 +121,7 @@ presubmits:
     preset-kubeconfig-ci: "true"
   spec:
     containers:
-      - image: quay.io/kubermatic/e2e-kind-cypress:v1.3.0
+      - image: quay.io/kubermatic/e2e-kind-cypress:v1.4.0
         command:
           - make
           - run-e2e-ci
@@ -152,7 +152,7 @@ presubmits:
     preset-goproxy: "true"
   spec:
     containers:
-      - image: quay.io/kubermatic/go-docker-node:v1.3.1
+      - image: quay.io/kubermatic/go-docker-node:v1.4.0
         command:
           - /bin/bash
           - -c

--- a/containers/custom-dashboard/Dockerfile
+++ b/containers/custom-dashboard/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/go-node:1.15.2-14
+FROM quay.io/kubermatic/go-node:1.16.1-14
 
 LABEL maintainer="sebastian@loodse.com"
 

--- a/containers/cypress/Dockerfile
+++ b/containers/cypress/Dockerfile
@@ -12,11 +12,11 @@
 FROM ubuntu:16.04 AS download
 
 ENV HELM2_VERSION="v2.17.0"
-ENV HELM3_VERSION="v3.4.2"
-ENV VAULT_VERSION="1.6.1"
+ENV HELM3_VERSION="v3.5.3"
+ENV VAULT_VERSION="1.6.3"
 ENV KIND_VERSION="v0.8.1"
 ENV YQ_VERSION="3.3.2"
-ENV KUBECTL_VERSION="v1.19.7"
+ENV KUBECTL_VERSION="v1.20.4"
 
 RUN apt-get update && \
     apt-get install -y unzip curl && \
@@ -53,7 +53,7 @@ COPY --from=download /usr/local/bin/yq /usr/local/bin/yq
 COPY --from=download /usr/local/bin/kind /usr/local/bin/kind
 COPY --from=download /usr/local/bin/vault /usr/local/bin/vault
 
-ENV GO_VERSION=1.15.2
+ENV GO_VERSION=1.16.1
 
 RUN apt-get update -qq && \
     apt-get install -y \

--- a/containers/cypress/build-and-release.sh
+++ b/containers/cypress/build-and-release.sh
@@ -14,7 +14,7 @@ set -e
 
 IMG_REPO="quay.io/kubermatic"
 IMG_NAME="e2e-kind-cypress"
-IMG_VERSION="v1.3.0"
+IMG_VERSION="v1.4.0"
 
 # preload node image (this has to match the kind version;
 # each kind release specifies the default node image)

--- a/containers/go-node/Dockerfile
+++ b/containers/go-node/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15.2
+FROM golang:1.16.1
 
 LABEL maintainer="sebastian.florek@loodse.com"
 

--- a/containers/go-node/build-and-release.sh
+++ b/containers/go-node/build-and-release.sh
@@ -14,7 +14,7 @@ set -e
 
 IMG_REPO="quay.io/kubermatic"
 IMG_NAME="go-node"
-IMG_VERSION="1.15.2-14"
+IMG_VERSION="1.16.1-14"
 
 docker build -t ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION} .
 docker push ${IMG_REPO}/${IMG_NAME}:${IMG_VERSION}

--- a/containers/test-chrome/Dockerfile
+++ b/containers/test-chrome/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15.2
+FROM golang:1.16.1
 
 RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
     && curl -sL https://deb.nodesource.com/setup_14.x | bash - \

--- a/containers/test-chrome/release.sh
+++ b/containers/test-chrome/release.sh
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v0.6
+TAG=v0.7
 
 set -euox pipefail
 


### PR DESCRIPTION
**What this PR does / why we need it**:
:tada:

**Release note**:
```release-note
NONE
```
