### PR TITLE
adjust .prow.yaml to recent cleanup efforts

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -173,4 +173,4 @@ presubmits:
             cpu: 1
             memory: 3Gi
     imagePullSecrets:
-      - name: quay
+      - name: kubermatic-quay


### PR DESCRIPTION
**What this PR does / why we need it**:
sig-infra is cleaning up Secrets in the CI cluster, and `quay` is now deprecated and `kubermatic-quay` should be used instead.

**Release note**:
```release-note
NONE
```
