### PR TITLE
can configure autoscaling options

### DIFF
--- a/src/app/cluster/cluster-details/machine-deployment-details/template.html
+++ b/src/app/cluster/cluster-details/machine-deployment-details/template.html
@@ -64,6 +64,18 @@ limitations under the License.
                  matTooltip="Number of available machines may be higher than number of desired machines from the template if deployment is updating."></div>
           </div>
         </km-property>
+        <km-property *ngIf="machineDeployment.spec.minReplicas">
+          <div key>Min Replicas</div>
+          <div value>
+            <span>{{machineDeployment.spec.minReplicas}}</span>
+          </div>
+        </km-property>
+        <km-property *ngIf="machineDeployment.spec.maxReplicas">
+          <div key>Max Replicas</div>
+          <div value>
+            <span>{{machineDeployment.spec.maxReplicas}}</span>
+          </div>
+        </km-property>
         <km-property>
           <div key>Paused</div>
           <div value>{{machineDeployment.spec.paused}}</div>

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -31,6 +31,8 @@ export class NodeService {
       spec: {
         template: nodeData.spec,
         replicas: nodeData.count,
+        minReplicas: nodeData.minReplicas,
+        maxReplicas: nodeData.maxReplicas,
         dynamicConfig: nodeData.dynamicConfig,
       },
     };

--- a/src/app/node-data/style.scss
+++ b/src/app/node-data/style.scss
@@ -17,6 +17,10 @@ div.km-os-options {
   margin: 0 0 10px;
 }
 
+mat-checkbox.km-use-autoscaling {
+  margin-bottom: 10px;
+}
+
 mat-button-toggle-group[group='operatingSystemGroup'] {
   flex-wrap: wrap;
 

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -48,7 +48,13 @@ limitations under the License.
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field>
+    <mat-checkbox [formControlName]="Controls.UseAutoscaling"
+                  class="km-use-autoscaling"
+                  fxFlex>
+      Use Horizontal Node Autoscaling
+    </mat-checkbox>
+
+    <mat-form-field *ngIf="!form.get(Controls.UseAutoscaling).value">
       <mat-label>Replicas</mat-label>
       <input [formControlName]="Controls.Count"
              id="km-node-count-input"
@@ -60,6 +66,33 @@ limitations under the License.
       <mat-error *ngIf="form.get(Controls.Count).hasError('required')">Number of replicas is required.</mat-error>
       <mat-error *ngIf="form.get(Controls.Count).hasError('ipsMissing')">
         Not enough IPs left. Reduce number of replicas or add more machine networks.
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field fxFlex
+                    *ngIf="form.get(Controls.UseAutoscaling).value">
+      <mat-label>Min Replicas*</mat-label>
+      <input [formControlName]="Controls.MinReplicas"
+             id="km-node-min-replicas-input"
+             matInput
+             type="number"
+             min="0"
+             autocomplete="off">
+    </mat-form-field>
+
+    <mat-form-field fxFlex
+                    *ngIf="form.get(Controls.UseAutoscaling).value">
+      <mat-label>Max Replicas</mat-label>
+      <input [formControlName]="Controls.MaxReplicas"
+             id="km-node-max-replicas-input"
+             matInput
+             type="number"
+             min="0"
+             min="1"
+             autocomplete="off">
+      <mat-error *ngIf="form.get(Controls.MaxReplicas).hasError('min')">Must be greater or equal 1.</mat-error>
+      <mat-error *ngIf="form.get(Controls.MaxReplicas).hasError('lessThanMin')">
+        Must be greater or equal to min replicas.
       </mat-error>
     </mat-form-field>
 

--- a/src/app/shared/entity/machine-deployment.ts
+++ b/src/app/shared/entity/machine-deployment.ts
@@ -22,6 +22,8 @@ export class MachineDeployment {
 
 export class MachineDeploymentSpec {
   replicas: number;
+  minReplicas?: number;
+  maxReplicas?: number;
   template: NodeSpec;
   paused?: boolean;
   dynamicConfig?: boolean;

--- a/src/app/shared/model/NodeSpecChange.ts
+++ b/src/app/shared/model/NodeSpecChange.ts
@@ -15,6 +15,8 @@ export class NodeData {
   name?: string;
   spec?: NodeSpec;
   count?: number;
+  minReplicas?: number;
+  maxReplicas?: number;
   valid?: boolean;
   dynamicConfig?: boolean;
 

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -163,6 +163,8 @@ export class WizardComponent implements OnInit, OnDestroy {
         spec: {
           template: nodeData.spec,
           replicas: nodeData.count,
+          minReplicas: nodeData.minReplicas,
+          maxReplicas: nodeData.maxReplicas,
           dynamicConfig: nodeData.dynamicConfig,
         },
       },


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds autoscaling options in machine deploymens, so users can set min/max replicas

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially Fixes https://github.com/kubermatic/kubermatic/issues/6507
Related API changes https://github.com/kubermatic/kubermatic/pull/6596

**Special notes for your reviewer**:
Right now I display autoscaler controls to any cluster. Should we add a condition for displaying them? Like if it certain type of cluster or check if autoscaler is deployed. What approach would you suggest?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
* Add autoscaler options in machine deployment
```
