### PR TITLE
Add e2e tests for ssh keys

### DIFF
--- a/cypress/integration/stories/node-deployment.spec.ts
+++ b/cypress/integration/stories/node-deployment.spec.ts
@@ -106,7 +106,7 @@ describe('DigitalOcean Provider', () => {
     ClustersPage.getMachineDeploymentList().should(Condition.Contain, initialMachineDeploymentName);
 
     ClustersPage.getMachineDeploymentRemoveBtn(initialMachineDeploymentName).click();
-    ClustersPage.getDeleteMachineDeploymentDialogBtn().click();
+    ClustersPage.getDeleteDialogConfirmButton().click();
     ClustersPage.getTableRowMachineDeploymentNameColumn(initialMachineDeploymentName).should(Condition.NotExist);
   });
 

--- a/cypress/integration/stories/ssh-keys.spec.ts
+++ b/cypress/integration/stories/ssh-keys.spec.ts
@@ -1,0 +1,116 @@
+// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ClustersPage, ProviderMenuOption} from '../../pages/clusters.po';
+import {ProjectsPage} from '../../pages/projects.po';
+import {SSHKeysPage} from '../../pages/ssh-keys.po';
+import {WizardPage} from '../../pages/wizard.po';
+import {login, logout} from '../../utils/auth';
+import {Condition} from '../../utils/condition';
+import {Datacenter, Provider} from '../../utils/provider';
+import {prefixedString} from '../../utils/random';
+import {View} from '../../utils/view';
+import {WizardStep} from '../../utils/wizard';
+
+describe('SSH Key Management Story', () => {
+  const email = Cypress.env('KUBERMATIC_DEX_DEV_E2E_USERNAME');
+  const password = Cypress.env('KUBERMATIC_DEX_DEV_E2E_PASSWORD');
+  const projectName = prefixedString('e2e-test-project');
+  const clusterName = prefixedString('e2e-test-cluster');
+  const sshKeyName = 'test-ssh-key';
+  const sshKeyPublic =
+    'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCo/3xm3JmJ7rp7I6GNYvjySYlWIGe75Oyr/u2cv5Fv2vsqfsiAP2xvIrJKxQ3+LwZAo0JnTvNQ' +
+    'bVKo+G6pV1HEXhRlPuLuKWtkKCJue0wJXnIUz3dSniQDSIovjM+j5FUQauE3KeVgII2SQ7vVIKJcpFNVoA6cUjCeV8S9IHndOERzbBMhFe2sI3Ej' +
+    'HSYSw2PCyXrUvDWBFjeUEV9jr3TJHLs7ea0bXJj+SA5o4nw/XOCqnoJsnBZa+I3KIAiHgV779R3XGlWZ1aD0ow4y3UzXy2U+aKKPBEoXFmKAKezt' +
+    'vopqZemjIGzQT8Bgu1inXcwMfo3sB5bYMDnnP3Wyn/gz';
+
+  it('should login', () => {
+    login(email, password);
+    cy.url().should(Condition.Include, View.Projects);
+  });
+
+  it('should create a new project', () => {
+    ProjectsPage.addProject(projectName);
+  });
+
+  it('should select project', () => {
+    ProjectsPage.selectProject(projectName);
+  });
+
+  it('should go to the ssh keys page', () => {
+    SSHKeysPage.visit();
+  });
+
+  it('should create the ssh key', () => {
+    SSHKeysPage.getAddSSHKeyButton().click();
+    SSHKeysPage.getAddSSHKeyNameInput().type(sshKeyName);
+    SSHKeysPage.getAddSSHKeyTextarea()
+      .click()
+      .then($element => {
+        $element.text(sshKeyPublic);
+        $element.val(sshKeyPublic);
+        cy.get($element).type(' {backspace}');
+      });
+    SSHKeysPage.getAddSSHKeySaveButton().click();
+
+    SSHKeysPage.getTable().should(Condition.Contain, sshKeyName);
+  });
+
+  it('should create the cluster with ssh key', () => {
+    ClustersPage.visit();
+    ClustersPage.openWizard();
+    WizardPage.getProviderBtn(Provider.BringYourOwn).click();
+    WizardPage.getDatacenterBtn(Datacenter.BringYourOwn.Frankfurt).click();
+    WizardPage.getClusterNameInput().type(clusterName).should(Condition.HaveValue, clusterName);
+    WizardPage.getSSHKeysSelect().click();
+    WizardPage.getSSHKeysSelectOption(sshKeyName).click();
+    WizardPage.getOverlayContainer().click();
+    WizardPage.getNextBtn(WizardStep.Cluster).click();
+    WizardPage.getCreateBtn().click({force: true});
+
+    ClustersPage.verifyUrl();
+  });
+
+  it('should remove the ssh key from the cluster', () => {
+    ClustersPage.getProviderMenuButton().click();
+    ClustersPage.getProviderMenuOption(ProviderMenuOption.ManageSSHKeys).click();
+    ClustersPage.getSSHKeysTableRemoveButton(sshKeyName).click();
+    ClustersPage.getDeleteDialogConfirmButton().click();
+    ClustersPage.getSSHKeysTableRow(sshKeyName).should(Condition.NotExist);
+  });
+
+  it('should re-add the ssh key to the cluster', () => {
+    ClustersPage.getSSHKeysAddDropdown().click();
+    ClustersPage.getSSHKeysDropdownOption(sshKeyName).click();
+    ClustersPage.getSSHKeysTableRow(sshKeyName).should(Condition.Exist);
+    ClustersPage.getDialogCloseButton().click();
+  });
+
+  it('should delete the ssh key', () => {
+    SSHKeysPage.visit();
+    SSHKeysPage.getDeleteSSHKeyButton(sshKeyName).click();
+    SSHKeysPage.getDeleteSSHKeyConfirmationButton().click();
+
+    SSHKeysPage.getTable().should(Condition.NotContain, sshKeyName);
+  });
+
+  it('should go to the projects page', () => {
+    ProjectsPage.visit();
+  });
+
+  it('should delete the project', () => {
+    ProjectsPage.deleteProject(projectName);
+  });
+
+  it('should logout', () => {
+    logout();
+  });
+});

--- a/cypress/pages/clusters.po.ts
+++ b/cypress/pages/clusters.po.ts
@@ -15,6 +15,12 @@ import {RequestType, TrafficMonitor} from '../utils/monitor';
 import {View} from '../utils/view';
 import {WizardPage} from './wizard.po';
 
+export enum ProviderMenuOption {
+  EditCluster = 'Edit Cluster',
+  ManageSSHKeys = 'Manage SSH keys',
+  RevokeToken = 'Revoke Token',
+}
+
 export class ClustersPage {
   static getAddClusterBtn(): Cypress.Chainable {
     return cy.get('#km-add-cluster-top-btn');
@@ -52,7 +58,7 @@ export class ClustersPage {
     return this.getTableRow(machineDeploymentName).find('button i.km-icon-delete');
   }
 
-  static getDeleteMachineDeploymentDialogBtn(): Cypress.Chainable {
+  static getDeleteDialogConfirmButton(): Cypress.Chainable {
     return cy.get('#km-confirmation-dialog-confirm-btn');
   }
 
@@ -66,6 +72,38 @@ export class ClustersPage {
 
   static getClusterStatus(): Cypress.Chainable {
     return cy.get('.km-cluster-name').find('i.km-cluster-health');
+  }
+
+  static getProviderMenuButton(): Cypress.Chainable {
+    return cy.get('.km-provider-menu-btn');
+  }
+
+  static getProviderMenuOption(option: ProviderMenuOption): Cypress.Chainable {
+    return cy.get('.km-provider-edit-settings').contains('span', option).parent();
+  }
+
+  static getSSHKeysTable(): Cypress.Chainable {
+    return cy.get('.km-content-edit-sshkeys').find('tbody');
+  }
+
+  static getSSHKeysTableRow(sshKeyName: string): Cypress.Chainable {
+    return this.getSSHKeysTable().contains('td', sshKeyName).parent();
+  }
+
+  static getSSHKeysTableRemoveButton(sshKeyName: string): Cypress.Chainable {
+    return this.getSSHKeysTableRow(sshKeyName).find('button i.km-icon-delete');
+  }
+
+  static getSSHKeysAddDropdown(): Cypress.Chainable {
+    return cy.get('.km-edit-sshkeys-dropdown').should(Condition.NotHaveClass, 'mat-form-field-disabled');
+  }
+
+  static getSSHKeysDropdownOption(name: string): Cypress.Chainable {
+    return cy.get('.km-add-dialog-dropdown').find('mat-option').contains('span', name);
+  }
+
+  static getDialogCloseButton(): Cypress.Chainable {
+    return cy.get('#km-close-dialog-btn');
   }
 
   // Utils.

--- a/cypress/pages/ssh-keys.po.ts
+++ b/cypress/pages/ssh-keys.po.ts
@@ -1,0 +1,84 @@
+// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Condition} from '../utils/condition';
+import {Endpoint} from '../utils/endpoint';
+import {RequestType, TrafficMonitor} from '../utils/monitor';
+import {View} from '../utils/view';
+
+export class SSHKeysPage {
+  static getAddSSHKeyButton(): Cypress.Chainable {
+    return cy.get('#km-add-ssh-key-top-btn');
+  }
+
+  static getAddSSHKeyNameInput(): Cypress.Chainable {
+    return cy.get('#name');
+  }
+
+  static getAddSSHKeyTextarea(): Cypress.Chainable {
+    return cy.get('#key');
+  }
+
+  static getAddSSHKeySaveButton(): Cypress.Chainable {
+    return cy.get('#km-add-ssh-key-dialog-save');
+  }
+
+  static getDeleteSSHKeyButton(name: string): Cypress.Chainable {
+    return cy.get(`#km-delete-sshkey-${name}`);
+  }
+
+  static getDeleteSSHKeyConfirmationButton(): Cypress.Chainable {
+    return cy.get('#km-confirmation-dialog-confirm-btn');
+  }
+
+  static getTable(): Cypress.Chainable {
+    return cy.get('tbody');
+  }
+
+  static getTableRow(name: string): Cypress.Chainable {
+    return cy.get('td').contains(name).parent();
+  }
+
+  // Utils.
+
+  static waitForRefresh(): void {
+    TrafficMonitor.newTrafficMonitor().method(RequestType.GET).url(Endpoint.SSHKeys).wait();
+  }
+
+  static verifyUrl(): void {
+    cy.url().should(Condition.Include, View.SSHKeys);
+  }
+
+  static visit(): void {
+    cy.get('#km-nav-item-sshkeys')
+      .click()
+      .then(() => {
+        this.waitForRefresh();
+        this.verifyUrl();
+      });
+  }
+
+  static addServiceAccount(name: string, sshKeyPublic: string): void {
+    this.getAddSSHKeyButton().should(Condition.NotBe, 'disabled').click();
+    this.getAddSSHKeyNameInput().type(name).should(Condition.HaveValue, name);
+    this.getAddSSHKeyTextarea().type(sshKeyPublic).should(Condition.HaveValue, sshKeyPublic);
+    this.getAddSSHKeySaveButton().should(Condition.NotBe, 'disabled').click();
+    this.waitForRefresh();
+    this.getTable().should(Condition.Contain, name);
+  }
+
+  static deleteServiceAccount(name: string): void {
+    this.getDeleteSSHKeyButton(name).should(Condition.NotBe, 'disabled').click();
+    this.getDeleteSSHKeyConfirmationButton().should(Condition.NotBe, 'disabled').click();
+    this.waitForRefresh();
+    this.getTable().should(Condition.NotContain, name);
+  }
+}

--- a/cypress/pages/wizard.po.ts
+++ b/cypress/pages/wizard.po.ts
@@ -82,6 +82,24 @@ export class WizardPage {
     return cy.get('#km-node-count-input');
   }
 
+  static getSSHKeysSelect(): Cypress.Chainable {
+    return cy.get('#keys');
+  }
+
+  static getSSHKeysSelectOption(name: string): Cypress.Chainable {
+    return cy.get('#keys-panel').then(option => {
+      if (option.find('mat-option').text(name).length > 0) {
+        return cy.get('mat-option').contains(name);
+      }
+
+      return cy.get('mat-option');
+    });
+  }
+
+  static getOverlayContainer(): Cypress.Chainable {
+    return cy.get('.cdk-overlay-backdrop');
+  }
+
   // Providers
   static readonly anexia = Anexia;
   static readonly kubeVirt = KubeVirt;

--- a/cypress/utils/condition.ts
+++ b/cypress/utils/condition.ts
@@ -15,6 +15,7 @@ export enum Condition {
   Exist = 'exist',
   HaveAttribute = 'have.attr',
   HaveClass = 'have.class',
+  NotHaveClass = 'not.have.class',
   HaveLength = 'have.length',
   HaveValue = 'have.value',
   Include = 'include',

--- a/cypress/utils/condition.ts
+++ b/cypress/utils/condition.ts
@@ -15,7 +15,6 @@ export enum Condition {
   Exist = 'exist',
   HaveAttribute = 'have.attr',
   HaveClass = 'have.class',
-  NotHaveClass = 'not.have.class',
   HaveLength = 'have.length',
   HaveValue = 'have.value',
   Include = 'include',

--- a/cypress/utils/endpoint.ts
+++ b/cypress/utils/endpoint.ts
@@ -21,4 +21,5 @@ export namespace Endpoint {
   export const Tokens = '**/tokens';
   export const ServiceAccounts = '**/serviceaccounts';
   export const Settings = '**/me/settings';
+  export const SSHKeys = '**/sshkeys';
 }

--- a/cypress/utils/view.ts
+++ b/cypress/utils/view.ts
@@ -15,5 +15,6 @@ export enum View {
   Account = 'account',
   Members = 'members',
   ServiceAccounts = 'serviceaccounts',
+  SSHKeys = 'sshkeys',
   Wizard = 'wizard',
 }

--- a/src/app/wizard/step/cluster/ssh-keys/template.html
+++ b/src/app/wizard/step/cluster/ssh-keys/template.html
@@ -17,6 +17,7 @@ limitations under the License.
   <mat-form-field *ngIf="hasKeys()">
     <mat-label>SSH Keys</mat-label>
     <mat-select [formControlName]="Controls.Keys"
+                [id]="Controls.Keys"
                 multiple
                 disableOptionCentering
                 panelClass="km-multiple-values-dropdown"


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a story to test ssh key management.

- Create ssh key
- Create a cluster with created ssh key
- Edit ssh keys from the cluster details:
  - remove the ssh key from the cluster
  - re-add the ssh key to the cluster
- remove ssh key from the project

**Which issue(s) this PR fixes**:
Fixes #2952

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If  no release note is required, just write "NONE".
-->
```release-note
NONE
```
