### PR TITLE
Add validation for token names

### DIFF
--- a/src/app/serviceaccount/token/add/steps/name/component.ts
+++ b/src/app/serviceaccount/token/add/steps/name/component.ts
@@ -14,6 +14,7 @@ import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angula
 import {ServiceAccountTokenDialogService} from '@app/serviceaccount/token/add/steps/service';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import {takeUntil} from 'rxjs/operators';
+import {LabelFormValidators} from '@shared/validators/label-form.validators';
 
 enum Controls {
   Name = 'name',
@@ -49,7 +50,14 @@ export class ServiceAccountTokenNameStepComponent extends BaseFormValidator impl
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Name]: this._builder.control('', Validators.required),
+      [Controls.Name]: this._builder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          LabelFormValidators.labelValueLength,
+          LabelFormValidators.labelValuePattern,
+        ])
+      ),
     });
 
     this.form

--- a/src/app/serviceaccount/token/add/steps/name/template.html
+++ b/src/app/serviceaccount/token/add/steps/name/template.html
@@ -25,5 +25,13 @@ limitations under the License.
            autocomplete="off"
            cdkFocusInitial
            required>
+    <mat-error *ngIf="form.get(controls.Name).errors?.validLabelValuePattern"
+               i18n>
+      Only alphanumeric characters, "." and "-" can be used. "-" and "." cannot be first or last character.
+    </mat-error>
+    <mat-error *ngIf="form.get(controls.Name).errors?.validLabelValueLength"
+               i18n>
+      Name cannot be longer than 63 characters.
+    </mat-error>
   </mat-form-field>
 </form>

--- a/src/app/serviceaccount/token/add/steps/name/template.html
+++ b/src/app/serviceaccount/token/add/steps/name/template.html
@@ -25,11 +25,14 @@ limitations under the License.
            autocomplete="off"
            cdkFocusInitial
            required>
-    <mat-error *ngIf="form.get(controls.Name).errors?.validLabelValuePattern"
+    <mat-error *ngIf="form.get(controls.Name).hasError('required')">
+      Name is <strong>required</strong>.
+    </mat-error>
+    <mat-error *ngIf="form.get(controls.Name).hasError('validLabelValuePattern')"
                i18n>
       Only alphanumeric characters, "." and "-" can be used. "-" and "." cannot be first or last character.
     </mat-error>
-    <mat-error *ngIf="form.get(controls.Name).errors?.validLabelValueLength"
+    <mat-error *ngIf="form.get(controls.Name).hasError('validLabelValueLength')"
                i18n>
       Name cannot be longer than 63 characters.
     </mat-error>


### PR DESCRIPTION
### What this PR does / why we need it
It adds validation for the token names on the frontend side. The methods from label form were reused as the token name is stored in the label in the end.

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3145.

### Special notes for your reviewer
If we would like to change the place where the token name is saved then it would take more time and might even be a breaking change. That's why this fix change doesn't touch that subject.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Added validation for service account token names.
```
