### PR TITLE
Do not delete custom links after pressing enter key

### DIFF
--- a/src/app/settings/admin/custom-link-form/template.html
+++ b/src/app/settings/admin/custom-link-form/template.html
@@ -58,6 +58,7 @@ limitations under the License.
       </mat-form-field>
       <button mat-icon-button
               class="km-custom-links-form-delete-button"
+              type="button"
               [disabled]="!isRemovable(i)"
               (click)="deleteLabel(i)">
         <i class="km-icon-delete"


### PR DESCRIPTION
### What this PR does / why we need it
Preiously enter key was invoking delete button which was by default "submit" type.

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3220.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Do not delete custom links after pressing enter key.
```
