### PR TITLE
Add alibaba e2e and fix wizard issues

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -68,6 +68,7 @@ presubmits:
         base_ref: master
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
+      preset-alibaba: "true"
       preset-anexia: "true"
       preset-aws: "true"
       preset-azure: "true"
@@ -118,6 +119,7 @@ presubmits:
         base_ref: master
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
+      preset-alibaba: "true"
       preset-anexia: "true"
       preset-aws: "true"
       preset-azure: "true"

--- a/cypress/integration/providers/alibaba.spec.ts
+++ b/cypress/integration/providers/alibaba.spec.ts
@@ -1,0 +1,102 @@
+// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ClustersPage} from '../../pages/clusters.po';
+import {ProjectsPage} from '../../pages/projects.po';
+import {WizardPage} from '../../pages/wizard.po';
+import {login, logout} from '../../utils/auth';
+import {Condition} from '../../utils/condition';
+import {Preset} from '../../utils/preset';
+import {Datacenter, Provider} from '../../utils/provider';
+import {prefixedString} from '../../utils/random';
+import {View} from '../../utils/view';
+import {WizardStep} from '../../utils/wizard';
+
+describe('Alibaba Provider', () => {
+  const email = Cypress.env('KUBERMATIC_DEX_DEV_E2E_USERNAME');
+  const password = Cypress.env('KUBERMATIC_DEX_DEV_E2E_PASSWORD');
+  const projectName = prefixedString('e2e-test-project');
+  const clusterName = prefixedString('e2e-test-cluster');
+  const initialMachineDeploymentName = prefixedString('e2e-test-md');
+  const initialMachineDeploymentReplicas = '0';
+
+  it('should login', () => {
+    login(email, password);
+    cy.url().should(Condition.Include, View.Projects);
+  });
+
+  it('should create a new project', () => {
+    ProjectsPage.addProject(projectName);
+  });
+
+  it('should select project', () => {
+    ProjectsPage.selectProject(projectName);
+  });
+
+  it('should go to wizard', () => {
+    ClustersPage.openWizard();
+  });
+
+  it('should create a new cluster', () => {
+    WizardPage.getProviderBtn(Provider.Alibaba).click();
+    WizardPage.getDatacenterBtn(Datacenter.Alibaba.Frankfurt).click();
+    WizardPage.getClusterNameInput().type(clusterName).should(Condition.HaveValue, clusterName);
+    WizardPage.getNextBtn(WizardStep.Cluster).click({force: true});
+    WizardPage.getCustomPresetsCombobox().click();
+    WizardPage.getPreset(Preset.Alibaba).click();
+    WizardPage.getNextBtn(WizardStep.ProviderSettings).click({force: true});
+    WizardPage.getNodeNameInput()
+      .type(initialMachineDeploymentName)
+      .should(Condition.HaveValue, initialMachineDeploymentName);
+    WizardPage.getNodeCountInput()
+      .clear()
+      .type(initialMachineDeploymentReplicas)
+      .should(Condition.HaveValue, initialMachineDeploymentReplicas);
+    WizardPage.getNextBtn(WizardStep.NodeSettings).should(Condition.BeEnabled).click({force: true});
+    WizardPage.getCreateBtn().click({force: true});
+
+    cy.url().should(Condition.Contain, View.Clusters);
+  });
+
+  it('should check if cluster was created', () => {
+    ClustersPage.visit();
+    ClustersPage.getTable().should(Condition.Contain, clusterName);
+  });
+
+  it('should go to cluster details page', () => {
+    ClustersPage.getClusterItem(clusterName).click();
+  });
+
+  it('should wait for the cluster to be ready', () => {
+    ClustersPage.getClusterName().should(Condition.Contain, clusterName);
+    ClustersPage.getClusterStatus().should(Condition.HaveClass, 'km-success-bg');
+  });
+
+  it('should delete created cluster', () => {
+    ClustersPage.deleteCluster(clusterName);
+  });
+
+  it('should verify that there are no clusters', () => {
+    ClustersPage.verifyNoClusters();
+  });
+
+  it('should go to the projects page', () => {
+    ProjectsPage.visit();
+  });
+
+  it('should delete the project', () => {
+    ProjectsPage.deleteProject(projectName);
+  });
+
+  it('should logout', () => {
+    logout();
+  });
+});

--- a/cypress/pages/wizard.po.ts
+++ b/cypress/pages/wizard.po.ts
@@ -14,6 +14,12 @@ import {Preset} from '../utils/preset';
 import {View} from '../utils/view';
 import {WizardStep} from '../utils/wizard';
 
+class Alibaba {
+  static getVSwitchIDInput(): Cypress.Chainable {
+    return cy.get('#vSwitchID');
+  }
+}
+
 class Anexia {
   static getTemplateIDInput(): Cypress.Chainable {
     return cy.get('#templateID');
@@ -103,6 +109,7 @@ export class WizardPage {
   // Providers
   static readonly anexia = Anexia;
   static readonly kubeVirt = KubeVirt;
+  static readonly alibaba = Alibaba;
 
   // Utils
 

--- a/cypress/utils/preset.ts
+++ b/cypress/utils/preset.ts
@@ -10,6 +10,7 @@
 // limitations under the License.
 
 export enum Preset {
+  Alibaba = 'e2e-alibaba',
   Anexia = 'e2e-anexia',
   AWS = 'e2e-aws',
   Azure = 'e2e-azure',

--- a/cypress/utils/provider.ts
+++ b/cypress/utils/provider.ts
@@ -10,6 +10,7 @@
 // limitations under the License.
 
 export enum Provider {
+  Alibaba = 'alibaba',
   Anexia = 'anexia',
   AWS = 'aws',
   Azure = 'azure',
@@ -24,6 +25,10 @@ export enum Provider {
 }
 
 export namespace Datacenter {
+  export enum Alibaba {
+    Frankfurt = 'Frankfurt',
+  }
+
   export enum Anexia {
     Vienna = 'Vienna',
   }

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -303,7 +303,7 @@ metadata:
   namespace: kubermatic
 spec:
   alibaba:
-    accessKeyID: ${ALIBABA_ACCESS_KEY_ID}
+    accessKeyId: ${ALIBABA_ACCESS_KEY_ID}
     accessKeySecret: ${ALIBABA_ACCESS_KEY_SECRET}
 EOF
 retry 2 kubectl apply -f preset-alibaba.yaml

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -294,5 +294,19 @@ spec:
 EOF
 retry 2 kubectl apply -f preset-vsphere.yaml
 
+echodate "Creating UI Alibaba preset..."
+cat <<EOF > preset-alibaba.yaml
+apiVersion: kubermatic.k8s.io/v1
+kind: Preset
+metadata:
+  name: e2e-alibaba
+  namespace: kubermatic
+spec:
+  alibaba:
+    accessKeyID: ${ALIBABA_ACCESS_KEY_ID}
+    accessKeySecret: ${ALIBABA_ACCESS_KEY_SECRET}
+EOF
+retry 2 kubectl apply -f preset-alibaba.yaml
+
 echodate "Applying user..."
 retry 2 kubectl apply -f hack/e2e/fixtures/user.yaml

--- a/src/app/node-data/basic/provider/alibaba/component.ts
+++ b/src/app/node-data/basic/provider/alibaba/component.ts
@@ -85,6 +85,7 @@ export class AlibabaBasicNodeDataComponent extends BaseFormValidator implements 
   diskTypes = this._diskTypes.map(type => ({name: type}));
   selectedDiskType = '';
   vSwitches: string[] = [];
+  isLoadingVSwitches = false;
 
   @ViewChild('instanceTypeCombobox')
   private _instanceTypeCombobox: FilteredComboboxComponent;
@@ -209,6 +210,7 @@ export class AlibabaBasicNodeDataComponent extends BaseFormValidator implements 
   }
 
   private _onVSwitchLoading(): void {
+    this.isLoadingVSwitches = true;
     this._clearVSwitch();
     this._cdr.detectChanges();
   }
@@ -270,9 +272,15 @@ export class AlibabaBasicNodeDataComponent extends BaseFormValidator implements 
   }
 
   private _setDefaultVSwitch(vSwitches: AlibabaVSwitch[]): void {
-    this.vSwitches = _(vSwitches).map('id').sortBy().value();
-    this.form.get(Controls.VSwitchID).setValue({main: this._nodeDataService.nodeData.spec.cloud.alibaba.vSwitchID});
+    this.isLoadingVSwitches = false;
+    this.vSwitches = _.sortBy(vSwitches, it => it.id.toLowerCase()).map(it => it.id);
+    let selectedVSwitch = this._nodeDataService.nodeData.spec.cloud.alibaba.vSwitchID;
 
+    if (!selectedVSwitch && this.vSwitches.length > 0) {
+      selectedVSwitch = this.vSwitches[0];
+    }
+
+    this.form.get(Controls.VSwitchID).setValue({main: selectedVSwitch});
     this._cdr.detectChanges();
   }
 

--- a/src/app/node-data/basic/provider/alibaba/template.html
+++ b/src/app/node-data/basic/provider/alibaba/template.html
@@ -56,6 +56,7 @@ limitations under the License.
 
   <km-autocomplete label="VSwitch ID"
                    [formControlName]="Controls.VSwitchID"
+                   [isLoading]="isLoadingVSwitches"
                    [options]="vSwitches"
                    required="true">
   </km-autocomplete>

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -108,7 +108,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       this._settings = settings;
-      this.form.get(Controls.OPAIntegration).setValue(this._settings.opaOptions.enabled);
+      this.form.get(Controls.OPAIntegration).setValue(this._settings.opaOptions.enabled, {emitEvent: false});
       this._enforce(Controls.OPAIntegration, this._settings.opaOptions.enforced);
     });
 


### PR DESCRIPTION
### What this PR does / why we need it
I have found and fixed a bug in wizard that most likely was introduced with the OPA integration and caused some fields reset after admin settings were updated by someone. Additionally, `vSwitchID` field was not automatically filled out in the wizard.

Both fixes have to be cherry-picked to the v2.17 release branch.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #2942

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
