### PR TITLE
Re-Name Node Deployment to Machine Deployment

### DIFF
--- a/src/app/cluster/cluster-details/cluster-details.component.ts
+++ b/src/app/cluster/cluster-details/cluster-details.component.ts
@@ -262,7 +262,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(
         _ => this._clusterService.onClusterUpdate.next(),
-        _ => this._notificationService.error('There was an error during node deployment creation.')
+        _ => this._notificationService.error('There was an error during machine deployment creation.')
       );
   }
 

--- a/src/app/cluster/cluster-details/machine-deployment-details/machine-deployment-details.component.ts
+++ b/src/app/cluster/cluster-details/machine-deployment-details/machine-deployment-details.component.ts
@@ -202,10 +202,10 @@ export class MachineDeploymentDetailsComponent implements OnInit, OnDestroy {
           this.loadMachineDeployment();
           this.loadNodes();
           this._notificationService.success(
-            `The <strong>${this.machineDeployment.name}</strong> node deployment was updated`
+            `The <strong>${this.machineDeployment.name}</strong> machine deployment was updated`
           );
         },
-        _ => this._notificationService.error('There was an error during node deployment edition.')
+        _ => this._notificationService.error('There was an error during machine deployment edition.')
       );
   }
 

--- a/src/app/cluster/cluster-details/machine-deployment-list/machine-deployment-list.component.ts
+++ b/src/app/cluster/cluster-details/machine-deployment-list/machine-deployment-list.component.ts
@@ -116,10 +116,10 @@ export class MachineDeploymentListComponent implements OnInit, OnChanges, OnDest
       .pipe(take(1))
       .subscribe(
         _ => {
-          this._notificationService.success(`The <strong>${md.name}</strong> node deployment was updated`);
+          this._notificationService.success(`The <strong>${md.name}</strong> machine deployment was updated`);
           this.changeMachineDeployment.emit(md);
         },
-        _ => this._notificationService.error('There was an error during node deployment edition.')
+        _ => this._notificationService.error('There was an error during machine deployment edition.')
       );
   }
 

--- a/src/app/cluster/services/node.service.ts
+++ b/src/app/cluster/services/node.service.ts
@@ -155,7 +155,7 @@ export class NodeService {
                 .pipe(first())
                 .pipe(
                   catchError(() => {
-                    this._notificationService.error('Could not remove the <strong>${md.name}</strong> node deployment');
+                    this._notificationService.error('Could not remove the <strong>${md.name}</strong> machine deployment');
                     return of(false);
                   })
                 );
@@ -168,7 +168,7 @@ export class NodeService {
         flatMap(
           (data: any): Observable<boolean> => {
             if (data) {
-              this._notificationService.success(`The <strong>${md.name}</strong> node deployment was removed`);
+              this._notificationService.success(`The <strong>${md.name}</strong> machine deployment was removed`);
               if (changeEventEmitter) {
                 changeEventEmitter.emit(md);
               }

--- a/src/app/cluster/services/node.service.ts
+++ b/src/app/cluster/services/node.service.ts
@@ -155,7 +155,9 @@ export class NodeService {
                 .pipe(first())
                 .pipe(
                   catchError(() => {
-                    this._notificationService.error('Could not remove the <strong>${md.name}</strong> machine deployment');
+                    this._notificationService.error(
+                      'Could not remove the <strong>${md.name}</strong> machine deployment'
+                    );
                     return of(false);
                   })
                 );

--- a/src/app/node-data/dialog/template.html
+++ b/src/app/node-data/dialog/template.html
@@ -12,7 +12,7 @@ limitations under the License.
 -->
 
 <form [formGroup]="form">
-  <km-dialog-title>{{mode}} Node Deployment</km-dialog-title>
+  <km-dialog-title>{{mode}} Machine Deployment</km-dialog-title>
   <mat-dialog-content class="km-add-node-outer">
     <km-node-data [provider]="provider"
                   [showExtended]="isExtended"
@@ -37,7 +37,7 @@ limitations under the License.
             (click)="onConfirm()"
             [disabled]="form.invalid"
             class="btn btn-primary">
-      {{mode}} Node Deployment
+      {{mode}} Machine Deployment
     </button>
   </mat-dialog-actions>
 </form>


### PR DESCRIPTION
### What this PR does / why we need it
currently on some places the term "Machine Deployment" is used while in
some others "Node Deployment" is used.

This PR fixes this by re-naming everything that is left on "Node
Deployment" to "Machine Deployment"

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Re-Naming every occurrence of "Node Deployment" in the UI to "Machine Deployment"
```
