### PR TITLE
Fix project card headers

### DIFF
--- a/src/app/project/style.scss
+++ b/src/app/project/style.scss
@@ -79,8 +79,12 @@ $project-card-width: 330px;
 
   .mat-card-title {
     line-height: 23px;
-    margin: 0;
+    margin: 0 5px 0 0;
+    overflow: hidden;
     padding: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 185px;
   }
 
   .mat-card-subtitle {

--- a/src/app/project/template.html
+++ b/src/app/project/template.html
@@ -209,7 +209,10 @@ limitations under the License.
            class="km-health-state km-project-cards-status"
            fxFlexAlign=" center"></i>
         <mat-card-title [matTooltip]="getProjectTooltip(project.name)"
-                        [attr.id]="'km-project-name-' + project.name">{{getName(project.name)}}</mat-card-title>
+                        [attr.id]="'km-project-name-' + project.name"
+                        class="card-header">
+          {{project.name}}
+        </mat-card-title>
         <mat-card-subtitle>
           <strong>ID</strong> {{project.id}}
         </mat-card-subtitle>

--- a/src/app/project/template.html
+++ b/src/app/project/template.html
@@ -209,8 +209,7 @@ limitations under the License.
            class="km-health-state km-project-cards-status"
            fxFlexAlign=" center"></i>
         <mat-card-title [matTooltip]="getProjectTooltip(project.name)"
-                        [attr.id]="'km-project-name-' + project.name"
-                        class="card-header">
+                        [attr.id]="'km-project-name-' + project.name">
           {{project.name}}
         </mat-card-title>
         <mat-card-subtitle>


### PR DESCRIPTION
### What this PR does / why we need it
Previously longer names with `-` in it were automatically wrapped and this was causing some visual glitches. I've set `nowrap` and switched to CSS method as it is more stable (not all letters have the same width and this sets limit on div size not letter count).

<img width="1060" alt="Zrzut ekranu 2021-04-28 o 08 55 39" src="https://user-images.githubusercontent.com/2823399/116360140-e6772880-a7ff-11eb-89e5-2b60c0b39ba8.png">

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3271.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
