### PR TITLE
Fix handling of instanceReadyCheckPeriod and instanceReadyCheckTimeout variables

### DIFF
--- a/src/app/node-data/basic/provider/openstack/template.html
+++ b/src/app/node-data/basic/provider/openstack/template.html
@@ -90,12 +90,12 @@ limitations under the License.
     <mat-label>Instance Ready Check Period</mat-label>
     <input [formControlName]="Controls.InstanceReadyCheckPeriod"
            matInput
-           min="0"
+           min="1"
            type="number"
            autocomplete="off">
     <mat-hint>Time in seconds between running a check for instance ready status.</mat-hint>
     <mat-error *ngIf="form.get(Controls.InstanceReadyCheckPeriod).hasError('min')">
-      Instance Ready Check Period has to be at least 0.
+      Instance Ready Check Period has to be at least 1.
     </mat-error>
   </mat-form-field>
 
@@ -103,12 +103,12 @@ limitations under the License.
     <mat-label>Instance Ready Check Timeout</mat-label>
     <input [formControlName]="Controls.InstanceReadyCheckTimeout"
            matInput
-           min="1"
+           min="0"
            type="number"
            autocomplete="off">
-    <mat-hint>Time in seconds to wait for instance to be in ready status before timing out.</mat-hint>
+    <mat-hint>Time in seconds to wait for instance to be in ready status before timing out. Set to 0 to disable timeout.</mat-hint>
     <mat-error *ngIf="form.get(Controls.InstanceReadyCheckTimeout).hasError('min')">
-      Instance Ready Check Timeout has to be at least 1.
+      Instance Ready Check Timeout has to be at least 0.
     </mat-error>
   </mat-form-field>
 </form>

--- a/src/app/node-data/basic/provider/openstack/template.html
+++ b/src/app/node-data/basic/provider/openstack/template.html
@@ -90,19 +90,33 @@ limitations under the License.
     <mat-label>Instance Ready Check Period</mat-label>
     <input [formControlName]="Controls.InstanceReadyCheckPeriod"
            matInput
-           min="1"
+           min="0"
            type="number"
-           autocomplete="off">
+           autocomplete="off"
+           required>
     <mat-hint>Time in seconds between running a check for instance ready status.</mat-hint>
+    <mat-error *ngIf="form.get(Controls.InstanceReadyCheckPeriod).hasError('required')">
+      Instance Ready Check Period is <strong>required</strong>.
+    </mat-error>
+    <mat-error *ngIf="form.get(Controls.InstanceReadyCheckPeriod).hasError('min')">
+      Instance Ready Check Period has to be at least 0.
+    </mat-error>
   </mat-form-field>
 
   <mat-form-field fxFlex>
     <mat-label>Instance Ready Check Timeout</mat-label>
     <input [formControlName]="Controls.InstanceReadyCheckTimeout"
            matInput
-           min="1"
+           min="0"
            type="number"
-           autocomplete="off">
+           autocomplete="off"
+           required>
     <mat-hint>Time in seconds to wait for instance to be in ready status before timing out.</mat-hint>
+    <mat-error *ngIf="form.get(Controls.InstanceReadyCheckTimeout).hasError('required')">
+      Instance Ready Check Timeout is <strong>required</strong>.
+    </mat-error>
+    <mat-error *ngIf="form.get(Controls.InstanceReadyCheckTimeout).hasError('min')">
+      Instance Ready Check Timeout has to be at least 0.
+    </mat-error>
   </mat-form-field>
 </form>

--- a/src/app/node-data/basic/provider/openstack/template.html
+++ b/src/app/node-data/basic/provider/openstack/template.html
@@ -92,8 +92,7 @@ limitations under the License.
            matInput
            min="1"
            type="number"
-           autocomplete="off"
-           required>
+           autocomplete="off">
     <mat-hint>Time in seconds between running a check for instance ready status.</mat-hint>
   </mat-form-field>
 
@@ -103,8 +102,7 @@ limitations under the License.
            matInput
            min="1"
            type="number"
-           autocomplete="off"
-           required>
+           autocomplete="off">
     <mat-hint>Time in seconds to wait for instance to be in ready status before timing out.</mat-hint>
   </mat-form-field>
 </form>

--- a/src/app/node-data/basic/provider/openstack/template.html
+++ b/src/app/node-data/basic/provider/openstack/template.html
@@ -92,12 +92,8 @@ limitations under the License.
            matInput
            min="0"
            type="number"
-           autocomplete="off"
-           required>
+           autocomplete="off">
     <mat-hint>Time in seconds between running a check for instance ready status.</mat-hint>
-    <mat-error *ngIf="form.get(Controls.InstanceReadyCheckPeriod).hasError('required')">
-      Instance Ready Check Period is <strong>required</strong>.
-    </mat-error>
     <mat-error *ngIf="form.get(Controls.InstanceReadyCheckPeriod).hasError('min')">
       Instance Ready Check Period has to be at least 0.
     </mat-error>
@@ -107,16 +103,12 @@ limitations under the License.
     <mat-label>Instance Ready Check Timeout</mat-label>
     <input [formControlName]="Controls.InstanceReadyCheckTimeout"
            matInput
-           min="0"
+           min="1"
            type="number"
-           autocomplete="off"
-           required>
+           autocomplete="off">
     <mat-hint>Time in seconds to wait for instance to be in ready status before timing out.</mat-hint>
-    <mat-error *ngIf="form.get(Controls.InstanceReadyCheckTimeout).hasError('required')">
-      Instance Ready Check Timeout is <strong>required</strong>.
-    </mat-error>
     <mat-error *ngIf="form.get(Controls.InstanceReadyCheckTimeout).hasError('min')">
-      Instance Ready Check Timeout has to be at least 0.
+      Instance Ready Check Timeout has to be at least 1.
     </mat-error>
   </mat-form-field>
 </form>

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -245,6 +245,8 @@ export function getDefaultNodeProviderSpec(provider: string): object {
         image: '',
         useFloatingIP: false,
         tags: {},
+        instanceReadyCheckPeriod: '5s',
+        instanceReadyCheckTimeout: '120s',
       } as OpenstackNodeSpec;
     case NodeProvider.VSPHERE:
       return {


### PR DESCRIPTION
### What this PR does / why we need it

- [x] fixes defaulting in the existing clusters
- [x] sets proper min values (0 and 1) and adds error messages for values out of range
- [x] makes both variables optional (will be defaulted by MC)

See:
- https://github.com/kubermatic/kubermatic/blob/master/pkg/api/v1/types.go#L1408
- https://github.com/kubermatic/machine-controller/blob/master/pkg/cloudprovider/provider/openstack/provider.go#L188-L205
- https://github.com/kubermatic/machine-controller/blob/master/pkg/cloudprovider/provider/openstack/provider.go#L207-L223

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3382.

### Release note
```release-note
NONE
```
