### PR TITLE
bumped dashboard to 2.17.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ ifeq (${HUMAN_VERSION},)
 	TARGET_BRANCH=$(or ${PULL_BASE_REF},${CURRENT_BRANCH})
 
 	ifeq (${TARGET_BRANCH},master)
-	HUMAN_VERSION=v2.17.0-dev-g$(shell git rev-parse --short HEAD)
+	HUMAN_VERSION=v2.17.1-dev-g$(shell git rev-parse --short HEAD)
 	else
-	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.17.0-dev-g$(shell git rev-parse --short HEAD))
+	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.17.1-dev-g$(shell git rev-parse --short HEAD))
 	endif
 endif
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "v2.17.0",
+  "version": "v2.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "private": true,
-  "version": "v2.17.0",
+  "version": "v2.17.1",
   "description": "Kubermatic Dashboard",
   "repository": "https://github.com/kubermatic/dashboard",
   "license": "proprietary",


### PR DESCRIPTION
### What this PR does / why we need it
Bump dashboard release 2.17.0 to 2.17.1

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
