### PR TITLE
Clarify PV cleanup during cluster delete

### DIFF
--- a/src/app/cluster/cluster-details/cluster-delete-confirmation/template.html
+++ b/src/app/cluster/cluster-details/cluster-delete-confirmation/template.html
@@ -40,7 +40,7 @@ limitations under the License.
     <div class="km-delete-cluster-checkbox"
          [matTooltip]="getCheckboxTooltip()">
       <mat-checkbox formControlName="clusterVolumeCleanupCheckbox"
-                    id="km-delete-cluster-volume-cleanup">Cleanup connected volumes (PVs and PVCs)</mat-checkbox>
+                    id="km-delete-cluster-volume-cleanup">Cleanup connected volumes (dynamically provisioned PVs and PVCs)</mat-checkbox>
     </div>
 
     <div class="km-dialog-warning"


### PR DESCRIPTION
### What this PR does / why we need it
https://github.com/kubermatic/kubermatic/pull/7189
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#retain

Our cluster cleanup algorithm can still leave some residual volumes in the cloud provider. Deleting dynamically provisioned `PVs` bypasses kubernetes triggers for remote volumes cleanup. Mostly we leverage dynamically provisioned `PVs`, at which point we can rely on the CSI plugins and cloud providers to do their job. For statically provisioned `PVs` that have `retain` as their `ReclaimPolicy`, we can't do much and need to leave it to the user to cleanup the volumes in the cloud provider manually.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Special notes for your reviewer
<!-- Remove if not needed -->
I didn't want to overload the message here by adding all the context explained above, but I think it might be worth adding a better explanation than what I am proposing, I am open to suggestions.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
