### PR TITLE
Fix custom link icon display in the sidenav

### DIFF
--- a/src/app/core/components/sidenav/style.scss
+++ b/src/app/core/components/sidenav/style.scss
@@ -38,6 +38,7 @@ $sidenav-item-margin: 10px;
       i {
         @include size(24px);
 
+        background-size: contain;
         margin-right: 20px;
 
         &.km-icon-arrow-left {


### PR DESCRIPTION
### What this PR does / why we need it
<img width="273" alt="Zrzut ekranu 2021-06-15 o 12 15 36" src="https://user-images.githubusercontent.com/2823399/122036075-720a4000-cdd3-11eb-8507-99bdd10db6a6.png">

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3435.

### Release note
```release-note
Fixed custom link icon display in the sidenav.
```
