### PR TITLE
Add support for app credentials to the openstack provider

### DIFF
--- a/src/app/core/services/node-data/provider/openstack.ts
+++ b/src/app/core/services/node-data/provider/openstack.ts
@@ -50,6 +50,10 @@ export class NodeDataOpenstackProvider {
                 .domain(this._clusterSpecService.cluster.spec.cloud.openstack.domain)
                 .username(this._clusterSpecService.cluster.spec.cloud.openstack.username)
                 .password(this._clusterSpecService.cluster.spec.cloud.openstack.password)
+                .applicationCredentialID(this._clusterSpecService.cluster.spec.cloud.openstack.applicationCredentialID)
+                .applicationCredentialPassword(
+                  this._clusterSpecService.cluster.spec.cloud.openstack.applicationCredentialSecret
+                )
                 .tenant(this._clusterSpecService.cluster.spec.cloud.openstack.tenant)
                 .tenantID(this._clusterSpecService.cluster.spec.cloud.openstack.tenantID)
                 .datacenter(this._clusterSpecService.cluster.spec.cloud.dc)
@@ -104,6 +108,10 @@ export class NodeDataOpenstackProvider {
                 .domain(this._clusterSpecService.cluster.spec.cloud.openstack.domain)
                 .username(this._clusterSpecService.cluster.spec.cloud.openstack.username)
                 .password(this._clusterSpecService.cluster.spec.cloud.openstack.password)
+                .applicationCredentialID(this._clusterSpecService.cluster.spec.cloud.openstack.applicationCredentialID)
+                .applicationCredentialPassword(
+                  this._clusterSpecService.cluster.spec.cloud.openstack.applicationCredentialSecret
+                )
                 .tenant(this._clusterSpecService.cluster.spec.cloud.openstack.tenant)
                 .tenantID(this._clusterSpecService.cluster.spec.cloud.openstack.tenantID)
                 .datacenter(this._clusterSpecService.cluster.spec.cloud.dc)

--- a/src/app/core/services/wizard/provider/openstack.ts
+++ b/src/app/core/services/wizard/provider/openstack.ts
@@ -10,7 +10,14 @@
 // limitations under the License.
 
 import {HttpClient} from '@angular/common/http';
-import {OpenstackAvailabilityZone, OpenstackFlavor, OpenstackNetwork, OpenstackSecurityGroup, OpenstackSubnet, OpenstackTenant,} from '@shared/entity/provider/openstack';
+import {
+  OpenstackAvailabilityZone,
+  OpenstackFlavor,
+  OpenstackNetwork,
+  OpenstackSecurityGroup,
+  OpenstackSubnet,
+  OpenstackTenant,
+} from '@shared/entity/provider/openstack';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {EMPTY, Observable} from 'rxjs';
 import {Provider} from './provider';

--- a/src/app/core/services/wizard/provider/openstack.ts
+++ b/src/app/core/services/wizard/provider/openstack.ts
@@ -10,23 +10,17 @@
 // limitations under the License.
 
 import {HttpClient} from '@angular/common/http';
-import {EMPTY, Observable} from 'rxjs';
+import {OpenstackAvailabilityZone, OpenstackFlavor, OpenstackNetwork, OpenstackSecurityGroup, OpenstackSubnet, OpenstackTenant,} from '@shared/entity/provider/openstack';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
+import {EMPTY, Observable} from 'rxjs';
 import {Provider} from './provider';
-import {
-  OpenstackAvailabilityZone,
-  OpenstackFlavor,
-  OpenstackNetwork,
-  OpenstackSecurityGroup,
-  OpenstackSubnet,
-  OpenstackTenant,
-} from '@shared/entity/provider/openstack';
 
 export class Openstack extends Provider {
   private readonly _tenantsUrl = `${this._restRoot}/providers/openstack/tenants`;
   private readonly _securityGroupsUrl = `${this._restRoot}/providers/openstack/securitygroups`;
   private readonly _networksUrl = `${this._restRoot}/providers/openstack/networks`;
   private readonly _availabilityZonesUrl = `${this._restRoot}/providers/openstack/availabilityzones`;
+  private _usingApplicationCredentials = false;
 
   constructor(http: HttpClient, provider: NodeProvider) {
     super(http, provider);
@@ -35,8 +29,7 @@ export class Openstack extends Provider {
       Openstack.Header.Username,
       Openstack.Header.Password,
       Openstack.Header.Domain,
-      Openstack.Header.Datacenter,
-      Openstack.Header.Tenant
+      Openstack.Header.Datacenter
     );
   }
 
@@ -55,6 +48,22 @@ export class Openstack extends Provider {
   password(password: string): Openstack {
     if (password) {
       this._headers = this._headers.set(Openstack.Header.Password, password);
+    }
+    return this;
+  }
+
+  applicationCredentialID(id: string): Openstack {
+    if (id) {
+      this._usingApplicationCredentials = true;
+      this._headers = this._headers.set(Openstack.Header.ApplicationCredentialID, id);
+    }
+    return this;
+  }
+
+  applicationCredentialPassword(password: string): Openstack {
+    if (password) {
+      this._usingApplicationCredentials = true;
+      this._headers = this._headers.set(Openstack.Header.ApplicationCredentialSecret, password);
     }
     return this;
   }
@@ -82,13 +91,22 @@ export class Openstack extends Provider {
 
   tenantID(tenantID: string): Openstack {
     if (tenantID) {
-      this._changeRequiredHeader(Openstack.Header.Tenant, Openstack.Header.TenantID);
       this._headers = this._headers.set(Openstack.Header.TenantID, tenantID);
     }
     return this;
   }
 
   flavors(onLoadingCb: () => void = null): Observable<OpenstackFlavor[]> {
+    if (this._usingApplicationCredentials) {
+      this._setRequiredHeaders(
+        Openstack.Header.ApplicationCredentialID,
+        Openstack.Header.ApplicationCredentialSecret,
+        Openstack.Header.Datacenter
+      );
+
+      this._cleanupOptionalHeaders();
+    }
+
     if (!this._hasRequiredHeaders()) {
       return EMPTY;
     }
@@ -103,12 +121,16 @@ export class Openstack extends Provider {
   }
 
   tenants(onLoadingCb: () => void = null): Observable<OpenstackTenant[]> {
-    this._setRequiredHeaders(
-      Openstack.Header.Username,
-      Openstack.Header.Password,
-      Openstack.Header.Domain,
-      Openstack.Header.Datacenter
-    );
+    if (this._usingApplicationCredentials) {
+      this._setRequiredHeaders(
+        Openstack.Header.ApplicationCredentialID,
+        Openstack.Header.ApplicationCredentialSecret,
+        Openstack.Header.Datacenter
+      );
+
+      this._cleanupOptionalHeaders();
+    }
+
     if (!this._hasRequiredHeaders()) {
       return EMPTY;
     }
@@ -123,6 +145,16 @@ export class Openstack extends Provider {
   }
 
   securityGroups(onLoadingCb: () => void = null): Observable<OpenstackSecurityGroup[]> {
+    if (this._usingApplicationCredentials) {
+      this._setRequiredHeaders(
+        Openstack.Header.ApplicationCredentialID,
+        Openstack.Header.ApplicationCredentialSecret,
+        Openstack.Header.Datacenter
+      );
+
+      this._cleanupOptionalHeaders();
+    }
+
     if (!this._hasRequiredHeaders()) {
       return EMPTY;
     }
@@ -137,6 +169,16 @@ export class Openstack extends Provider {
   }
 
   networks(onLoadingCb: () => void = null): Observable<OpenstackNetwork[]> {
+    if (this._usingApplicationCredentials) {
+      this._setRequiredHeaders(
+        Openstack.Header.ApplicationCredentialID,
+        Openstack.Header.ApplicationCredentialSecret,
+        Openstack.Header.Datacenter
+      );
+
+      this._cleanupOptionalHeaders();
+    }
+
     if (!this._hasRequiredHeaders()) {
       return EMPTY;
     }
@@ -151,6 +193,16 @@ export class Openstack extends Provider {
   }
 
   subnets(network: string, onLoadingCb: () => void = null): Observable<OpenstackSubnet[]> {
+    if (this._usingApplicationCredentials) {
+      this._setRequiredHeaders(
+        Openstack.Header.ApplicationCredentialID,
+        Openstack.Header.ApplicationCredentialSecret,
+        Openstack.Header.Datacenter
+      );
+
+      this._cleanupOptionalHeaders();
+    }
+
     if (!this._hasRequiredHeaders() || !network) {
       return EMPTY;
     }
@@ -164,6 +216,16 @@ export class Openstack extends Provider {
   }
 
   availabilityZones(onLoadingCb: () => void = null): Observable<OpenstackAvailabilityZone[]> {
+    if (this._usingApplicationCredentials) {
+      this._setRequiredHeaders(
+        Openstack.Header.ApplicationCredentialID,
+        Openstack.Header.ApplicationCredentialSecret,
+        Openstack.Header.Datacenter
+      );
+
+      this._cleanupOptionalHeaders();
+    }
+
     if (!this._hasRequiredHeaders()) {
       return EMPTY;
     }
@@ -182,6 +244,8 @@ export namespace Openstack {
   export enum Header {
     Username = 'Username',
     Password = 'Password',
+    ApplicationCredentialID = 'ApplicationCredentialID',
+    ApplicationCredentialSecret = 'ApplicationCredentialSecret',
     Domain = 'Domain',
     Datacenter = 'DatacenterName',
     Tenant = 'Tenant',

--- a/src/app/core/services/wizard/provider/provider.ts
+++ b/src/app/core/services/wizard/provider/provider.ts
@@ -27,11 +27,8 @@ export abstract class Provider {
     this._requiredHeaders = headers;
   }
 
-  protected _changeRequiredHeader(from: any, to: any): void {
-    const idx = this._requiredHeaders.indexOf(from);
-    if (idx > -1) {
-      this._requiredHeaders[idx] = to;
-    }
+  protected _addRequiredHeader(header: any): void {
+    this._requiredHeaders.push(header);
   }
 
   protected _hasRequiredHeaders(): boolean {
@@ -40,6 +37,14 @@ export abstract class Provider {
       this._requiredHeaders.filter(header => this._headers.keys().includes(header)).length ===
         this._requiredHeaders.length
     );
+  }
+
+  protected _cleanupOptionalHeaders(): void {
+    for (const hKey of this._headers.keys()) {
+      if (!this._requiredHeaders.includes(hKey)) {
+        this._headers = this._headers.delete(hKey);
+      }
+    }
   }
 
   protected _credential(credential: string): void {

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -161,6 +161,9 @@ export class KubeVirtCloudSpec {
 }
 
 export class OpenstackCloudSpec {
+  useToken?: boolean;
+  applicationCredentialID?: string;
+  applicationCredentialSecret?: string;
   username: string;
   password: string;
   tenant: string;

--- a/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
@@ -19,8 +19,8 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
-import {Auth} from '@core/services/auth/service';
 import {AppConfigService} from '@app/config.service';
+import {Auth} from '@core/services/auth/service';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {DatacenterService} from '@core/services/datacenter';
 import {PresetsService} from '@core/services/wizard/presets';
@@ -36,9 +36,9 @@ import {
   debounceTime,
   distinctUntilChanged,
   filter,
-  take,
   map,
   switchMap,
+  take,
   takeUntil,
   tap,
 } from 'rxjs/operators';
@@ -47,6 +47,8 @@ enum Controls {
   Domain = 'domain',
   Username = 'username',
   Password = 'password',
+  ApplicationCredentialID = 'applicationCredentialID',
+  ApplicationCredentialSecret = 'applicationCredentialSecret',
   Project = 'project',
   ProjectID = 'projectID',
   FloatingIPPool = 'floatingIPPool',
@@ -115,6 +117,8 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       [Controls.Domain]: this._builder.control('', Validators.required),
       [Controls.Username]: this._builder.control('', Validators.required),
       [Controls.Password]: this._builder.control('', Validators.required),
+      [Controls.ApplicationCredentialID]: this._builder.control('', Validators.required),
+      [Controls.ApplicationCredentialSecret]: this._builder.control('', Validators.required),
       [Controls.Project]: this._builder.control('', Validators.required),
       [Controls.ProjectID]: this._builder.control('', Validators.required),
       [Controls.FloatingIPPool]: this._builder.control('', Validators.required),
@@ -153,7 +157,9 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
     merge(
       this.form.get(Controls.Domain).valueChanges,
       this.form.get(Controls.Username).valueChanges,
-      this.form.get(Controls.Password).valueChanges
+      this.form.get(Controls.Password).valueChanges,
+      this.form.get(Controls.ApplicationCredentialID).valueChanges,
+      this.form.get(Controls.ApplicationCredentialSecret).valueChanges
     )
       .pipe(debounceTime(this._debounceTime))
       .pipe(tap(_ => this._clearProject()))
@@ -168,7 +174,13 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
         }
       });
 
-    merge(this.form.get(Controls.Project).valueChanges, this.form.get(Controls.ProjectID).valueChanges)
+    merge(
+      this.form.get(Controls.Domain).valueChanges,
+      this.form.get(Controls.Username).valueChanges,
+      this.form.get(Controls.Password).valueChanges,
+      this.form.get(Controls.ApplicationCredentialID).valueChanges,
+      this.form.get(Controls.ApplicationCredentialSecret).valueChanges
+    )
       .pipe(tap(_ => this._clearFloatingIPPool()))
       .pipe(switchMap(_ => this._floatingIPPoolListObservable()))
       .pipe(takeUntil(this._unsubscribe))
@@ -196,6 +208,37 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .subscribe(value => {
         value ? this.form.get(Controls.Project).disable() : this.form.get(Controls.Project).enable();
       });
+
+    merge(this.form.get(Controls.Username).valueChanges, this.form.get(Controls.Password).valueChanges)
+      .pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(value => {
+        if (value) {
+          this._enable(false, Controls.ApplicationCredentialID);
+          this._enable(false, Controls.ApplicationCredentialSecret);
+          return;
+        }
+
+        this._enable(true, Controls.ApplicationCredentialID);
+        this._enable(true, Controls.ApplicationCredentialSecret);
+      });
+
+    merge(
+      this.form.get(Controls.ApplicationCredentialID).valueChanges,
+      this.form.get(Controls.ApplicationCredentialSecret).valueChanges
+    )
+      .pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(value => {
+        if (value) {
+          this._enable(false, Controls.Username);
+          this._enable(false, Controls.Password);
+          return;
+        }
+
+        this._enable(true, Controls.Username);
+        this._enable(true, Controls.Password);
+      });
   }
 
   private _formReset(): void {
@@ -222,10 +265,9 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
 
   getHint(control: Controls): string {
     switch (control) {
-      case Controls.Project:
-        return this._hasRequiredBasicCredentials() ? '' : 'Please enter your credentials first.';
       case Controls.FloatingIPPool:
-        return this._hasRequiredCredentials() ? '' : 'Please enter your credentials first & project/project ID.';
+      case Controls.Project:
+        return this._hasRequiredCredentials() ? '' : 'Please enter your credentials first.';
     }
 
     return '';
@@ -233,6 +275,16 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
 
   isRequired(control: Controls): boolean {
     switch (control) {
+      case Controls.Username:
+      case Controls.Password:
+        return !this._hasRequiredApplicationCredentials();
+      case Controls.ApplicationCredentialID:
+      case Controls.ApplicationCredentialSecret:
+        return (
+          !!this._clusterSpecService.cluster.spec.cloud.openstack &&
+          !!this._clusterSpecService.cluster.spec.cloud.openstack.domain &&
+          !!this._clusterSpecService.cluster.spec.cloud.openstack.username
+        );
       case Controls.Project:
         return !this.form.get(Controls.ProjectID).value;
       case Controls.ProjectID:
@@ -254,20 +306,23 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
     }
   }
 
+  private _hasRequiredCredentials(): boolean {
+    return this._hasRequiredBasicCredentials() || this._hasRequiredApplicationCredentials();
+  }
+
   private _hasRequiredBasicCredentials(): boolean {
     return (
       !!this._clusterSpecService.cluster.spec.cloud.openstack &&
-      !!this._clusterSpecService.cluster.spec.cloud.openstack.domain &&
       !!this._clusterSpecService.cluster.spec.cloud.openstack.username &&
       !!this._clusterSpecService.cluster.spec.cloud.openstack.password
     );
   }
 
-  private _hasRequiredCredentials(): boolean {
+  private _hasRequiredApplicationCredentials(): boolean {
     return (
-      this._hasRequiredBasicCredentials() &&
-      (!!this._clusterSpecService.cluster.spec.cloud.openstack.tenant ||
-        !!this._clusterSpecService.cluster.spec.cloud.openstack.tenantID)
+      !!this._clusterSpecService.cluster.spec.cloud.openstack &&
+      !!this._clusterSpecService.cluster.spec.cloud.openstack.applicationCredentialID &&
+      !!this._clusterSpecService.cluster.spec.cloud.openstack.applicationCredentialSecret
     );
   }
 
@@ -277,6 +332,8 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .domain(this.form.get(Controls.Domain).value)
       .username(this.form.get(Controls.Username).value)
       .password(this.form.get(Controls.Password).value)
+      .applicationCredentialID(this.form.get(Controls.ApplicationCredentialID).value)
+      .applicationCredentialPassword(this.form.get(Controls.ApplicationCredentialSecret).value)
       .datacenter(this._clusterSpecService.cluster.spec.cloud.dc)
       .tenants(this._onProjectLoading.bind(this))
       .pipe(map(projects => _.sortBy(projects, p => p.name.toLowerCase())))
@@ -308,8 +365,8 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .domain(this.form.get(Controls.Domain).value)
       .username(this.form.get(Controls.Username).value)
       .password(this.form.get(Controls.Password).value)
-      .tenant(this.form.get(Controls.Project).value)
-      .tenantID(this.form.get(Controls.ProjectID).value)
+      .applicationCredentialID(this.form.get(Controls.ApplicationCredentialID).value)
+      .applicationCredentialPassword(this.form.get(Controls.ApplicationCredentialSecret).value)
       .datacenter(this._clusterSpecService.cluster.spec.cloud.dc)
       .networks(this._onFloatingIPPoolLoading.bind(this))
       .pipe(
@@ -349,6 +406,8 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
             password: this.form.get(Controls.Password).value,
             tenant: this.form.get(Controls.Project).value,
             tenantID: this.form.get(Controls.ProjectID).value,
+            applicationCredentialID: this.form.get(Controls.ApplicationCredentialID).value,
+            applicationCredentialSecret: this.form.get(Controls.ApplicationCredentialSecret).value,
           } as OpenstackCloudSpec,
         } as CloudSpec,
       } as ClusterSpec,

--- a/src/app/wizard/step/provider-settings/provider/basic/openstack/template.html
+++ b/src/app/wizard/step/provider-settings/provider/basic/openstack/template.html
@@ -58,6 +58,31 @@ limitations under the License.
   </mat-form-field>
 
   <mat-form-field fxFlex>
+    <mat-label>Application Credential ID</mat-label>
+    <input [formControlName]="Controls.ApplicationCredentialID"
+           [name]="Controls.ApplicationCredentialID"
+           matInput
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.ApplicationCredentialID).hasError('required')">
+      Application Credential ID is <strong>required</strong>.
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Application Credential Secret</mat-label>
+    <input [formControlName]="Controls.ApplicationCredentialSecret"
+           [name]="Controls.ApplicationCredentialSecret"
+           matInput
+           type="password"
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.ApplicationCredentialSecret).hasError('required')">
+      Application Credential Secret is <strong>required</strong>.
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
     <mat-label>{{projectsLabel}}</mat-label>
     <input matInput
            [formControlName]="Controls.Project"


### PR DESCRIPTION
### What this PR does / why we need it
- Added 2 new fields (app credentials id/secret)
- Some logic refactoring 

I am still not sure if I have checked all scenarios as there were basically no functional requirements here and providing app credentials highly impacts other related endpoints such as projects/floatingIPs/securityGroups/networks/subnets listing.

We should reconsider keeping mutually exclusive fields on a single wizard step as it makes the underlying logic very complex and it is hard to ensure a nice user experience.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #3470

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Added support for Application Credentials to the Openstack provider
```
