### PR TITLE
admin settings for alermanager domain + link to alertmanager ui

### DIFF
--- a/src/app/cluster/cluster-details/alertmanager-config/component.spec.ts
+++ b/src/app/cluster/cluster-details/alertmanager-config/component.spec.ts
@@ -17,9 +17,11 @@ import {DialogTestModule, NoopConfirmDialogComponent} from '@app/testing/compone
 import {fakeDigitaloceanCluster} from '@app/testing/fake-data/cluster';
 import {fakeAlertmanagerConfig} from '@app/testing/fake-data/mla';
 import {fakeProject} from '@app/testing/fake-data/project';
+import {SettingsMockService} from '@app/testing/services/settings-mock';
 import {CoreModule} from '@core/module';
 import {NotificationService} from '@core/services/notification';
 import {MLAService} from '@core/services/mla';
+import {SettingsService} from '@core/services/settings';
 import {SharedModule} from '@shared/module';
 import {of} from 'rxjs';
 import {AlertmanagerConfigComponent} from './component';
@@ -43,7 +45,12 @@ describe('AlertmanagerConfigComponent', () => {
       TestBed.configureTestingModule({
         imports: [...modules],
         declarations: [AlertmanagerConfigComponent],
-        providers: [{provide: MLAService, useValue: mlaMock}, MatDialog, NotificationService],
+        providers: [
+          {provide: MLAService, useValue: mlaMock},
+          {provide: SettingsService, useClass: SettingsMockService},
+          MatDialog,
+          NotificationService,
+        ],
       }).compileComponents();
     })
   );

--- a/src/app/cluster/cluster-details/alertmanager-config/component.ts
+++ b/src/app/cluster/cluster-details/alertmanager-config/component.ts
@@ -45,9 +45,9 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
-      this._settings = settings;
-    });
+    this._settingsService.adminSettings
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(settings => (this._settings = settings));
   }
 
   ngOnDestroy(): void {

--- a/src/app/cluster/cluster-details/alertmanager-config/component.ts
+++ b/src/app/cluster/cluster-details/alertmanager-config/component.ts
@@ -9,16 +9,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, OnDestroy} from '@angular/core';
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {NotificationService} from '@core/services/notification';
 import {MLAService} from '@core/services/mla';
+import {SettingsService} from '@core/services/settings';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {Cluster} from '@shared/entity/cluster';
 import {AlertmanagerConfig} from '@shared/entity/mla';
+import {AdminSettings} from '@shared/entity/settings';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {filter, switchMap, take} from 'rxjs/operators';
+import {filter, switchMap, take, takeUntil} from 'rxjs/operators';
 import {AlertmanagerConfigDialog} from './alertmanager-config-dialog/component';
 
 @Component({
@@ -26,19 +28,27 @@ import {AlertmanagerConfigDialog} from './alertmanager-config-dialog/component';
   templateUrl: './template.html',
   styleUrls: ['./style.scss'],
 })
-export class AlertmanagerConfigComponent implements OnDestroy {
+export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
   @Input() cluster: Cluster;
   @Input() projectID: string;
   @Input() isClusterRunning: boolean;
   @Input() alertmanagerConfig: AlertmanagerConfig;
 
+  private _settings: AdminSettings;
   private readonly _unsubscribe = new Subject<void>();
 
   constructor(
     private readonly _matDialog: MatDialog,
     private readonly _mlaService: MLAService,
-    private readonly _notificationService: NotificationService
+    private readonly _notificationService: NotificationService,
+    private readonly _settingsService: SettingsService
   ) {}
+
+  ngOnInit(): void {
+    this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
+      this._settings = settings;
+    });
+  }
 
   ngOnDestroy(): void {
     this._unsubscribe.next();
@@ -47,6 +57,18 @@ export class AlertmanagerConfigComponent implements OnDestroy {
 
   isLoadingData(): boolean {
     return _.isEmpty(this.alertmanagerConfig) && !this.isClusterRunning;
+  }
+
+  displayAlertmanagerUILink(): boolean {
+    return !!this._settings && !!this._settings.mlaAlertmanagerDomain;
+  }
+
+  getAlertmanagerURL(): string {
+    const domain = this._settings.mlaAlertmanagerDomain || '';
+    if (domain.slice(domain.length - 1) === '/') {
+      return this._settings.mlaAlertmanagerDomain + this.cluster.id;
+    }
+    return this._settings.mlaAlertmanagerDomain + '/' + this.cluster.id;
   }
 
   edit(): void {

--- a/src/app/cluster/cluster-details/alertmanager-config/component.ts
+++ b/src/app/cluster/cluster-details/alertmanager-config/component.ts
@@ -59,7 +59,7 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
     return _.isEmpty(this.alertmanagerConfig) && !this.isClusterRunning;
   }
 
-  displayAlertmanagerUILink(): boolean {
+  shouldDisplayAlertmanagerUILink(): boolean {
     return !!this._settings && !!this._settings.mlaAlertmanagerDomain;
   }
 

--- a/src/app/cluster/cluster-details/alertmanager-config/template.html
+++ b/src/app/cluster/cluster-details/alertmanager-config/template.html
@@ -20,7 +20,7 @@ limitations under the License.
          target="_blank"
          mat-flat-button
          color="quaternary"
-         *ngIf="displayAlertmanagerUILink()">
+         *ngIf="shouldDisplayAlertmanagerUILink()">
         <i class="km-icon-external-link"></i>
         <span>Open Alertmanager UI</span>
       </a>

--- a/src/app/cluster/cluster-details/alertmanager-config/template.html
+++ b/src/app/cluster/cluster-details/alertmanager-config/template.html
@@ -16,6 +16,14 @@ limitations under the License.
   <ng-container *ngIf="!isLoadingData()">
     <div fxLayout="row"
          fxLayoutGap="10px">
+      <a [href]="getAlertmanagerURL()"
+         target="_blank"
+         mat-flat-button
+         color="quaternary"
+         *ngIf="displayAlertmanagerUILink()">
+        <i class="km-icon-external-link"></i>
+        <span>Open Alertmanager UI</span>
+      </a>
       <button id="km-alertmanager-config-reset-btn"
               mat-icon-button
               color="tertiary"

--- a/src/app/settings/admin/component.spec.ts
+++ b/src/app/settings/admin/component.spec.ts
@@ -14,6 +14,8 @@ import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterTestingModule} from '@angular/router/testing';
+import {AppConfigService} from '@app/config.service';
+import {AppConfigMockService} from '@app/testing/services/app-config-mock';
 import {DatacenterMockService} from '@app/testing/services/datacenter-mock';
 import {MatDialogMock} from '@app/testing/services/mat-dialog-mock';
 import {MatDialogRefMock} from '@app/testing/services/mat-dialog-ref-mock';
@@ -64,6 +66,7 @@ describe('AdminSettingsComponent', () => {
         {provide: MatDialog, useClass: MatDialogMock},
         {provide: DatacenterService, useClass: DatacenterMockService},
         {provide: OPAService, useValue: opaMock},
+        {provide: AppConfigService, useClass: AppConfigMockService},
         HistoryService,
         NotificationService,
       ],

--- a/src/app/settings/admin/defaults/template.html
+++ b/src/app/settings/admin/defaults/template.html
@@ -121,6 +121,24 @@ limitations under the License.
         <div fxLayout="row">
           <div fxFlex="16%"
                fxLayoutAlign=" center"
+               class="entry-label">
+            <span>User Cluster Alertmanager Domain</span>
+            <div class="km-icon-info km-pointer"
+                 matTooltip="Set &quot;User Cluster Alertmanager Domain&quot; to expose the Alertmanager UI to users. It has to be the same domain that has been set up during the MLA stack installation in the seed (e.g. &quot;https://alertmanager.mla.kkp.example.com&quot;). A link to it will then be visible in tab &quot;User Cluster Alertmanager&quot; in cluster details view."></div>
+          </div>
+          <mat-form-field fxFlex="40">
+            <mat-label>User Cluster Alertmanager Domain</mat-label>
+            <input matInput
+                   (keyup)="onSettingsChange()"
+                   [(ngModel)]="settings.mlaAlertmanagerDomain"
+                   type="text">
+          </mat-form-field>
+          <km-spinner-with-confirmation [isSaved]="isEqual(settings.mlaAlertmanagerDomain, apiSettings.mlaAlertmanagerDomain)"></km-spinner-with-confirmation>
+        </div>
+
+        <div fxLayout="row">
+          <div fxFlex="16%"
+               fxLayoutAlign=" center"
                class="entry-label">Machine Deployment
           </div>
           <mat-form-field class="input km-no-padding">

--- a/src/app/shared/entity/settings.ts
+++ b/src/app/shared/entity/settings.ts
@@ -36,6 +36,7 @@ export class AdminSettings {
   machineDeploymentVMResourceQuota: MachineDeploymentVMResourceQuota;
   opaOptions: OpaOptions;
   mlaOptions: MLAOptions;
+  mlaAlertmanagerDomain: string;
 }
 
 export class MachineDeploymentVMResourceQuota {
@@ -153,4 +154,5 @@ export const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
     monitoringEnforced: false,
     monitoringEnabled: false,
   },
+  mlaAlertmanagerDomain: '',
 };

--- a/src/app/testing/services/settings-mock.ts
+++ b/src/app/testing/services/settings-mock.ts
@@ -51,6 +51,7 @@ export const DEFAULT_ADMIN_SETTINGS_MOCK: AdminSettings = {
     monitoringEnforced: false,
     monitoringEnabled: false,
   },
+  mlaAlertmanagerDomain: '',
 };
 
 @Injectable()

--- a/src/assets/css/material/_main.scss
+++ b/src/assets/css/material/_main.scss
@@ -617,6 +617,7 @@ mat-chip-list {
 mat-tooltip-component .mat-tooltip {
   font-size: $font-size-caption;
   margin-top: 5px;
+  word-wrap: break-word;
 }
 
 .mat-tooltip-panel {


### PR DESCRIPTION
### What this PR does / why we need it
Added admin settings for alermanager domain & a link to alertmanager ui.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3280

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Added admin settings for alermanager domain and the link to alertmanager ui.
```
