### PR TITLE
fix reset of opa integration checkbox

### DIFF
--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -131,7 +131,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.ServicesCIDR]: new FormControl('', [CIDR_PATTERN_VALIDATOR]),
     });
 
-    this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
+    this._settingsService.adminSettings.pipe(take(1)).subscribe(settings => {
       this._settings = settings;
 
       this.form.get(Controls.MLALogging).setValue(this._settings.mlaOptions.loggingEnabled, {emitEvent: false});


### PR DESCRIPTION
### What this PR does / why we need it
The OPA integration checkbox sometimes got reset during cluster creation due to a reload of the admin settings.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
