### PR TITLE
Fix opa selection on edit cluster dialog

### DIFF
--- a/src/app/cluster/cluster-details/edit-cluster/component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/component.ts
@@ -31,7 +31,7 @@ import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plu
 import {AsyncValidators} from '@shared/validators/async-label-form.validator';
 import * as _ from 'lodash';
 import {Subject} from 'rxjs';
-import {startWith, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import * as semver from 'semver';
 
 enum Controls {
@@ -109,10 +109,12 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.Labels]: new FormControl(''),
     });
 
-    this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
+    this._settingsService.adminSettings.pipe(take(1)).subscribe(settings => {
       this._settings = settings;
 
-      this.form.get(Controls.OPAIntegration).setValue(this._settings.opaOptions.enabled);
+      if (this._settings.opaOptions.enabled) {
+        this.form.get(Controls.OPAIntegration).setValue(true);
+      }
       if (this._settings.opaOptions.enforced) {
         this.form.get(Controls.OPAIntegration).disable();
       }


### PR DESCRIPTION
### What this PR does / why we need it
Unfortunately the `OPA Integration` checkbox was not checked correctly, as it was "overwritten" by the admin settings. 
e.g. not enabled in admin settings, but enabled on cluster -> the checkbox wasn't enabled -> OPA got disabled on cluster edit again

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
