### PR TITLE
Use merge when applying cluster network changes to avoid overrides

### DIFF
--- a/src/app/core/services/cluster-spec.ts
+++ b/src/app/core/services/cluster-spec.ts
@@ -44,9 +44,14 @@ export class ClusterSpecService {
       _.isArray(dest) && _.isArray(src) ? dest : undefined
     );
 
-    // Copy cluster network without using customizer from above.
-    if (cluster && cluster.spec) {
-      this._cluster.spec.clusterNetwork = cluster.spec.clusterNetwork;
+    // Copy cluster network using different customizer, it will overwrite
+    // destination array with source array instead of ignoring the changes.
+    if (cluster && cluster.spec && cluster.spec.clusterNetwork) {
+      this._cluster.spec.clusterNetwork = _.mergeWith(
+        this._cluster.spec.clusterNetwork,
+        cluster.spec.clusterNetwork,
+        (dest, src) => (_.isArray(dest) && _.isArray(src) ? src : undefined)
+      );
     }
 
     this.clusterChanges.emit(this._cluster);


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3536.

### Special notes for your reviewer
Previous implementation was based on a wrong assumption that cluster setter in the service is always invoked with full cluster objects. In reality sometimes partial cluster objects are sent and this was causing overwrites of cluster network. I've changed pure assignment to the merge method, however it uses a different customizer. I'm not sure why in the code above the changed one we are ignoring the source array and using destination one. In my case I needed to do the opposite.

### Release note
```release-note
NONE
```
