### PR TITLE
Move provider settings from cluster edit to dedicated dialog

### DIFF
--- a/src/app/cluster/cluster-details/component.ts
+++ b/src/app/cluster/cluster-details/component.ts
@@ -12,6 +12,7 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {ActivatedRoute, Router} from '@angular/router';
+import {EditProviderSettingsComponent} from '@app/cluster/cluster-details/edit-provider-settings/component';
 import {AppConfigService} from '@app/config.service';
 import {ApiService} from '@core/services/api';
 import {ClusterService} from '@core/services/cluster';
@@ -328,6 +329,11 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     const modal = this._matDialog.open(EditClusterComponent);
     modal.componentInstance.cluster = this.cluster;
     modal.componentInstance.projectID = this.projectID;
+  }
+
+  editProviderSettings(): void {
+    const modal = this._matDialog.open(EditProviderSettingsComponent);
+    modal.componentInstance.cluster = this.cluster;
   }
 
   isSSHKeysEditEnabled(): boolean {

--- a/src/app/cluster/cluster-details/edit-cluster/template.html
+++ b/src/app/cluster/cluster-details/edit-cluster/template.html
@@ -137,8 +137,6 @@ limitations under the License.
                      [inheritedLabels]="cluster.inheritedLabels"
                      [asyncKeyValidators]=asyncLabelValidators
                      [formControlName]="Controls.Labels"></km-label-form>
-      <km-edit-provider-settings [cluster]="cluster"
-                                 *ngIf="!cluster.spec.cloud.bringyourown"></km-edit-provider-settings>
     </form>
   </mat-dialog-content>
   <mat-dialog-actions>

--- a/src/app/cluster/cluster-details/edit-provider-settings/alibaba-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/alibaba-provider-settings/component.spec.ts
@@ -69,6 +69,6 @@ describe('AlibabaProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/alibaba-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/alibaba-provider-settings/template.html
@@ -10,27 +10,29 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>Access Key ID{{addRequiredIndicator()}}</mat-label>
+    <mat-label>Access Key ID</mat-label>
     <input matInput
-           formControlName="accessKeyID"
-           name="accessKeyID"
-           type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.accessKeyID.hasError('required')">
+           [formControlName]="Control.AccessKeyID"
+           [name]="Control.AccessKeyID"
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.AccessKeyID).hasError('required')">
       Access key ID is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
   <mat-form-field fxFlex>
-    <mat-label>Access Key Secret{{addRequiredIndicator()}}</mat-label>
+    <mat-label>Access Key Secret</mat-label>
     <input matInput
-           formControlName="accessKeySecret"
-           name="accessKeySecret"
+           [formControlName]="Control.AccessKeySecret"
+           [name]="Control.AccessKeySecret"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.accessKeySecret.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.AccessKeySecret).hasError('required')">
       Access Key Secret is <strong>required</strong>.
     </mat-error>
   </mat-form-field>

--- a/src/app/cluster/cluster-details/edit-provider-settings/anexia-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/anexia-provider-settings/component.spec.ts
@@ -27,13 +27,13 @@ import {KubevirtProviderSettingsComponent} from '../kubevirt-provider-settings/c
 import {OpenstackProviderSettingsComponent} from '../openstack-provider-settings/component';
 import {PacketProviderSettingsComponent} from '../packet-provider-settings/component';
 import {VSphereProviderSettingsComponent} from '../vsphere-provider-settings/component';
-import {DigitaloceanProviderSettingsComponent} from './component';
+import {AnexiaProviderSettingsComponent} from './component';
 
 const modules: any[] = [BrowserModule, BrowserAnimationsModule, SharedModule];
 
-describe('DigitaloceanProviderSettingsComponent', () => {
-  let fixture: ComponentFixture<DigitaloceanProviderSettingsComponent>;
-  let component: DigitaloceanProviderSettingsComponent;
+describe('AnexiaProviderSettingsComponent', () => {
+  let fixture: ComponentFixture<AnexiaProviderSettingsComponent>;
+  let component: AnexiaProviderSettingsComponent;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -41,7 +41,7 @@ describe('DigitaloceanProviderSettingsComponent', () => {
       declarations: [
         EditProviderSettingsComponent,
         AWSProviderSettingsComponent,
-        DigitaloceanProviderSettingsComponent,
+        AnexiaProviderSettingsComponent,
         HetznerProviderSettingsComponent,
         OpenstackProviderSettingsComponent,
         VSphereProviderSettingsComponent,
@@ -59,16 +59,16 @@ describe('DigitaloceanProviderSettingsComponent', () => {
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(DigitaloceanProviderSettingsComponent);
+    fixture = TestBed.createComponent(AnexiaProviderSettingsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create the digitalocean provider settings cmp', () => {
+  it('should create the anexia provider settings cmp', () => {
     expect(component).toBeTruthy();
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/anexia-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/anexia-provider-settings/component.spec.ts
@@ -1,0 +1,74 @@
+// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatDialogRef} from '@angular/material/dialog';
+import {BrowserModule} from '@angular/platform-browser';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {ClusterMockService} from '@app/testing/services/cluster-mock';
+import {MatDialogRefMock} from '@app/testing/services/mat-dialog-ref-mock';
+import {ClusterService} from '@core/services/cluster';
+import {SharedModule} from '@shared/module';
+import {AlibabaProviderSettingsComponent} from '../alibaba-provider-settings/component';
+import {AWSProviderSettingsComponent} from '../aws-provider-settings/component';
+import {AzureProviderSettingsComponent} from '../azure-provider-settings/component';
+import {EditProviderSettingsComponent} from '../component';
+import {GCPProviderSettingsComponent} from '../gcp-provider-settings/component';
+import {HetznerProviderSettingsComponent} from '../hetzner-provider-settings/component';
+import {KubevirtProviderSettingsComponent} from '../kubevirt-provider-settings/component';
+import {OpenstackProviderSettingsComponent} from '../openstack-provider-settings/component';
+import {PacketProviderSettingsComponent} from '../packet-provider-settings/component';
+import {VSphereProviderSettingsComponent} from '../vsphere-provider-settings/component';
+import {DigitaloceanProviderSettingsComponent} from './component';
+
+const modules: any[] = [BrowserModule, BrowserAnimationsModule, SharedModule];
+
+describe('DigitaloceanProviderSettingsComponent', () => {
+  let fixture: ComponentFixture<DigitaloceanProviderSettingsComponent>;
+  let component: DigitaloceanProviderSettingsComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [...modules],
+      declarations: [
+        EditProviderSettingsComponent,
+        AWSProviderSettingsComponent,
+        DigitaloceanProviderSettingsComponent,
+        HetznerProviderSettingsComponent,
+        OpenstackProviderSettingsComponent,
+        VSphereProviderSettingsComponent,
+        AzureProviderSettingsComponent,
+        PacketProviderSettingsComponent,
+        GCPProviderSettingsComponent,
+        KubevirtProviderSettingsComponent,
+        AlibabaProviderSettingsComponent,
+      ],
+      providers: [
+        {provide: ClusterService, useClass: ClusterMockService},
+        {provide: MatDialogRef, useClass: MatDialogRefMock},
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DigitaloceanProviderSettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the digitalocean provider settings cmp', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('form valid after creating', () => {
+    expect(component.form.valid).toBeTruthy();
+  });
+});

--- a/src/app/cluster/cluster-details/edit-provider-settings/anexia-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/anexia-provider-settings/template.html
@@ -10,21 +10,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>API Token</mat-label>
+    <mat-label>Token</mat-label>
     <input matInput
            [formControlName]="Control.Token"
            [name]="Control.Token"
            type="password"
            autocomplete="off"
            required>
-    <mat-error *ngIf="form.get(Control.Token).hasError('minlength') || form.get(Control.Token).hasError('maxlength')">
-      Tokens must be exactly <strong>64</strong> characters long.
-    </mat-error>
     <mat-error *ngIf="form.get(Control.Token).hasError('required')">
-      API Token is <strong>required</strong>.
+      Token is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
 </form>

--- a/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/component.spec.ts
@@ -69,6 +69,6 @@ describe('AWSProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/aws-provider-settings/template.html
@@ -10,27 +10,29 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>Access Key ID{{isRequiredField()}}</mat-label>
+    <mat-label>Access Key ID</mat-label>
     <input matInput
-           formControlName="accessKeyId"
-           name="accessKeyId"
-           type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.accessKeyId.hasError('required')">
+           [formControlName]="Control.AccessKeyID"
+           [name]="Control.AccessKeyID"
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.AccessKeyID).hasError('required')">
       Access key ID is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
   <mat-form-field fxFlex>
-    <mat-label>Secret Access Key{{isRequiredField()}}</mat-label>
+    <mat-label>Secret Access Key</mat-label>
     <input matInput
-           formControlName="secretAccessKey"
-           name="secretAccessKey"
+           [formControlName]="Control.SecretAccessKey"
+           [name]="Control.SecretAccessKey"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.secretAccessKey.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.SecretAccessKey).hasError('required')">
       Secret Access Key is <strong>required</strong>.
     </mat-error>
   </mat-form-field>

--- a/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/component.spec.ts
@@ -69,6 +69,6 @@ describe('AzureProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/azure-provider-settings/template.html
@@ -13,47 +13,48 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>Client ID{{isRequiredField()}}</mat-label>
+    <mat-label>Client ID</mat-label>
     <input matInput
-           formControlName="clientID"
-           name="clientID"
-           type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.clientID.hasError('required')">
+           [formControlName]="Control.ClientID"
+           [name]="Control.ClientID"
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.ClientID).hasError('required')">
       Client ID is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
 
   <mat-form-field fxFlex>
-    <mat-label>Client Secret{{isRequiredField()}}</mat-label>
+    <mat-label>Client Secret</mat-label>
     <input matInput
-           formControlName="clientSecret"
-           name="clientSecret"
+           [formControlName]="Control.ClientSecret"
+           [name]="Control.ClientSecret"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.clientSecret.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.ClientSecret).hasError('required')">
       Client Secret is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
 
   <mat-form-field fxFlex>
-    <mat-label>Tenant ID{{isRequiredField()}}</mat-label>
+    <mat-label>Tenant ID</mat-label>
     <input matInput
-           formControlName="tenantID"
-           type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.tenantID.hasError('required')">
+           [formControlName]="Control.TenantID"
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.TenantID).hasError('required')">
       Tenant ID is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
 
   <mat-form-field fxFlex>
-    <mat-label>Subscription ID{{isRequiredField()}}</mat-label>
+    <mat-label>Subscription ID</mat-label>
     <input matInput
-           formControlName="subscriptionID"
-           type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.subscriptionID.hasError('required')">
+           [formControlName]="Control.SubscriptionID"
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.SubscriptionID).hasError('required')">
       Subscription ID is <strong>required</strong>.
     </mat-error>
   </mat-form-field>

--- a/src/app/cluster/cluster-details/edit-provider-settings/component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/component.ts
@@ -9,15 +9,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input} from '@angular/core';
-import {Cluster} from '@shared/entity/cluster';
+import {Component, Input, OnInit} from '@angular/core';
+import {ClusterService} from '@core/services/cluster';
+import {Cluster, ProviderSettingsPatch} from '@shared/entity/cluster';
+import {Subject} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 
 @Component({
   selector: 'km-edit-provider-settings',
   templateUrl: './template.html',
 })
-export class EditProviderSettingsComponent {
-  @Input() cluster: Cluster;
+export class EditProviderSettingsComponent implements OnInit {
+  private _unsubscribe = new Subject<void>();
 
-  constructor() {}
+  @Input() cluster: Cluster;
+  providerSettingsPatch: ProviderSettingsPatch = {
+    isValid: false,
+    cloudSpecPatch: {},
+  };
+
+  constructor(private readonly _clusterService: ClusterService) {}
+
+  ngOnInit(): void {
+    this._clusterService.providerSettingsPatchChanges$
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(patch => (this.providerSettingsPatch = patch));
+  }
 }

--- a/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/component.spec.ts
@@ -69,6 +69,6 @@ describe('DigitaloceanProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/component.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/component.ts
@@ -10,59 +10,44 @@
 // limitations under the License.
 
 import {Component, OnDestroy, OnInit} from '@angular/core';
-import {AbstractControl, FormControl, FormGroup, Validators} from '@angular/forms';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {Subject} from 'rxjs';
-import {debounceTime, takeUntil} from 'rxjs/operators';
+import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+
+enum Control {
+  Token = 'token',
+}
 
 @Component({
   selector: 'km-digitalocean-provider-settings',
   templateUrl: './template.html',
 })
 export class DigitaloceanProviderSettingsComponent implements OnInit, OnDestroy {
+  private readonly _debounceTime = 500;
+  private readonly _tokenLength = 64;
+  private readonly _unsubscribe = new Subject<void>();
+  readonly Control = Control;
   form: FormGroup;
 
-  private readonly _debounceTime = 1000;
-  private _formData = {token: ''};
-  private _unsubscribe = new Subject<void>();
-
-  constructor(private clusterService: ClusterService) {}
+  constructor(private readonly _clusterService: ClusterService, private readonly _builder: FormBuilder) {}
 
   ngOnInit(): void {
-    this.form = new FormGroup({
-      token: new FormControl(''),
+    this.form = this._builder.group({
+      [Control.Token]: this._builder.control('', [
+        Validators.required,
+        Validators.minLength(this._tokenLength),
+        Validators.maxLength(this._tokenLength),
+      ]),
     });
 
-    this.form.valueChanges
+    this.form
+      .get(Control.Token)
+      .valueChanges.pipe(distinctUntilChanged())
       .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(data => {
-        if (data.token !== this._formData.token) {
-          this._formData = data;
-          this.setValidators();
-          this.clusterService.changeProviderSettingsPatch(this.getProviderSettingsPatch());
-        }
-      });
-  }
-
-  get token(): AbstractControl {
-    return this.form.controls.token;
-  }
-
-  setValidators(): void {
-    if (!this.token.value) {
-      this.token.clearValidators();
-    } else {
-      const tokenLen = 64;
-      this.token.setValidators([Validators.required, Validators.minLength(tokenLen), Validators.maxLength(tokenLen)]);
-    }
-
-    this.token.updateValueAndValidity();
-  }
-
-  isRequiredField(): string {
-    return !this.token.value ? '' : '*';
+      .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }
 
   ngOnDestroy(): void {
@@ -70,11 +55,11 @@ export class DigitaloceanProviderSettingsComponent implements OnInit, OnDestroy 
     this._unsubscribe.complete();
   }
 
-  getProviderSettingsPatch(): ProviderSettingsPatch {
+  private _getProviderSettingsPatch(): ProviderSettingsPatch {
     return {
       cloudSpecPatch: {
         digitalocean: {
-          token: this.form.controls.token.value,
+          token: this.form.get(Control.Token).value,
         },
       },
       isValid: this.form.valid,

--- a/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/digitalocean-provider-settings/template.html
@@ -10,19 +10,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>API Token{{isRequiredField()}}</mat-label>
+    <mat-label>API Token</mat-label>
     <input matInput
-           formControlName="token"
-           name="token"
+           [formControlName]="Control.Token"
+           [name]="Control.Token"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="(form.controls.token.hasError('minlength') || form.controls.token.hasError('maxlength'))">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.Token).hasError('minlength') || form.get(Control.Token).hasError('maxlength')">
       DigitalOcean Personal Access Tokens must be exactly <strong>64</strong> characters long.
     </mat-error>
-    <mat-error *ngIf="form.controls.token.hasError('required')">
+    <mat-error *ngIf="form.get(Control.Token).hasError('required')">
       API Token is <strong>required</strong>.
     </mat-error>
   </mat-form-field>

--- a/src/app/cluster/cluster-details/edit-provider-settings/gcp-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/gcp-provider-settings/component.spec.ts
@@ -69,6 +69,6 @@ describe('GCPProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/gcp-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/gcp-provider-settings/template.html
@@ -13,12 +13,13 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>Service Account{{isRequiredField()}}</mat-label>
+    <mat-label>Service Account</mat-label>
     <input matInput
-           formControlName="serviceAccount"
+           [formControlName]="Control.ServiceAccount"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.serviceAccount.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.ServiceAccount).hasError('required')">
       Service Account is <strong>required</strong>.
     </mat-error>
   </mat-form-field>

--- a/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/hetzner-provider-settings/component.spec.ts
@@ -69,6 +69,6 @@ describe('HetznerProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/kubevirt-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/kubevirt-provider-settings/component.spec.ts
@@ -69,6 +69,6 @@ describe('KubevirtProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/kubevirt-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/kubevirt-provider-settings/template.html
@@ -13,13 +13,14 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>Kubeconfig{{isRequiredField()}}</mat-label>
+    <mat-label>Kubeconfig</mat-label>
     <input matInput
-           formControlName="kubeconfig"
-           name="kubeconfig"
+           [formControlName]="Control.Kubeconfig"
+           [name]="Control.Kubeconfig"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.kubeconfig.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.Kubeconfig).hasError('required')">
       Kubeconfig is <strong>required</strong>.
     </mat-error>
   </mat-form-field>

--- a/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/component.spec.ts
@@ -72,6 +72,6 @@ describe('OpenstackProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/openstack-provider-settings/template.html
@@ -13,25 +13,27 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>Username{{isRequiredField()}}</mat-label>
+    <mat-label>Username</mat-label>
     <input matInput
-           formControlName="username"
-           name="username"
+           [formControlName]="Control.Username"
+           [name]="Control.Username"
            type="text"
            title="Username"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.username.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.Username).hasError('required')">
       Username is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
   <mat-form-field fxFlex>
-    <mat-label>Password{{isRequiredField()}}</mat-label>
+    <mat-label>Password</mat-label>
     <input matInput
-           formControlName="password"
+           [formControlName]="Control.Password"
            type="password"
            title="Password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.password.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.Password).hasError('required')">
       Password is <strong>required</strong>.
     </mat-error>
   </mat-form-field>

--- a/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/component.spec.ts
@@ -13,7 +13,6 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatDialogRef} from '@angular/material/dialog';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {fakePacketCluster} from '@app/testing/fake-data/cluster';
 import {ApiMockService} from '@app/testing/services/api-mock';
 import {ClusterMockService} from '@app/testing/services/cluster-mock';
 import {MatDialogRefMock} from '@app/testing/services/mat-dialog-ref-mock';
@@ -23,8 +22,8 @@ import {SharedModule} from '@shared/module';
 import {AlibabaProviderSettingsComponent} from '../alibaba-provider-settings/component';
 import {AWSProviderSettingsComponent} from '../aws-provider-settings/component';
 import {AzureProviderSettingsComponent} from '../azure-provider-settings/component';
-import {DigitaloceanProviderSettingsComponent} from '../digitalocean-provider-settings/component';
 import {EditProviderSettingsComponent} from '../component';
+import {DigitaloceanProviderSettingsComponent} from '../digitalocean-provider-settings/component';
 import {GCPProviderSettingsComponent} from '../gcp-provider-settings/component';
 import {HetznerProviderSettingsComponent} from '../hetzner-provider-settings/component';
 import {KubevirtProviderSettingsComponent} from '../kubevirt-provider-settings/component';
@@ -66,10 +65,7 @@ describe('PacketProviderSettingsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PacketProviderSettingsComponent);
     component = fixture.componentInstance;
-    component.cluster = fakePacketCluster();
-    component.cluster.spec.cloud.packet.billingCycle = '';
-    component.cluster.spec.cloud.packet.apiKey = '';
-    component.cluster.spec.cloud.packet.projectID = '';
+    component.billingCycle = '';
     fixture.detectChanges();
   });
 
@@ -78,6 +74,6 @@ describe('PacketProviderSettingsComponent', () => {
   });
 
   it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/packet-provider-settings/template.html
@@ -13,31 +13,33 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>API Token{{isRequiredField()}}</mat-label>
+    <mat-label>API Token</mat-label>
     <input matInput
-           formControlName="apiKey"
-           name="apiKey"
+           [formControlName]="Control.ApiKey"
+           [name]="Control.ApiKey"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.apiKey.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.ApiKey).hasError('required')">
       Packet API key is <strong>required</strong>.
     </mat-error>
-    <mat-error *ngIf="form.controls.apiKey.hasError('maxlength')">
+    <mat-error *ngIf="form.get(Control.ApiKey).hasError('maxlength')">
       Packet API key must be less than <strong>256</strong> characters long.
     </mat-error>
   </mat-form-field>
 
   <mat-form-field fxFlex>
-    <mat-label>Project ID{{isRequiredField()}}</mat-label>
+    <mat-label>Project ID</mat-label>
     <input matInput
-           formControlName="projectID"
-           name="projectID"
+           [formControlName]="Control.ProjectID"
+           [name]="Control.ProjectID"
            type="text"
-           autocomplete="off">
-    <mat-error *ngIf="form.controls.projectID.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.ProjectID).hasError('required')">
       Packet project ID is <strong>required</strong>.
     </mat-error>
-    <mat-error *ngIf="form.controls.projectID.hasError('maxlength')">
+    <mat-error *ngIf="form.get(Control.ProjectID).hasError('maxlength')">
       Packet project ID must be less than <strong>256</strong> characters long.
     </mat-error>
   </mat-form-field>
@@ -46,8 +48,9 @@ limitations under the License.
        class="mat-select-container">
     <mat-form-field>
       <mat-label>Billing Cycle</mat-label>
-      <mat-select formControlName="billingCycle"
-                  disableOptionCentering>
+      <mat-select [formControlName]="Control.BillingCycle"
+                  disableOptionCentering
+                  required>
         <mat-option *ngFor="let billingCycle of getAvailableBillingCycles()"
                     [value]="billingCycle">
           {{billingCycle}}

--- a/src/app/cluster/cluster-details/edit-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/template.html
@@ -10,18 +10,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<mat-card-header>
-  <mat-card-title>Provider Credentials</mat-card-title>
-</mat-card-header>
 
-<km-alibaba-provider-settings *ngIf="!!cluster.spec.cloud.alibaba"></km-alibaba-provider-settings>
-<km-aws-provider-settings *ngIf="!!cluster.spec.cloud.aws"></km-aws-provider-settings>
-<km-digitalocean-provider-settings *ngIf="!!cluster.spec.cloud.digitalocean"></km-digitalocean-provider-settings>
-<km-hetzner-provider-settings *ngIf="!!cluster.spec.cloud.hetzner"></km-hetzner-provider-settings>
-<km-openstack-provider-settings *ngIf="!!cluster.spec.cloud.openstack"></km-openstack-provider-settings>
-<km-vsphere-provider-settings *ngIf="!!cluster.spec.cloud.vsphere"></km-vsphere-provider-settings>
-<km-azure-provider-settings *ngIf="!!cluster.spec.cloud.azure"></km-azure-provider-settings>
-<km-packet-provider-settings *ngIf="!!cluster.spec.cloud.packet"
-                             [cluster]="cluster"></km-packet-provider-settings>
-<km-gcp-provider-settings *ngIf="!!cluster.spec.cloud.gcp"></km-gcp-provider-settings>
-<km-kubevirt-provider-settings *ngIf="!!cluster.spec.cloud.kubevirt"></km-kubevirt-provider-settings>
+<div id="km-edit-cluster-dialog">
+  <km-dialog-title>Provider Settings</km-dialog-title>
+
+  <mat-dialog-content>
+    <km-anexia-provider-settings *ngIf="!!cluster.spec.cloud.anexia"></km-anexia-provider-settings>
+    <km-alibaba-provider-settings *ngIf="!!cluster.spec.cloud.alibaba"></km-alibaba-provider-settings>
+    <km-aws-provider-settings *ngIf="!!cluster.spec.cloud.aws"></km-aws-provider-settings>
+    <km-digitalocean-provider-settings *ngIf="!!cluster.spec.cloud.digitalocean"></km-digitalocean-provider-settings>
+    <km-hetzner-provider-settings *ngIf="!!cluster.spec.cloud.hetzner"></km-hetzner-provider-settings>
+    <km-openstack-provider-settings *ngIf="!!cluster.spec.cloud.openstack"></km-openstack-provider-settings>
+    <km-vsphere-provider-settings *ngIf="!!cluster.spec.cloud.vsphere"></km-vsphere-provider-settings>
+    <km-azure-provider-settings *ngIf="!!cluster.spec.cloud.azure"></km-azure-provider-settings>
+    <km-packet-provider-settings *ngIf="!!cluster.spec.cloud.packet"
+                                 [billingCycle]="cluster.spec.cloud.packet.billingCycle"></km-packet-provider-settings>
+    <km-gcp-provider-settings *ngIf="!!cluster.spec.cloud.gcp"></km-gcp-provider-settings>
+    <km-kubevirt-provider-settings *ngIf="!!cluster.spec.cloud.kubevirt"></km-kubevirt-provider-settings>
+  </mat-dialog-content>
+
+  <mat-dialog-actions>
+    <button id="km-edit-cluster-dialog-edit-btn"
+            mat-flat-button
+            type="submit"
+            [disabled]="!providerSettingsPatch.isValid">
+      Save
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/component.spec.ts
+++ b/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/component.spec.ts
@@ -68,7 +68,7 @@ describe('VSphereProviderSettingsComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('form valid after creating', () => {
-    expect(component.form.valid).toBeTruthy();
+  it('form invalid after creating', () => {
+    expect(component.form.valid).toBeFalsy();
   });
 });

--- a/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/template.html
+++ b/src/app/cluster/cluster-details/edit-provider-settings/vsphere-provider-settings/template.html
@@ -13,41 +13,48 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column">
   <mat-form-field fxFlex>
-    <mat-label>Username{{isRequiredField()}}</mat-label>
+    <mat-label>Username</mat-label>
     <input matInput
-           formControlName="infraManagementUsername"
-           name="infraManagementUsername"
+           [formControlName]="Control.InfraManagementUsername"
+           [name]="Control.InfraManagementUsername"
            type="text"
-           autocomplete="off">
-    <mat-error *ngIf="form?.controls.infraManagementUsername.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.InfraManagementUsername).hasError('required')">
       Username is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
+
   <mat-form-field fxFlex>
-    <mat-label>Password{{isRequiredField()}}</mat-label>
+    <mat-label>Password</mat-label>
     <input matInput
-           formControlName="infraManagementPassword"
-           name="infraManagementPassword"
+           [formControlName]="Control.InfraManagementPassword"
+           [name]="Control.InfraManagementPassword"
            type="password"
-           autocomplete="off">
-    <mat-error *ngIf="form?.controls.infraManagementPassword.hasError('required')">
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Control.InfraManagementPassword).hasError('required')">
       Password is <strong>required</strong>.
     </mat-error>
   </mat-form-field>
+
   <mat-form-field fxFlex>
     <mat-label>VSphere Cloud Provider Username</mat-label>
     <input matInput
-           formControlName="username"
-           name="username"
+           [formControlName]="Control.Username"
+           [name]="Control.Username"
            type="text"
-           autocomplete="off">
+           autocomplete="off"
+           required>
   </mat-form-field>
+
   <mat-form-field fxFlex>
     <mat-label>VSphere Cloud Provider Password</mat-label>
     <input matInput
-           formControlName="password"
-           name="password"
+           [formControlName]="Control.Password"
+           [name]="Control.Password"
            type="password"
-           autocomplete="off">
+           autocomplete="off"
+           required>
   </mat-form-field>
 </form>

--- a/src/app/cluster/cluster-details/template.html
+++ b/src/app/cluster/cluster-details/template.html
@@ -98,6 +98,11 @@ limitations under the License.
             <span>Edit Cluster</span>
           </button>
           <button mat-menu-item
+                  (click)="editProviderSettings()"
+                  [disabled]="!isClusterRunning || !isEditEnabled()">
+            <span>Edit Provider</span>
+          </button>
+          <button mat-menu-item
                   (click)="editSSHKeys()"
                   *ngIf="cluster.spec.enableUserSSHKeyAgent"
                   [disabled]="!isSSHKeysEditEnabled()">

--- a/src/app/cluster/module.ts
+++ b/src/app/cluster/module.ts
@@ -11,6 +11,7 @@
 
 import {NgModule} from '@angular/core';
 import {AddMachineNetworkComponent} from '@app/cluster/cluster-details/add-machine-network/component';
+import {AnexiaProviderSettingsComponent} from '@app/cluster/cluster-details/edit-provider-settings/anexia-provider-settings/component';
 import {NODE_DATA_CONFIG, NodeDataConfig, NodeDataMode} from '@app/node-data/config';
 import {NodeDataModule} from '@app/node-data/module';
 import {NodeService} from '@core/services/node';
@@ -74,6 +75,7 @@ const components: any[] = [
   RevokeTokenComponent,
   EditProviderSettingsComponent,
   AWSProviderSettingsComponent,
+  AnexiaProviderSettingsComponent,
   DigitaloceanProviderSettingsComponent,
   HetznerProviderSettingsComponent,
   GCPProviderSettingsComponent,

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -284,6 +284,7 @@ export class ClusterSpecPatch {
 }
 
 export class CloudSpecPatch {
+  anexia?: AnexiaCloudSpecPatch;
   digitalocean?: DigitaloceanCloudSpecPatch;
   aws?: AWSCloudSpecPatch;
   openstack?: OpenstackCloudSpecPatch;
@@ -294,6 +295,10 @@ export class CloudSpecPatch {
   gcp?: GCPCloudSpecPatch;
   kubevirt?: KubevirtCloudSpecPatch;
   alibaba?: AlibabaCloudSpecPatch;
+}
+
+export class AnexiaCloudSpecPatch {
+  token?: string;
 }
 
 export class DigitaloceanCloudSpecPatch {


### PR DESCRIPTION
### What this PR does / why we need it
- added support for anexia provider
- moved all provider settings to the `edit provider` dialog
- refactored code
- made all fields required by default in this new dialog

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3089

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Extract provider settings management from the cluster edit dialog to dedicated dialog
```
