### PR TITLE
Adjust changelog dialog to work with smaller screens

### DIFF
--- a/src/app/core/components/changelog/style.scss
+++ b/src/app/core/components/changelog/style.scss
@@ -17,6 +17,10 @@
   padding: 2px 4px 2px 2px;
 }
 
+:host {
+  height: 100%;
+}
+
 .header-title {
   font-size: $font-size-card-title;
   padding-bottom: 8px;

--- a/src/assets/css/global/_main.scss
+++ b/src/assets/css/global/_main.scss
@@ -477,7 +477,10 @@ km-dashboard {
 
   &.km-changelog-dialog {
     .mat-dialog-container {
+      height: auto;
+      margin: 20px 0;
       max-width: 600px;
+      min-height: 400px;
       min-width: 600px;
 
       .mat-dialog-content {


### PR DESCRIPTION
### What this PR does / why we need it
Set min-height to 400px and adjusted dialog height scaling to better work on smaller screens.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3590

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
