### PR TITLE
Extend AWS spot instance configuration options

### DIFF
--- a/src/app/node-data/extended/provider/aws/component.ts
+++ b/src/app/node-data/extended/provider/aws/component.ts
@@ -10,18 +10,21 @@
 // limitations under the License.
 
 import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
-import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import {NodeDataService} from '@core/services/node-data/service';
-import {takeUntil} from 'rxjs/operators';
+import {pushDown} from '@shared/animations/push';
 import {NodeCloudSpec, NodeSpec} from '@shared/entity/node';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
-import {NodeDataMode} from '../../../config';
 import {merge} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+import {NodeDataMode} from '../../../config';
 
 enum Controls {
   AssignPublicIP = 'assignPublicIP',
   IsSpotInstance = 'isSpotInstance',
+  SpotInstanceMaxPrice = 'spotInstanceMaxPrice',
+  SpotInstancePersistentRequest = 'spotInstancePersistentRequest',
   Tags = 'tags',
 }
 
@@ -41,6 +44,7 @@ enum Controls {
       multi: true,
     },
   ],
+  animations: [pushDown],
 })
 export class AWSExtendedNodeDataComponent extends BaseFormValidator implements OnInit, OnDestroy {
   tags: object;
@@ -49,6 +53,10 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
 
   get nodeData(): NodeData {
     return this._nodeDataService.nodeData;
+  }
+
+  get isSpotInstance(): boolean {
+    return this.form.get(Controls.IsSpotInstance).value;
   }
 
   constructor(private readonly _builder: FormBuilder, private readonly _nodeDataService: NodeDataService) {
@@ -60,12 +68,19 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
       [Controls.AssignPublicIP]: this._builder.control(true),
       [Controls.IsSpotInstance]: this._builder.control(false),
       [Controls.Tags]: this._builder.control(''),
+      [Controls.SpotInstanceMaxPrice]: this._builder.control('', [Validators.min(1)]),
+      [Controls.SpotInstancePersistentRequest]: this._builder.control(false),
     });
 
     this._init();
     this._nodeDataService.nodeData = this._getNodeData();
 
-    merge(this.form.get(Controls.AssignPublicIP).valueChanges, this.form.get(Controls.IsSpotInstance).valueChanges)
+    merge(
+      this.form.get(Controls.AssignPublicIP).valueChanges,
+      this.form.get(Controls.IsSpotInstance).valueChanges,
+      this.form.get(Controls.SpotInstanceMaxPrice).valueChanges,
+      this.form.get(Controls.SpotInstancePersistentRequest).valueChanges
+    )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._nodeDataService.nodeData = this._getNodeData()));
   }
@@ -90,6 +105,18 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
           ? this.nodeData.spec.cloud.aws.isSpotInstance
           : false;
       this.form.get(Controls.IsSpotInstance).setValue(isSpotInstance);
+
+      const spotInstanceMaxPrice =
+        this._nodeDataService.mode === NodeDataMode.Dialog && !!this.nodeData.name
+          ? this.nodeData.spec.cloud.aws.spotInstanceMaxPrice
+          : false;
+      this.form.get(Controls.SpotInstanceMaxPrice).setValue(spotInstanceMaxPrice);
+
+      const spotInstancePersistentRequest =
+        this._nodeDataService.mode === NodeDataMode.Dialog && !!this.nodeData.name
+          ? this.nodeData.spec.cloud.aws.spotInstancePersistentRequest
+          : false;
+      this.form.get(Controls.SpotInstancePersistentRequest).setValue(spotInstancePersistentRequest);
     }
   }
 
@@ -100,6 +127,8 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
           aws: {
             assignPublicIP: this.form.get(Controls.AssignPublicIP).value,
             isSpotInstance: this.form.get(Controls.IsSpotInstance).value,
+            spotInstanceMaxPrice: this.form.get(Controls.SpotInstanceMaxPrice).value,
+            spotInstancePersistentRequest: this.form.get(Controls.SpotInstancePersistentRequest).value,
           },
         } as NodeCloudSpec,
       } as NodeSpec,

--- a/src/app/node-data/extended/provider/aws/component.ts
+++ b/src/app/node-data/extended/provider/aws/component.ts
@@ -127,7 +127,7 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
           aws: {
             assignPublicIP: this.form.get(Controls.AssignPublicIP).value,
             isSpotInstance: this.form.get(Controls.IsSpotInstance).value,
-            spotInstanceMaxPrice: this.form.get(Controls.SpotInstanceMaxPrice).value,
+            spotInstanceMaxPrice: `${this.form.get(Controls.SpotInstanceMaxPrice).value}`,
             spotInstancePersistentRequest: this.form.get(Controls.SpotInstancePersistentRequest).value,
           },
         } as NodeCloudSpec,

--- a/src/app/node-data/extended/provider/aws/style.scss
+++ b/src/app/node-data/extended/provider/aws/style.scss
@@ -14,3 +14,7 @@
 .checkbox {
   margin-bottom: 34px;
 }
+
+.km-icon-info {
+  margin: 4px 8px;
+}

--- a/src/app/node-data/extended/provider/aws/template.html
+++ b/src/app/node-data/extended/provider/aws/template.html
@@ -20,7 +20,34 @@ limitations under the License.
 
   <mat-checkbox [id]="Controls.IsSpotInstance"
                 [formControlName]="Controls.IsSpotInstance"
-                class="checkbox">Spot Instance</mat-checkbox>
+                class="checkbox">
+    Spot Instance
+    <i class="km-icon-info km-pointer"
+       matTooltip="Indicates whether the created machine is an AWS EC2 Spot Instance or on-demand EC2 instance."></i>
+  </mat-checkbox>
+
+  <div *ngIf="isSpotInstance"
+       @pushDown
+       fxLayout="column"
+       fxLayoutGap="16px">
+    <mat-form-field fxFlex>
+      <mat-label>Spot Instance Max Price (in USD)</mat-label>
+      <input [formControlName]="Controls.SpotInstanceMaxPrice"
+             min="1"
+             type="number"
+             autocomplete="off"
+             matInput>
+      <mat-hint>Maximum price you are willing to pay per instance hour. Your instance runs when your maximum price is greater than the Spot Instance price.</mat-hint>
+      <mat-error>Spot Instance Max Price has to be bigger than 0.</mat-error>
+    </mat-form-field>
+
+    <mat-checkbox [id]="Controls.SpotInstancePersistentRequest"
+                  [formControlName]="Controls.SpotInstancePersistentRequest">
+      Spot Instance Persistent Request
+      <i class="km-icon-info km-pointer"
+         matTooltip="Defines the interruption behavior of the spot instance when capacity is no longer available at the price you specified."></i>
+    </mat-checkbox>
+  </div>
 
   <mat-checkbox [id]="Controls.AssignPublicIP"
                 [formControlName]="Controls.AssignPublicIP"

--- a/src/app/shared/animations/push.ts
+++ b/src/app/shared/animations/push.ts
@@ -9,7 +9,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {animate, style, transition, trigger} from '@angular/animations';
+import {animate, keyframes, style, transition, trigger} from '@angular/animations';
 
 export const pushToSide = trigger('pushToSide', [
   transition(':enter', [
@@ -20,4 +20,18 @@ export const pushToSide = trigger('pushToSide', [
     animate('200ms', style({opacity: 1, width: '*'})),
   ]),
   transition(':leave', [animate('200ms', style({opacity: 0, width: 0}))]),
+]);
+
+export const pushDown = trigger('pushDown', [
+  transition(':enter', [
+    style({
+      opacity: 0,
+      height: 0,
+    }),
+    animate(
+      '200ms',
+      keyframes([style({opacity: 0, height: '*', offset: 0.5}), style({opacity: 1, height: '*', offset: 1})])
+    ),
+  ]),
+  transition(':leave', [animate('200ms', style({opacity: 0, height: 0}))]),
 ]);

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -152,6 +152,8 @@ export class AWSNodeSpec {
   availabilityZone: string;
   assignPublicIP?: boolean;
   isSpotInstance?: boolean;
+  spotInstanceMaxPrice?: string;
+  spotInstancePersistentRequest?: boolean;
 }
 
 export class AzureNodeSpec {

--- a/src/app/wizard/step/summary/template.html
+++ b/src/app/wizard/step/summary/template.html
@@ -400,6 +400,10 @@ limitations under the License.
                 <div key>AMI ID</div>
                 <div value>{{nodeData.spec.cloud?.aws?.ami}}</div>
               </km-property>
+              <km-property *ngIf="nodeData.spec.cloud?.aws?.spotInstanceMaxPrice">
+                <div key>Spot Instance Max Price (in USD)</div>
+                <div value>{{nodeData.spec.cloud.aws.spotInstanceMaxPrice}}</div>
+              </km-property>
             </ng-container>
 
             <!-- Azure Nodes -->
@@ -587,19 +591,19 @@ limitations under the License.
               </km-property>
             </ng-container>
 
-            <km-property-boolean label="Dynamic kubelet Config"
-                                 [value]="nodeData.dynamicConfig">
-            </km-property-boolean>
-
             <!-- AWS Node Options -->
             <ng-container *ngIf="cluster.spec.cloud?.aws">
-              <km-property-boolean *ngIf="nodeData.spec.cloud?.aws?.assignPublicIP !== undefined"
-                                   label="Assign Public IP"
-                                   [value]="nodeData.spec.cloud?.aws?.assignPublicIP">
-              </km-property-boolean>
               <km-property-boolean *ngIf="nodeData.spec.cloud?.aws?.isSpotInstance !== undefined"
                                    label="Spot Instance"
                                    [value]="nodeData.spec.cloud?.aws?.isSpotInstance">
+              </km-property-boolean>
+              <km-property-boolean *ngIf="nodeData.spec.cloud?.aws?.spotInstancePersistentRequest !== undefined"
+                                   label="Spot Instance Persistent Request"
+                                   [value]="nodeData.spec.cloud.aws.spotInstancePersistentRequest">
+              </km-property-boolean>
+              <km-property-boolean *ngIf="nodeData.spec.cloud?.aws?.assignPublicIP !== undefined"
+                                   label="Assign Public IP"
+                                   [value]="nodeData.spec.cloud?.aws?.assignPublicIP">
               </km-property-boolean>
             </ng-container>
 
@@ -636,6 +640,10 @@ limitations under the License.
                                    [value]="nodeData.spec.cloud?.openstack?.useFloatingIP">
               </km-property-boolean>
             </ng-container>
+
+            <km-property-boolean label="Dynamic kubelet Config"
+                                 [value]="nodeData.dynamicConfig">
+            </km-property-boolean>
 
             <div [ngSwitch]="displayTags(nodeData.spec.labels)">
               <km-property *ngSwitchCase="true">

--- a/src/app/wizard/template.html
+++ b/src/app/wizard/template.html
@@ -14,7 +14,7 @@ limitations under the License.
   <mat-card fxFlex="100%">
     <mat-horizontal-stepper linear
                             disableRipple
-                            [@.disabled]="true"
+                            style="transition: none;"
                             #stepper>
       <ng-template matStepperIcon="edit">
         <i class="km-icon-done"></i>
@@ -22,7 +22,8 @@ limitations under the License.
 
       <mat-step *ngFor="let step of steps; index as i;"
                 [stepControl]="form.get(step.name)"
-                fxFlex="100%">
+                fxFlex="100%"
+                style="transition: none;">
         <ng-template matStepLabel>{{step.name}}</ng-template>
         <div [ngSwitch]="step.name"
              id="{{step.id}}-step"

--- a/src/assets/css/material/_main.scss
+++ b/src/assets/css/material/_main.scss
@@ -205,8 +205,14 @@ mat-card {
     margin: 0 20px;
   }
 
-  .mat-horizontal-stepper-content[aria-expanded="false"] {
-    width: 0;
+  .mat-horizontal-stepper-content {
+    // Required to disable wizard step animation without disabling all child animations
+    transform: none !important;
+    transition: none;
+
+    &[aria-expanded="false"] {
+      width: 0;
+    }
   }
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
- Added support for spotInstanceMaxPrice field
- Added support for spotInstancePersistentRequest field
- Added slight animation when showing those additional fields
- Updated the way we disable `mat-step` animations to not disable animations for all inner children.
- 
![spot-instance](https://user-images.githubusercontent.com/2285385/128881040-ae840126-c0dc-4577-9fad-fff82832d098.gif)

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #3606

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Extend AWS spot instance support with 'spotInstanceMaxPrice' and 'spotInstancePersistentRequest' fields.
```
