### PR TITLE
Fix issue with wizard form validation on settings step

### DIFF
--- a/src/app/shared/validators/base-form.validator.ts
+++ b/src/app/shared/validators/base-form.validator.ts
@@ -13,11 +13,11 @@ import {AbstractControl, ControlValueAccessor, FormGroup, ValidationErrors, Vali
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
-export class BaseFormValidator implements ControlValueAccessor, Validator {
+export abstract class BaseFormValidator implements ControlValueAccessor, Validator {
   form: FormGroup;
   protected _unsubscribe = new Subject<void>();
 
-  constructor(private _formName = 'Form') {}
+  protected constructor(private _formName = 'Form') {}
 
   // Validator interface implementation
   validate(_: AbstractControl): ValidationErrors | null {

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -134,8 +134,8 @@ export class WizardComponent implements OnInit, OnDestroy {
         })
       )
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(
-        (keys: SSHKey[]) => {
+      .subscribe({
+        next: (keys: SSHKey[]) => {
           this._router.navigate([`/projects/${this.project.id}/clusters/${createdCluster.id}`]);
           keys.forEach(key =>
             this._notificationService.success(
@@ -143,12 +143,12 @@ export class WizardComponent implements OnInit, OnDestroy {
             )
           );
         },
-        () => {
+        error: () => {
           this._notificationService.error(`Could not create the ${createCluster.cluster.name} cluster`);
           this._googleAnalyticsService.emitEvent('clusterCreation', 'clusterCreationFailed');
           this.creating = false;
-        }
-      );
+        },
+      });
   }
 
   private _getCreateClusterModel(cluster: Cluster, nodeData: NodeData): CreateClusterModel {

--- a/src/app/wizard/step/provider-settings/provider/basic/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/component.ts
@@ -52,7 +52,7 @@ export class ProviderBasicComponent extends BaseFormValidator implements OnInit 
       [Controls.ProviderBasic]: this._builder.control(''),
     });
 
-    merge(this._clusterSpecService.providerChanges, this._clusterSpecService.datacenterChanges)
+    merge(this._clusterSpecService.providerChanges)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => {
         this.form.removeControl(Controls.ProviderBasic);


### PR DESCRIPTION
### What this PR does / why we need it
Removed provider control removal and recreation on datacenter change. As it does not influence provider fields, it should not be required and it also does not override the provide form initialization.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3611

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
