### PR TITLE
Update aws spot instance max price to be bigger than 0

### DIFF
--- a/src/app/cluster/cluster-details/node-list/template.html
+++ b/src/app/cluster/cluster-details/node-list/template.html
@@ -235,6 +235,10 @@ limitations under the License.
               <div key>AMI ID</div>
               <div value>{{element.spec.cloud.aws.ami}}</div>
             </km-property>
+            <km-property *ngIf="element.spec.cloud.aws?.spotInstanceMaxPrice">
+              <div key>Spot Instance Max Price</div>
+              <div value>{{element.spec.cloud.aws.spotInstanceMaxPrice | currency:'USD'}}</div>
+            </km-property>
 
             <km-property *ngIf="element.spec.cloud.openstack">
               <div key>Node Image</div>
@@ -430,6 +434,10 @@ limitations under the License.
             <km-property-boolean *ngIf="element.spec.cloud.aws"
                                  label="Spot Instance"
                                  [value]="element.spec.cloud.aws.isSpotInstance">
+            </km-property-boolean>
+            <km-property-boolean *ngIf="element.spec.cloud.aws"
+                                 label="Spot Instance Persistent Request"
+                                 [value]="element.spec.cloud.aws.spotInstancePersistentRequest">
             </km-property-boolean>
             <!-- End of boolean properties. -->
 

--- a/src/app/node-data/extended/provider/aws/component.ts
+++ b/src/app/node-data/extended/provider/aws/component.ts
@@ -115,7 +115,7 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
       const spotInstanceMaxPrice =
         this._nodeDataService.mode === NodeDataMode.Dialog && !!this.nodeData.name
           ? this.nodeData.spec.cloud.aws.spotInstanceMaxPrice
-          : false;
+          : '';
       this.form.get(Controls.SpotInstanceMaxPrice).setValue(spotInstanceMaxPrice);
 
       const spotInstancePersistentRequest =

--- a/src/app/node-data/extended/provider/aws/component.ts
+++ b/src/app/node-data/extended/provider/aws/component.ts
@@ -10,12 +10,13 @@
 // limitations under the License.
 
 import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
-import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {NodeDataService} from '@core/services/node-data/service';
 import {pushDown} from '@shared/animations/push';
 import {NodeCloudSpec, NodeSpec} from '@shared/entity/node';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import {KmValidators} from '@shared/validators/validators';
 import {merge} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {NodeDataMode} from '../../../config';
@@ -68,7 +69,7 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
       [Controls.AssignPublicIP]: this._builder.control(true),
       [Controls.IsSpotInstance]: this._builder.control(false),
       [Controls.Tags]: this._builder.control(''),
-      [Controls.SpotInstanceMaxPrice]: this._builder.control('', [Validators.min(1)]),
+      [Controls.SpotInstanceMaxPrice]: this._builder.control('', [KmValidators.largerThan(0)]),
       [Controls.SpotInstancePersistentRequest]: this._builder.control(false),
     });
 

--- a/src/app/node-data/extended/provider/aws/component.ts
+++ b/src/app/node-data/extended/provider/aws/component.ts
@@ -91,6 +91,11 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
     this._nodeDataService.aws.tags = tags;
   }
 
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
   private _init(): void {
     if (this.nodeData.spec.cloud.aws) {
       this.onTagsChange(this.nodeData.spec.cloud.aws.tags);
@@ -134,10 +139,5 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
         } as NodeCloudSpec,
       } as NodeSpec,
     } as NodeData;
-  }
-
-  ngOnDestroy(): void {
-    this._unsubscribe.next();
-    this._unsubscribe.complete();
   }
 }

--- a/src/app/node-data/extended/provider/aws/template.html
+++ b/src/app/node-data/extended/provider/aws/template.html
@@ -44,7 +44,7 @@ limitations under the License.
                   [formControlName]="Controls.SpotInstancePersistentRequest">
       Spot Instance Persistent Request
       <i class="km-icon-info km-pointer"
-         matTooltip="Defines the interruption behavior of the spot instance when capacity is no longer available at the price you specified."></i>
+         matTooltip="Ensures that your request will be submitted every time your Spot Instance is terminated."></i>
     </mat-checkbox>
   </div>
 

--- a/src/app/node-data/extended/provider/aws/template.html
+++ b/src/app/node-data/extended/provider/aws/template.html
@@ -33,7 +33,6 @@ limitations under the License.
     <mat-form-field fxFlex>
       <mat-label>Spot Instance Max Price (in USD)</mat-label>
       <input [formControlName]="Controls.SpotInstanceMaxPrice"
-             min="1"
              type="number"
              autocomplete="off"
              matInput>

--- a/src/app/shared/validators/larger-than.validator.ts
+++ b/src/app/shared/validators/larger-than.validator.ts
@@ -15,6 +15,10 @@ export class LargerThanValidator implements Validator {
   constructor(readonly min: number, readonly inclusive: boolean) {}
 
   validate(control: AbstractControl): ValidationErrors | null {
+    if ((!control.value && control.value !== 0) || control.value.length === 0) {
+      return null;
+    }
+
     const value = +control.value;
 
     if (isNaN(value)) {

--- a/src/app/shared/validators/larger-than.validator.ts
+++ b/src/app/shared/validators/larger-than.validator.ts
@@ -1,0 +1,42 @@
+// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AbstractControl, ValidationErrors, Validator} from '@angular/forms';
+
+export class LargerThanValidator implements Validator {
+  constructor(readonly min: number, readonly inclusive: boolean) {}
+
+  validate(control: AbstractControl): ValidationErrors | null {
+    const value = +control.value;
+
+    if (isNaN(value)) {
+      return this._error(value);
+    }
+
+    return this.inclusive
+      ? value >= this.min
+        ? null
+        : this._error(value)
+      : value > this.min
+      ? null
+      : this._error(value);
+  }
+
+  private _error(value: number) {
+    return {
+      largerThan: {
+        min: this.min,
+        inclusive: this.inclusive,
+        actual: value,
+      },
+    };
+  }
+}

--- a/src/app/shared/validators/validators.ts
+++ b/src/app/shared/validators/validators.ts
@@ -1,0 +1,20 @@
+// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ValidatorFn} from '@angular/forms';
+import {LargerThanValidator} from '@shared/validators/larger-than.validator';
+
+export class KmValidators {
+  static largerThan(min: number, inclusive = false): ValidatorFn {
+    const validator = new LargerThanValidator(min, inclusive);
+    return validator.validate.bind(validator);
+  }
+}

--- a/src/app/wizard/step/summary/template.html
+++ b/src/app/wizard/step/summary/template.html
@@ -400,7 +400,7 @@ limitations under the License.
                 <div key>AMI ID</div>
                 <div value>{{nodeData.spec.cloud?.aws?.ami}}</div>
               </km-property>
-              <km-property *ngIf="nodeData.spec.cloud?.aws?.spotInstanceMaxPrice">
+              <km-property *ngIf="nodeData.spec.cloud?.aws?.spotInstanceMaxPrice > 0">
                 <div key>Spot Instance Max Price</div>
                 <div value>{{nodeData.spec.cloud.aws.spotInstanceMaxPrice | currency:'USD'}}</div>
               </km-property>

--- a/src/app/wizard/step/summary/template.html
+++ b/src/app/wizard/step/summary/template.html
@@ -401,8 +401,8 @@ limitations under the License.
                 <div value>{{nodeData.spec.cloud?.aws?.ami}}</div>
               </km-property>
               <km-property *ngIf="nodeData.spec.cloud?.aws?.spotInstanceMaxPrice">
-                <div key>Spot Instance Max Price (in USD)</div>
-                <div value>{{nodeData.spec.cloud.aws.spotInstanceMaxPrice}}</div>
+                <div key>Spot Instance Max Price</div>
+                <div value>{{nodeData.spec.cloud.aws.spotInstanceMaxPrice | currency:'USD'}}</div>
               </km-property>
             </ng-container>
 


### PR DESCRIPTION
### What this PR does / why we need it
- Added `largerThan` validator
- Updated spot instance validation to allow numbers bigger than 0

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3613

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
