### PR TITLE
Adjust User Cluster Alertmanager Link

### DIFF
--- a/src/app/cluster/cluster-details/alertmanager-config/component.spec.ts
+++ b/src/app/cluster/cluster-details/alertmanager-config/component.spec.ts
@@ -17,8 +17,10 @@ import {DialogTestModule, NoopConfirmDialogComponent} from '@app/testing/compone
 import {fakeDigitaloceanCluster} from '@app/testing/fake-data/cluster';
 import {fakeAlertmanagerConfig} from '@app/testing/fake-data/mla';
 import {fakeProject} from '@app/testing/fake-data/project';
+import {DatacenterMockService} from '@app/testing/services/datacenter-mock';
 import {SettingsMockService} from '@app/testing/services/settings-mock';
 import {CoreModule} from '@core/module';
+import {DatacenterService} from '@core/services/datacenter';
 import {NotificationService} from '@core/services/notification';
 import {MLAService} from '@core/services/mla';
 import {SettingsService} from '@core/services/settings';
@@ -48,6 +50,7 @@ describe('AlertmanagerConfigComponent', () => {
         providers: [
           {provide: MLAService, useValue: mlaMock},
           {provide: SettingsService, useClass: SettingsMockService},
+          {provide: DatacenterService, useClass: DatacenterMockService},
           MatDialog,
           NotificationService,
         ],

--- a/src/app/settings/admin/defaults/template.html
+++ b/src/app/settings/admin/defaults/template.html
@@ -122,18 +122,18 @@ limitations under the License.
           <div fxFlex="16%"
                fxLayoutAlign=" center"
                class="entry-label">
-            <span>User Cluster Alertmanager Domain</span>
+            <span>User Cluster Alertmanager Prefix</span>
             <div class="km-icon-info km-pointer"
-                 matTooltip="Set &quot;User Cluster Alertmanager Domain&quot; to expose the Alertmanager UI to users. It has to be the same domain that has been set up during the MLA stack installation in the seed (e.g. &quot;https://alertmanager.mla.kkp.example.com&quot;). A link to it will then be visible in tab &quot;User Cluster Alertmanager&quot; in cluster details view."></div>
+                 matTooltip="Domain name prefix on which the User Cluster Alertmanager is running. Seed name and the base domain under which KKP is running will be appended to it, e.g. for prefix &quot;alertmanger&quot; the final url would be &quot;https://alertmanager.<seed-name>.<kkp-domain>&quot;"></div>
           </div>
           <mat-form-field fxFlex="40">
-            <mat-label>User Cluster Alertmanager Domain</mat-label>
+            <mat-label>User Cluster Alertmanager Prefix</mat-label>
             <input matInput
                    (keyup)="onSettingsChange()"
-                   [(ngModel)]="settings.mlaAlertmanagerDomain"
+                   [(ngModel)]="settings.mlaAlertmanagerPrefix"
                    type="text">
           </mat-form-field>
-          <km-spinner-with-confirmation [isSaved]="isEqual(settings.mlaAlertmanagerDomain, apiSettings.mlaAlertmanagerDomain)"></km-spinner-with-confirmation>
+          <km-spinner-with-confirmation [isSaved]="isEqual(settings.mlaAlertmanagerPrefix, apiSettings.mlaAlertmanagerPrefix)"></km-spinner-with-confirmation>
         </div>
 
         <div fxLayout="row">

--- a/src/app/shared/entity/settings.ts
+++ b/src/app/shared/entity/settings.ts
@@ -36,7 +36,7 @@ export class AdminSettings {
   machineDeploymentVMResourceQuota: MachineDeploymentVMResourceQuota;
   opaOptions: OpaOptions;
   mlaOptions: MLAOptions;
-  mlaAlertmanagerDomain: string;
+  mlaAlertmanagerPrefix: string;
 }
 
 export class MachineDeploymentVMResourceQuota {
@@ -154,5 +154,5 @@ export const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
     monitoringEnforced: false,
     monitoringEnabled: false,
   },
-  mlaAlertmanagerDomain: '',
+  mlaAlertmanagerPrefix: '',
 };

--- a/src/app/testing/services/settings-mock.ts
+++ b/src/app/testing/services/settings-mock.ts
@@ -51,7 +51,7 @@ export const DEFAULT_ADMIN_SETTINGS_MOCK: AdminSettings = {
     monitoringEnforced: false,
     monitoringEnabled: false,
   },
-  mlaAlertmanagerDomain: '',
+  mlaAlertmanagerPrefix: '',
 };
 
 @Injectable()


### PR DESCRIPTION
### What this PR does / why we need it
Rename `User Cluster Alertmanager Domain` to `User Cluster Alertmanager Prefix` and adjust related link in Alertmanager Tab.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
