### PR TITLE
temporary skip provider + opa e2e tests

### DIFF
--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -14,12 +14,8 @@ import failFast from 'cypress-fail-fast/plugin';
 import {configuration} from './cy-ts-preprocessor';
 
 export default async (on, config) => {
+  config.ignoreTestFiles = '**/integration/providers/*.spec.ts';
   on('file:preprocessor', webpack(configuration));
   failFast(on, config);
-  return config;
-};
-
-module.exports = (on, config) => {
-  config.ignoreTestFiles = '**/integration/providers/*.spec.ts';
   return config;
 };

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -14,7 +14,7 @@ import failFast from 'cypress-fail-fast/plugin';
 import {configuration} from './cy-ts-preprocessor';
 
 export default async (on, config) => {
-  config.ignoreTestFiles = '**/integration/providers/*.spec.ts';
+  config.ignoreTestFiles = ['**/integration/providers/*.spec.ts', '**/integration/stories/opa.spec.ts'];
   on('file:preprocessor', webpack(configuration));
   failFast(on, config);
   return config;

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -18,3 +18,8 @@ export default async (on, config) => {
   failFast(on, config);
   return config;
 };
+
+module.exports = (on, config) => {
+  config.ignoreTestFiles = '**/integration/providers/*.spec.ts';
+  return config;
+};


### PR DESCRIPTION
### What this PR does / why we need it
Temporary skip provider e2e tests as they are blocking ci too much atm

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
