### PR TITLE
Turn off e2e log colors and update job images

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.16-kind-0.8-nodejs-14.16-0
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-2
           command:
             - make
             - verify-go
@@ -21,7 +21,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.16-kind-0.8-nodejs-14.16-0
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-2
           command:
             - make
             - check
@@ -174,7 +174,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.16-kind-0.8-nodejs-14.16-0
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-2
           imagePullPolicy: Always
           command:
             - /bin/bash
@@ -202,7 +202,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.16-kind-0.8-nodejs-14.16-0
+        - image: quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-2
           imagePullPolicy: Always
           command:
             - /bin/bash

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -39,7 +39,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v0.8
+        - image: quay.io/kubermatic/chrome-headless:v0.9
           command:
             - make
             - test-headless

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -102,6 +102,8 @@ presubmits:
               memory: 6Gi
               cpu: 4
           env:
+            - name: NO_COLOR
+              value: 1
             - name: SERVICE_ACCOUNT_KEY
               valueFrom:
                 secretKeyRef:
@@ -155,6 +157,8 @@ presubmits:
           env:
             - name: KUBERMATIC_EDITION
               value: ce
+            - name: NO_COLOR
+              value: 1
             - name: SERVICE_ACCOUNT_KEY
               valueFrom:
                 secretKeyRef:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -103,7 +103,7 @@ presubmits:
               cpu: 4
           env:
             - name: NO_COLOR
-              value: 1
+              value: "1"
             - name: SERVICE_ACCOUNT_KEY
               valueFrom:
                 secretKeyRef:
@@ -158,7 +158,7 @@ presubmits:
             - name: KUBERMATIC_EDITION
               value: ce
             - name: NO_COLOR
-              value: 1
+              value: "1"
             - name: SERVICE_ACCOUNT_KEY
               valueFrom:
                 secretKeyRef:

--- a/containers/chrome-headless/Dockerfile
+++ b/containers/chrome-headless/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.16-kind-0.8-nodejs-14.16-0
+FROM quay.io/kubermatic/build:go-1.16-node-14-kind-0.11-2
 LABEL maintainer="support@kubermatic.com"
 
 # Install Google Chrome

--- a/containers/chrome-headless/release.sh
+++ b/containers/chrome-headless/release.sh
@@ -10,9 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v0.8
+TAG=v0.9
 
-set -euox pipefail
+set -euo pipefail
 
 cd $(dirname $0)
 


### PR DESCRIPTION
### What this PR does / why we need it
Disables log colors to see if that speeds up time needed to display all logs in prow.

### Release note
```release-note
NONE
```
