### PR TITLE
Replace tick icon

### DIFF
--- a/src/assets/css/_images.scss
+++ b/src/assets/css/_images.scss
@@ -76,7 +76,7 @@
 }
 
 .km-icon-done {
-  @include mixins.mask-image("/assets/images/icons/tick.svg", 12px, $color: #00a3d9);
+  @include mixins.mask-image("/assets/images/icons/check.svg#16", 12px, $color: #00a3d9);
 }
 
 .km-icon-delete {
@@ -236,7 +236,7 @@
 }
 
 .km-icon-running {
-  @include mixins.mask-image("/assets/images/icons/tick.svg", 16px, $color: #1dc67f);
+  @include mixins.mask-image("/assets/images/icons/check.svg#16", 16px, $color: #1dc67f);
 }
 
 .km-icon-failed {


### PR DESCRIPTION
### What this PR does / why we need it
Replace tick icon by the new check icon, as it is no longer available and neither steps in wizard nor the health status in cluster details view was displaying checkmarks anymore.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
