### PR TITLE
Enable provider tests

### DIFF
--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -14,7 +14,7 @@ import failFast from 'cypress-fail-fast/plugin';
 import {configuration} from './cy-ts-preprocessor';
 
 export default async (on, config) => {
-  config.ignoreTestFiles = ['**/integration/providers/*.spec.ts', '**/integration/stories/opa.spec.ts'];
+  config.ignoreTestFiles = ['**/integration/stories/opa.spec.ts'];
   on('file:preprocessor', webpack(configuration));
   failFast(on, config);
   return config;


### PR DESCRIPTION
### What this PR does / why we need it
Enables provider tests to check automatically if all the providers are working. I'm not adding hold as it doesn't belong to the 2.18 milestone anyways.

### Release note
```release-note
NONE
```
