### PR TITLE
Expose CNI config in wizard

### DIFF
--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -67,6 +67,10 @@ limitations under the License.
           <span>{{operatingSystem}}</span>
         </div>
       </km-property>
+      <km-property *ngIf="cluster.spec.cniPlugin?.type">
+        <div key>CNI Plugin</div>
+        <div value>{{cluster.spec.cniPlugin.type}}</div>
+      </km-property>
       <km-property *ngIf="cluster.spec.clusterNetwork?.proxyMode">
         <div key>Proxy Mode</div>
         <div value>{{cluster.spec.clusterNetwork.proxyMode}}</div>

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -223,7 +223,6 @@ export class ClusterNetwork {
 
 export class CNIPlugin {
   type: string;
-  version: string;
 }
 
 export class NetworkRanges {

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -212,7 +212,7 @@ export class ClusterSpec {
   mla?: MLASettings;
   containerRuntime?: ContainerRuntime;
   clusterNetwork?: ClusterNetwork;
-  cniPlugin?: CNIPlugin;
+  cniPlugin?: CNIPluginConfig;
 }
 
 export class ClusterNetwork {
@@ -221,7 +221,7 @@ export class ClusterNetwork {
   services?: NetworkRanges;
 }
 
-export class CNIPlugin {
+export class CNIPluginConfig {
   type: string;
 }
 
@@ -234,9 +234,9 @@ export enum ProxyMode {
   iptables = 'iptables',
 }
 
-export enum CNIPlugins {
-  canal = 'canal',
-  cilium = 'cilium',
+export enum CNIPlugin {
+  Canal = 'canal',
+  Cilium = 'cilium',
 }
 
 export class AuditLoggingSettings {

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -212,12 +212,18 @@ export class ClusterSpec {
   mla?: MLASettings;
   containerRuntime?: ContainerRuntime;
   clusterNetwork?: ClusterNetwork;
+  cniPlugin?: CNIPlugin;
 }
 
 export class ClusterNetwork {
   pods?: NetworkRanges;
   proxyMode?: ProxyMode;
   services?: NetworkRanges;
+}
+
+export class CNIPlugin {
+  type: string;
+  version: string;
 }
 
 export class NetworkRanges {
@@ -227,6 +233,11 @@ export class NetworkRanges {
 export enum ProxyMode {
   ipvs = 'ipvs',
   iptables = 'iptables',
+}
+
+export enum CNIPlugins {
+  canal = 'canal',
+  cilium = 'cilium',
 }
 
 export class AuditLoggingSettings {

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -33,6 +33,7 @@ import {
   END_OF_DOCKER_SUPPORT_VERSION,
   MasterVersion,
   ProxyMode,
+  CNIPlugins,
 } from '@shared/entity/cluster';
 import {ResourceType} from '@shared/entity/common';
 import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
@@ -62,6 +63,8 @@ enum Controls {
   ProxyMode = 'proxyMode',
   PodsCIDR = 'podsCIDR',
   ServicesCIDR = 'servicesCIDR',
+  CNIPlugin = 'cniPlugin',
+  CNIPluginVersion = 'cniPluginVersion',
 }
 
 @Component({
@@ -90,6 +93,9 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   podNodeSelectorAdmissionPluginConfig: object;
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
   proxyMode = ProxyMode;
+  cniPlugin = CNIPlugins;
+  csiPluginVersions = [];
+  availableProxyModes = [];
   readonly Controls = Controls;
   private _datacenterSpec: Datacenter;
   private _seedSettings: SeedSettings;
@@ -129,6 +135,8 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.ProxyMode]: this._builder.control(''),
       [Controls.PodsCIDR]: new FormControl('', [CIDR_PATTERN_VALIDATOR]),
       [Controls.ServicesCIDR]: new FormControl('', [CIDR_PATTERN_VALIDATOR]),
+      [Controls.CNIPlugin]: new FormControl(''),
+      [Controls.CNIPluginVersion]: new FormControl(''),
     });
 
     this._settingsService.adminSettings.pipe(take(1)).subscribe(settings => {
@@ -193,6 +201,10 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       .valueChanges.pipe(takeUntil(this._unsubscribe))
       .subscribe(() => (this._clusterSpecService.admissionPlugins = this.form.get(Controls.AdmissionPlugins).value));
 
+    this.control(Controls.AdmissionPlugins).valueChanges.subscribe(() => {
+      this.updateCNIPluginOptions();
+    });
+
     merge(
       this.form.get(Controls.Name).valueChanges,
       this.form.get(Controls.Version).valueChanges,
@@ -204,7 +216,9 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.get(Controls.ContainerRuntime).valueChanges,
       this.form.get(Controls.ProxyMode).valueChanges,
       this.form.get(Controls.PodsCIDR).valueChanges,
-      this.form.get(Controls.ServicesCIDR).valueChanges
+      this.form.get(Controls.ServicesCIDR).valueChanges,
+      this.form.get(Controls.CNIPlugin).valueChanges,
+      this.form.get(Controls.CNIPluginVersion).valueChanges
     )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
@@ -247,6 +261,25 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     return AdmissionPluginUtils.getPluginName(name);
   }
 
+  updateCNIPluginOptions() {
+    switch (this.controlValue(Controls.CNIPlugin)) {
+      case 'canal':
+        this.availableProxyModes = ['ipvs', 'iptables'];
+        this.csiPluginVersions = ['v3.19'];
+        this.control(Controls.CNIPluginVersion).setValue('v3.19');
+        break;
+      case 'cilium':
+        this.availableProxyModes = ['ipvs', 'iptables', 'eBPF'];
+        this.csiPluginVersions = ['v1.10'];
+        this.control(Controls.CNIPluginVersion).setValue('v1.10');
+        break;
+      default:
+        this.availableProxyModes = ['ipvs', 'iptables'];
+        this.csiPluginVersions = [];
+        break;
+    }
+  }
+
   isPluginEnabled(name: string): boolean {
     return AdmissionPluginUtils.isPluginEnabled(this.form.get(Controls.AdmissionPlugins), name);
   }
@@ -279,6 +312,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         this.control(Controls.Version).setValue(version.version);
       }
     }
+    this.control(Controls.CNIPlugin).setValue('canal');
   }
 
   private _getClusterEntity(): Cluster {
@@ -305,6 +339,10 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           proxyMode: this.controlValue(Controls.ProxyMode),
           pods: {cidrBlocks: pods ? [pods] : []},
           services: {cidrBlocks: services ? [services] : []},
+        },
+        cniPlugin: {
+          type: this.controlValue(Controls.CNIPlugin),
+          version: this.controlValue(Controls.CNIPluginVersion),
         },
       } as ClusterSpec,
     } as Cluster;

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -52,30 +52,15 @@ limitations under the License.
         <mat-card-title>Network Configuration</mat-card-title>
       </mat-card-header>
       <div fxLayout="column">
-        <div fxFlex="100"
-             fxLayoutGap="10px"
-             fxLayout="row">
-          <mat-form-field class="km-dropdown-with-suffix">
-            <mat-label>CNI Plugin</mat-label>
-            <mat-select [formControlName]="Controls.CNIPlugin"
-                        class="km-select-ellipsis"
-                        disableOptionCentering>
-              <mat-option [value]="cniPlugin.canal">canal</mat-option>
-              <mat-option [value]="cniPlugin.cilium">cilium</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <mat-form-field class="km-dropdown-with-suffix">
-            <mat-label>CNI Plugin Version</mat-label>
-            <mat-select [formControlName]="Controls.CNIPluginVersion"
-                        class="km-select-ellipsis"
-                        disableOptionCentering>
-              <mat-option *ngFor="let version of csiPluginVersions"
-                          [value]="version">
-                {{version}}
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
-        </div>
+        <mat-form-field class="km-dropdown-with-suffix">
+          <mat-label>CNI Plugin</mat-label>
+          <mat-select [formControlName]="Controls.CNIPlugin"
+                      class="km-select-ellipsis"
+                      disableOptionCentering>
+            <mat-option [value]="cniPlugin.canal">canal</mat-option>
+            <mat-option [value]="cniPlugin.cilium">cilium</mat-option>
+          </mat-select>
+        </mat-form-field>
 
         <mat-form-field class="km-dropdown-with-suffix">
           <mat-label>Proxy Mode</mat-label>
@@ -109,6 +94,7 @@ limitations under the License.
           </mat-error>
         </mat-form-field>
       </div>
+
       <km-wizard-cluster-ssh-keys [formControl]="form.get(Controls.SSHKeys)"></km-wizard-cluster-ssh-keys>
     </div>
 

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -52,13 +52,40 @@ limitations under the License.
         <mat-card-title>Network Configuration</mat-card-title>
       </mat-card-header>
       <div fxLayout="column">
+        <div fxFlex="100"
+             fxLayoutGap="10px"
+             fxLayout="row">
+          <mat-form-field class="km-dropdown-with-suffix">
+            <mat-label>CNI Plugin</mat-label>
+            <mat-select [formControlName]="Controls.CNIPlugin"
+                        class="km-select-ellipsis"
+                        disableOptionCentering>
+              <mat-option [value]="cniPlugin.canal">canal</mat-option>
+              <mat-option [value]="cniPlugin.cilium">cilium</mat-option>
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field class="km-dropdown-with-suffix">
+            <mat-label>CNI Plugin Version</mat-label>
+            <mat-select [formControlName]="Controls.CNIPluginVersion"
+                        class="km-select-ellipsis"
+                        disableOptionCentering>
+              <mat-option *ngFor="let version of csiPluginVersions"
+                          [value]="version">
+                {{version}}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
         <mat-form-field class="km-dropdown-with-suffix">
           <mat-label>Proxy Mode</mat-label>
           <mat-select [formControlName]="Controls.ProxyMode"
                       class="km-select-ellipsis"
                       disableOptionCentering>
-            <mat-option [value]="proxyMode.ipvs">ipvs</mat-option>
-            <mat-option [value]="proxyMode.iptables">iptables</mat-option>
+            <mat-option *ngFor="let proxyMode of availableProxyModes"
+                        [value]="proxyMode">
+              {{proxyMode}}
+            </mat-option>
           </mat-select>
         </mat-form-field>
         <mat-form-field fxFlex>
@@ -82,7 +109,6 @@ limitations under the License.
           </mat-error>
         </mat-form-field>
       </div>
-
       <km-wizard-cluster-ssh-keys [formControl]="form.get(Controls.SSHKeys)"></km-wizard-cluster-ssh-keys>
     </div>
 

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -57,8 +57,8 @@ limitations under the License.
           <mat-select [formControlName]="Controls.CNIPlugin"
                       class="km-select-ellipsis"
                       disableOptionCentering>
-            <mat-option [value]="cniPlugin.canal">canal</mat-option>
-            <mat-option [value]="cniPlugin.cilium">cilium</mat-option>
+            <mat-option [value]="cniPlugin.Canal">Canal</mat-option>
+            <mat-option [value]="cniPlugin.Cilium">Cilium</mat-option>
           </mat-select>
         </mat-form-field>
 


### PR DESCRIPTION
### What this PR does / why we need it
By default, all our clusters have Canal CNI. Backend already exposes CNI configuration knobs and internally we can spin up a cluster with Cilium. This exposes the CNI config to the end user.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
depends on: https://github.com/kubermatic/kubermatic/pull/7853, https://github.com/kubermatic/kubermatic/pull/7851, https://github.com/kubermatic/kubermatic/pull/7862
closes: https://github.com/kubermatic/kubermatic/issues/7577

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Allow users to select one of the two supported CNIs - Canal or Cilium
```
