### PR TITLE
Support EnabledOperatingSystems for Datacenters

### DIFF
--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -191,35 +191,44 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   }
 
   isOperatingSystemSupported(os: OperatingSystem): boolean {
-    // If VSphere is selected enable OS only if it is also defined in the datacenter spec
-    if (this._hasSystemTemplate(NodeProvider.VSPHERE, os)) {
-      return true;
-    }
+    if (this._datacenterSpec.spec.enabledOperatingSystems.length > 0) {
+      for (const enabledOS of this._datacenterSpec.spec.enabledOperatingSystems) {
+        if (enabledOS as OperatingSystem == os ) {
+          return true
+        }
+      }
+      return false
+    } else {
+      // If VSphere is selected enable OS only if it is also defined in the datacenter spec
+      if (this._hasSystemTemplate(NodeProvider.VSPHERE, os)) {
+        return true;
+      }
 
-    // Enable OS per-provider basis
-    switch (os) {
-      case OperatingSystem.SLES:
-        return this.isProvider(NodeProvider.AWS);
-      case OperatingSystem.RHEL:
-        return this.isProvider(
-          NodeProvider.AWS,
-          NodeProvider.AZURE,
-          NodeProvider.GCP,
-          NodeProvider.KUBEVIRT,
-          NodeProvider.OPENSTACK
-        );
-      case OperatingSystem.Flatcar:
-        return this.isProvider(
-          NodeProvider.AWS,
-          NodeProvider.AZURE,
-          NodeProvider.OPENSTACK,
-          NodeProvider.ANEXIA,
-          NodeProvider.KUBEVIRT
-        );
-      case OperatingSystem.Ubuntu:
-        return !this.isProvider(NodeProvider.VSPHERE, NodeProvider.ANEXIA);
-      case OperatingSystem.CentOS:
-        return !this.isProvider(NodeProvider.VSPHERE, NodeProvider.ANEXIA, NodeProvider.GCP);
+      // Enable OS per-provider basis
+      switch (os) {
+        case OperatingSystem.SLES:
+          return this.isProvider(NodeProvider.AWS);
+        case OperatingSystem.RHEL:
+          return this.isProvider(
+            NodeProvider.AWS,
+            NodeProvider.AZURE,
+            NodeProvider.GCP,
+            NodeProvider.KUBEVIRT,
+            NodeProvider.OPENSTACK
+          );
+        case OperatingSystem.Flatcar:
+          return this.isProvider(
+            NodeProvider.AWS,
+            NodeProvider.AZURE,
+            NodeProvider.OPENSTACK,
+            NodeProvider.ANEXIA,
+            NodeProvider.KUBEVIRT
+          );
+        case OperatingSystem.Ubuntu:
+          return !this.isProvider(NodeProvider.VSPHERE, NodeProvider.ANEXIA);
+        case OperatingSystem.CentOS:
+          return !this.isProvider(NodeProvider.VSPHERE, NodeProvider.ANEXIA, NodeProvider.GCP);
+      }
     }
   }
 

--- a/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
+++ b/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
@@ -42,6 +42,7 @@ export enum Controls {
   RequiredEmailDomains = 'requiredEmailDomains',
   EnforcePodSecurityPolicy = 'enforcePodSecurityPolicy',
   EnforceAuditLogging = 'enforceAuditLogging',
+  EnabledOperatingSystems = 'enabledOperatingSystems',
 }
 
 @Component({
@@ -57,6 +58,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
   seeds: string[] = [];
   form: FormGroup;
   requiredEmailDomains: string[] = [];
+  enabledOperatingSystems: string[] = [];
   providerConfig = '';
   private _unsubscribe = new Subject<void>();
 
@@ -82,6 +84,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
       country: new FormControl(this.data.isEditing ? this.data.datacenter.spec.country : '', [Validators.required]),
       location: new FormControl(this.data.isEditing ? this.data.datacenter.spec.location : '', [Validators.required]),
       requiredEmailDomains: new FormControl(),
+      enabledOperatingSystems: new FormControl(),
       enforcePodSecurityPolicy: new FormControl(
         this.data.isEditing && this.data.datacenter.spec.enforcePodSecurityPolicy
       ),
@@ -89,6 +92,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
     });
 
     this._initRequiredEmailDomainsInput();
+    this._initEnabledOperatingSystemsInput();
     this._initProviderConfigEditor();
   }
 
@@ -106,6 +110,14 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
       this.requiredEmailDomains = this.data.datacenter.spec.requiredEmailDomains;
     } else {
       this.requiredEmailDomains = [];
+    }
+  }
+
+  private _initEnabledOperatingSystemsInput(): void {
+    if (this.data.isEditing && !_.isEmpty(this.data.datacenter.spec.enabledOperatingSystems)) {
+      this.enabledOperatingSystems = this.data.datacenter.spec.enabledOperatingSystems;
+    } else {
+      this.enabledOperatingSystems = [];
     }
   }
 
@@ -148,6 +160,27 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
     }
   }
 
+  addOS(event: MatChipInputEvent): void {
+    const input = event.input;
+    const value = event.value;
+
+    if ((value || '').trim()) {
+      this.enabledOperatingSystems.push(value.trim());
+    }
+
+    if (input) {
+      input.value = '';
+    }
+  }
+
+  removeOS(os: string): void {
+    const index = this.enabledOperatingSystems.indexOf(os);
+
+    if (index >= 0) {
+      this.enabledOperatingSystems.splice(index, 1);
+    }
+  }
+
   private _getProviderConfig(): any {
     const raw = load(this.providerConfig);
     return !_.isEmpty(raw) ? raw : {};
@@ -164,6 +197,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
         country: this.form.get(Controls.Country).value,
         location: this.form.get(Controls.Location).value,
         requiredEmailDomains: this.requiredEmailDomains,
+        enabledOperatingSystems: this.enabledOperatingSystems,
         enforcePodSecurityPolicy: this.form.get(Controls.EnforcePodSecurityPolicy).value,
         enforceAuditLogging: this.form.get(Controls.EnforceAuditLogging).value,
       },

--- a/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
+++ b/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
@@ -129,6 +129,27 @@ limitations under the License.
       <mat-hint>Use commas or enter key as the separators.</mat-hint>
     </mat-form-field>
 
+    <mat-form-field class="domain-input">
+      <mat-label>Enabled Operating Systems</mat-label>
+      <mat-chip-list #chipList
+                     class="km-chip-list-with-input">
+        <mat-chip *ngFor="let os of enabledOperatingSystems"
+                  removable
+                  (removed)="removeOS(os)"
+                  [selectable]="false">
+          {{os}}
+          <i matChipRemove
+             class="km-icon-mask km-icon-remove"></i>
+        </mat-chip>
+        <input [formControlName]="controls.EnabledOperatingSystems"
+               matChipInputAddOnBlur
+               [matChipInputFor]="chipList"
+               [matChipInputSeparatorKeyCodes]="separatorKeyCodes"
+               (matChipInputTokenEnd)="addOS($event)">
+      </mat-chip-list>
+      <mat-hint>Use commas or enter key as the separators. Supported: [ubuntu, flatcar, centos, sles, rhel]</mat-hint>
+    </mat-form-field>
+
     <mat-checkbox [formControlName]="controls.EnforcePodSecurityPolicy">Enforce Pod Security Policy</mat-checkbox>
     <mat-checkbox [formControlName]="controls.EnforceAuditLogging">Enforce Audit Logging</mat-checkbox>
   </form>

--- a/src/app/shared/entity/datacenter.ts
+++ b/src/app/shared/entity/datacenter.ts
@@ -28,6 +28,7 @@ export class DatacenterSpec {
   location: string;
   provider: string;
   requiredEmailDomains?: string[];
+  enabledOperatingSystems?: string[];
   enforceAuditLogging: boolean;
   enforcePodSecurityPolicy: boolean;
   digitalocean?: DigitaloceanDatacenterSpec;


### PR DESCRIPTION
### What this PR does / why we need it
Add support for EnabledOperatingSystems for Datacenters.

Currently, you filter OS on provider what is not very general. There are private Clouds which belong to a certain Provider but it doesn't serve your OS configurations. E.g. not all Openstack DCs server Flatcar images.

Accordingly, I introduce an option `datacenter.spec.enabledOperatingSystems` to configure available OS per Datacenter. This is more general and allows the KKP admins to define their own supported OSs.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/kubermatic/kubermatic/issues/7842

### Special notes for your reviewer
<!-- Remove if not needed -->
I keep the backwards compatibility by checking if `datacenter.spec.enabledOperatingSystems.length > 0` and apply the check agains `enabledOperatingSystems` in `isOperatingSystemSupported` only if it was defined.

I also added the functionality into the dynamic DC dashboard.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Add support for EnabledOperatingSystems which configures available OS on datacenter level.
```
