### PR TITLE
[release/v2.18] remove default endpoint hint + make it required (#3726)

### DIFF
--- a/src/app/settings/admin/bucket-settings/edit-bucket-setting-dialog/component.ts
+++ b/src/app/settings/admin/bucket-settings/edit-bucket-setting-dialog/component.ts
@@ -45,7 +45,7 @@ export class EditBucketSettingDialog implements OnInit {
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.Bucket]: this._builder.control(this._bucketName, [Validators.required]),
-      [Controls.Endpoint]: this._builder.control(this._endpoint),
+      [Controls.Endpoint]: this._builder.control(this._endpoint, [Validators.required]),
     });
   }
 

--- a/src/app/settings/admin/bucket-settings/edit-bucket-setting-dialog/template.html
+++ b/src/app/settings/admin/bucket-settings/edit-bucket-setting-dialog/template.html
@@ -19,7 +19,6 @@ limitations under the License.
       <input matInput
              [formControlName]="Controls.Bucket"
              type="text"
-             title="name"
              autocomplete="off"
              required>
     </mat-form-field>
@@ -29,9 +28,8 @@ limitations under the License.
       <input matInput
              [formControlName]="Controls.Endpoint"
              type="text"
-             title="name"
-             autocomplete="off">
-      <mat-hint>If not specified default endpoint `s3.amazonaws.com` will be used.</mat-hint>
+             autocomplete="off"
+             required>
     </mat-form-field>
   </form>
 </mat-dialog-content>


### PR DESCRIPTION
### What this PR does / why we need it
This is a manual backport of #3726.

### Release note
```release-note
NONE
```
