### PR TITLE
Display CNI plugin type in cluster details

### DIFF
--- a/src/app/cluster/cluster-details/template.html
+++ b/src/app/cluster/cluster-details/template.html
@@ -150,6 +150,11 @@ limitations under the License.
           <div value>{{cluster.spec.clusterNetwork.services.cidrBlocks.join(', ')}}</div>
         </km-property>
 
+        <km-property *ngIf="cluster.spec.cniPlugin?.type">
+          <div key>CNI Plugin</div>
+          <div value>{{cluster.spec.cniPlugin.type}}</div>
+        </km-property>
+
         <km-property *ngIf="cluster.spec.clusterNetwork?.proxyMode">
           <div key>Proxy Mode</div>
           <div value>{{cluster.spec.clusterNetwork.proxyMode}}</div>


### PR DESCRIPTION
### What this PR does / why we need it
This is a followup to https://github.com/kubermatic/dashboard/pull/3709, I forgot to include CNI information in cluster details

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
