### PR TITLE
Update OS selection logic for vsphere and RHEL fields

### DIFF
--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -114,8 +114,8 @@ limitations under the License.
           <input [formControlName]="Controls.RhelSubscriptionManagerUser"
                  matInput
                  type="text"
-                 autocomplete="off"
-                 required>
+                 autocomplete="off">
+          <mat-hint>RHEL Subscription Manager User is required to register a machine.</mat-hint>
         </mat-form-field>
 
         <mat-form-field>
@@ -123,13 +123,13 @@ limitations under the License.
           <input [formControlName]="Controls.RhelSubscriptionManagerPassword"
                  matInput
                  type="password"
-                 autocomplete="off"
-                 required>
+                 autocomplete="off">
+          <mat-hint>RHEL Subscription Manager Password is required to register a machine.</mat-hint>
         </mat-form-field>
 
         <mat-form-field>
           <mat-label>RHEL Subscription Manager Offline Token</mat-label>
-          <input [formControlName]="Controls.RhsmOfflineToken"
+          <input [formControlName]="Controls.RhelOfflineToken"
                  matInput
                  type="password"
                  autocomplete="off">


### PR DESCRIPTION
### What this PR does / why we need it
- Make RHEL subscription manager user/password fields optional
- Add small note saying that they are still required in order to register a machine
- Enable RHEL and Flatcar for VSphere
- Remove old logic that enabled VSphere OS based on the image templates defined in the datacenter spec

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3819
Fixes #3820

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Add support for RHEL and Flatcar to the VSphere provider. Make RHEL subscription manager fields optional.
```
