### PR TITLE
Disable form until existing template is selected

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "typescript": "4.3.5"
   },
   "engines": {
-    "node": ">=14.11.0 <16.0.0"
+    "node": ">=14.11.0 <17.0.0"
   },
   "browserslist": [
     "last 2 chrome versions",

--- a/src/app/shared/components/select-cluster-template/component.ts
+++ b/src/app/shared/components/select-cluster-template/component.ts
@@ -67,6 +67,13 @@ export class SelectClusterTemplateDialogComponent implements OnInit, OnDestroy {
     this._unsubscribe.complete();
   }
 
+  get disabled(): boolean {
+    return (
+      !this.form.valid ||
+      !this.templateNames.includes(this.form.get(Control.ClusterTemplate).value[AutocompleteControls.Main])
+    );
+  }
+
   create(): void {
     const templateName = this.form.get(Control.ClusterTemplate).value[AutocompleteControls.Main];
     const dialogConfig: MatDialogConfig = {

--- a/src/app/shared/components/select-cluster-template/template.html
+++ b/src/app/shared/components/select-cluster-template/template.html
@@ -35,7 +35,7 @@ limitations under the License.
           type="submit"
           form="select-template-form"
           fxLayoutAlign="center center"
-          [disabled]="!form.valid">
+          [disabled]="disabled">
     <i class="km-icon-mask km-icon-add"></i>
     <span>Create Clusters from Template</span>
   </button>


### PR DESCRIPTION
### What this PR does / why we need it
<img width="726" alt="Zrzut ekranu 2021-11-9 o 12 05 50" src="https://user-images.githubusercontent.com/2823399/140913651-e0bec501-47aa-428b-92bd-e6156ccb9d0d.png">
<img width="701" alt="Zrzut ekranu 2021-11-9 o 12 05 53" src="https://user-images.githubusercontent.com/2823399/140913648-de12cd80-5a46-4127-a21a-2721fb677dbd.png">

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3832.

### Release note
```release-note
Disable dialog select form until existing template is selected.
```
