### PR TITLE
Improve OPA loading check

### DIFF
--- a/src/app/cluster/cluster-details/component.ts
+++ b/src/app/cluster/cluster-details/component.ts
@@ -159,7 +159,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
                 : of([] as MasterVersion[])
             )
             .concat(
-              this._canReloadNodes()
+              this.isClusterRunning
                 ? [
                     this._clusterService.addons(this.projectID, this.cluster.id),
                     this._clusterService.nodes(this.projectID, this.cluster.id),
@@ -169,7 +169,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
                 : [of([] as Addon[]), of([] as Node[]), of([] as MachineDeployment[]), of({} as ClusterMetrics)]
             )
             .concat(
-              this._canReloadNodes() && this.isMLAEnabled()
+              this.isClusterRunning && this.isMLAEnabled()
                 ? [
                     this._mlaService.alertmanagerConfig(this.projectID, this.cluster.id),
                     this._mlaService.ruleGroups(this.projectID, this.cluster.id),
@@ -177,7 +177,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
                 : [of([]), of([] as RuleGroup[])]
             )
             .concat(
-              this._canReloadNodes() && this.isOPAEnabled() && this.isClusterRunning
+              this.isClusterRunning && this.isOPAEnabled()
                 ? [
                     this._opaService.constraints(this.projectID, this.cluster.id),
                     this._opaService.gatekeeperConfig(this.projectID, this.cluster.id),
@@ -247,10 +247,6 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
       HealthState.isUp(this.health.apiserver) &&
       HealthState.isUp(this.health.machineController)
     );
-  }
-
-  private _canReloadNodes(): boolean {
-    return this.cluster && Health.allHealthy(this.health);
   }
 
   getProvider(provider: string): string {

--- a/src/app/cluster/cluster-details/component.ts
+++ b/src/app/cluster/cluster-details/component.ts
@@ -75,6 +75,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   machineDeployments: MachineDeployment[];
   isClusterRunning = false;
   isClusterAPIRunning = false;
+  isOPARunning = false;
   clusterHealthStatus: ClusterHealthStatus;
   health: Health;
   config: Config = {share_kubeconfig: false};
@@ -149,6 +150,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
           this.isClusterAPIRunning = ClusterHealthStatus.isClusterAPIRunning(this.cluster, health);
           this.isClusterRunning = ClusterHealthStatus.isClusterRunning(this.cluster, health);
           this.clusterHealthStatus = ClusterHealthStatus.getHealthStatus(this.cluster, health);
+          this.isOPARunning = ClusterHealthStatus.isOPARunning(this.cluster, health);
 
           // Conditionally create an array of observables to use for 'combineLatest' operator.
           // In case real observable should not be returned, observable emitting empty array will be added to the array.
@@ -177,7 +179,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
                 : [of([]), of([] as RuleGroup[])]
             )
             .concat(
-              this.isClusterRunning && this.isOPAEnabled()
+              this.isClusterRunning && this.isOPARunning && this.isOPAEnabled()
                 ? [
                     this._opaService.constraints(this.projectID, this.cluster.id),
                     this._opaService.gatekeeperConfig(this.projectID, this.cluster.id),

--- a/src/app/cluster/cluster-details/component.ts
+++ b/src/app/cluster/cluster-details/component.ts
@@ -177,7 +177,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
                 : [of([]), of([] as RuleGroup[])]
             )
             .concat(
-              this._canReloadNodes() && this.isOPAEnabled() && this._hasMachineDeployments()
+              this._canReloadNodes() && this.isOPAEnabled() && this.isClusterRunning
                 ? [
                     this._opaService.constraints(this.projectID, this.cluster.id),
                     this._opaService.gatekeeperConfig(this.projectID, this.cluster.id),
@@ -251,10 +251,6 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
 
   private _canReloadNodes(): boolean {
     return this.cluster && Health.allHealthy(this.health);
-  }
-
-  private _hasMachineDeployments(): boolean {
-    return !_.isEmpty(this.machineDeployments);
   }
 
   getProvider(provider: string): string {

--- a/src/app/cluster/cluster-details/template.html
+++ b/src/app/cluster/cluster-details/template.html
@@ -340,14 +340,14 @@ limitations under the License.
       <km-constraint-list [constraints]="constraints"
                           [cluster]="cluster"
                           [projectID]="projectID"
-                          [isClusterRunning]="isClusterRunning"></km-constraint-list>
+                          [isClusterRunning]="isClusterRunning && isOPARunning"></km-constraint-list>
     </km-tab>
     <km-tab label="OPA Gatekeeper Config"
             *ngIf="isOPAEnabled()">
       <km-gatekeeper-config [gatekeeperConfig]="gatekeeperConfig"
                             [cluster]="cluster"
                             [projectID]="projectID"
-                            [isClusterRunning]="isClusterRunning"></km-gatekeeper-config>
+                            [isClusterRunning]="isClusterRunning && isOPARunning"></km-gatekeeper-config>
     </km-tab>
     <km-tab label="Monitoring, Logging & Alerting"
             *ngIf="isMLAEnabled()">

--- a/src/app/shared/utils/health-status/cluster-health-status.ts
+++ b/src/app/shared/utils/health-status/cluster-health-status.ts
@@ -39,11 +39,7 @@ export class ClusterHealthStatus extends HealthStatus {
   }
 
   static isClusterRunning(c: Cluster, h: Health): boolean {
-    if (c.spec.cloud.bringyourown) {
-      return true;
-    }
-
-    return !!h && Health.allHealthy(h) && !c.deletionTimestamp;
+    return !!c && !!h && Health.allHealthy(h) && !c.deletionTimestamp;
   }
 
   static isClusterAPIRunning(c: Cluster, h: Health): boolean {

--- a/src/app/shared/utils/health-status/cluster-health-status.ts
+++ b/src/app/shared/utils/health-status/cluster-health-status.ts
@@ -46,6 +46,12 @@ export class ClusterHealthStatus extends HealthStatus {
     return !!h && HealthState.isUp(h.apiserver) && !c.deletionTimestamp;
   }
 
+  static isOPARunning(c: Cluster, h: Health): boolean {
+    return (
+      !!h && HealthState.isUp(h.gatekeeperAudit) && HealthState.isUp(h.gatekeeperController) && !c.deletionTimestamp
+    );
+  }
+
   css: string;
 
   constructor(message: HealthStatusMessage, color: HealthStatusColor, css: string) {


### PR DESCRIPTION
### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3694.

Previous check was preventing from loading the data if the cluster had no machine deployments created. Machine deployments are loaded in the same `combineLatest` as OPA stuff.

### Release note
```release-note
Fix a bug where OPA data was not retrieved when there were no machine deployments in the cluster.
```
