### PR TITLE
Allow audit policy preset changes during cluster edit

### DIFF
--- a/src/app/cluster/cluster-details/edit-cluster/component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/component.ts
@@ -21,6 +21,7 @@ import {DatacenterService} from '@core/services/datacenter';
 import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {
+  AuditPolicyPreset,
   Cluster,
   ClusterPatch,
   ContainerRuntime,
@@ -42,6 +43,7 @@ enum Controls {
   Name = 'name',
   ContainerRuntime = 'containerRuntime',
   AuditLogging = 'auditLogging',
+  AuditPolicyPreset = 'auditPolicyPreset',
   Labels = 'labels',
   AdmissionPlugins = 'admissionPlugins',
   PodNodeSelectorAdmissionPluginConfig = 'podNodeSelectorAdmissionPluginConfig',
@@ -74,6 +76,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
 
   readonly Controls = Controls;
+  readonly AuditPolicyPreset = AuditPolicyPreset;
   private readonly _nameMinLen = 3;
   private _settings: AdminSettings;
   private _seedSettings: SeedSettings;
@@ -110,6 +113,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.AuditLogging]: new FormControl(
         !!this.cluster.spec.auditLogging && this.cluster.spec.auditLogging.enabled
       ),
+      [Controls.AuditPolicyPreset]: new FormControl(this._getAuditPolicyPresetInitialState()),
       [Controls.OPAIntegration]: new FormControl(
         !!this.cluster.spec.opaIntegration && this.cluster.spec.opaIntegration.enabled
       ),
@@ -170,6 +174,16 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .subscribe(plugins => (this.admissionPlugins = plugins));
 
     this.checkForLegacyAdmissionPlugins();
+  }
+
+  private _getAuditPolicyPresetInitialState(): AuditPolicyPreset | '' {
+    if (!this.cluster.spec.auditLogging) {
+      return '';
+    }
+
+    return this.cluster.spec.auditLogging.policyPreset
+      ? this.cluster.spec.auditLogging.policyPreset
+      : AuditPolicyPreset.Custom;
   }
 
   checkForLegacyAdmissionPlugins(): void {
@@ -255,6 +269,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         cloud: this.providerSettingsPatch.cloudSpecPatch,
         auditLogging: {
           enabled: this.form.get(Controls.AuditLogging).value,
+          policyPreset: this.form.get(Controls.AuditPolicyPreset).value,
         },
         opaIntegration: {
           enabled: this.form.get(Controls.OPAIntegration).value,

--- a/src/app/cluster/cluster-details/edit-cluster/style.scss
+++ b/src/app/cluster/cluster-details/edit-cluster/style.scss
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@use 'variables';
+
 .km-edit-cluster-form {
   margin-bottom: 30px;
 }
@@ -23,5 +25,34 @@ km-label-form:not(.pod-node-selector-config) {
 mat-checkbox {
   i {
     margin: 4px 8px;
+  }
+}
+
+mat-button-toggle-group[group='auditLogging'] {
+  margin: 0 10px;
+
+  mat-button-toggle {
+    margin: 0 0 0 -1px;
+    max-height: 28px;
+    min-height: 28px;
+    min-width: unset;
+
+    &.mat-button-toggle-checked {
+      z-index: 1;
+    }
+
+    &:not(:first-of-type),
+    &:not(:last-of-type) {
+      border-radius: 0;
+    }
+
+    &:first-of-type {
+      border-radius: variables.$border-radius 0 0 variables.$border-radius;
+      margin: 0;
+    }
+
+    &:last-of-type {
+      border-radius: 0 variables.$border-radius variables.$border-radius 0;
+    }
   }
 }

--- a/src/app/cluster/cluster-details/edit-cluster/template.html
+++ b/src/app/cluster/cluster-details/edit-cluster/template.html
@@ -105,17 +105,31 @@ limitations under the License.
         Konnectivity
       </mat-checkbox>
 
-      <div fxLayout="row"
-           fxLayoutGap="16px">
-        <div fxLayout="row"
-             fxLayoutGap="8px"
-             fxLayoutAlign=" center">
-          <mat-checkbox [formControlName]="Controls.AuditLogging">Audit Logging</mat-checkbox>
-          <i *ngIf="!!datacenter.spec.enforceAuditLogging"
-             class="km-icon-error km-warning"
-             matTooltip="Audit Logging is enforced by your admin in the chosen datacenter.">
-          </i>
-        </div>
+      <div fxLayoutAlign=" center">
+        <mat-checkbox [formControlName]="Controls.AuditLogging">Audit Logging</mat-checkbox>
+        <mat-button-toggle-group *ngIf="!!form.get(Controls.AuditLogging).value"
+                                 [formControlName]="Controls.AuditPolicyPreset"
+                                 group="auditLogging">
+          <mat-button-toggle [value]="AuditPolicyPreset.Custom"
+                             matTooltip="Sets up cluster with a metadata audit policy that can be edited after the cluster has been created.">
+            custom
+          </mat-button-toggle>
+          <mat-button-toggle [value]="AuditPolicyPreset.Metadata"
+                             matTooltip="Logs metadata for all requests received by the Kubernetes API.">
+            metadata
+          </mat-button-toggle>
+          <mat-button-toggle [value]="AuditPolicyPreset.Minimal"
+                             matTooltip="Logs extended information about key security concerns like workload modifications and access to sensitive information.">
+            minimal
+          </mat-button-toggle>
+          <mat-button-toggle [value]="AuditPolicyPreset.Recommended"
+                             matTooltip="Logs extended information about key security concerns and metadata for all other requests. Recommended for best security coverage.">
+            recommended
+          </mat-button-toggle>
+        </mat-button-toggle-group>
+        <i *ngIf="isEnforced(Controls.AuditLogging)"
+           class="km-icon-info km-pointer"
+           matTooltip="Audit Logging is enforced by your admin in the chosen datacenter."></i>
       </div>
 
       <mat-checkbox [formControlName]="Controls.OPAIntegration">

--- a/src/app/cluster/cluster-details/edit-cluster/template.html
+++ b/src/app/cluster/cluster-details/edit-cluster/template.html
@@ -127,7 +127,7 @@ limitations under the License.
             recommended
           </mat-button-toggle>
         </mat-button-toggle-group>
-        <i *ngIf="isEnforced(Controls.AuditLogging)"
+        <i *ngIf="!!datacenter.spec.enforceAuditLogging"
            class="km-icon-info km-pointer"
            matTooltip="Audit Logging is enforced by your admin in the chosen datacenter."></i>
       </div>


### PR DESCRIPTION
### What this PR does / why we need it
<img width="686" alt="Zrzut ekranu 2021-11-30 o 12 49 48" src="https://user-images.githubusercontent.com/2823399/144043271-05089568-8b86-4df5-85e9-9eea05be6e61.png">

### Which issue(s) this PR fixes
Closes https://github.com/kubermatic/edgematic/issues/74.

### Release note
```release-note
Allow audit policy preset changes during cluster edit.
```
