### PR TITLE
Hide edit provider settings action for kubeAdm as it is not supported anyways

### DIFF
--- a/src/app/cluster/cluster-details/template.html
+++ b/src/app/cluster/cluster-details/template.html
@@ -103,6 +103,7 @@ limitations under the License.
           </button>
           <button mat-menu-item
                   (click)="editProviderSettings()"
+                  *ngIf="!cluster.spec.cloud.bringyourown"
                   [disabled]="!isClusterRunning || !isEditEnabled()">
             <span>Edit Provider</span>
           </button>


### PR DESCRIPTION
### What this PR does / why we need it
<img width="206" alt="Zrzut ekranu 2021-11-30 o 13 56 58" src="https://user-images.githubusercontent.com/2823399/144052096-57d5a1ec-cbe7-43a6-a3a2-f721df96f97c.png">

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3909.

### Release note
```release-note
Hidden edit provider settings action for kubeAdm as it is not supported.
```
