### PR TITLE
Update name validation to be more compliant with RFC1123 DNS names

### DIFF
--- a/src/app/cluster/cluster-details/edit-cluster/component.ts
+++ b/src/app/cluster/cluster-details/edit-cluster/component.ts
@@ -105,7 +105,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.Name]: new FormControl(this.cluster.name, [
         Validators.required,
         Validators.minLength(this._nameMinLen),
-        Validators.pattern('[a-zA-Z0-9-]*'),
+        Validators.pattern('[a-z0-9]+[a-z0-9-]*[a-z0-9]+'),
       ]),
       [Controls.ContainerRuntime]: new FormControl(this.cluster.spec.containerRuntime || ContainerRuntime.Containerd, [
         Validators.required,

--- a/src/app/cluster/cluster-details/edit-cluster/template.html
+++ b/src/app/cluster/cluster-details/edit-cluster/template.html
@@ -37,7 +37,7 @@ limitations under the License.
           Name must be at least {{form.get(Controls.Name).getError('minlength').requiredLength}} characters.
         </mat-error>
         <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
-          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -).
+          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
         </mat-error>
       </mat-form-field>
 

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -100,7 +100,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.Name]: this._builder.control(this._nodeDataService.nodeData.name, [
-        Validators.pattern('[a-zA-Z0-9-]*'),
+        Validators.pattern('[a-z0-9]+[a-z0-9-]*[a-z0-9]+'),
       ]),
       [Controls.Count]: this._builder.control(0),
       [Controls.DynamicConfig]: this._builder.control(this._nodeDataService.nodeData.dynamicConfig),

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -47,7 +47,7 @@ limitations under the License.
       </button>
       <mat-hint *ngIf="!dialogEditMode">Leave this field blank to use automatic name generation.</mat-hint>
       <mat-error *ngIf="form.get(Controls.Name).hasError( 'pattern')">
-        Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -).
+        Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
       </mat-error>
     </mat-form-field>
 

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -133,7 +133,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.Name]: new FormControl('', [
         Validators.required,
         Validators.minLength(this._minNameLength),
-        Validators.pattern('[a-zA-Z0-9-]*'),
+        Validators.pattern('[a-z0-9]+[a-z0-9-]*[a-z0-9]+'),
       ]),
       [Controls.Version]: new FormControl('', [Validators.required]),
       [Controls.ContainerRuntime]: new FormControl(ContainerRuntime.Containerd, [Validators.required]),

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -48,7 +48,7 @@ limitations under the License.
           Name must be at least {{ control(Controls.Name).getError('minlength').requiredLength }} characters.
         </mat-error>
         <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
-          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -).
+          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
         </mat-error>
       </mat-form-field>
 


### PR DESCRIPTION


### What this PR does / why we need it

The UI validation for MachineDeployment names was allowing uppercase letters, which would subsequently fail the MachineDeployment creation at the Kubernetes API in the backend. This PR tightens the validation logic for the MachineDeployment fields. Apart from uppercase letters, it also blocks dashes in the start and end of the name, as that's not valid under RFC1123 DNS names either (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).

In addition, as cluster names are used for name generation of MachineDeployments, they need tighter validation too. Otherwise, users can create a cluster that cannot generate MachineDeployments (if no name is passed for them).

The error message was tested across the various UI elements. I experimented with better wording, but that broke into multi-line output for editing resources, which looks ugly.

I was also looking at adding this to the KKP API on the backend side, but there's the major refactor of validation in KKP going on right now, so I'd like to postpone that until that PR has settled.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/kubermatic/kubermatic/issues/8301

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Cluster and MachineDeployment names are validated to be lowercase, alphanumerical and with dashes in between
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>