### PR TITLE
Add warning to grafana link if special addons aren't enabled

### DIFF
--- a/src/app/cluster/details/cluster/mla/alertmanager-config/component.spec.ts
+++ b/src/app/cluster/details/cluster/mla/alertmanager-config/component.spec.ts
@@ -20,9 +20,11 @@ import {DialogTestModule, NoopConfirmDialogComponent} from '@app/testing/compone
 import {fakeDigitaloceanCluster} from '@app/testing/fake-data/cluster';
 import {fakeAlertmanagerConfig} from '@app/testing/fake-data/mla';
 import {fakeProject} from '@app/testing/fake-data/project';
+import {ApiMockService} from '@app/testing/services/api-mock';
 import {DatacenterMockService} from '@app/testing/services/datacenter-mock';
 import {SettingsMockService} from '@app/testing/services/settings-mock';
 import {CoreModule} from '@core/module';
+import {ApiService} from '@core/services/api';
 import {DatacenterService} from '@core/services/datacenter';
 import {NotificationService} from '@core/services/notification';
 import {MLAService} from '@core/services/mla';
@@ -54,6 +56,7 @@ describe('AlertmanagerConfigComponent', () => {
           {provide: MLAService, useValue: mlaMock},
           {provide: SettingsService, useClass: SettingsMockService},
           {provide: DatacenterService, useClass: DatacenterMockService},
+          {provide: ApiService, useClass: ApiMockService},
           MatDialog,
           NotificationService,
         ],

--- a/src/app/cluster/details/cluster/mla/alertmanager-config/style.scss
+++ b/src/app/cluster/details/cluster/mla/alertmanager-config/style.scss
@@ -29,3 +29,7 @@ h3 {
   font-weight: normal;
   padding-right: 30px;
 }
+
+.addon-disabled-icon {
+  margin-left: 8px;
+}

--- a/src/app/cluster/details/cluster/mla/alertmanager-config/template.html
+++ b/src/app/cluster/details/cluster/mla/alertmanager-config/template.html
@@ -35,7 +35,8 @@ limitations under the License.
     </button>
   </div>
   <div fxFlex></div>
-  <div fxLayout="row">
+  <div fxLayout="row"
+       fxLayoutAlign=" center">
     <a [href]="getLinkURL(Type.Alertmanager)"
        target="_blank"
        mat-flat-button
@@ -56,5 +57,8 @@ limitations under the License.
       <i class="km-icon-mask km-icon-external-link"></i>
       <span>Open Grafana UI</span>
     </a>
+    <i *ngIf="displayGrafanaWarning()"
+       matTooltip="{{getTextForWarning()}}"
+       class="km-icon-warning addon-disabled-icon"></i>
   </div>
 </div>

--- a/src/app/cluster/details/cluster/mla/alertmanager-config/template.html
+++ b/src/app/cluster/details/cluster/mla/alertmanager-config/template.html
@@ -58,7 +58,7 @@ limitations under the License.
       <span>Open Grafana UI</span>
     </a>
     <i *ngIf="displayGrafanaWarning()"
-       matTooltip="{{getTextForWarning()}}"
+       matTooltip="{{getAddonsEnabledWarningText()}} {{getAddonsAvailableWarningText()}}"
        class="km-icon-warning addon-disabled-icon"></i>
   </div>
 </div>

--- a/src/app/cluster/details/cluster/mla/component.ts
+++ b/src/app/cluster/details/cluster/mla/component.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Component, Input} from '@angular/core';
+import {Addon} from '@shared/entity/addon';
 import {Cluster} from '@shared/entity/cluster';
 import {AlertmanagerConfig, RuleGroup} from '@shared/entity/mla';
 import _ from 'lodash';
@@ -27,6 +28,7 @@ export class MLAComponent {
   @Input() isClusterRunning: boolean;
   @Input() alertmanagerConfig: AlertmanagerConfig;
   @Input() ruleGroups: RuleGroup[];
+  @Input() addons: Addon[];
 
   isLoadingData(): boolean {
     return _.isEmpty(this.alertmanagerConfig) && _.isEmpty(this.ruleGroups) && !this.isClusterRunning;

--- a/src/app/cluster/details/cluster/mla/template.html
+++ b/src/app/cluster/details/cluster/mla/template.html
@@ -18,7 +18,8 @@ limitations under the License.
   <km-alertmanager-config [alertmanagerConfig]="alertmanagerConfig"
                           [cluster]="cluster"
                           [projectID]="projectID"
-                          [isClusterRunning]="isClusterRunning"></km-alertmanager-config>
+                          [isClusterRunning]="isClusterRunning"
+                          [addons]="addons"></km-alertmanager-config>
 
   <km-rule-groups [ruleGroups]="ruleGroups"
                   [cluster]="cluster"

--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -371,7 +371,8 @@ limitations under the License.
               [ruleGroups]="ruleGroups"
               [cluster]="cluster"
               [projectID]="projectID"
-              [isClusterRunning]="isClusterRunning"></km-mla>
+              [isClusterRunning]="isClusterRunning"
+              [addons]="addons"></km-mla>
     </km-tab>
   </km-tab-card>
 </div>


### PR DESCRIPTION
### What this PR does / why we need it
Add warning to grafana link if node-exporter and/or kube-state-metrics addons aren't enabled

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes https://github.com/kubermatic/kubermatic/issues/7961

### Special notes for your reviewer

![grafana-warning](https://user-images.githubusercontent.com/19547196/147205206-60e1ae14-9328-425b-9985-d512136d36f1.png)

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
