### PR TITLE
Bump END_OF_DOCKER_SUPPORT_VERSION to 1.24.0

### DIFF
--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -29,7 +29,7 @@ export enum ContainerRuntime {
   Docker = 'docker',
 }
 
-export const END_OF_DOCKER_SUPPORT_VERSION = '1.22.0';
+export const END_OF_DOCKER_SUPPORT_VERSION = '1.24.0';
 
 export class Cluster {
   creationTimestamp?: Date;


### PR DESCRIPTION
### What this PR does / why we need it

We have decided to allow Docker to be used on Kubernetes clusters up to 1.24.0.

### Release note
```release-note
NONE
```

cc: @moadqassem 