### PR TITLE
Hide CNI version picker arrow if it is disabled

### DIFF
--- a/src/assets/css/global/_main.scss
+++ b/src/assets/css/global/_main.scss
@@ -386,6 +386,18 @@ hr {
   }
 }
 
+.cni-version {
+  &.disabled {
+    mat-form-field.mat-primary {
+      .mat-select-arrow-wrapper {
+        .mat-select-arrow {
+          display: none;
+        }
+      }
+    }
+  }
+}
+
 .km-number-stepper-input {
   &.mat-form-field {
     &:not(.message) {


### PR DESCRIPTION
### What this PR does / why we need it
Before (disabled):
![image](https://user-images.githubusercontent.com/2823399/147563852-1a8e190c-a9e4-49e0-967f-e05d4e34bd2f.png)

After:
<img width="225" alt="Zrzut ekranu 2021-12-28 o 12 43 25" src="https://user-images.githubusercontent.com/2823399/147563862-6cd13313-dadf-4f4d-a2cf-fedee5c9602a.png">
<img width="228" alt="Zrzut ekranu 2021-12-28 o 12 54 23" src="https://user-images.githubusercontent.com/2823399/147563860-8b6dfb10-3b9f-41ee-972e-55703aac93c5.png">

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/3999.

### Release note
```release-note
NONE
```
