### PR TITLE
Block non-admin access to admin settings

### DIFF
--- a/src/app/core/module.ts
+++ b/src/app/core/module.ts
@@ -20,7 +20,7 @@ import {RouterModule} from '@angular/router';
 import {ChangelogDialog} from '@core/components/changelog/dialog';
 import {HelpPanelComponent} from '@core/components/help-panel/component';
 import {ApiService} from '@core/services/api';
-import {AuthGuard, AuthzGuard} from '@core/services/auth/guard';
+import {AdminGuard, AuthGuard, AuthzGuard} from '@core/services/auth/guard';
 import {Auth} from '@core/services/auth/service';
 import {BackupService} from '@core/services/backup';
 import {ChangelogManagerService} from '@core/services/changelog-manager';
@@ -88,6 +88,7 @@ const services: any[] = [
   Auth,
   AuthGuard,
   AuthzGuard,
+  AdminGuard,
   DatacenterService,
   StepsService,
   NameGeneratorService,

--- a/src/app/core/services/auth/guard.ts
+++ b/src/app/core/services/auth/guard.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Injectable} from '@angular/core';
-import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
+import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
 import {View} from '@shared/entity/common';
 import {Member} from '@shared/entity/member';
 import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
@@ -21,6 +21,17 @@ import {from, Observable} from 'rxjs';
 import {catchError, map} from 'rxjs/operators';
 import {UserService} from '../user';
 import {Auth} from './service';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(private readonly _userService: UserService, private readonly _router: Router) {}
+
+  canActivate(_route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): Observable<boolean | UrlTree> {
+    return this._userService.currentUser.pipe(
+      map(user => (user.isAdmin ? true : this._router.parseUrl(View.Projects)))
+    );
+  }
+}
 
 @Injectable()
 export class AuthGuard implements CanActivate {

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -14,6 +14,7 @@
 
 import {NgModule} from '@angular/core';
 import {PreloadingStrategy, Route, RouterModule, Routes} from '@angular/router';
+import {AdminGuard} from '@core/services/auth/guard';
 import {Observable, of} from 'rxjs';
 import {DashboardComponent} from './dashboard/component';
 
@@ -69,6 +70,7 @@ function createRouting(): Routes {
         {
           path: 'settings',
           loadChildren: () => import('./settings/admin/module').then(m => m.AdminSettingsModule),
+          canActivate: [AdminGuard],
         },
         {
           path: '',


### PR DESCRIPTION
### What this PR does / why we need it
Added view guard to properly check for admin user before allowing access to the view.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4026

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
