### PR TITLE
UI fixes

### DIFF
--- a/src/app/cluster/details/cluster/cluster-delete-confirmation/component.ts
+++ b/src/app/cluster/details/cluster/cluster-delete-confirmation/component.ts
@@ -21,6 +21,7 @@ import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {Cluster, Finalizer} from '@shared/entity/cluster';
 import {AdminSettings} from '@shared/entity/settings';
+import {ClipboardService} from 'ngx-clipboard';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
@@ -44,6 +45,7 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck, OnDe
     private readonly _settingsService: SettingsService,
     private readonly _dialogRef: MatDialogRef<ClusterDeleteConfirmationComponent>,
     private readonly _googleAnalyticsService: GoogleAnalyticsService,
+    private readonly _clipboardService: ClipboardService,
     private readonly _notificationService: NotificationService
   ) {}
 
@@ -112,5 +114,9 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck, OnDe
         this._clusterService.refreshClusters();
       });
     this._dialogRef.close(true);
+  }
+
+  copy(clipboard: string): void {
+    this._clipboardService.copy(clipboard);
   }
 }

--- a/src/app/cluster/details/cluster/cluster-delete-confirmation/template.html
+++ b/src/app/cluster/details/cluster/cluster-delete-confirmation/template.html
@@ -19,8 +19,7 @@ limitations under the License.
         (submit)="deleteCluster()"
         id="km-delete-cluster-dialog">
     <p>Delete
-      <b ngxClipboard
-         [cbContent]="cluster.name"
+      <b (click)="copy(cluster.name)"
          matTooltip="Click to copy"
          class="km-copy">{{cluster.name}}</b>
       cluster permanently?

--- a/src/app/cluster/details/cluster/mla/alertmanager-config/alertmanager-config-dialog/template.html
+++ b/src/app/cluster/details/cluster/mla/alertmanager-config/alertmanager-config-dialog/template.html
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <km-dialog-title>{{data.title}}</km-dialog-title>
 <mat-dialog-content>
-  <p class="km-dialog-context-description">Edit alertmanager config of <b>{{data.cluster.name}}</b> cluster</p>
+  <p class="km-dialog-context-description">Edit alertmanager config of <b>{{data?.cluster?.name}}</b> cluster</p>
   <div class="spec">Spec</div>
   <km-editor [(model)]="spec"
              header="YAML"></km-editor>

--- a/src/app/cluster/details/cluster/mla/component.ts
+++ b/src/app/cluster/details/cluster/mla/component.ts
@@ -31,6 +31,6 @@ export class MLAComponent {
   @Input() addons: Addon[];
 
   isLoadingData(): boolean {
-    return _.isEmpty(this.alertmanagerConfig) && _.isEmpty(this.ruleGroups) && !this.isClusterRunning;
+    return _.isEmpty(this.alertmanagerConfig) || _.isEmpty(this.ruleGroups) || !this.isClusterRunning;
   }
 }


### PR DESCRIPTION
### What this PR does / why we need it
- Fixed edit alertmanager dialog not loading due to initialized data
- Fixed `click to copy` option in the cluster delete dialog

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4047 
Fixes #4030

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
