### PR TITLE
Hide SLES if container runtime is containerd and remove RHEL as supported OS for GCP

### DIFF
--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -27,6 +27,7 @@ import {DatacenterService} from '@core/services/datacenter';
 import {NameGeneratorService} from '@core/services/name-generator';
 import {NodeDataService} from '@core/services/node-data/service';
 import {SettingsService} from '@core/services/settings';
+import {ContainerRuntime} from '@shared/entity/cluster';
 import {Datacenter} from '@shared/entity/datacenter';
 import {OperatingSystemSpec, Taint} from '@shared/entity/node';
 import {NodeProvider, NodeProviderConstants, OperatingSystem} from '@shared/model/NodeProviderConstants';
@@ -179,7 +180,11 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     // Enable OS per-provider basis
     switch (os) {
       case OperatingSystem.SLES:
-        return this.isProvider(NodeProvider.AWS);
+        // SLES only supports docker as container runtime
+        return (
+          this._clusterSpecService.cluster.spec.containerRuntime === ContainerRuntime.Docker &&
+          this.isProvider(NodeProvider.AWS)
+        );
       case OperatingSystem.RHEL:
         return this.isProvider(
           NodeProvider.AWS,

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -189,7 +189,6 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
         return this.isProvider(
           NodeProvider.AWS,
           NodeProvider.AZURE,
-          NodeProvider.GCP,
           NodeProvider.KUBEVIRT,
           NodeProvider.OPENSTACK,
           NodeProvider.VSPHERE


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

### What this PR does / why we need it
SLES doesn't support `containerd` as container runtime. Hide it from the list of supported operating systems from dashboard.

Similarly, RHEL is not supported on GCP.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4072 #4075

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
