### PR TITLE
Add option to set a default destination

### DIFF
--- a/src/app/settings/admin/bucket-settings/destinations/component.ts
+++ b/src/app/settings/admin/bucket-settings/destinations/component.ts
@@ -77,6 +77,13 @@ export class DestinationsComponent implements OnInit {
     return !!destination?.credentials;
   }
 
+  isDefault(name: string): boolean {
+    return (
+      this.seed?.spec?.etcdBackupRestore?.defaultDestination &&
+      this.seed.spec.etcdBackupRestore.defaultDestination === name
+    );
+  }
+
   addDestination(): void {
     const dialogConfig: MatDialogConfig = {
       data: {

--- a/src/app/settings/admin/bucket-settings/destinations/component.ts
+++ b/src/app/settings/admin/bucket-settings/destinations/component.ts
@@ -78,10 +78,7 @@ export class DestinationsComponent implements OnInit {
   }
 
   isDefault(name: string): boolean {
-    return (
-      this.seed?.spec?.etcdBackupRestore?.defaultDestination &&
-      this.seed.spec.etcdBackupRestore.defaultDestination === name
-    );
+    return this.seed?.spec?.etcdBackupRestore?.defaultDestination === name;
   }
 
   addDestination(): void {

--- a/src/app/settings/admin/bucket-settings/destinations/destination-dialog/component.ts
+++ b/src/app/settings/admin/bucket-settings/destinations/destination-dialog/component.ts
@@ -41,11 +41,13 @@ export enum Controls {
   DestinationName = 'destinationName',
   Bucket = 'bucketName',
   Endpoint = 'endpoint',
+  Default = 'default',
 }
 
 @Component({
   selector: 'km-destination-dialog',
   templateUrl: './template.html',
+  styleUrls: ['style.scss'],
 })
 export class DestinationDialog implements OnInit, OnDestroy {
   readonly Controls = Controls;
@@ -61,6 +63,10 @@ export class DestinationDialog implements OnInit, OnDestroy {
     @Inject(MAT_DIALOG_DATA) public data: DestinationDialogData
   ) {}
 
+  get currentDefault(): string {
+    return this.data?.seed?.spec?.etcdBackupRestore?.defaultDestination;
+  }
+
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.DestinationName]: this._builder.control(
@@ -73,6 +79,9 @@ export class DestinationDialog implements OnInit, OnDestroy {
       [Controls.Endpoint]: this._builder.control(this.data.mode === Mode.Edit ? this.data.destination.endpoint : '', [
         Validators.required,
       ]),
+      [Controls.Default]: this._builder.control(
+        this.data.mode === Mode.Edit && this.currentDefault === this.data.destination.destinationName
+      ),
     });
   }
 
@@ -96,6 +105,10 @@ export class DestinationDialog implements OnInit, OnDestroy {
 
     const configuration: AdminSeed = this.data.seed;
     configuration.spec.etcdBackupRestore.destinations = destination;
+
+    if (this.form.get(Controls.Default).value) {
+      configuration.spec.etcdBackupRestore.defaultDestination = this.form.get(Controls.DestinationName).value;
+    }
 
     this._datacenterService.patchAdminSeed(configuration.name, configuration).subscribe(_ => {
       this._matDialogRef.close();

--- a/src/app/settings/admin/bucket-settings/destinations/destination-dialog/style.scss
+++ b/src/app/settings/admin/bucket-settings/destinations/destination-dialog/style.scss
@@ -1,0 +1,21 @@
+// Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.default-checkbox {
+  margin-bottom: 10px;
+
+  .has-default-info-icon {
+    margin: 4px 0 0 8px;
+  }
+}

--- a/src/app/settings/admin/bucket-settings/destinations/destination-dialog/template.html
+++ b/src/app/settings/admin/bucket-settings/destinations/destination-dialog/template.html
@@ -46,6 +46,14 @@ limitations under the License.
              autocomplete="off"
              required>
     </mat-form-field>
+
+    <mat-checkbox [formControlName]="Controls.Default"
+                  class="default-checkbox">
+      <span>Use as default for automatically generated etcd backups</span>
+      <i *ngIf="currentDefault"
+         class="km-icon-info km-pointer has-default-info-icon"
+         matTooltip="Will overwrite the current default: {{currentDefault}}"></i>
+    </mat-checkbox>
   </form>
 </mat-dialog-content>
 <mat-dialog-actions>

--- a/src/app/settings/admin/bucket-settings/destinations/template.html
+++ b/src/app/settings/admin/bucket-settings/destinations/template.html
@@ -42,17 +42,24 @@ limitations under the License.
   <ng-container matColumnDef="name">
     <th mat-header-cell
         *matHeaderCellDef
-        class="km-header-cell"
+        class="km-header-cell p-25"
         mat-sort-header>Destination Name
     </th>
     <td mat-cell
-        *matCellDef="let element">{{element.destinationName}}</td>
+        *matCellDef="let element">
+      <div fxLayoutAlign=" center"
+           fxLayoutGap="8px">
+        <span>{{element.destinationName}}</span>
+        <span *ngIf="isDefault(element.destinationName)"
+              class="km-label-primary">default</span>
+      </div>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="bucket">
     <th mat-header-cell
         *matHeaderCellDef
-        class="km-header-cell"
+        class="km-header-cell p-25"
         mat-sort-header>Bucket
     </th>
     <td mat-cell
@@ -62,7 +69,7 @@ limitations under the License.
   <ng-container matColumnDef="endpoint">
     <th mat-header-cell
         *matHeaderCellDef
-        class="km-header-cell"
+        class="km-header-cell p-25"
         mat-sort-header>Endpoint
     </th>
     <td mat-cell
@@ -72,7 +79,7 @@ limitations under the License.
   <ng-container matColumnDef="credentials">
     <th mat-header-cell
         *matHeaderCellDef
-        class="km-header-cell"
+        class="km-header-cell p-10"
         mat-sort-header>Credentials
     </th>
     <td mat-cell
@@ -85,7 +92,7 @@ limitations under the License.
   <ng-container matColumnDef="actions">
     <th mat-header-cell
         *matHeaderCellDef
-        class="km-header-cell"></th>
+        class="km-header-cell p-15"></th>
     <td mat-cell
         *matCellDef="let element">
       <div fxLayoutAlign="end"

--- a/src/app/shared/entity/datacenter.ts
+++ b/src/app/shared/entity/datacenter.ts
@@ -162,6 +162,7 @@ export class MeteringCredentials {
 
 export class EtcdBackupRestore {
   destinations: Destinations;
+  defaultDestination?: string;
 }
 
 export class Destinations {


### PR DESCRIPTION
### What this PR does / why we need it
Add option to set a default destination. It'll then be used for automatic etcd backups after cluster creation.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4079

### Special notes for your reviewer

![defaultdestination1](https://user-images.githubusercontent.com/19547196/149800599-2ab95a04-ff56-4e38-b13e-a5b9224a03c7.PNG)

![defaultdestination2](https://user-images.githubusercontent.com/19547196/149800603-15c48725-df30-4167-92be-f79da2d30395.PNG)

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Add option for administrators to specify default destination in "Backup Destinations" view.
```
