### PR TITLE
Fix mla tab

### DIFF
--- a/src/app/cluster/details/cluster/mla/component.ts
+++ b/src/app/cluster/details/cluster/mla/component.ts
@@ -31,6 +31,6 @@ export class MLAComponent {
   @Input() addons: Addon[];
 
   isLoadingData(): boolean {
-    return _.isEmpty(this.alertmanagerConfig) || _.isEmpty(this.ruleGroups) || !this.isClusterRunning;
+    return !this.isClusterRunning;
   }
 }

--- a/src/app/cluster/details/cluster/mla/component.ts
+++ b/src/app/cluster/details/cluster/mla/component.ts
@@ -29,8 +29,4 @@ export class MLAComponent {
   @Input() alertmanagerConfig: AlertmanagerConfig;
   @Input() ruleGroups: RuleGroup[];
   @Input() addons: Addon[];
-
-  isLoadingData(): boolean {
-    return !this.isClusterRunning;
-  }
 }

--- a/src/app/cluster/details/cluster/mla/template.html
+++ b/src/app/cluster/details/cluster/mla/template.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<ng-container *ngIf="!isLoadingData()">
+<ng-container *ngIf="isClusterRunning">
   <km-alertmanager-config [alertmanagerConfig]="alertmanagerConfig"
                           [cluster]="cluster"
                           [projectID]="projectID"

--- a/src/app/cluster/details/cluster/mla/template.html
+++ b/src/app/cluster/details/cluster/mla/template.html
@@ -27,4 +27,4 @@ limitations under the License.
                   [isClusterRunning]="isClusterRunning"></km-rule-groups>
 </ng-container>
 
-<km-loader *ngIf="isLoadingData()"></km-loader>
+<km-loader *ngIf="!isClusterRunning"></km-loader>


### PR DESCRIPTION
### What this PR does / why we need it
Fixes mla tab, as the current `isLoading()` function basically every time returned true. Especially in case there aren't any default rule groups it is not possible that this tab ever gets enabled.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
