### PR TITLE
Disable multiple fields in opa edit dialogs

### DIFF
--- a/src/app/cluster/details/cluster/constraints/constraint-dialog/component.ts
+++ b/src/app/cluster/details/cluster/constraints/constraint-dialog/component.ts
@@ -54,6 +54,7 @@ export enum Controls {
 })
 export class ConstraintDialog implements OnInit, OnDestroy {
   readonly Controls = Controls;
+  readonly Mode = Mode;
   form: FormGroup;
   spec = '';
   constraintTemplates: ConstraintTemplate[] = [];
@@ -73,7 +74,10 @@ export class ConstraintDialog implements OnInit, OnDestroy {
         Validators.required,
       ]),
       [Controls.ConstraintTemplate]: this._builder.control(
-        this.data.mode === Mode.Edit ? this.data.constraint.spec.constraintType : '',
+        {
+          value: this.data.mode === Mode.Edit ? this.data.constraint.spec.constraintType : '',
+          disabled: this.data.mode === Mode.Edit,
+        },
         [Validators.required]
       ),
     });

--- a/src/app/cluster/details/cluster/constraints/constraint-dialog/template.html
+++ b/src/app/cluster/details/cluster/constraints/constraint-dialog/template.html
@@ -20,7 +20,8 @@ limitations under the License.
 
   <form [formGroup]="form"
         fxLayout="column">
-    <mat-form-field fxFlex>
+    <mat-form-field fxFlex
+                    *ngIf="data.mode === Mode.Add">
       <mat-label>Constraint Name</mat-label>
       <input required
              matInput

--- a/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/component.ts
+++ b/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/component.ts
@@ -53,6 +53,7 @@ export enum Controls {
 })
 export class AllowedRegistryDialog implements OnInit, OnDestroy {
   readonly controls = Controls;
+  readonly Mode = Mode;
   form: FormGroup;
   private readonly _unsubscribe = new Subject<void>();
 

--- a/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/template.html
+++ b/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/template.html
@@ -27,7 +27,8 @@ END OF TERMS AND CONDITIONS
 
   <form [formGroup]="form"
         fxLayout="column">
-    <mat-form-field fxFlex>
+    <mat-form-field fxFlex
+                    *ngIf="data.mode === Mode.Add">
       <mat-label>Name</mat-label>
       <input required
              matInput

--- a/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/component.ts
+++ b/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/component.ts
@@ -51,6 +51,7 @@ export enum Controls {
 })
 export class DefaultConstraintDialog implements OnInit, OnDestroy {
   readonly Controls = Controls;
+  readonly Mode = Mode;
   form: FormGroup;
   spec = '';
   constraintTemplates: ConstraintTemplate[] = [];
@@ -70,7 +71,10 @@ export class DefaultConstraintDialog implements OnInit, OnDestroy {
         Validators.required,
       ]),
       [Controls.ConstraintTemplate]: this._builder.control(
-        this.data.mode === Mode.Edit ? this.data.defaultConstraint.spec.constraintType : '',
+        {
+          value: this.data.mode === Mode.Edit ? this.data.defaultConstraint.spec.constraintType : '',
+          disabled: this.data.mode === Mode.Edit,
+        },
         [Validators.required]
       ),
     });

--- a/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/template.html
+++ b/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/template.html
@@ -19,7 +19,8 @@ limitations under the License.
      class="km-dialog-context-description">Edit <b>{{data.defaultConstraint.name}}</b> default constraint</p>
   <form [formGroup]="form"
         fxLayout="column">
-    <mat-form-field fxFlex>
+    <mat-form-field fxFlex
+                    *ngIf="data.mode === Mode.Add">
       <mat-label>Constraint Name</mat-label>
       <input required
              matInput


### PR DESCRIPTION
### What this PR does / why we need it
This change is relevant for `Constraints`, `Default Constraints` and `Allowed Registry` dialogs.
1. For all of them, it is not possible to edit the name after creation (API is returning an error). Since we already have the name information in the dialog description, we can simply hide this field completely.
2. For `Default Constraints` + `Constraints` there is also a field for the `Constraint Template`, which also can't be changed after creation (API also is returning an error). Therefor we need to disable it visually.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4065
Fixes #4064

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
