### PR TITLE
Fix undefined error on cluster details

### DIFF
--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -287,7 +287,7 @@ limitations under the License.
                                  [value]="isAdmissionPluginEnabled(plugin)">
             </km-property-boolean>
 
-            <km-property *ngIf="cluster?.spec?.eventRateLimitConfig">
+            <km-property *ngIf="cluster?.spec?.eventRateLimitConfig?.namespace">
               <div key>Event Rate Limit Config</div>
               <div value
                    fxLayout="row wrap"
@@ -322,9 +322,9 @@ limitations under the License.
 
             <div fxLayout="row">
               <km-property-boolean label="Audit Logging"
-                                   [value]="cluster.spec.auditLogging.enabled">
+                                   [value]="cluster.spec.auditLogging?.enabled">
               </km-property-boolean>
-              <span *ngIf="cluster.spec.auditLogging.enabled"
+              <span *ngIf="cluster.spec.auditLogging?.enabled"
                     class="km-label-primary secondary">{{cluster.spec.auditLogging.policyPreset || 'custom'}}</span>
             </div>
 


### PR DESCRIPTION
### What this PR does / why we need it
Fix for an issue when after using cluster patch event rate limit config breaks the cluster details view.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
