### PR TITLE
Fix long event messages causing page to stretch

### DIFF
--- a/src/app/shared/components/event-list/style.scss
+++ b/src/app/shared/components/event-list/style.scss
@@ -16,6 +16,7 @@
 
 .km-events-long-text {
   line-height: 20px;
+  word-break: break-word;
 }
 
 .km-events-timestamp {


### PR DESCRIPTION
### What this PR does / why we need it

#### Before
![2022-01-20_11-48_1](https://user-images.githubusercontent.com/2285385/150324791-537e8c23-fb70-440a-b784-3fdd80c8e8e5.png)

#### After
![2022-01-20_11-48](https://user-images.githubusercontent.com/2285385/150324800-0dca0020-a0e3-41df-88da-46b3c84b661f.png)

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4103

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
