### PR TITLE
Fix the default image selection in the MD edit dialog

### DIFF
--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -279,7 +279,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
   private _setDefaultImage(os: OperatingSystem): void {
     let defaultImage = this._getDefaultImage(os);
 
-    if (this._defaultImage.length === 0) {
+    if (_.isEmpty(this._defaultImage)) {
       this._defaultImage = defaultImage;
     }
 

--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -81,6 +81,7 @@ enum AvailabilityZoneState {
 })
 export class OpenstackBasicNodeDataComponent extends BaseFormValidator implements OnInit, OnDestroy, AfterViewInit {
   private _defaultImage = '';
+  private _defaultOS: OperatingSystem;
   private _images: DatacenterOperatingSystemOptions;
   private readonly _instanceReadyCheckPeriodDefault = 5; // seconds
   private readonly _instanceReadyCheckTimeoutDefault = 120; // seconds
@@ -220,6 +221,9 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
       this.form.get(Controls.InstanceReadyCheckPeriod).setValue(instanceReadyCheckPeriod);
       this.form.get(Controls.InstanceReadyCheckTimeout).setValue(instanceReadyCheckTimeout);
 
+      this._defaultOS = this._nodeDataService.operatingSystem;
+      this._defaultImage = this._nodeDataService.nodeData.spec.cloud.openstack.image;
+
       this._cdr.detectChanges();
     }
   }
@@ -273,28 +277,35 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
   }
 
   private _setDefaultImage(os: OperatingSystem): void {
-    switch (os) {
-      case OperatingSystem.CentOS:
-        this._defaultImage = this._images.centos;
-        break;
-      case OperatingSystem.Ubuntu:
-        this._defaultImage = this._images.ubuntu;
-        break;
-      case OperatingSystem.SLES:
-        this._defaultImage = this._images.sles;
-        break;
-      case OperatingSystem.RHEL:
-        this._defaultImage = this._images.rhel;
-        break;
-      case OperatingSystem.Flatcar:
-        this._defaultImage = this._images.flatcar;
-        break;
-      default:
-        this._defaultImage = this._images.ubuntu;
+    let defaultImage = this._getDefaultImage(os);
+
+    if (this._defaultImage.length === 0) {
+      this._defaultImage = defaultImage;
     }
 
-    this.form.get(Controls.Image).setValue(this._defaultImage);
+    if (os === this._defaultOS) {
+      defaultImage = this._defaultImage;
+    }
+
+    this.form.get(Controls.Image).setValue(defaultImage);
     this._cdr.detectChanges();
+  }
+
+  private _getDefaultImage(os: OperatingSystem): string {
+    switch (os) {
+      case OperatingSystem.CentOS:
+        return this._images.centos;
+      case OperatingSystem.Ubuntu:
+        return this._images.ubuntu;
+      case OperatingSystem.SLES:
+        return this._images.sles;
+      case OperatingSystem.RHEL:
+        return this._images.rhel;
+      case OperatingSystem.Flatcar:
+        return this._images.flatcar;
+      default:
+        return this._images.ubuntu;
+    }
   }
 
   private _enforceFloatingIP(isEnforced: boolean): void {


### PR DESCRIPTION
### What this PR does / why we need it
The information taken from the edited MD was overridden during defaulting. Now they are saved and reused.

![Peek 2022-01-20 13-39](https://user-images.githubusercontent.com/2285385/150341096-29e08f6c-de17-4546-ac1f-e33214cae490.gif)

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4100

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
