### PR TITLE
Update provider/ssh keys fields key display

### DIFF
--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -163,13 +163,15 @@ limitations under the License.
           <div key>Container Runtime</div>
           <div value>{{cluster.spec.containerRuntime}}</div>
         </km-property>
-        <km-property mode="value">
+        <km-property>
+          <div key>Provider</div>
           <div value
                class="km-provider-logo-value">
             <span class="km-provider-logo km-provider-logo-{{getProvider(nodeDc?.spec?.provider)}}"></span>
           </div>
         </km-property>
-        <km-property mode="value">
+        <km-property>
+          <div key>SSH Keys</div>
           <div value>
             <km-ssh-key-list [sshKeys]="sshKeys"></km-ssh-key-list>
           </div>

--- a/src/app/shared/components/cluster-summary/component.ts
+++ b/src/app/shared/components/cluster-summary/component.ts
@@ -13,15 +13,16 @@
 // limitations under the License.
 
 import {Component, Input} from '@angular/core';
+import {LabelFormComponent} from '@shared/components/label-form/component';
 import {Cluster} from '@shared/entity/cluster';
 import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
+import {MachineDeployment} from '@shared/entity/machine-deployment';
 import {getOperatingSystem, getOperatingSystemLogoClass} from '@shared/entity/node';
+import {SSHKey} from '@shared/entity/ssh-key';
 import {getIpCount} from '@shared/functions/get-ip-count';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
-import _ from 'lodash';
-import {MachineDeployment} from '@shared/entity/machine-deployment';
-import {LabelFormComponent} from '@shared/components/label-form/component';
 import {AdmissionPluginUtils} from '@shared/utils/admission-plugin-utils/admission-plugin-utils';
+import _ from 'lodash';
 
 @Component({
   selector: 'km-cluster-summary',
@@ -29,12 +30,17 @@ import {AdmissionPluginUtils} from '@shared/utils/admission-plugin-utils/admissi
   styleUrls: ['./style.scss'],
 })
 export class ClusterSummaryComponent {
+  private _sshKeys: SSHKey[] = [];
   @Input() cluster: Cluster;
   @Input() machineDeployment: MachineDeployment;
   @Input() datacenter: Datacenter;
   @Input() seedSettings: SeedSettings;
-  @Input() sshKeys: string[] = [];
   @Input() flipLayout = false;
+
+  @Input()
+  set sshKeys(keys: string[]) {
+    this._sshKeys = keys?.map(key => ({name: key} as SSHKey));
+  }
 
   get provider(): NodeProvider {
     const providers = Object.values(NodeProvider)
@@ -66,6 +72,10 @@ export class ClusterSummaryComponent {
   get hasIPLeft(): boolean {
     const ipCount = getIpCount(this.cluster.spec.machineNetworks);
     return ipCount > 0 ? ipCount < this.machineDeployment.spec.replicas : false;
+  }
+
+  getSSHKeys(): SSHKey[] {
+    return this._sshKeys;
   }
 
   displaySettings(): boolean {

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -90,6 +90,12 @@ limitations under the License.
         <div key>Services CIDR</div>
         <div value>{{cluster.spec.clusterNetwork.services.cidrBlocks.join(', ')}}</div>
       </km-property>
+      <km-property>
+        <div key>SSH Keys</div>
+        <div value>
+          <km-ssh-key-list [sshKeys]="getSSHKeys()"></km-ssh-key-list>
+        </div>
+      </km-property>
       <km-property-boolean label="Konnectivity"
                            [value]="cluster.spec.clusterNetwork?.konnectivityEnabled">
       </km-property-boolean>
@@ -129,7 +135,7 @@ limitations under the License.
           <div value
                fxLayout="row"
                fxLayoutGap="10px"
-               class="event-rate-limit" >
+               class="event-rate-limit">
             <div><span class="km-text-muted">Limit Type:</span> Namespace</div>
             <div><span class="km-text-muted">QPS:</span> {{cluster.spec.eventRateLimitConfig.namespace.qps}}</div>
             <div><span class="km-text-muted">Burst:</span> {{cluster.spec.eventRateLimitConfig.namespace.burst}}</div>
@@ -181,13 +187,6 @@ limitations under the License.
                            label="Disable system auto-update"
                            [value]="machineDeployment.spec.template.operatingSystem.flatcar.disableAutoUpdate">
       </km-property-boolean>
-      <div fxLayout="row"
-           fxLayoutAlign=" center"
-           fxLayoutGap="10px"
-           *ngIf="sshKeys && sshKeys.length">
-        <i class="km-icon-key"></i>
-        <span>{{sshKeys.join(', ')}}</span>
-      </div>
     </div>
   </div>
 

--- a/src/app/shared/components/property/template.html
+++ b/src/app/shared/components/property/template.html
@@ -21,6 +21,7 @@ limitations under the License.
       <div *ngIf="mode === Mode.Value"></div>
       <ng-content select="[key]"></ng-content>
     </div>
+    <div fxFlex></div>
     <div class="value km-text">
       <ng-content select="[value]"></ng-content>
     </div>


### PR DESCRIPTION
### What this PR does / why we need it
Added key labels to the provider and ssh keys fields.

![2022-01-20_14-17](https://user-images.githubusercontent.com/2285385/150349907-192fa68b-427e-49fe-af8c-d550f7e82701.png)

![2022-01-20_14-16](https://user-images.githubusercontent.com/2285385/150349911-76ba500a-fcb0-44dc-8ec7-1e76eb714182.png)

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4107

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
