### PR TITLE
Fixes for Kubevirt machine deployment creation

### DIFF
--- a/cypress/integration/providers/kubevirt.spec.ts
+++ b/cypress/integration/providers/kubevirt.spec.ts
@@ -29,7 +29,6 @@ describe('KubeVirt Provider', () => {
   const projectName = Mocks.enabled() ? 'test-project' : _.uniqueId('test-project-');
   const clusterName = Mocks.enabled() ? 'test-cluster' : _.uniqueId('test-cluster-');
   const initialMachineDeploymentReplicas = '0';
-  const namespace = 'kube-system';
   const sourceURL = 'http://10.102.236.197/ubuntu.img';
   const storageClassName = 'kubermatic-fast';
 
@@ -68,7 +67,6 @@ describe('KubeVirt Provider', () => {
       .clear()
       .type(initialMachineDeploymentReplicas)
       .should(Condition.HaveValue, initialMachineDeploymentReplicas);
-    WizardPage.kubeVirt.getNamespaceInput().type(namespace).should(Condition.HaveValue, namespace);
     WizardPage.kubeVirt.getSourceURLInput().type(sourceURL).should(Condition.HaveValue, sourceURL);
     WizardPage.kubeVirt.getStorageClassNameInput().type(storageClassName).should(Condition.HaveValue, storageClassName);
     WizardPage.getNextBtn(WizardStep.NodeSettings).should(Condition.BeEnabled).click({force: true});

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "typescript": "4.5.4"
       },
       "engines": {
-        "node": ">=16.0.0 <17.0.0"
+        "node": ">=16.0.0 <17.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "typescript": "4.5.4"
   },
   "engines": {
-    "node": ">=16.0.0 <17.0.0"
+    "node": ">=16.0.0 <17.4.0"
   },
   "browserslist": [
     "last 2 chrome versions",

--- a/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -47,7 +47,7 @@ enum Controls {
   ],
 })
 export class KubeVirtBasicNodeDataComponent extends BaseFormValidator implements OnInit, OnDestroy, AfterViewChecked {
-  private readonly _sizeSuffixPattern = /^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$/;
+  private readonly _memorySizePattern = /^([0-9.]+)(Gi|Mi)$/;
 
   readonly Controls = Controls;
 
@@ -60,14 +60,14 @@ export class KubeVirtBasicNodeDataComponent extends BaseFormValidator implements
       [Controls.CPUs]: this._builder.control('1', Validators.required),
       [Controls.Memory]: this._builder.control('2Gi', [
         Validators.required,
-        Validators.pattern(this._sizeSuffixPattern),
+        Validators.pattern(this._memorySizePattern),
       ]),
-      [Controls.Namespace]: this._builder.control('', Validators.required),
+      [Controls.Namespace]: this._builder.control('kube-system', Validators.required),
       [Controls.SourceURL]: this._builder.control('', Validators.required),
       [Controls.StorageClassName]: this._builder.control('', Validators.required),
       [Controls.PVCSize]: this._builder.control('10Gi', [
         Validators.required,
-        Validators.pattern(this._sizeSuffixPattern),
+        Validators.pattern(this._memorySizePattern),
       ]),
     });
 

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -34,7 +34,7 @@ limitations under the License.
       Memory is <strong>required</strong>.
     </mat-error>
     <mat-error *ngIf="form.get(Controls.Memory).hasError('pattern')">
-      Wrong format, use values like 3Gi and 2MI.
+      Wrong format, use values like 3Gi and 2Mi.
     </mat-error>
   </mat-form-field>
 

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -34,7 +34,7 @@ limitations under the License.
       Memory is <strong>required</strong>.
     </mat-error>
     <mat-error *ngIf="form.get(Controls.Memory).hasError('pattern')">
-      Wrong quantity format, use values like 2, 3Gi and 2M.
+      Wrong format, use values like 3Gi and 2MI.
     </mat-error>
   </mat-form-field>
 
@@ -63,7 +63,7 @@ limitations under the License.
       PVC Size is <strong>required</strong>.
     </mat-error>
     <mat-error *ngIf="form.get(Controls.PVCSize).hasError('pattern')">
-      Wrong quantity format, use values like 2, 3Gi and 2M.
+      Wrong format, use values like 3Gi and 2Mi.
     </mat-error>
   </mat-form-field>
 

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -305,6 +305,13 @@ export function getDefaultNodeProviderSpec(provider: string): object {
         memory: 2048,
         diskSize: 20,
       } as AnexiaNodeSpec;
+    case NodeProvider.KUBEVIRT:
+      return {
+        cpus: '1',
+        memory: '2Gi',
+        pvcSize: '10Gi',
+        namespace: 'kube-system',
+      } as KubeVirtNodeSpec;
   }
   return {};
 }


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
This PR introduces the following changes for machine deployment create/edit view for **KubeVirt**:
* Fix regex for validating memory size for Kubevirt machines. Right now values without units are allowed which results in machine provisioning failures. For example, "1" is a valid value.
* Defaults for node were not defined which were initializing the values as `undefined`
* Default namespace to `kube-system`

### Special notes for your reviewer
<!-- Remove if not needed -->
![kubevirt-md-edit](https://user-images.githubusercontent.com/18264334/150502633-9000a2e4-80d4-4b65-85fe-be5481eb71af.gif)

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
* Minor fixes covering machine deployment creation/edit for KubeVirt
```
