### PR TITLE
Move update indicator

### DIFF
--- a/src/app/cluster/details/shared/version-picker/style.scss
+++ b/src/app/cluster/details/shared/version-picker/style.scss
@@ -64,6 +64,10 @@
     .mat-form-field {
       font-size: variables.$font-size-subhead;
       max-width: 140px;
+
+      &.cluster-external {
+        max-width: 200px;
+      }
     }
   }
 

--- a/src/app/cluster/details/shared/version-picker/style.scss
+++ b/src/app/cluster/details/shared/version-picker/style.scss
@@ -41,20 +41,29 @@
 
         margin: 0 auto;
       }
+    }
 
-      .km-icon-update-available,
-      .km-icon-warning,
-      .km-icon-error {
-        @include mixins.size(16px);
+    .update-available-icon {
+      @include mixins.size(16px);
 
-        margin: 0 0 12px 22px;
-        position: absolute;
-      }
+      position: absolute;
+      right: 28px;
+      top: -9px;
+    }
+
+    .warning-icon,
+    .error-icon {
+      @include mixins.size(16px);
+
+      margin-right: 0;
+      position: absolute;
+      right: 28px;
+      top: -13px;
     }
 
     .mat-form-field {
       font-size: variables.$font-size-subhead;
-      max-width: 180px;
+      max-width: 140px;
     }
   }
 

--- a/src/app/cluster/details/shared/version-picker/template.html
+++ b/src/app/cluster/details/shared/version-picker/template.html
@@ -28,13 +28,6 @@ limitations under the License.
     <div class="km-version-picker-type"
          fxLayoutAlign="center center">
       <i class="km-icon-kubernetes"></i>
-      <i *ngIf="hasAvailableUpdates()"
-         matTooltip="Updates available"
-         class="km-icon-update-available"></i>
-      <i *ngIf="isClusterBeforeEOL()"
-         class="km-icon-warning"></i>
-      <i *ngIf="isClusterAfterEOL()"
-         class="km-icon-error"></i>
     </div>
 
     <mat-form-field>
@@ -46,6 +39,16 @@ limitations under the License.
           {{cluster.spec.version}}
         </mat-option>
       </mat-select>
+      <i *ngIf="hasAvailableUpdates()"
+         matSuffix
+         matTooltip="Updates available"
+         class="km-icon-update-available update-available-icon"></i>
+      <i *ngIf="isClusterBeforeEOL()"
+         matSuffix
+         class="km-icon-warning warning-icon"></i>
+      <i *ngIf="isClusterAfterEOL()"
+         matSuffix
+         class="km-icon-error error-icon"></i>
     </mat-form-field>
 
   </div>

--- a/src/app/cluster/details/shared/version-picker/template.html
+++ b/src/app/cluster/details/shared/version-picker/template.html
@@ -30,7 +30,7 @@ limitations under the License.
       <i class="km-icon-kubernetes"></i>
     </div>
 
-    <mat-form-field>
+    <mat-form-field [ngClass]="isClusterExternal ? 'cluster-external' : ''">
       <mat-label>Control Plane</mat-label>
       <mat-select [ngModel]="cluster.spec.version"
                   disabled


### PR DESCRIPTION
### What this PR does / why we need it
As decided in slack, we wanted to move the update available indicator next to the dropdown arrow.
Also slightly reduced the width of the whole version picker, as we also shortened the name to "Control Plane" and there is plenty of space left.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4113

### Special notes for your reviewer
![ua4](https://user-images.githubusercontent.com/19547196/150764707-ee3b4acf-f7a7-47ff-bc1e-93a7b54a3978.PNG)

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
