### PR TITLE
Update event grouping and more information section logic

### DIFF
--- a/src/app/cluster/details/cluster/component.ts
+++ b/src/app/cluster/details/cluster/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Component, EventEmitter, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {ActivatedRoute, Router} from '@angular/router';
 import {EditProviderSettingsComponent} from '@app/cluster/details/cluster/edit-provider-settings/component';
@@ -27,6 +27,7 @@ import {OPAService} from '@core/services/opa';
 import {PathParam} from '@core/services/params';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
+import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {Addon} from '@shared/entity/addon';
 import {
   Cluster,
@@ -39,13 +40,13 @@ import {
 } from '@shared/entity/cluster';
 import {View} from '@shared/entity/common';
 import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
-import {Node} from '@shared/entity/node';
 import {Event} from '@shared/entity/event';
 import {Health, HealthState, HealthType} from '@shared/entity/health';
 import {MachineDeployment} from '@shared/entity/machine-deployment';
 import {Member} from '@shared/entity/member';
 import {ClusterMetrics} from '@shared/entity/metrics';
 import {AlertmanagerConfig, RuleGroup} from '@shared/entity/mla';
+import {Node} from '@shared/entity/node';
 import {Constraint, GatekeeperConfig} from '@shared/entity/opa';
 import {SSHKey} from '@shared/entity/ssh-key';
 import {Config, GroupConfig} from '@shared/model/Config';
@@ -55,13 +56,12 @@ import {MemberUtils, Permission} from '@shared/utils/member-utils/member-utils';
 import _ from 'lodash';
 import {combineLatest, iif, Observable, of, Subject} from 'rxjs';
 import {filter, map, switchMap, take, takeUntil} from 'rxjs/operators';
+import {coerce, compare} from 'semver';
 import {ClusterDeleteConfirmationComponent} from './cluster-delete-confirmation/component';
 import {EditClusterComponent} from './edit-cluster/component';
 import {EditSSHKeysComponent} from './edit-sshkeys/component';
 import {RevokeTokenComponent} from './revoke-token/component';
 import {ShareKubeconfigComponent} from './share-kubeconfig/component';
-import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
-import {coerce, compare} from 'semver';
 
 @Component({
   selector: 'km-cluster-details',
@@ -69,6 +69,13 @@ import {coerce, compare} from 'semver';
   styleUrls: ['./style.scss'],
 })
 export class ClusterDetailsComponent implements OnInit, OnDestroy {
+  private _unsubscribe: Subject<void> = new Subject<void>();
+  private _user: Member;
+  private _currentGroupConfig: GroupConfig;
+  private _seedSettings: SeedSettings;
+
+  readonly HealthType = HealthType;
+
   externalCCMMigrationStatus = ExternalCCMMigrationStatus;
   cluster: Cluster;
   nodeDc: Datacenter;
@@ -93,11 +100,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   gatekeeperConfig: GatekeeperConfig;
   alertmanagerConfig: AlertmanagerConfig;
   ruleGroups: RuleGroup[];
-  readonly HealthType = HealthType;
-  private _unsubscribe: Subject<void> = new Subject<void>();
-  private _user: Member;
-  private _currentGroupConfig: GroupConfig;
-  private _seedSettings: SeedSettings;
+  onExpandChange$ = new EventEmitter<boolean>();
 
   get admissionPlugins(): string[] {
     return Object.keys(AdmissionPlugin);
@@ -252,6 +255,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
             : cniVersions.versions.sort((a, b) => compare(coerce(a), coerce(b)));
           this.constraints = constraints;
           this.gatekeeperConfig = gatekeeperConfig;
+          this.onExpandChange$.next(!this.isClusterRunning);
         },
         error: error => {
           const errorCodeNotFound = 404;
@@ -260,15 +264,6 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
           }
         },
       });
-  }
-
-  private _canReloadVersions(): boolean {
-    return (
-      this.cluster &&
-      this.health &&
-      HealthState.isUp(this.health.apiserver) &&
-      HealthState.isUp(this.health.machineController)
-    );
   }
 
   getProvider(provider: string): string {
@@ -513,5 +508,14 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
 
   isHavingCNI(): boolean {
     return !!this.cluster?.spec?.cniPlugin && this.cluster?.spec?.cniPlugin?.type !== CNIPlugin.None;
+  }
+
+  private _canReloadVersions(): boolean {
+    return (
+      this.cluster &&
+      this.health &&
+      HealthState.isUp(this.health.apiserver) &&
+      HealthState.isUp(this.health.machineController)
+    );
   }
 }

--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -200,7 +200,8 @@ limitations under the License.
       </div>
 
       <km-expansion-panel expandLabel="SHOW ADDITIONAL CLUSTER INFORMATION"
-                          collapseLabel="HIDE ADDITIONAL CLUSTER INFORMATION">
+                          collapseLabel="HIDE ADDITIONAL CLUSTER INFORMATION"
+                          [expanded]="!isClusterRunning && areMachineDeploymentsInitialized">
         <div fxLayout="row wrap"
              class="cluster-info-container">
           <div fxFlex="33"

--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -201,7 +201,7 @@ limitations under the License.
 
       <km-expansion-panel expandLabel="SHOW ADDITIONAL CLUSTER INFORMATION"
                           collapseLabel="HIDE ADDITIONAL CLUSTER INFORMATION"
-                          [expanded]="!isClusterRunning && areMachineDeploymentsInitialized">
+                          [expanded]="onExpandChange$ | async">
         <div fxLayout="row wrap"
              class="cluster-info-container">
           <div fxFlex="33"

--- a/src/app/shared/components/event-list/component.ts
+++ b/src/app/shared/components/event-list/component.ts
@@ -27,11 +27,10 @@ import {takeUntil} from 'rxjs/operators';
   styleUrls: ['./style.scss'],
 })
 export class EventListComponent implements OnInit, OnChanges, OnDestroy {
+  private _unsubscribe = new Subject<void>();
   @Input() events: Event[] = [];
-
   @ViewChild(MatSort, {static: true}) sort: MatSort;
   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
-
   dataSource = new MatTableDataSource<Event>();
   displayedColumns: string[] = [
     'status',
@@ -41,7 +40,6 @@ export class EventListComponent implements OnInit, OnChanges, OnDestroy {
     'count',
     'lastTimestamp',
   ];
-  private _unsubscribe = new Subject<void>();
 
   constructor(private readonly _userService: UserService) {}
 
@@ -60,7 +58,7 @@ export class EventListComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(): void {
-    this.dataSource.data = this.events;
+    this.dataSource.data = this._group(this.events);
   }
 
   ngOnDestroy(): void {
@@ -85,5 +83,40 @@ export class EventListComponent implements OnInit, OnChanges, OnDestroy {
 
   isPaginatorVisible(): boolean {
     return this.hasEvents() && this.paginator && this.events.length >= this.paginator.pageSize;
+  }
+
+  private _hash(event: Event): number {
+    const s = event.message + event.type + event.involvedObject?.name || '';
+    const shift = 5;
+    let hash = 0;
+
+    if (s.length === 0) {
+      return hash;
+    }
+
+    for (let i = 0; i < s.length; i++) {
+      const char = s.charCodeAt(i);
+      hash = (hash << shift) - hash + char;
+      hash = hash & hash;
+    }
+
+    return hash;
+  }
+
+  private _group(events: Event[]): Event[] {
+    const map = new Map<number, Event>();
+
+    events.forEach(event => {
+      const hash = this._hash(event);
+      if (map.has(hash)) {
+        const ev = event;
+        ev.count += map.get(hash).count;
+        map.set(hash, ev);
+      }
+
+      map.set(hash, event);
+    });
+
+    return Array.from(map.values());
   }
 }

--- a/src/app/shared/components/expansion-panel/component.ts
+++ b/src/app/shared/components/expansion-panel/component.ts
@@ -24,5 +24,5 @@ import {shrinkGrow} from '@shared/animations/grow';
 export class ExpansionPanelComponent {
   @Input() expandLabel = 'Show more';
   @Input() collapseLabel = 'Show less';
-  isExpanded = false;
+  @Input() expanded = false;
 }

--- a/src/app/shared/components/expansion-panel/component.ts
+++ b/src/app/shared/components/expansion-panel/component.ts
@@ -22,7 +22,27 @@ import {shrinkGrow} from '@shared/animations/grow';
   animations: [shrinkGrow],
 })
 export class ExpansionPanelComponent {
+  private _initialized = false;
   @Input() expandLabel = 'Show more';
   @Input() collapseLabel = 'Show less';
-  @Input() expanded = false;
+
+  private _expanded = false;
+
+  get expanded(): boolean {
+    return this._expanded;
+  }
+
+  @Input()
+  set expanded(expanded: boolean) {
+    if (this._initialized || expanded === null || expanded === undefined) {
+      return;
+    }
+
+    this._expanded = expanded;
+    this._initialized = true;
+  }
+
+  onClick(): void {
+    this._expanded = !this._expanded;
+  }
 }

--- a/src/app/shared/components/expansion-panel/template.html
+++ b/src/app/shared/components/expansion-panel/template.html
@@ -17,7 +17,7 @@ limitations under the License.
 <div fxLayout="column">
   <div class="bar"
        [ngClass]="expanded ? 'expanded' : ''"
-       (click)="expanded = !expanded"
+       (click)="onClick()"
        [ngSwitch]="expanded">
     <div fxLayoutAlign="center center"
          fxLayoutGap="4px"

--- a/src/app/shared/components/expansion-panel/template.html
+++ b/src/app/shared/components/expansion-panel/template.html
@@ -16,20 +16,20 @@ limitations under the License.
 
 <div fxLayout="column">
   <div class="bar"
-       [ngClass]="isExpanded ? 'expanded' : ''"
-       (click)="isExpanded = !isExpanded"
-       [ngSwitch]="isExpanded">
+       [ngClass]="expanded ? 'expanded' : ''"
+       (click)="expanded = !expanded"
+       [ngSwitch]="expanded">
     <div fxLayoutAlign="center center"
          fxLayoutGap="4px"
          class="label km-text-muted">
       <hr fxFlex>
       <div *ngSwitchCase="true">{{collapseLabel}}</div>
       <div *ngSwitchCase="false">{{expandLabel}}</div>
-      <i class="km-icon-mask km-icon-arrow-{{isExpanded ? 'up' : 'down'}}"></i>
+      <i class="km-icon-mask km-icon-arrow-{{expanded ? 'up' : 'down'}}"></i>
       <hr fxFlex>
     </div>
   </div>
-  <div *ngIf="isExpanded"
+  <div *ngIf="expanded"
        @shrinkGrow>
     <ng-content></ng-content>
   </div>


### PR DESCRIPTION
### What this PR does / why we need it
- Additional custom events grouping by the message/type/id
- Expand additional information section by default when cluster is not in running state

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4116

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
