### PR TITLE
Migrate to kubermatic.k8c.io

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -96,8 +96,8 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: master
-        clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+        base_ref: crd-migration-use-new-apis
+        clone_uri: "ssh://git@github.com/xrstf/kubermatic.git"
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"
@@ -152,8 +152,8 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: master
-        clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+        base_ref: crd-migration-use-new-apis
+        clone_uri: "ssh://git@github.com/xrstf/kubermatic.git"
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -96,8 +96,8 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: crd-migration-use-new-apis
-        clone_uri: "ssh://git@github.com/xrstf/kubermatic.git"
+        base_ref: master
+        clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"
@@ -152,8 +152,8 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: crd-migration-use-new-apis
-        clone_uri: "ssh://git@github.com/xrstf/kubermatic.git"
+        base_ref: master
+        clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"

--- a/cypress/fixtures/alibaba/cluster.json
+++ b/cypress/fixtures/alibaba/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-alibaba-dc",
-      "alibaba": {}
+      "alibaba": {},
+      "providerName": "alibaba"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/alibaba/clusters.json
+++ b/cypress/fixtures/alibaba/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-alibaba-dc",
-        "alibaba": {}
+        "alibaba": {},
+        "providerName": "alibaba"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/anexia/cluster.json
+++ b/cypress/fixtures/anexia/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-anexia-dc",
-      "anexia": {}
+      "anexia": {},
+      "providerName": "anexia"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/anexia/clusters.json
+++ b/cypress/fixtures/anexia/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-anexia-dc",
-        "anexia": {}
+        "anexia": {},
+        "providerName": "anexia"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/aws/cluster.json
+++ b/cypress/fixtures/aws/cluster.json
@@ -7,7 +7,8 @@
   "spec": {
     "cloud": {
       "dc": "test-aws-dc",
-      "aws": {}
+      "aws": {},
+      "providerName": "aws"
     },
     "version": "1.21.3",
     "oidc": {},

--- a/cypress/fixtures/aws/clusters.json
+++ b/cypress/fixtures/aws/clusters.json
@@ -8,7 +8,8 @@
     "spec": {
       "cloud": {
         "dc": "test-aws-dc",
-        "aws": {}
+        "aws": {},
+        "providerName": "aws"
       },
       "version": "1.21.3",
       "oidc": {},

--- a/cypress/fixtures/azure/cluster.json
+++ b/cypress/fixtures/azure/cluster.json
@@ -8,7 +8,8 @@
       "dc": "test-azure-dc",
       "azure": {
         "assignAvailabilitySet": true
-      }
+      },
+      "providerName": "azure"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/azure/clusters.json
+++ b/cypress/fixtures/azure/clusters.json
@@ -9,7 +9,8 @@
         "dc": "test-azure-dc",
         "azure": {
           "assignAvailabilitySet": true
-        }
+        },
+        "providerName": "azure"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/bringyourown/cluster.json
+++ b/cypress/fixtures/bringyourown/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "byo-europe-west3-c",
-      "bringyourown": {}
+      "bringyourown": {},
+      "providerName": "bringyourown"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/bringyourown/clusters.json
+++ b/cypress/fixtures/bringyourown/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "byo-europe-west3-c",
-        "bringyourown": {}
+        "bringyourown": {},
+        "providerName": "bringyourown"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/cluster-templates.json
+++ b/cypress/fixtures/cluster-templates.json
@@ -15,7 +15,8 @@
       "spec": {
         "cloud": {
           "dc": "byo-europe-west3-c",
-          "bringyourown": {}
+          "bringyourown": {},
+          "providerName": "bringyourown"
         },
         "version": "1.21.5",
         "oidc": {},

--- a/cypress/fixtures/datacenters.json
+++ b/cypress/fixtures/datacenters.json
@@ -205,7 +205,7 @@
       "location": "Germany - dbl1",
       "provider": "openstack",
       "openstack": {
-        "auth_url": "https://api.cloud.test.net:5000/v3",
+        "authURL": "https://api.cloud.test.net:5000/v3",
         "availabilityZone": "dbl1",
         "region": "dbl",
         "ignoreVolumeAZ": false,

--- a/cypress/fixtures/datacenters.json
+++ b/cypress/fixtures/datacenters.json
@@ -26,7 +26,7 @@
       "location": "Vienna",
       "provider": "anexia",
       "anexia": {
-        "location_id": "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
+        "locationID": "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
       },
       "node": {},
       "enforceAuditLogging": false,
@@ -126,7 +126,7 @@
       "provider": "gcp",
       "gcp": {
         "region": "europe-west3",
-        "zone_suffixes": [
+        "zoneSuffixes": [
           "c"
         ]
       },
@@ -164,8 +164,8 @@
       "location": "Frankfurt",
       "provider": "kubevirt",
       "kubevirt": {
-        "dns_policy": "None",
-        "dns_config": {
+        "dnsPolicy": "None",
+        "dnsConfig": {
           "nameservers": [
             "8.8.8.8"
           ]
@@ -206,11 +206,11 @@
       "provider": "openstack",
       "openstack": {
         "auth_url": "https://api.cloud.test.net:5000/v3",
-        "availability_zone": "dbl1",
+        "availabilityZone": "dbl1",
         "region": "dbl",
-        "ignore_volume_az": false,
-        "enforce_floating_ip": true,
-        "dns_servers": [
+        "ignoreVolumeAZ": false,
+        "enforceFloatingIP": true,
+        "dnsServers": [
           "68.123.44.116",
           "68.123.44.117"
         ],
@@ -219,14 +219,14 @@
           "coreos": "kubermatic-e2e-coreos",
           "ubuntu": "kubermatic-e2e-ubuntu"
         },
-        "manage_security_groups": null,
-        "use_octavia": null,
-        "trust_device_path": null,
-        "node_size_requirements": {
-          "minimum_vcpus": 0,
-          "minimum_memory": 0
+        "manageSecurityGroups": null,
+        "useOctavia": null,
+        "trustDevicePath": null,
+        "nodeSizeRequirements": {
+          "minimumVCPUs": 0,
+          "minimumMemory": 0
         },
-        "enabled_flavors": null
+        "enabledFlavors": null
       },
       "node": {},
       "enforceAuditLogging": false,
@@ -244,12 +244,12 @@
       "provider": "vsphere",
       "vsphere": {
         "endpoint": "https://vcenter.test.com",
-        "allow_insecure": false,
+        "allowInsecure": false,
         "datastore": "exsi-nas",
         "datacenter": "dc-1",
         "cluster": "cl-1",
-        "storage_policy": "",
-        "root_path": "/dc-1/vm/test",
+        "storageSolicy": "",
+        "rootPath": "/dc-1/vm/test",
         "templates": {
           "centos": "machine-controller-e2e-centos",
           "coreos": "machine-controller-e2e-coreos",

--- a/cypress/fixtures/digitalocean/cluster.json
+++ b/cypress/fixtures/digitalocean/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-digitalocean-dc",
-      "digitalocean": {}
+      "digitalocean": {},
+      "providerName": "digitalocean"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/digitalocean/clusters.json
+++ b/cypress/fixtures/digitalocean/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-digitalocean-dc",
-        "digitalocean": {}
+        "digitalocean": {},
+        "providerName": "digitalocean"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/gcp/cluster.json
+++ b/cypress/fixtures/gcp/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-gcp-dc",
-      "gcp": {}
+      "gcp": {},
+      "providerName": "gcp"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/gcp/clusters.json
+++ b/cypress/fixtures/gcp/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-gcp-dc",
-        "gcp": {}
+        "gcp": {},
+        "providerName": "gcp"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/health.json
+++ b/cypress/fixtures/health.json
@@ -1,11 +1,11 @@
 {
-  "apiserver": 1,
-  "scheduler": 1,
-  "controller": 1,
-  "machineController": 1,
-  "etcd": 1,
-  "cloudProviderInfrastructure": 1,
-  "userClusterControllerManager": 1,
-  "gatekeeperAudit": 1,
-  "gatekeeperController": 1
+  "apiserver": "HealthStatusUp",
+  "scheduler": "HealthStatusUp",
+  "controller": "HealthStatusUp",
+  "machineController": "HealthStatusUp",
+  "etcd": "HealthStatusUp",
+  "cloudProviderInfrastructure": "HealthStatusUp",
+  "userClusterControllerManager": "HealthStatusUp",
+  "gatekeeperAudit": "HealthStatusUp",
+  "gatekeeperController": "HealthStatusUp"
 }

--- a/cypress/fixtures/hetzner/cluster.json
+++ b/cypress/fixtures/hetzner/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-hetzner-dc",
-      "hetzner": {}
+      "hetzner": {},
+      "providerName": "hetzner"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/hetzner/clusters.json
+++ b/cypress/fixtures/hetzner/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-hetzner-dc",
-        "hetzner": {}
+        "hetzner": {},
+        "providerName": "hetzner"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/kubevirt/cluster.json
+++ b/cypress/fixtures/kubevirt/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-kubevirt-dc",
-      "kubevirt": {}
+      "kubevirt": {},
+      "providerName": "kubevirt"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/kubevirt/clusters.json
+++ b/cypress/fixtures/kubevirt/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-kubevirt-dc",
-        "kubevirt": {}
+        "kubevirt": {},
+        "providerName": "kubevirt"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/openstack/cluster.json
+++ b/cypress/fixtures/openstack/cluster.json
@@ -7,7 +7,7 @@
     "cloud": {
       "dc": "test-openstack-dc",
       "openstack": {
-        "floatingIpPool": "ext-net",
+        "floatingIPPool": "ext-net",
         "network": "",
         "securityGroups": "",
         "routerID": "",

--- a/cypress/fixtures/openstack/cluster.json
+++ b/cypress/fixtures/openstack/cluster.json
@@ -12,7 +12,8 @@
         "securityGroups": "",
         "routerID": "",
         "subnetID": ""
-      }
+      },
+      "providerName": "openstack"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/openstack/clusters.json
+++ b/cypress/fixtures/openstack/clusters.json
@@ -13,7 +13,8 @@
           "securityGroups": "",
           "routerID": "",
           "subnetID": ""
-        }
+        },
+        "providerName": "openstack"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/openstack/clusters.json
+++ b/cypress/fixtures/openstack/clusters.json
@@ -8,7 +8,7 @@
       "cloud": {
         "dc": "test-openstack-dc",
         "openstack": {
-          "floatingIpPool": "ext-net",
+          "floatingIPPool": "ext-net",
           "network": "",
           "securityGroups": "",
           "routerID": "",

--- a/cypress/fixtures/packet/cluster.json
+++ b/cypress/fixtures/packet/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-equinix-dc",
-      "packet": {}
+      "packet": {},
+      "providerName": "packet"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/packet/clusters.json
+++ b/cypress/fixtures/packet/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-equinix-dc",
-        "packet": {}
+        "packet": {},
+        "providerName": "packet"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/fixtures/seed-settings.json
+++ b/cypress/fixtures/seed-settings.json
@@ -1,6 +1,6 @@
 {
   "mla": {
-    "user_cluster_mla_enabled": true
+    "userClusterMLAEnabled": true
   },
   "metering": {
     "enabled": true,

--- a/cypress/fixtures/vsphere/cluster.json
+++ b/cypress/fixtures/vsphere/cluster.json
@@ -6,7 +6,8 @@
   "spec": {
     "cloud": {
       "dc": "test-vsphere-dc",
-      "vsphere": {}
+      "vsphere": {},
+      "providerName": "vsphere"
     },
     "version": "1.21.5",
     "oidc": {},

--- a/cypress/fixtures/vsphere/clusters.json
+++ b/cypress/fixtures/vsphere/clusters.json
@@ -7,7 +7,8 @@
     "spec": {
       "cloud": {
         "dc": "test-vsphere-dc",
-        "vsphere": {}
+        "vsphere": {},
+        "providerName": "vsphere"
       },
       "version": "1.21.5",
       "oidc": {},

--- a/cypress/integration/stories/user-settings.spec.ts
+++ b/cypress/integration/stories/user-settings.spec.ts
@@ -71,7 +71,7 @@ describe('User Settings Story', () => {
 
   it(`should set ${projectName} as default project`, () => {
     if (Mocks.enabled()) {
-      Mocks.currentUser.userSettings.selectedProjectId = 'fn9234fn1d';
+      Mocks.currentUser.userSettings.selectedProjectID = 'fn9234fn1d';
     } else {
       UserSettingsPage.getDefaultProjectInput().click();
       UserSettingsPage.getDefaultProjectInput().get('mat-option').contains(projectName).click();
@@ -108,7 +108,7 @@ describe('User Settings Story', () => {
 
   it('should set default items per page', () => {
     if (Mocks.enabled()) {
-      Mocks.currentUser.userSettings.selectedProjectId = '';
+      Mocks.currentUser.userSettings.selectedProjectID = '';
     } else {
       UserSettingsPage.getItemsPerPageInput().click();
       UserSettingsPage.getItemsPerPageInput().get('mat-option').contains('10').click();

--- a/cypress/utils/mocks.ts
+++ b/cypress/utils/mocks.ts
@@ -39,18 +39,17 @@ export class Mocks {
     userSettings: {
       itemsPerPage: 5,
       lastSeenChangelogVersion: 'v9.0.0',
-      selectedProjectId: '',
+      selectedProjectID: '',
     },
   };
 
   static adminSettings: any = {
     customLinks: [],
     cleanupOptions: {
-      Enabled: false,
-      Enforced: false,
+      enabled: false,
+      enforced: false,
     },
     defaultNodeCount: 1,
-    clusterTypeOptions: 0,
     displayDemoInfo: false,
     displayAPIDocs: false,
     displayTermsOfService: false,

--- a/hack/e2e/fixtures/kubermatic.yaml
+++ b/hack/e2e/fixtures/kubermatic.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: operator.kubermatic.io/v1alpha1
+apiVersion: kubermatic.k8c.io/v1
 kind: KubermaticConfiguration
 metadata:
   name: e2e

--- a/hack/e2e/fixtures/seed.yaml
+++ b/hack/e2e/fixtures/seed.yaml
@@ -40,7 +40,7 @@ spec:
       location: Frankfurt
       country: DE
       spec:
-         bringyourown: {}
+        bringyourown: {}
     alibaba-eu-central-1a:
       location: Frankfurt
       country: DE
@@ -59,6 +59,7 @@ spec:
       spec:
         hetzner:
           datacenter: nbg1-dc3
+          network: kubermatic-e2e
     vsphere-ger:
       location: Hamburg
       country: DE

--- a/hack/e2e/fixtures/seed.yaml
+++ b/hack/e2e/fixtures/seed.yaml
@@ -22,7 +22,7 @@ data:
 
 ---
 kind: Seed
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 metadata:
   name: __SEED_NAME__
   namespace: kubermatic
@@ -68,7 +68,7 @@ spec:
           datacenter: "dc-1"
           datastore: "exsi-nas"
           cluster: "cl-1"
-          root_path: "/dc-1/vm/e2e-tests"
+          rootPath: "/dc-1/vm/e2e-tests"
           templates:
             ubuntu: "machine-controller-e2e-ubuntu"
             centos: "machine-controller-e2e-centos"
@@ -84,7 +84,7 @@ spec:
       spec:
         gcp:
           region: europe-west3
-          zone_suffixes:
+          zoneSuffixes:
           - c
     packet-ewr1:
       location: "Packet EWR1 (New York)"
@@ -116,23 +116,24 @@ spec:
       node: { }
       spec:
         anexia:
-          location_id: b164595577114876af7662092da89f76
+          locationID: b164595577114876af7662092da89f76
     syseleven-dbl1:
       country: DE
       location: Syseleven - dbl1
       spec:
         openstack:
-          auth_url: https://api.cbk.cloud.syseleven.net:5000/v3
-          availability_zone: dbl1
-          dns_servers:
+          authURL: https://api.cbk.cloud.syseleven.net:5000/v3
+          availabilityZone: dbl1
+          dnsServers:
           - 37.123.105.116
           - 37.123.105.117
-          enforce_floating_ip: true
-          ignore_volume_az: false
+          enforceFloatingIP: true
+          ignoreVolumeAZ: false
           images:
             centos: kubermatic-e2e-centos
+            coreos: kubermatic-e2e-coreos
             ubuntu: kubermatic-e2e-ubuntu
-          node_size_requirements:
-            minimum_memory: 0
-            minimum_vcpus: 0
+          nodeSizeRequirements:
+            minimumMemory: 0
+            minimumVCPUs: 0
           region: dbl

--- a/hack/e2e/fixtures/user.yaml
+++ b/hack/e2e/fixtures/user.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: User
 metadata:
   name: c41724e256445bf133d6af1168c2d96a7533cd437618fdbe6dc2ef1fee97acd3

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -155,39 +155,39 @@ echodate "Finished exposing components"
 
 echodate "Creating UI AWS preset..."
 cat <<EOF > preset-aws.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-aws
   namespace: kubermatic
 spec:
   aws:
-    accessKeyId: ${AWS_E2E_TESTS_KEY_ID}
+    accessKeyID: ${AWS_E2E_TESTS_KEY_ID}
     secretAccessKey: ${AWS_E2E_TESTS_SECRET}
     datacenter: ${AWS_E2E_TESTS_DATACENTER}
-    vpcId: ${AWS_E2E_TESTS_VPC_ID}
+    vpcID: ${AWS_E2E_TESTS_VPC_ID}
 EOF
 retry 2 kubectl apply -f preset-aws.yaml
 
 echodate "Creating UI Azure preset..."
 cat <<EOF > preset-azure.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-azure
   namespace: kubermatic
 spec:
   azure:
-    tenantId: ${AZURE_E2E_TESTS_TENANT_ID}
-    subscriptionId: ${AZURE_E2E_TESTS_SUBSCRIPTION_ID}
-    clientId: ${AZURE_E2E_TESTS_CLIENT_ID}
+    tenantID: ${AZURE_E2E_TESTS_TENANT_ID}
+    subscriptionID: ${AZURE_E2E_TESTS_SUBSCRIPTION_ID}
+    clientID: ${AZURE_E2E_TESTS_CLIENT_ID}
     clientSecret: ${AZURE_E2E_TESTS_CLIENT_SECRET}
 EOF
 retry 2 kubectl apply -f preset-azure.yaml
 
 echodate "Creating UI DigitalOcean preset..."
 cat <<EOF > preset-digitalocean.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-digitalocean
@@ -200,7 +200,7 @@ retry 2 kubectl apply -f preset-digitalocean.yaml
 
 echodate "Creating UI GCP preset..."
 cat <<EOF > preset-gcp.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-gcp
@@ -213,7 +213,7 @@ retry 2 kubectl apply -f preset-gcp.yaml
 
 echodate "Creating UI KubeVirt preset..."
 cat <<EOF > preset-kubevirt.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-kubevirt
@@ -227,7 +227,7 @@ retry 2 kubectl apply -f preset-kubevirt.yaml
 
 echodate "Creating UI OpenStack preset..."
 cat <<EOF > preset-openstack.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-openstack
@@ -236,7 +236,7 @@ spec:
   openstack:
     datacenter: ${OS_DATACENTER}
     domain: ${OS_DOMAIN}
-    floatingIpPool: ${OS_FLOATING_IP_POOL}
+    floatingIPPool: ${OS_FLOATING_IP_POOL}
     password: ${OS_PASSWORD}
     project: ${OS_TENANT_NAME}
     projectID: ${OS_TENANT_ID}
@@ -246,7 +246,7 @@ retry 2 kubectl apply -f preset-openstack.yaml
 
 echodate "Creating UI Equinix Metal preset..."
 cat <<EOF > preset-equinix.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-equinix
@@ -254,13 +254,13 @@ metadata:
 spec:
   packet:
     apiKey: ${PACKET_API_KEY}
-    projectId: ${PACKET_PROJECT_ID}
+    projectID: ${PACKET_PROJECT_ID}
 EOF
 retry 2 kubectl apply -f preset-equinix.yaml
 
 echodate "Creating UI Anexia preset..."
 cat <<EOF > preset-anexia.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-anexia
@@ -273,7 +273,7 @@ retry 2 kubectl apply -f preset-anexia.yaml
 
 echodate "Creating UI Hetzner preset..."
 cat <<EOF > preset-hetzner.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-hetzner
@@ -286,7 +286,7 @@ retry 2 kubectl apply -f preset-hetzner.yaml
 
 echodate "Creating UI VSPhere preset..."
 cat <<EOF > preset-vsphere.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-vsphere
@@ -300,14 +300,14 @@ retry 2 kubectl apply -f preset-vsphere.yaml
 
 echodate "Creating UI Alibaba preset..."
 cat <<EOF > preset-alibaba.yaml
-apiVersion: kubermatic.k8s.io/v1
+apiVersion: kubermatic.k8c.io/v1
 kind: Preset
 metadata:
   name: e2e-alibaba
   namespace: kubermatic
 spec:
   alibaba:
-    accessKeyId: ${ALIBABA_ACCESS_KEY_ID}
+    accessKeyID: ${ALIBABA_ACCESS_KEY_ID}
     accessKeySecret: ${ALIBABA_ACCESS_KEY_SECRET}
 EOF
 retry 2 kubectl apply -f preset-alibaba.yaml

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -182,6 +182,7 @@ spec:
     subscriptionID: ${AZURE_E2E_TESTS_SUBSCRIPTION_ID}
     clientID: ${AZURE_E2E_TESTS_CLIENT_ID}
     clientSecret: ${AZURE_E2E_TESTS_CLIENT_SECRET}
+    loadBalancerSKU: "standard"
 EOF
 retry 2 kubectl apply -f preset-azure.yaml
 
@@ -238,8 +239,10 @@ spec:
     domain: ${OS_DOMAIN}
     floatingIPPool: ${OS_FLOATING_IP_POOL}
     password: ${OS_PASSWORD}
-    project: ${OS_TENANT_NAME}
-    projectID: ${OS_TENANT_ID}
+    # quotes are important, so empty values do not lead
+    # to nil values and cause validation errors
+    project: "${OS_TENANT_NAME}"
+    projectID: "${OS_TENANT_ID}"
     username: ${OS_USERNAME}
 EOF
 retry 2 kubectl apply -f preset-openstack.yaml

--- a/src/app/cluster/details/cluster/cluster-delete-confirmation/component.ts
+++ b/src/app/cluster/details/cluster/cluster-delete-confirmation/component.ts
@@ -57,9 +57,9 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck, OnDe
 
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       this.settings = settings;
-      this.deleteForm.controls.clusterLBCleanupCheckbox.setValue(this.settings.cleanupOptions.Enabled);
-      this.deleteForm.controls.clusterVolumeCleanupCheckbox.setValue(this.settings.cleanupOptions.Enabled);
-      if (this.settings.cleanupOptions.Enforced) {
+      this.deleteForm.controls.clusterLBCleanupCheckbox.setValue(this.settings.cleanupOptions.enabled);
+      this.deleteForm.controls.clusterVolumeCleanupCheckbox.setValue(this.settings.cleanupOptions.enabled);
+      if (this.settings.cleanupOptions.enforced) {
         this.deleteForm.controls.clusterLBCleanupCheckbox.disable();
         this.deleteForm.controls.clusterVolumeCleanupCheckbox.disable();
       } else {
@@ -73,7 +73,7 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck, OnDe
   }
 
   getCheckboxTooltip(): string {
-    return this.settings && this.settings.cleanupOptions.Enforced
+    return this.settings && this.settings.cleanupOptions.enforced
       ? 'These settings are enforced by the admin and cannot be changed.'
       : '';
   }
@@ -89,7 +89,7 @@ export class ClusterDeleteConfirmationComponent implements OnInit, DoCheck, OnDe
 
   showWarning(): boolean {
     return (
-      !this.settings?.cleanupOptions.Enforced &&
+      !this.settings?.cleanupOptions.enforced &&
       (!this.deleteForm.controls.clusterLBCleanupCheckbox.value ||
         !this.deleteForm.controls.clusterVolumeCleanupCheckbox.value)
     );

--- a/src/app/cluster/details/cluster/component.ts
+++ b/src/app/cluster/details/cluster/component.ts
@@ -487,7 +487,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   isMLAEnabledInSeed(): boolean {
-    return !!this._seedSettings && !!this._seedSettings.mla && !!this._seedSettings.mla.user_cluster_mla_enabled;
+    return !!this._seedSettings && !!this._seedSettings.mla && !!this._seedSettings.mla.userClusterMLAEnabled;
   }
 
   isMLAEnabled(): boolean {

--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -241,7 +241,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   isMLAEnabled(): boolean {
-    return !!this._seedSettings && !!this._seedSettings.mla && !!this._seedSettings.mla.user_cluster_mla_enabled;
+    return !!this._seedSettings && !!this._seedSettings.mla && !!this._seedSettings.mla.userClusterMLAEnabled;
   }
 
   isPodSecurityPolicyEnforced(): boolean {

--- a/src/app/cluster/details/cluster/edit-provider-settings/aws-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/aws-provider-settings/component.ts
@@ -90,7 +90,7 @@ export class AWSProviderSettingsComponent implements OnInit, OnDestroy {
     return {
       cloudSpecPatch: {
         aws: {
-          accessKeyId: this.form.get(Control.AccessKeyID).value,
+          accessKeyID: this.form.get(Control.AccessKeyID).value,
           secretAccessKey: this.form.get(Control.SecretAccessKey).value,
         },
       },

--- a/src/app/core/components/sidenav/component.ts
+++ b/src/app/core/components/sidenav/component.ts
@@ -100,10 +100,10 @@ export class SidenavComponent implements OnInit, OnDestroy {
   }
 
   checkUrl(url: string): boolean {
-    const selectedProjectId = this._selectedProject.id;
+    const selectedProjectID = this._selectedProject.id;
     const urlArray = this._router.routerState.snapshot.url.split('/');
     return (
-      !!urlArray.find(x => x === selectedProjectId) &&
+      !!urlArray.find(x => x === selectedProjectID) &&
       (!!urlArray.find(x => x === url) || (url === View.Clusters && !!urlArray.find(x => x === View.Wizard)))
     );
   }

--- a/src/app/core/services/node-data/provider/anexia.ts
+++ b/src/app/core/services/node-data/provider/anexia.ts
@@ -93,7 +93,7 @@ export class NodeDataAnexiaProvider {
           .pipe(debounceTime(this._debounce))
           .pipe(tap(c => (cluster = c)))
           .pipe(switchMap(_ => this._datacenterService.getDatacenter(cluster.spec.cloud.dc).pipe(take(1))))
-          .pipe(tap(dc => (location = dc?.spec.anexia.location_id)))
+          .pipe(tap(dc => (location = dc?.spec.anexia.locationID)))
           .pipe(filter(_ => location?.length > 0))
           .pipe(
             switchMap(_ =>
@@ -126,7 +126,7 @@ export class NodeDataAnexiaProvider {
               this._anexiaService.getTemplates(
                 selectedProject,
                 this._clusterSpecService.cluster.id,
-                dc.spec.anexia.location_id
+                dc.spec.anexia.locationID
               )
             )
           )

--- a/src/app/core/services/node-data/provider/aws.ts
+++ b/src/app/core/services/node-data/provider/aws.ts
@@ -94,11 +94,11 @@ export class NodeDataAWSProvider {
             switchMap(cluster =>
               this._presetService
                 .provider(NodeProvider.AWS)
-                .accessKeyID(cluster.spec.cloud.aws.accessKeyId)
+                .accessKeyID(cluster.spec.cloud.aws.accessKeyID)
                 .secretAccessKey(cluster.spec.cloud.aws.secretAccessKey)
                 .assumeRoleARN(cluster.spec.cloud.aws.assumeRoleARN)
                 .assumeRoleExternalID(cluster.spec.cloud.aws.assumeRoleExternalID)
-                .vpc(cluster.spec.cloud.aws.vpcId)
+                .vpc(cluster.spec.cloud.aws.vpcID)
                 .credential(this._presetService.preset)
                 .subnets(cluster.spec.cloud.dc, onLoadingCb)
                 .pipe(

--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -161,7 +161,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(dc => {
         this._setDefaultImage(OperatingSystem.Ubuntu);
-        this._enforceFloatingIP(dc.spec.openstack.enforce_floating_ip);
+        this._enforceFloatingIP(dc.spec.openstack.enforceFloatingIP);
       });
 
     this._nodeDataService.operatingSystemChanges
@@ -317,7 +317,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
 
     if (
       !this._nodeDataService.isInWizardMode() &&
-      !this._clusterSpecService.cluster.spec.cloud.openstack.floatingIpPool
+      !this._clusterSpecService.cluster.spec.cloud.openstack.floatingIPPool
     ) {
       this.form.get(Controls.UseFloatingIP).setValue(false);
       this.form.get(Controls.UseFloatingIP).disable();

--- a/src/app/project/component.ts
+++ b/src/app/project/component.ts
@@ -319,11 +319,11 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
     if (
       !!this.settings &&
       !!this.projects &&
-      !!this.settings.selectedProjectId &&
+      !!this.settings.selectedProjectID &&
       this._previousRouteService.getPreviousUrl() === '/' &&
       this._previousRouteService.getHistory().length === 1
     ) {
-      const defaultProject = this.projects.find(x => x.id === this.settings.selectedProjectId);
+      const defaultProject = this.projects.find(x => x.id === this.settings.selectedProjectID);
       this.selectProject(defaultProject);
     }
   }

--- a/src/app/settings/admin/bucket-settings/destinations/edit-credentials-dialog/component.ts
+++ b/src/app/settings/admin/bucket-settings/destinations/edit-credentials-dialog/component.ts
@@ -27,7 +27,7 @@ export interface EditCredentialsDialogConfig {
 
 enum Controls {
   SecretAccessKey = 'secretAccessKey',
-  AccessKey = 'accessKeyId',
+  AccessKey = 'accessKeyID',
 }
 
 @Component({

--- a/src/app/settings/admin/defaults/template.html
+++ b/src/app/settings/admin/defaults/template.html
@@ -39,12 +39,12 @@ limitations under the License.
           </div>
           <div fxFlexAlign=" center"
                fxLayout="row">
-            <mat-checkbox [(ngModel)]="settings.cleanupOptions.Enabled"
+            <mat-checkbox [(ngModel)]="settings.cleanupOptions.enabled"
                           (change)="onSettingsChange()"
                           id="km-cleanup-enable-setting"
                           fxFlexAlign=" center">Enable by Default
             </mat-checkbox>
-            <mat-checkbox [(ngModel)]="settings.cleanupOptions.Enforced"
+            <mat-checkbox [(ngModel)]="settings.cleanupOptions.enforced"
                           (change)="onSettingsChange()"
                           id="km-cleanup-enforce-setting"
                           fxFlexAlign=" center">Enforce Default

--- a/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
+++ b/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
@@ -42,7 +42,7 @@ export enum Controls {
   Seed = 'seed',
   Country = 'country',
   Location = 'location',
-  RequiredEmailDomains = 'requiredEmailDomains',
+  RequiredEmails = 'requiredEmails',
   EnforcePodSecurityPolicy = 'enforcePodSecurityPolicy',
   EnforceAuditLogging = 'enforceAuditLogging',
 }
@@ -59,7 +59,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
   readonly providers = INTERNAL_NODE_PROVIDERS;
   seeds: string[] = [];
   form: FormGroup;
-  requiredEmailDomains: string[] = [];
+  requiredEmails: string[] = [];
   providerConfig = '';
   private _unsubscribe = new Subject<void>();
 
@@ -84,14 +84,14 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
       ),
       country: new FormControl(this.data.isEditing ? this.data.datacenter.spec.country : '', [Validators.required]),
       location: new FormControl(this.data.isEditing ? this.data.datacenter.spec.location : '', [Validators.required]),
-      requiredEmailDomains: new FormControl(),
+      requiredEmails: new FormControl(),
       enforcePodSecurityPolicy: new FormControl(
         this.data.isEditing && this.data.datacenter.spec.enforcePodSecurityPolicy
       ),
       enforceAuditLogging: new FormControl(this.data.isEditing && this.data.datacenter.spec.enforceAuditLogging),
     });
 
-    this._initRequiredEmailDomainsInput();
+    this._initRequiredEmailsInput();
     this._initProviderConfigEditor();
   }
 
@@ -104,11 +104,11 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
     return getIconClassForButton(this.data.confirmLabel);
   }
 
-  private _initRequiredEmailDomainsInput(): void {
-    if (this.data.isEditing && !_.isEmpty(this.data.datacenter.spec.requiredEmailDomains)) {
-      this.requiredEmailDomains = this.data.datacenter.spec.requiredEmailDomains;
+  private _initRequiredEmailsInput(): void {
+    if (this.data.isEditing && !_.isEmpty(this.data.datacenter.spec.requiredEmails)) {
+      this.requiredEmails = this.data.datacenter.spec.requiredEmails;
     } else {
-      this.requiredEmailDomains = [];
+      this.requiredEmails = [];
     }
   }
 
@@ -135,7 +135,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
     const value = event.value;
 
     if ((value || '').trim()) {
-      this.requiredEmailDomains.push(value.trim());
+      this.requiredEmails.push(value.trim());
     }
 
     if (input) {
@@ -144,10 +144,10 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
   }
 
   removeDomain(domain: string): void {
-    const index = this.requiredEmailDomains.indexOf(domain);
+    const index = this.requiredEmails.indexOf(domain);
 
     if (index >= 0) {
-      this.requiredEmailDomains.splice(index, 1);
+      this.requiredEmails.splice(index, 1);
     }
   }
 
@@ -166,7 +166,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
         seed: this.form.get(Controls.Seed).value,
         country: this.form.get(Controls.Country).value,
         location: this.form.get(Controls.Location).value,
-        requiredEmailDomains: this.requiredEmailDomains,
+        requiredEmails: this.requiredEmails,
         enforcePodSecurityPolicy: this.form.get(Controls.EnforcePodSecurityPolicy).value,
         enforceAuditLogging: this.form.get(Controls.EnforceAuditLogging).value,
       },

--- a/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
+++ b/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
@@ -115,10 +115,10 @@ limitations under the License.
     </mat-form-field>
 
     <mat-form-field class="domain-input">
-      <mat-label>Required Email Domains</mat-label>
+      <mat-label>Required Emails</mat-label>
       <mat-chip-list #chipList
                      class="km-chip-list-with-input">
-        <mat-chip *ngFor="let domain of requiredEmailDomains"
+        <mat-chip *ngFor="let domain of requiredEmails"
                   removable
                   (removed)="removeDomain(domain)"
                   [selectable]="false">
@@ -126,7 +126,7 @@ limitations under the License.
           <i matChipRemove
              class="km-icon-mask km-icon-remove"></i>
         </mat-chip>
-        <input [formControlName]="controls.RequiredEmailDomains"
+        <input [formControlName]="controls.RequiredEmails"
                matChipInputAddOnBlur
                [matChipInputFor]="chipList"
                [matChipInputSeparatorKeyCodes]="separatorKeyCodes"

--- a/src/app/settings/admin/presets/dialog/steps/preset/component.ts
+++ b/src/app/settings/admin/presets/dialog/steps/preset/component.ts
@@ -68,7 +68,7 @@ export class PresetStepComponent extends BaseFormValidator implements OnInit {
 
   private _update(): void {
     this._presetDialogService.preset.metadata.name = this.form.get(Controls.Name).value;
-    this._presetDialogService.preset.spec.requiredEmailDomain = this.form.get(Controls.Domain).value;
+    this._presetDialogService.preset.spec.requiredEmails = this.form.get(Controls.Domain).value;
     this._presetDialogService.preset.spec.enabled = !this.form.get(Controls.Disable).value;
   }
 }

--- a/src/app/settings/admin/presets/dialog/steps/settings/provider/alibaba/component.ts
+++ b/src/app/settings/admin/presets/dialog/steps/settings/provider/alibaba/component.ts
@@ -21,7 +21,7 @@ import {merge, of} from 'rxjs';
 import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Controls {
-  AccessKeyID = 'accessKeyId',
+  AccessKeyID = 'accessKeyID',
   AccessKeySecret = 'secretAccessKey',
 }
 
@@ -72,7 +72,7 @@ export class AlibabaSettingsComponent extends BaseFormValidator implements OnIni
 
   private _update(): void {
     this._presetDialogService.preset.spec.alibaba = {
-      accessKeyId: this.form.get(Controls.AccessKeyID).value,
+      accessKeyID: this.form.get(Controls.AccessKeyID).value,
       accessKeySecret: this.form.get(Controls.AccessKeySecret).value,
     } as AlibabaPresetSpec;
   }

--- a/src/app/settings/admin/presets/dialog/steps/settings/provider/openstack/component.ts
+++ b/src/app/settings/admin/presets/dialog/steps/settings/provider/openstack/component.ts
@@ -28,7 +28,7 @@ export enum Controls {
   Domain = 'domain',
   Network = 'network',
   SecurityGroups = 'securityGroups',
-  FloatingIpPool = 'floatingIpPool',
+  FloatingIPPool = 'floatingIPPool',
   RouterID = 'routerID',
   SubnetID = 'subnetID',
 }
@@ -65,7 +65,7 @@ export class OpenstackSettingsComponent extends BaseFormValidator implements OnI
       [Controls.Domain]: this._builder.control('', Validators.required),
       [Controls.Network]: this._builder.control(''),
       [Controls.SecurityGroups]: this._builder.control(''),
-      [Controls.FloatingIpPool]: this._builder.control(''),
+      [Controls.FloatingIPPool]: this._builder.control(''),
       [Controls.RouterID]: this._builder.control(''),
       [Controls.SubnetID]: this._builder.control(''),
     });
@@ -95,7 +95,7 @@ export class OpenstackSettingsComponent extends BaseFormValidator implements OnI
       domain: this.form.get(Controls.Domain).value,
       network: this.form.get(Controls.Network).value,
       securityGroups: this.form.get(Controls.SecurityGroups).value,
-      floatingIpPool: this.form.get(Controls.FloatingIpPool).value,
+      floatingIPPool: this.form.get(Controls.FloatingIPPool).value,
       routerID: this.form.get(Controls.RouterID).value,
       subnetID: this.form.get(Controls.SubnetID).value,
     } as OpenstackPresetSpec;

--- a/src/app/settings/admin/presets/dialog/steps/settings/provider/openstack/template.html
+++ b/src/app/settings/admin/presets/dialog/steps/settings/provider/openstack/template.html
@@ -102,8 +102,8 @@ limitations under the License.
   <mat-form-field fxFlex>
     <mat-label>Floating IP Pool</mat-label>
     <input matInput
-           [formControlName]="Controls.FloatingIpPool"
-           [name]="Controls.FloatingIpPool"
+           [formControlName]="Controls.FloatingIPPool"
+           [name]="Controls.FloatingIPPool"
            type="text"
            autocomplete="off">
   </mat-form-field>

--- a/src/app/settings/admin/presets/dialog/steps/settings/template.html
+++ b/src/app/settings/admin/presets/dialog/steps/settings/template.html
@@ -20,9 +20,9 @@ limitations under the License.
       <div key>Preset Name</div>
       <div value>{{preset.metadata.name}}</div>
     </km-property>
-    <km-property *ngIf="preset?.spec?.requiredEmailDomain">
-      <div key>Restrict Preset Group to Domain</div>
-      <div value>{{preset.spec.requiredEmailDomain}}</div>
+    <km-property *ngIf="preset?.spec?.requiredEmails">
+      <div key>Restrict Preset Group to Domain(s)</div>
+      <div value>{{preset.spec.requiredEmails}}</div>
     </km-property>
     <km-property-boolean *ngIf="!preset?.spec?.enabled"
                          [value]="!preset.spec.enabled"

--- a/src/app/settings/user/component.ts
+++ b/src/app/settings/user/component.ts
@@ -97,12 +97,12 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
   }
 
   hasDefaultProject(): string {
-    return this.settings.selectedProjectId ? '' : 'None';
+    return this.settings.selectedProjectID ? '' : 'None';
   }
 
   private _checkDefaultProject(): void {
-    if (!!this.settings.selectedProjectId && !this.projectIds.includes(this.settings.selectedProjectId)) {
-      this.settings.selectedProjectId = '';
+    if (!!this.settings.selectedProjectID && !this.projectIds.includes(this.settings.selectedProjectID)) {
+      this.settings.selectedProjectID = '';
       this.onSettingsChange();
     }
   }

--- a/src/app/settings/user/template.html
+++ b/src/app/settings/user/template.html
@@ -83,7 +83,7 @@ limitations under the License.
         <mat-form-field class="input">
           <mat-select disableOptionCentering
                       id="km-default-project-select"
-                      [(ngModel)]="settings.selectedProjectId"
+                      [(ngModel)]="settings.selectedProjectID"
                       (selectionChange)="onSettingsChange()"
                       [placeholder]="hasDefaultProject()">
             <mat-option value=""
@@ -95,7 +95,7 @@ limitations under the License.
             </mat-option>
           </mat-select>
         </mat-form-field>
-        <km-spinner-with-confirmation [isSaved]="isEqual(settings.selectedProjectId, apiSettings.selectedProjectId)"
+        <km-spinner-with-confirmation [isSaved]="isEqual(settings.selectedProjectID, apiSettings.selectedProjectID)"
                                       fxFlexAlign=" center"></km-spinner-with-confirmation>
       </div>
     </div>

--- a/src/app/shared/components/cluster-summary/component.ts
+++ b/src/app/shared/components/cluster-summary/component.ts
@@ -66,7 +66,7 @@ export class ClusterSummaryComponent {
   }
 
   get isMLAEnabled(): boolean {
-    return !!this.seedSettings && !!this.seedSettings.mla && !!this.seedSettings.mla.user_cluster_mla_enabled;
+    return !!this.seedSettings && !!this.seedSettings.mla && !!this.seedSettings.mla.userClusterMLAEnabled;
   }
 
   get hasIPLeft(): boolean {

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -57,13 +57,13 @@ limitations under the License.
             <div key>Security Group ID</div>
             <div value>{{cluster.spec.cloud?.aws?.securityGroupID}}</div>
           </km-property>
-          <km-property *ngIf="cluster.spec.cloud?.aws?.vpcId">
+          <km-property *ngIf="cluster.spec.cloud?.aws?.vpcID">
             <div key>VPC ID</div>
-            <div value>{{cluster.spec.cloud?.aws?.vpcId}}</div>
+            <div value>{{cluster.spec.cloud?.aws?.vpcID}}</div>
           </km-property>
-          <km-property *ngIf="cluster.spec.cloud?.aws?.routeTableId">
+          <km-property *ngIf="cluster.spec.cloud?.aws?.routeTableID">
             <div key>Route Table ID</div>
-            <div value>{{cluster.spec.cloud?.aws?.routeTableId}}</div>
+            <div value>{{cluster.spec.cloud?.aws?.routeTableID}}</div>
           </km-property>
           <km-property *ngIf="cluster.spec.cloud?.aws?.instanceProfileName">
             <div key>Instance Profile Name</div>
@@ -158,9 +158,9 @@ limitations under the License.
             <div key>Security Groups</div>
             <div value>{{cluster.spec.cloud?.openstack.securityGroups}}</div>
           </km-property>
-          <km-property *ngIf="cluster.spec.cloud?.openstack.floatingIpPool">
+          <km-property *ngIf="cluster.spec.cloud?.openstack.floatingIPPool">
             <div key>Floating IP Pool</div>
-            <div value>{{cluster.spec.cloud?.openstack.floatingIpPool}}</div>
+            <div value>{{cluster.spec.cloud?.openstack.floatingIPPool}}</div>
           </km-property>
           <km-property *ngIf="cluster.spec.cloud?.openstack.subnetID">
             <div key>Subnet ID</div>

--- a/src/app/shared/entity/backup.ts
+++ b/src/app/shared/entity/backup.ts
@@ -128,6 +128,6 @@ export class S3Credentials {
 }
 
 export class S3BackupCredentials {
-  accessKeyId: string;
+  accessKeyID: string;
   secretAccessKey: string;
 }

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -54,10 +54,6 @@ export const enum Finalizer {
   DeleteLoadBalancers = 'DeleteLoadBalancers',
 }
 
-export enum ClusterType {
-  Kubernetes = 'kubernetes',
-}
-
 export enum ContainerRuntime {
   Containerd = 'containerd',
   Docker = 'docker',
@@ -72,7 +68,6 @@ export class Cluster {
   name: string;
   spec: ClusterSpec;
   status?: Status;
-  type: ClusterType;
   labels?: object;
   inheritedLabels?: object;
   credential?: string;
@@ -98,6 +93,7 @@ export class Cluster {
 
 export class CloudSpec {
   dc: string;
+  providerName: string;
   digitalocean?: DigitaloceanCloudSpec;
   aws?: AWSCloudSpec;
   bringyourown?: BringYourOwnCloudSpec;
@@ -119,12 +115,12 @@ export class AlibabaCloudSpec {
 }
 
 export class AWSCloudSpec {
-  accessKeyId: string;
+  accessKeyID: string;
   secretAccessKey: string;
   assumeRoleARN: string;
   assumeRoleExternalID: string;
-  vpcId: string;
-  routeTableId: string;
+  vpcID: string;
+  routeTableID: string;
   securityGroupID: string;
   instanceProfileName: string;
   roleARN: string;
@@ -185,7 +181,7 @@ export class OpenstackCloudSpec {
   domain: string;
   network: string;
   securityGroups: string;
-  floatingIpPool: string;
+  floatingIPPool: string;
   subnetID: string;
 }
 
@@ -411,7 +407,7 @@ export class HetznerCloudSpecPatch {
 }
 
 export class AWSCloudSpecPatch {
-  accessKeyId?: string;
+  accessKeyID?: string;
   secretAccessKey?: string;
 }
 
@@ -451,10 +447,10 @@ export function getEmptyCloudProviderSpec(provider: NodeProvider): object {
   switch (provider) {
     case NodeProvider.AWS:
       return {
-        accessKeyId: '',
+        accessKeyID: '',
         secretAccessKey: '',
-        routeTableId: '',
-        vpcId: '',
+        routeTableID: '',
+        vpcID: '',
         securityGroupID: '',
         instanceProfileName: '',
         roleARN: '',
@@ -467,7 +463,7 @@ export function getEmptyCloudProviderSpec(provider: NodeProvider): object {
       return {
         username: '',
         password: '',
-        floatingIpPool: '',
+        floatingIPPool: '',
         securityGroups: '',
         network: '',
         domain: '',
@@ -541,6 +537,5 @@ class ClusterModel {
   name: string;
   spec: ClusterSpec;
   labels?: object;
-  type: string;
   credential?: string;
 }

--- a/src/app/shared/entity/datacenter.ts
+++ b/src/app/shared/entity/datacenter.ts
@@ -56,7 +56,7 @@ export class DatacenterOperatingSystemOptions {
 }
 
 export class AnexiaDatacenterSpec {
-  location_id: string;
+  locationID: string;
 }
 
 export class AlibabaDatacenterSpec {
@@ -80,7 +80,7 @@ export class DigitaloceanDatacenterSpec {
 export class GCPDatacenterSpec {
   region: string;
   regional: boolean;
-  zone_suffixes: string[];
+  zoneSuffixes: string[];
 }
 
 export class HetznerDatacenterSpec {
@@ -92,11 +92,11 @@ export class HetznerDatacenterSpec {
 export class KubeVirtDatacenterSpec {}
 
 export class OpenStackDatacenterSpec {
-  availability_zone: string;
-  auth_url: string;
+  availabilityZone: string;
+  authURL: string;
   region: string;
   images: DatacenterOperatingSystemOptions;
-  enforce_floating_ip: boolean;
+  enforceFloatingIP: boolean;
 }
 
 export class EquinixDatacenterSpec {
@@ -127,7 +127,7 @@ export class MeteringConfiguration {
 }
 
 export class MLA {
-  user_cluster_mla_enabled: boolean;
+  userClusterMLAEnabled: boolean;
 }
 
 export class AdminSeed {

--- a/src/app/shared/entity/datacenter.ts
+++ b/src/app/shared/entity/datacenter.ts
@@ -30,7 +30,7 @@ export class DatacenterSpec {
   country: string;
   location: string;
   provider: string;
-  requiredEmailDomains?: string[];
+  requiredEmails?: string[];
   enforceAuditLogging: boolean;
   enforcePodSecurityPolicy: boolean;
   digitalocean?: DigitaloceanDatacenterSpec;

--- a/src/app/shared/entity/health.ts
+++ b/src/app/shared/entity/health.ts
@@ -43,9 +43,9 @@ export class Health {
 }
 
 export enum HealthState {
-  Down = 0,
-  Up = 1,
-  Provisioning = 2,
+  Down = 'HealthStatusDown',
+  Up = 'HealthStatusUp',
+  Provisioning = 'HealthStatusProvisioning',
 }
 
 export enum HealthType {

--- a/src/app/shared/entity/preset.ts
+++ b/src/app/shared/entity/preset.ts
@@ -69,7 +69,7 @@ export class CreatePresetSpec {
   packet?: EquinixPresetSpec;
   vsphere?: VSpherePresetSpec;
 
-  requiredEmailDomain?: string;
+  requiredEmails?: string[];
   enabled?: boolean;
 
   provider(): NodeProvider {

--- a/src/app/shared/entity/preset.ts
+++ b/src/app/shared/entity/preset.ts
@@ -84,7 +84,7 @@ export class PresetProviderSpec {
 }
 
 export class AlibabaPresetSpec extends PresetProviderSpec {
-  accessKeyId: string;
+  accessKeyID: string;
   accessKeySecret: string;
 }
 
@@ -162,7 +162,7 @@ export class OpenstackPresetSpec extends PresetProviderSpec {
 
   network?: string;
   securityGroups?: string;
-  floatingIpPool?: string;
+  floatingIPPool?: string;
   routerID?: string;
   subnetID?: string;
 }

--- a/src/app/shared/entity/provider/aws.ts
+++ b/src/app/shared/entity/provider/aws.ts
@@ -32,7 +32,7 @@ export class AWSTags {
 }
 
 export class AWSVPC {
-  vpcId: string;
+  vpcID: string;
   name: string;
   cidrBlock: string;
   cidrBlockAssociationSet: AWSCidrBlockSet[];
@@ -45,7 +45,7 @@ export class AWSVPC {
   tags: AWSTags[];
 
   get displayName(): string {
-    return this.name !== '' ? `${this.name} (${this.vpcId})` : this.vpcId;
+    return this.name !== '' ? `${this.name} (${this.vpcID})` : this.vpcID;
   }
 }
 

--- a/src/app/shared/entity/provider/openstack.ts
+++ b/src/app/shared/entity/provider/openstack.ts
@@ -33,7 +33,7 @@ export class OpenstackNetwork {
   external: boolean;
 }
 
-export class OpenstackFloatingIpPool {
+export class OpenstackFloatingIPPool {
   id: string;
   name: string;
   external: boolean;

--- a/src/app/shared/entity/settings.ts
+++ b/src/app/shared/entity/settings.ts
@@ -16,7 +16,7 @@ import _ from 'lodash';
 
 export class UserSettings {
   selectedTheme?: string;
-  selectedProjectId?: string;
+  selectedProjectID?: string;
   itemsPerPage?: number;
   selectProjectTableView?: boolean;
   collapseSidenav?: boolean;
@@ -52,8 +52,8 @@ export class MachineDeploymentVMResourceQuota {
 }
 
 export class CleanupOptions {
-  Enabled: boolean;
-  Enforced: boolean;
+  enabled: boolean;
+  enforced: boolean;
 }
 
 export class OpaOptions {
@@ -128,8 +128,8 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
 
 export const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
   cleanupOptions: {
-    Enforced: false,
-    Enabled: false,
+    enforced: false,
+    enabled: false,
   },
   userProjectsLimit: 0,
   customLinks: [],

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -162,7 +162,6 @@ export class WizardComponent implements OnInit, OnDestroy {
         name: cluster.name,
         labels: cluster.labels,
         spec: cluster.spec,
-        type: cluster.type,
         credential: cluster.credential,
       },
       nodeDeployment: {

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -31,7 +31,6 @@ import {
   AuditPolicyPreset,
   Cluster,
   ClusterSpec,
-  ClusterType,
   CNIPlugin,
   ContainerRuntime,
   END_OF_DOCKER_SUPPORT_VERSION,
@@ -326,7 +325,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   isMLAEnabled(): boolean {
-    return !!this._seedSettings && !!this._seedSettings.mla && !!this._seedSettings.mla.user_cluster_mla_enabled;
+    return !!this._seedSettings && !!this._seedSettings.mla && !!this._seedSettings.mla.userClusterMLAEnabled;
   }
 
   hasCNIPluginType(): boolean {
@@ -375,7 +374,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
     return {
       name: this.controlValue(Controls.Name),
-      type: ClusterType.Kubernetes,
       spec: {
         version: this.controlValue(Controls.Version),
         auditLogging: {

--- a/src/app/wizard/step/provider-settings/provider/basic/alibaba/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/alibaba/component.ts
@@ -23,7 +23,7 @@ import {merge} from 'rxjs';
 import {distinctUntilChanged, filter, takeUntil} from 'rxjs/operators';
 
 export enum Controls {
-  AccessKeyID = 'accessKeyId',
+  AccessKeyID = 'accessKeyID',
   AccessKeySecret = 'secretAccessKey',
 }
 

--- a/src/app/wizard/step/provider-settings/provider/basic/aws/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/aws/component.ts
@@ -36,7 +36,7 @@ import {catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, 
 export enum Controls {
   AccessKeyID = 'accessKeyID',
   AccessKeySecret = 'accessKeySecret',
-  VPCID = 'vpcId',
+  VPCID = 'vpcID',
   AssumeRoleARN = 'assumeRoleARN',
   AssumeRoleExternalID = 'assumeRoleID',
   UseAssumeRole = 'useAssumeRole',
@@ -69,7 +69,7 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
   private readonly _debounceTime = 500;
   readonly Controls = Controls;
   isPresetSelected = false;
-  vpcIds: AWSVPC[] = [];
+  vpcIDs: AWSVPC[] = [];
   selectedVPC = '';
   vpcLabel = VPCState.Empty;
 
@@ -170,8 +170,8 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
     return '';
   }
 
-  onVPCChange(vpcId: string): void {
-    this._clusterSpecService.cluster.spec.cloud.aws.vpcId = vpcId;
+  onVPCChange(vpcID: string): void {
+    this._clusterSpecService.cluster.spec.cloud.aws.vpcID = vpcID;
   }
 
   ngOnDestroy(): void {
@@ -182,7 +182,7 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
   private _hasRequiredCredentials(): boolean {
     return (
       !!this._clusterSpecService.cluster.spec.cloud.aws &&
-      !!this._clusterSpecService.cluster.spec.cloud.aws.accessKeyId &&
+      !!this._clusterSpecService.cluster.spec.cloud.aws.accessKeyID &&
       !!this._clusterSpecService.cluster.spec.cloud.aws.secretAccessKey
     );
   }
@@ -221,7 +221,7 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
   }
 
   private _clearVPC(): void {
-    this.vpcIds = [];
+    this.vpcIDs = [];
     this.selectedVPC = '';
     this.vpcLabel = VPCState.Empty;
     this._vpcCombobox.reset();
@@ -229,10 +229,10 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
   }
 
   private _setDefaultVPC(vpcs: AWSVPC[]): void {
-    this.vpcIds = vpcs;
-    const defaultVPC = this.vpcIds.find(vpc => vpc.isDefault);
-    this.selectedVPC = defaultVPC ? defaultVPC.vpcId : undefined;
-    this.vpcLabel = !_.isEmpty(this.vpcIds) ? VPCState.Ready : VPCState.Empty;
+    this.vpcIDs = vpcs;
+    const defaultVPC = this.vpcIDs.find(vpc => vpc.isDefault);
+    this.selectedVPC = defaultVPC ? defaultVPC.vpcID : undefined;
+    this.vpcLabel = !_.isEmpty(this.vpcIDs) ? VPCState.Ready : VPCState.Empty;
     this._cdr.detectChanges();
   }
 
@@ -241,7 +241,7 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
       spec: {
         cloud: {
           aws: {
-            accessKeyId: this.form.get(Controls.AccessKeyID).value,
+            accessKeyID: this.form.get(Controls.AccessKeyID).value,
             secretAccessKey: this.form.get(Controls.AccessKeySecret).value,
             assumeRoleARN: this.form.get(Controls.AssumeRoleARN).value,
             assumeRoleExternalID: this.form.get(Controls.AssumeRoleExternalID).value,

--- a/src/app/wizard/step/provider-settings/provider/basic/aws/template.html
+++ b/src/app/wizard/step/provider-settings/provider/basic/aws/template.html
@@ -55,14 +55,14 @@ limitations under the License.
                [required]="true"
                [grouped]="false"
                [isDisabled]="isPresetSelected"
-               [options]="vpcIds"
+               [options]="vpcIDs"
                [selected]="selectedVPC"
                [hint]="getHint(Controls.VPCID)"
                [formControlName]="Controls.VPCID"
                [label]="vpcLabel"
                (changed)="onVPCChange($event)"
                inputLabel="Select VPC..."
-               filterBy="vpcId">
+               filterBy="vpcID">
     <div *option="let vpc">
       {{vpc.displayName}}
     </div>

--- a/src/app/wizard/step/provider-settings/provider/basic/openstack/application/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/openstack/application/component.ts
@@ -28,7 +28,7 @@ import {DatacenterService} from '@core/services/datacenter';
 import {PresetsService} from '@core/services/wizard/presets';
 import {FilteredComboboxComponent} from '@shared/components/combobox/component';
 import {CloudSpec, Cluster, ClusterSpec, OpenstackCloudSpec} from '@shared/entity/cluster';
-import {OpenstackFloatingIpPool} from '@shared/entity/provider/openstack';
+import {OpenstackFloatingIPPool} from '@shared/entity/provider/openstack';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import _ from 'lodash';
@@ -81,7 +81,7 @@ export class OpenstackProviderBasicAppCredentialsComponent extends BaseFormValid
   private readonly _floatingIPPoolCombobox: FilteredComboboxComponent;
   readonly Controls = Controls;
   isPresetSelected = false;
-  floatingIPPools: OpenstackFloatingIpPool[] = [];
+  floatingIPPools: OpenstackFloatingIPPool[] = [];
   floatingIPPoolsLabel = FloatingIPPoolState.Empty;
 
   constructor(
@@ -134,7 +134,7 @@ export class OpenstackProviderBasicAppCredentialsComponent extends BaseFormValid
       .pipe(tap(_ => this._clearFloatingIPPool()))
       .pipe(switchMap(_ => this._floatingIPPoolListObservable()))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe((floatingIPPools: OpenstackFloatingIpPool[]) => {
+      .subscribe((floatingIPPools: OpenstackFloatingIPPool[]) => {
         this.floatingIPPools = floatingIPPools;
 
         if (!_.isEmpty(this.floatingIPPools)) {
@@ -150,7 +150,7 @@ export class OpenstackProviderBasicAppCredentialsComponent extends BaseFormValid
     )
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
       .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterSpecService.datacenter).pipe(take(1))))
-      .pipe(tap(dc => (this._isFloatingPoolIPEnforced = dc.spec.openstack.enforce_floating_ip)))
+      .pipe(tap(dc => (this._isFloatingPoolIPEnforced = dc.spec.openstack.enforceFloatingIP)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this.form.reset());
 
@@ -172,7 +172,7 @@ export class OpenstackProviderBasicAppCredentialsComponent extends BaseFormValid
   }
 
   onFloatingIPPoolChange(floatingIPPool: string): void {
-    this._clusterSpecService.cluster.spec.cloud.openstack.floatingIpPool = floatingIPPool;
+    this._clusterSpecService.cluster.spec.cloud.openstack.floatingIPPool = floatingIPPool;
   }
 
   getHint(control: Controls): string {
@@ -202,7 +202,7 @@ export class OpenstackProviderBasicAppCredentialsComponent extends BaseFormValid
     );
   }
 
-  private _floatingIPPoolListObservable(): Observable<OpenstackFloatingIpPool[]> {
+  private _floatingIPPoolListObservable(): Observable<OpenstackFloatingIPPool[]> {
     return this._presets
       .provider(NodeProvider.OPENSTACK)
       .applicationCredentialID(this.form.get(Controls.ApplicationCredentialID).value)

--- a/src/app/wizard/step/provider-settings/provider/basic/openstack/default/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/openstack/default/component.ts
@@ -30,7 +30,7 @@ import {DatacenterService} from '@core/services/datacenter';
 import {PresetsService} from '@core/services/wizard/presets';
 import {FilteredComboboxComponent} from '@shared/components/combobox/component';
 import {CloudSpec, Cluster, ClusterSpec, OpenstackCloudSpec} from '@shared/entity/cluster';
-import {OpenstackFloatingIpPool, OpenstackTenant} from '@shared/entity/provider/openstack';
+import {OpenstackFloatingIPPool, OpenstackTenant} from '@shared/entity/provider/openstack';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import _ from 'lodash';
@@ -93,7 +93,7 @@ export class OpenstackProviderBasicDefaultCredentialsComponent extends BaseFormV
   isPresetSelected = false;
   projects: OpenstackTenant[] = [];
   projectsLabel = ProjectState.Empty;
-  floatingIPPools: OpenstackFloatingIpPool[] = [];
+  floatingIPPools: OpenstackFloatingIPPool[] = [];
   floatingIPPoolsLabel = FloatingIPPoolState.Empty;
 
   constructor(
@@ -141,7 +141,7 @@ export class OpenstackProviderBasicDefaultCredentialsComponent extends BaseFormV
     )
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
       .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterSpecService.datacenter).pipe(take(1))))
-      .pipe(tap(dc => (this._isFloatingPoolIPEnforced = dc.spec.openstack.enforce_floating_ip)))
+      .pipe(tap(dc => (this._isFloatingPoolIPEnforced = dc.spec.openstack.enforceFloatingIP)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(this._formReset.bind(this));
 
@@ -181,7 +181,7 @@ export class OpenstackProviderBasicDefaultCredentialsComponent extends BaseFormV
       .pipe(tap(_ => this._clearFloatingIPPool()))
       .pipe(switchMap(_ => this._floatingIPPoolListObservable()))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe((floatingIPPools: OpenstackFloatingIpPool[]) => {
+      .subscribe((floatingIPPools: OpenstackFloatingIPPool[]) => {
         this.floatingIPPools = floatingIPPools;
 
         if (!_.isEmpty(this.floatingIPPools)) {
@@ -225,7 +225,7 @@ export class OpenstackProviderBasicDefaultCredentialsComponent extends BaseFormV
   }
 
   onFloatingIPPoolChange(floatingIPPool: string): void {
-    this._clusterSpecService.cluster.spec.cloud.openstack.floatingIpPool = floatingIPPool;
+    this._clusterSpecService.cluster.spec.cloud.openstack.floatingIPPool = floatingIPPool;
   }
 
   getHint(control: Controls): string {
@@ -321,7 +321,7 @@ export class OpenstackProviderBasicDefaultCredentialsComponent extends BaseFormV
     this._cdr.detectChanges();
   }
 
-  private _floatingIPPoolListObservable(): Observable<OpenstackFloatingIpPool[]> {
+  private _floatingIPPoolListObservable(): Observable<OpenstackFloatingIPPool[]> {
     return this._presets
       .provider(NodeProvider.OPENSTACK)
       .domain(this._clusterSpecService.cluster.spec.cloud.openstack.domain)

--- a/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
@@ -26,7 +26,7 @@ import {AutocompleteControls, AutocompleteInitialState} from '@shared/components
 
 enum Controls {
   SecurityGroup = 'securityGroup',
-  RouteTableID = 'routeTableId',
+  RouteTableID = 'routeTableID',
   InstanceProfileName = 'instanceProfileName',
   RoleARN = 'roleARN',
 }
@@ -126,7 +126,7 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
       !!this._clusterSpecService.cluster.spec.cloud.aws.assumeRoleExternalID
     ) {
       return (
-        !!this._clusterSpecService.cluster.spec.cloud.aws.accessKeyId &&
+        !!this._clusterSpecService.cluster.spec.cloud.aws.accessKeyID &&
         !!this._clusterSpecService.cluster.spec.cloud.aws.secretAccessKey &&
         !!this._clusterSpecService.cluster.spec.cloud.aws.assumeRoleExternalID &&
         !!this._clusterSpecService.cluster.spec.cloud.aws.assumeRoleARN
@@ -134,7 +134,7 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
     }
 
     return (
-      !!this._clusterSpecService.cluster.spec.cloud.aws.accessKeyId &&
+      !!this._clusterSpecService.cluster.spec.cloud.aws.accessKeyID &&
       !!this._clusterSpecService.cluster.spec.cloud.aws.secretAccessKey
     );
   }
@@ -142,7 +142,7 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
   private _securityGroupObservable(): Observable<string[]> {
     return this._presets
       .provider(NodeProvider.AWS)
-      .accessKeyID(this._clusterSpecService.cluster.spec.cloud.aws.accessKeyId)
+      .accessKeyID(this._clusterSpecService.cluster.spec.cloud.aws.accessKeyID)
       .secretAccessKey(this._clusterSpecService.cluster.spec.cloud.aws.secretAccessKey)
       .assumeRoleARN(this._clusterSpecService.cluster.spec.cloud.aws.assumeRoleARN)
       .assumeRoleExternalID(this._clusterSpecService.cluster.spec.cloud.aws.assumeRoleExternalID)
@@ -184,7 +184,7 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
           aws: {
             instanceProfileName: this.form.get(Controls.InstanceProfileName).value,
             roleARN: this.form.get(Controls.RoleARN).value,
-            routeTableId: this.form.get(Controls.RouteTableID).value,
+            routeTableID: this.form.get(Controls.RouteTableID).value,
           } as AWSCloudSpec,
         } as CloudSpec,
       } as ClusterSpec,

--- a/src/test/data/cluster-with-machine-networks.ts
+++ b/src/test/data/cluster-with-machine-networks.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Cluster, ClusterType, ExternalCCMMigrationStatus} from '@shared/entity/cluster';
+import {Cluster, ExternalCCMMigrationStatus} from '@shared/entity/cluster';
 
 // fakeClusterWithMachineNetwork could contain 6 IPs
 export function fakeClusterWithMachineNetwork(): Cluster {
@@ -33,6 +33,7 @@ export function fakeClusterWithMachineNetwork(): Cluster {
             password: 'bar',
           },
         },
+        providerName: 'vsphere',
       },
       version: '1.8.5',
       machineNetworks: [
@@ -48,7 +49,6 @@ export function fakeClusterWithMachineNetwork(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.NotNeeded,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -71,6 +71,7 @@ export function fakeGatewayInCidr(): Cluster {
             password: 'bar',
           },
         },
+        providerName: 'vsphere',
       },
       version: '1.8.5',
       machineNetworks: [
@@ -86,7 +87,6 @@ export function fakeGatewayInCidr(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.NotNeeded,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -109,6 +109,7 @@ export function fakeGatewayNotInCidr(): Cluster {
             password: 'bar',
           },
         },
+        providerName: 'vsphere',
       },
       version: '1.8.5',
       machineNetworks: [
@@ -124,6 +125,5 @@ export function fakeGatewayNotInCidr(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.NotNeeded,
     },
-    type: ClusterType.Kubernetes,
   };
 }

--- a/src/test/data/cluster.ts
+++ b/src/test/data/cluster.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Cluster, ClusterType, ExternalCCMMigrationStatus} from '@shared/entity/cluster';
+import {Cluster, ExternalCCMMigrationStatus} from '@shared/entity/cluster';
 
 export function fakeDigitaloceanCluster(): Cluster {
   return {
@@ -25,6 +25,7 @@ export function fakeDigitaloceanCluster(): Cluster {
         digitalocean: {
           token: 'token',
         },
+        providerName: 'digitalocean',
       },
       version: '1.8.5',
     },
@@ -33,7 +34,6 @@ export function fakeDigitaloceanCluster(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -50,6 +50,7 @@ export function fakeEquinixCluster(): Cluster {
           projectID: '1',
           billingCycle: 'hourly',
         },
+        providerName: 'packet',
       },
       version: '1.8.5',
     },
@@ -58,7 +59,6 @@ export function fakeEquinixCluster(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -73,6 +73,7 @@ export function fakeHetznerCluster(): Cluster {
         hetzner: {
           token: 'pixH4QgO2nbVY1Xoo8yVN0RPN2d3CBQYPKcPrfd1BWwFsWrKMsdUKyos7wYAa6hQ',
         },
+        providerName: 'digitalocean',
       },
       version: '1.8.5',
     },
@@ -81,7 +82,6 @@ export function fakeHetznerCluster(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.NotNeeded,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -103,6 +103,7 @@ export function fakeVSphereCluster(): Cluster {
             password: 'bar',
           },
         },
+        providerName: 'vsphere',
       },
       version: '1.8.5',
     },
@@ -111,7 +112,6 @@ export function fakeVSphereCluster(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -124,16 +124,17 @@ export function fakeAWSCluster(): Cluster {
       cloud: {
         dc: 'aws-fra1',
         aws: {
-          accessKeyId: 'aaaaaaaaaaaa',
+          accessKeyID: 'aaaaaaaaaaaa',
           secretAccessKey: 'bbbbbbbbbbbb',
           assumeRoleARN: '',
           assumeRoleExternalID: '',
           securityGroupID: '',
-          vpcId: '',
-          routeTableId: '',
+          vpcID: '',
+          routeTableID: '',
           instanceProfileName: '',
           roleARN: '',
         },
+        providerName: 'aws',
       },
       version: '1.9.6',
     },
@@ -142,7 +143,6 @@ export function fakeAWSCluster(): Cluster {
       version: '1.9.6',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -157,7 +157,7 @@ export function fakeOpenstackCluster(): Cluster {
         openstack: {
           username: 'test-username',
           password: 'test-password',
-          floatingIpPool: 'test-floating-ip-pool',
+          floatingIPPool: 'test-floating-ip-pool',
           securityGroups: 'test-security-group',
           network: 'test-network',
           domain: 'test-domain',
@@ -165,6 +165,7 @@ export function fakeOpenstackCluster(): Cluster {
           projectID: '',
           subnetID: 'test-subnet-id',
         },
+        providerName: 'openstack',
       },
       version: '1.9.6',
     },
@@ -173,7 +174,6 @@ export function fakeOpenstackCluster(): Cluster {
       version: '1.9.6',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -199,6 +199,7 @@ export function fakeAzureCluster(): Cluster {
           loadBalancerSKU: 'basic',
           assignAvailabilitySet: true,
         },
+        providerName: 'azure',
       },
       version: '1.8.5',
     },
@@ -207,7 +208,6 @@ export function fakeAzureCluster(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -220,6 +220,7 @@ export function fakeBringyourownCluster(): Cluster {
       cloud: {
         dc: 'do-fra1',
         bringyourown: {},
+        providerName: 'bringyourown',
       },
       version: '1.8.5',
     },
@@ -228,7 +229,6 @@ export function fakeBringyourownCluster(): Cluster {
       version: '1.8.5',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 
@@ -244,6 +244,7 @@ export function fakeAlibabaCluster(): Cluster {
           accessKeyID: 'ali-access-key-id',
           accessKeySecret: 'ali-access-key-secret',
         },
+        providerName: 'alibaba',
       },
       version: '1.9.6',
     },
@@ -252,7 +253,6 @@ export function fakeAlibabaCluster(): Cluster {
       version: '1.9.6',
       externalCCMMigration: ExternalCCMMigrationStatus.Unsupported,
     },
-    type: ClusterType.Kubernetes,
   };
 }
 

--- a/src/test/data/datacenter.ts
+++ b/src/test/data/datacenter.ts
@@ -76,8 +76,8 @@ export function fakeOpenstackDatacenter(): Datacenter {
       seed: 'europe-west3-c',
       country: 'DE',
       openstack: {
-        auth_url: 'kubermatic.com',
-        availability_zone: 'az1',
+        authURL: 'kubermatic.com',
+        availabilityZone: 'az1',
         region: '',
         images: {
           centos: '',
@@ -85,7 +85,7 @@ export function fakeOpenstackDatacenter(): Datacenter {
           sles: '',
           rhel: '',
         },
-        enforce_floating_ip: false,
+        enforceFloatingIP: false,
       },
       location: 'Frankfurt',
       provider: 'openstack',
@@ -157,5 +157,5 @@ export function fakeNodeDatacenters(): Datacenter[] {
 }
 
 export function fakeSeedSettings(): SeedSettings {
-  return {mla: {user_cluster_mla_enabled: true}, metering: {} as MeteringConfiguration};
+  return {mla: {userClusterMLAEnabled: true}, metering: {} as MeteringConfiguration};
 }

--- a/src/test/services/settings-mock.ts
+++ b/src/test/services/settings-mock.ts
@@ -24,8 +24,8 @@ export const DEFAULT_USER_SETTINGS_MOCK: UserSettings = {
 
 export const DEFAULT_ADMIN_SETTINGS_MOCK: AdminSettings = {
   cleanupOptions: {
-    Enforced: false,
-    Enabled: false,
+    enforced: false,
+    enabled: false,
   },
   customLinks: [],
   defaultNodeCount: 1,


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the API groups used for e2e tests to the new groups that are soon going to be used by KKP.

Currently, before https://github.com/kubermatic/kubermatic/pull/8783 is merged, this PR will always fail.

### Which issue(s) this PR fixes
This is part of kubermatic/kubermatic#6471

### Release note
```release-note
NONE
```
