### PR TITLE
Review and update the notification messages

### DIFF
--- a/src/app/backup/list/automatic-backup/component.ts
+++ b/src/app/backup/list/automatic-backup/component.ts
@@ -152,7 +152,7 @@ export class AutomaticBackupListComponent implements OnInit, OnDestroy {
       .pipe(switchMap(_ => this._backupService.delete(this._selectedProject.id, backup.spec.clusterId, backup.id)))
       .subscribe(_ => {
         this._backupService.refreshAutomaticBackups();
-        this._notificationService.success(`Deleted the ${backup.name} automatic backup`);
+        this._notificationService.success(`Deleting the ${backup.name} automatic backup`);
       });
   }
 

--- a/src/app/backup/list/snapshot/delete-dialog/component.ts
+++ b/src/app/backup/list/snapshot/delete-dialog/component.ts
@@ -42,7 +42,7 @@ export class DeleteSnapshotDialogComponent {
       .delete(this.config.projectID, this.config.snapshot.spec.clusterId, this.config.snapshot.id)
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success(`Deleted the ${this.config.snapshot.name} snapshot`);
+        this._notificationService.success(`Deleting the ${this.config.snapshot.name} snapshot`);
         this._dialogRef.close(true);
       });
   }

--- a/src/app/cluster/details/cluster/add-machine-network/component.ts
+++ b/src/app/cluster/details/cluster/add-machine-network/component.ts
@@ -51,7 +51,7 @@ export class AddMachineNetworkComponent {
       .pipe(take(1))
       .subscribe(res => {
         this._notificationService.success(
-          `Added machine network${this.machineNetworks.length > 1 ? 's' : ''} for the ${this.cluster.name} cluster`
+          `Added the machine network${this.machineNetworks.length > 1 ? 's' : ''} for the ${this.cluster.name} cluster`
         );
         this._dialogRef.close(res);
       });

--- a/src/app/cluster/details/cluster/cni-version/cni-version-dialog/component.ts
+++ b/src/app/cluster/details/cluster/cni-version/cni-version-dialog/component.ts
@@ -68,7 +68,7 @@ export class CNIVersionDialog implements OnInit, OnDestroy {
 
     this._clusterService.patch(this.project.id, this.data.cluster.id, patch).subscribe(() => {
       this._notificationService.success(
-        `The ${this.data.cluster.name} cluster is being updated to the ${this.selectedCNIVersion} CNI version`
+        `Updating the CNI version to the ${this.selectedCNIVersion} for the ${this.data.cluster.name} cluster`
       );
       this._clusterService.onClusterUpdate.next();
       this._matDialogRef.close(true);

--- a/src/app/cluster/details/cluster/constraints/component.ts
+++ b/src/app/cluster/details/cluster/constraints/component.ts
@@ -184,7 +184,7 @@ export class ConstraintsComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(take(1))
       .subscribe(_ => {
         this._opaService.refreshConstraint();
-        this._notificationService.success(`Deleted the ${constraint.name} constraint`);
+        this._notificationService.success(`Deleting the ${constraint.name} constraint`);
       });
   }
 }

--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -307,7 +307,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     this._clusterService.patch(this.projectID, this.cluster.id, patch).subscribe(cluster => {
       this._matDialogRef.close(cluster);
       this._clusterService.onClusterUpdate.next();
-      this._notificationService.success(`The ${this.cluster.name} cluster was updated`);
+      this._notificationService.success(`Updated the ${this.cluster.name} cluster`);
     });
   }
 

--- a/src/app/cluster/details/cluster/edit-sshkeys/component.ts
+++ b/src/app/cluster/details/cluster/edit-sshkeys/component.ts
@@ -140,9 +140,7 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
       .pipe(switchMap(_ => this._clusterService.deleteSSHKey(this.projectID, this.cluster.id, sshKey.id)))
       .pipe(take(1))
       .subscribe(() => {
-        this._notificationService.success(
-          `The ${sshKey.name} SSH key was removed from the ${this.cluster.name} cluster`
-        );
+        this._notificationService.success(`Removed the ${sshKey.name} SSH key from the ${this.cluster.name} cluster`);
         this._sshKeysUpdate.next();
       });
   }

--- a/src/app/cluster/details/cluster/gatekeeper-config/component.ts
+++ b/src/app/cluster/details/cluster/gatekeeper-config/component.ts
@@ -130,7 +130,7 @@ export class GatekeeperConfigComponent implements OnChanges, OnDestroy {
       .pipe(switchMap(_ => this._opaService.deleteGatekeeperConfig(this.projectID, this.cluster.id)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success('Deleted the Gatekeeper config');
+        this._notificationService.success('Deleting the Gatekeeper config');
         this._opaService.refreshGatekeeperConfig();
       });
   }

--- a/src/app/cluster/details/cluster/machine-deployment-list/component.ts
+++ b/src/app/cluster/details/cluster/machine-deployment-list/component.ts
@@ -121,7 +121,7 @@ export class MachineDeploymentListComponent implements OnInit, OnChanges, OnDest
       .pipe(take(1))
       .subscribe(
         _ => {
-          this._notificationService.success(`The ${md.name} machine deployment was updated`);
+          this._notificationService.success(`Updated the ${md.name} machine deployment`);
           this.changeMachineDeployment.emit(md);
         },
         _ => this._notificationService.error(`Could not edit the ${md.name} machine deployment`)

--- a/src/app/cluster/details/cluster/mla/alertmanager-config/alertmanager-config-dialog/component.ts
+++ b/src/app/cluster/details/cluster/mla/alertmanager-config/alertmanager-config-dialog/component.ts
@@ -94,7 +94,7 @@ export class AlertmanagerConfigDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(_ => {
         this._matDialogRef.close(true);
-        this._notificationService.success('The Alertmanager Config was updated');
+        this._notificationService.success('Updated the Alertmanager Config');
         this._mlaService.refreshAlertmanagerConfig();
       });
   }

--- a/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
+++ b/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
@@ -212,7 +212,7 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
       .pipe(switchMap(_ => this._mlaService.resetAlertmanagerConfig(this.projectID, this.cluster.id)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success('The Alertmanager config was reset to default');
+        this._notificationService.success('Reset the Alertmanager config to the default value');
         this._mlaService.refreshAlertmanagerConfig();
       });
   }

--- a/src/app/cluster/details/cluster/mla/rule-groups/component.ts
+++ b/src/app/cluster/details/cluster/mla/rule-groups/component.ts
@@ -150,7 +150,7 @@ export class RuleGroupsComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(switchMap(_ => this._mlaService.deleteRuleGroup(this.projectID, this.cluster.id, ruleGroup.name)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success(`The Rule Group ${ruleGroup.name} was deleted`);
+        this._notificationService.success(`Deleting the ${ruleGroup.name} Rule Group`);
         this._mlaService.refreshRuleGroups();
       });
   }

--- a/src/app/cluster/details/cluster/mla/rule-groups/rule-group-dialog/component.ts
+++ b/src/app/cluster/details/cluster/mla/rule-groups/rule-group-dialog/component.ts
@@ -121,7 +121,7 @@ export class RuleGroupDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(_ => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The Rule Group ${ruleGroup.name} was created`);
+        this._notificationService.success(`Created the ${ruleGroup.name} Rule Group`);
         this._mlaService.refreshRuleGroups();
       });
   }
@@ -132,7 +132,7 @@ export class RuleGroupDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(_ => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The Rule Group ${ruleGroup.name} was updated`);
+        this._notificationService.success(`Updated the ${ruleGroup.name} Rule Group`);
         this._mlaService.refreshRuleGroups();
       });
   }

--- a/src/app/cluster/details/cluster/node-list/component.ts
+++ b/src/app/cluster/details/cluster/node-list/component.ts
@@ -162,7 +162,7 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(switchMap(_ => this._clusterService.deleteNode(this.projectID, this.cluster.id, node.id)))
       .pipe(take(1))
       .subscribe(() => {
-        this._notificationService.success(`The ${node.name} node was removed from the ${this.cluster.name} cluster`);
+        this._notificationService.success(`Removing the ${node.name} node from the ${this.cluster.name} cluster`);
         this._googleAnalyticsService.emitEvent('clusterOverview', 'nodeDeleted');
         this.deleteNode.emit(node);
       });

--- a/src/app/cluster/details/cluster/rbac/add-binding/component.ts
+++ b/src/app/cluster/details/cluster/rbac/add-binding/component.ts
@@ -193,7 +193,7 @@ export class AddBindingComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(binding => {
         this._matDialogRef.close(binding);
-        this._notificationService.success(`The ${bindingName} binding was added`);
+        this._notificationService.success(`Added the ${bindingName} cluster binding`);
       });
   }
 
@@ -220,7 +220,7 @@ export class AddBindingComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(binding => {
         this._matDialogRef.close(binding);
-        this._notificationService.success(`The ${bindingName} binding was added`);
+        this._notificationService.success(`Added the ${bindingName} binding`);
       });
   }
 }

--- a/src/app/cluster/details/cluster/rbac/component.ts
+++ b/src/app/cluster/details/cluster/rbac/component.ts
@@ -167,7 +167,7 @@ export class RBACComponent implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(() => {
         this._refresh.next();
-        this._notificationService.success(`The ${element.name} ${element.kind} was removed from the binding`);
+        this._notificationService.success(`Removed ${element.name} ${element.kind} from the binding`);
       });
   }
 
@@ -204,7 +204,7 @@ export class RBACComponent implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(() => {
         this._refresh.next();
-        this._notificationService.success(`The ${element.name} ${element.kind} was removed from the binding`);
+        this._notificationService.success(`Removed ${element.name} ${element.kind} from the binding`);
       });
   }
 }

--- a/src/app/cluster/details/cluster/revoke-token/component.ts
+++ b/src/app/cluster/details/cluster/revoke-token/component.ts
@@ -59,14 +59,14 @@ export class RevokeTokenComponent implements OnInit {
   revokeToken(): void {
     if (this.revokeAdminToken) {
       this._clusterService.editToken(this.cluster, this.projectID, {token: ''}).subscribe(res => {
-        this._notificationService.success(`The admin token for the ${this.cluster.name} cluster was revoked`);
+        this._notificationService.success(`Revoked the admin token from the ${this.cluster.name} cluster`);
         this._matDialogRef.close(res);
       });
     }
 
     if (this.revokeViewerToken) {
       this._clusterService.editViewerToken(this.cluster, this.projectID, {token: ''}).subscribe(res => {
-        this._notificationService.success(`The viewer token for the ${this.cluster.name} cluster was revoked`);
+        this._notificationService.success(`Revoked the viewer token from the ${this.cluster.name} cluster`);
         this._matDialogRef.close(res);
       });
     }

--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -169,7 +169,7 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(_ => {
         this._clusterService.onClusterUpdate.next();
-        this._notificationService.success(`The ${this.cluster.name} cluster was updated`);
+        this._notificationService.success(`Updated the ${this.cluster.name} cluster`);
       });
   }
 
@@ -180,7 +180,7 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
   disconnect(): void {
     this._clusterService.showDisconnectClusterDialog(this.cluster, this.projectID).subscribe(_ => {
       this._router.navigate(['/projects/' + this.projectID + '/clusters']);
-      this._notificationService.success(`The ${this.cluster.name} cluster was disconnected`);
+      this._notificationService.success(`Disconnected the ${this.cluster.name} cluster`);
     });
   }
 }

--- a/src/app/cluster/details/external-cluster/replicas-dialog/component.ts
+++ b/src/app/cluster/details/external-cluster/replicas-dialog/component.ts
@@ -55,7 +55,7 @@ export class ReplicasDialogComponent implements OnInit {
       .patchExternalMachineDeployment(this.data.projectID, this.data.clusterID, this.data.machineDeployment.id, patch)
       .pipe(take(1))
       .subscribe(md => {
-        this._notificationService.success(`Number of ${md.name} machine deployment replicas is getting updated`);
+        this._notificationService.success(`Updated the number of ${md.name} machine deployment replicas`);
         this._dialogRef.close();
       });
   }

--- a/src/app/cluster/details/shared/version-change-dialog/component.ts
+++ b/src/app/cluster/details/shared/version-change-dialog/component.ts
@@ -80,7 +80,7 @@ export class VersionChangeDialogComponent implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
-          `The ${this.cluster.name} cluster is being updated to the ${this.selectedVersion} version`
+          `Updating the ${this.cluster.name} cluster to the ${this.selectedVersion} version`
         );
 
         this._googleAnalyticsService.emitEvent('clusterOverview', 'clusterVersionChanged');
@@ -99,7 +99,7 @@ export class VersionChangeDialogComponent implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
-          `The machine deployments from the ${this.cluster.name} cluster are being updated to the ${this.selectedVersion} version`
+          `Updating the machine deployments version to the ${this.selectedVersion} for the ${this.cluster.name} cluster`
         );
       });
   }

--- a/src/app/cluster/list/cluster/component.ts
+++ b/src/app/cluster/list/cluster/component.ts
@@ -104,6 +104,12 @@ export class ClusterListComponent implements OnInit, OnChanges, OnDestroy {
 
     this._projectChange$
       .pipe(
+        tap(_ => {
+          this.dataSource.data = [];
+          this.isInitialized = false;
+        })
+      )
+      .pipe(
         switchMap(_ =>
           combineLatest([
             this._userService.getCurrentUserGroup(this._selectedProject.id),

--- a/src/app/cluster/list/external-cluster/component.ts
+++ b/src/app/cluster/list/external-cluster/component.ts
@@ -189,7 +189,7 @@ export class ExternalClusterListComponent implements OnInit, OnChanges, OnDestro
     event.stopPropagation();
 
     this._clusterService.showDisconnectClusterDialog(cluster, this._selectedProject.id).subscribe(_ => {
-      this._notificationService.success(`The ${cluster.name} cluster was disconnected`);
+      this._notificationService.success(`Disconnected the ${cluster.name} cluster`);
     });
   }
 

--- a/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/component.ts
+++ b/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/component.ts
@@ -108,7 +108,7 @@ export class AllowedRegistryDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(result => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The allowed registry ${result.name} was created`);
+        this._notificationService.success(`Created the ${result.name} allowed registry`);
         this._allowedRegistriesService.refreshAllowedRegistries();
       });
   }
@@ -119,7 +119,7 @@ export class AllowedRegistryDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(result => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The allowed registry ${result.name} was updated`);
+        this._notificationService.success(`Updated the ${result.name} allowed registry`);
         this._allowedRegistriesService.refreshAllowedRegistries();
       });
   }

--- a/src/app/dynamic/enterprise/allowed-registries/component.ts
+++ b/src/app/dynamic/enterprise/allowed-registries/component.ts
@@ -139,7 +139,7 @@ export class AllowedRegistriesComponent extends DynamicTab implements OnInit, On
       .pipe(switchMap(_ => this._allowedRegistriesService.deleteAllowedRegistry(allowedRegistry.name)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success(`The constraint template ${allowedRegistry.name} was deleted`);
+        this._notificationService.success(`Deleting the ${allowedRegistry.name} allowed registry`);
         this._allowedRegistriesService.refreshAllowedRegistries();
       });
   }

--- a/src/app/member/add-member/component.ts
+++ b/src/app/member/add-member/component.ts
@@ -56,7 +56,7 @@ export class AddMemberComponent implements OnInit {
       )
       .subscribe((member: Member) => {
         this._matDialogRef.close(member);
-        this._notificationService.success(`The ${member.email} member was added to the ${this.project.name} project`);
+        this._notificationService.success(`Added the ${member.email} member to the ${this.project.name} project`);
       });
   }
 }

--- a/src/app/member/component.ts
+++ b/src/app/member/component.ts
@@ -196,7 +196,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
-          `The ${member.name} member was removed from the ${this._selectedProject.name} project`
+          `Removed the ${member.name} member from the ${this._selectedProject.name} project`
         );
         this._googleAnalyticsService.emitEvent('memberOverview', 'MemberDeleted');
       });

--- a/src/app/member/edit-member/component.ts
+++ b/src/app/member/edit-member/component.ts
@@ -61,7 +61,7 @@ export class EditMemberComponent implements OnInit {
       )
       .subscribe(() => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The ${this.member.name} member was updated`);
+        this._notificationService.success(`Updated the ${this.member.name} member`);
       });
   }
 }

--- a/src/app/project/component.ts
+++ b/src/app/project/component.ts
@@ -484,7 +484,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(switchMap(_ => this._projectService.delete(project.id)))
       .pipe(take(1))
       .subscribe(() => {
-        this._notificationService.success(`The ${project.name} project is being deleted`);
+        this._notificationService.success(`Deleting the ${project.name} project`);
         this._googleAnalyticsService.emitEvent('projectOverview', 'ProjectDeleted');
         this._projectService.onProjectsUpdate.next();
       });

--- a/src/app/project/edit-project/component.ts
+++ b/src/app/project/edit-project/component.ts
@@ -69,7 +69,7 @@ export class EditProjectComponent implements OnInit {
 
     this._projectService.edit(this.project.id, project).subscribe(project => {
       this._matDialogRef.close(project);
-      this._notificationService.success(`The ${this.project.name} project was updated`);
+      this._notificationService.success(`Updated the ${this.project.name} project`);
     });
   }
 }

--- a/src/app/serviceaccount/component.spec.ts
+++ b/src/app/serviceaccount/component.spec.ts
@@ -76,7 +76,6 @@ describe('ServiceAccountComponent', () => {
     fixture = TestBed.createComponent(ServiceAccountComponent);
     component = fixture.componentInstance;
     noop = TestBed.createComponent(NoopConfirmDialogComponent);
-    component.tokenList = fakeServiceAccountTokens();
     fixture.detectChanges();
     fixture.debugElement.injector.get(Router);
   });

--- a/src/app/serviceaccount/component.ts
+++ b/src/app/serviceaccount/component.ts
@@ -195,7 +195,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
         delete this.tokenList[serviceAccount.id];
         this._serviceAccountUpdate.next();
         this._notificationService.success(
-          `The ${serviceAccount.name} service account was removed from the ${this._selectedProject.name} project`
+          `Removed the ${serviceAccount.name} service account from the ${this._selectedProject.name} project`
         );
         this._googleAnalyticsService.emitEvent('serviceAccountOverview', 'ServiceAccountDeleted');
       });

--- a/src/app/serviceaccount/component.ts
+++ b/src/app/serviceaccount/component.ts
@@ -21,18 +21,26 @@ import {AppConfigService} from '@app/config.service';
 import {GoogleAnalyticsService} from '@app/google-analytics.service';
 import {NotificationService} from '@core/services/notification';
 import {ProjectService} from '@core/services/project';
+import {ServiceAccountService} from '@core/services/service-account';
 import {UserService} from '@core/services/user';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {Project} from '@shared/entity/project';
-import {ServiceAccount} from '@shared/entity/service-account';
+import {ServiceAccount, ServiceAccountToken} from '@shared/entity/service-account';
 import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils} from '@shared/utils/member';
 import _ from 'lodash';
-import {EMPTY, merge, of, Subject, timer} from 'rxjs';
+import {merge, of, Subject, timer} from 'rxjs';
 import {catchError, filter, switchMap, switchMapTo, take, takeUntil} from 'rxjs/operators';
 import {CreateServiceAccountDialogComponent} from './create-dialog/component';
 import {EditServiceAccountDialogComponent} from './edit-dialog/component';
-import {ServiceAccountService} from '@core/services/service-account';
+
+class TokenList {
+  initializing = true;
+  visible = false;
+  tokens: ServiceAccountToken[] = [];
+  unsubscribe = new Subject<void>();
+  onChange = new Subject<void>();
+}
 
 @Component({
   selector: 'km-serviceaccount',
@@ -42,21 +50,19 @@ import {ServiceAccountService} from '@core/services/service-account';
 export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
   isInitializing = true;
   serviceAccounts: ServiceAccount[] = [];
-  isShowToken = [];
-  tokenList = [];
-  isTokenInitializing = [];
   displayedColumns: string[] = ['stateArrow', 'name', 'group', 'creationDate', 'actions'];
-  toggledColumns: string[] = ['token'];
+  toggleableColumns: string[] = ['token'];
   dataSource = new MatTableDataSource<ServiceAccount>();
-
   @ViewChild(MatSort, {static: true}) sort: MatSort;
-  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
 
+  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
   private readonly _refreshTime = 10;
+
   private _unsubscribe: Subject<void> = new Subject<void>();
   private _serviceAccountUpdate: Subject<void> = new Subject<void>();
   private _selectedProject = {} as Project;
   private _currentGroupConfig: GroupConfig;
+  private _tokenMap = new Map<string, TokenList>();
 
   constructor(
     private readonly _serviceAccountService: ServiceAccountService,
@@ -121,29 +127,24 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
     return !this._currentGroupConfig || this._currentGroupConfig.serviceaccounts[action];
   }
 
-  toggleToken(element: ServiceAccount): void {
-    this.isShowToken[element.id] = !this.isShowToken[element.id];
-    if (this.isShowToken) {
-      this.getTokenList(element);
-      this.isTokenInitializing[element.id] = true;
-    }
+  isTokenVisible(id: string): boolean {
+    return this._tokenMap.has(id);
   }
 
-  getTokenList(serviceaccount: ServiceAccount): void {
-    this.tokenList[serviceaccount.id] = [];
-    timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase())
-      .pipe(takeUntil(this._unsubscribe))
-      .pipe(
-        switchMap(() =>
-          this.tokenList[serviceaccount.id]
-            ? this._serviceAccountService.getTokens(this._selectedProject.id, serviceaccount)
-            : EMPTY
-        )
-      )
-      .subscribe(tokens => {
-        this.tokenList[serviceaccount.id] = tokens;
-        this.isTokenInitializing[serviceaccount.id] = false;
-      });
+  isTokenInitializing(id: string): boolean {
+    return this._tokenMap.get(id)?.initializing;
+  }
+
+  getTokenList(id: string): ServiceAccountToken[] {
+    return this._tokenMap.get(id)?.tokens;
+  }
+
+  toggleToken(serviceAccount: ServiceAccount): void {
+    this.isTokenVisible(serviceAccount.id) ? this._hideToken(serviceAccount) : this._showToken(serviceAccount);
+  }
+
+  onTokenChange(id: string): void {
+    this._tokenMap.get(id).onChange.next();
   }
 
   createServiceAccount(): void {
@@ -192,7 +193,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(switchMap(_ => this._serviceAccountService.delete(this._selectedProject.id, serviceAccount)))
       .pipe(take(1))
       .subscribe(() => {
-        delete this.tokenList[serviceAccount.id];
+        this._hideToken(serviceAccount);
         this._serviceAccountUpdate.next();
         this._notificationService.success(
           `Removed the ${serviceAccount.name} service account from the ${this._selectedProject.name} project`
@@ -205,5 +206,36 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
 
   isPaginatorVisible(): boolean {
     return !_.isEmpty(this.serviceAccounts) && this.paginator && this.serviceAccounts.length > this.paginator.pageSize;
+  }
+
+  private _loadTokens(serviceAccount: ServiceAccount): void {
+    if (!this._tokenMap.has(serviceAccount.id)) {
+      this._tokenMap.set(serviceAccount.id, new TokenList());
+    }
+
+    this._tokenMap.get(serviceAccount.id).visible = true;
+    const tokenList = this._tokenMap.get(serviceAccount.id);
+    merge(
+      timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase()),
+      this._tokenMap.get(serviceAccount.id).onChange
+    )
+      .pipe(takeUntil(tokenList.unsubscribe))
+      .pipe(switchMap(() => this._serviceAccountService.getTokens(this._selectedProject.id, serviceAccount)))
+      .subscribe(tokens => {
+        tokenList.tokens = tokens;
+        tokenList.initializing = false;
+
+        this._tokenMap.set(serviceAccount.id, tokenList);
+      });
+  }
+
+  private _showToken(serviceAccount: ServiceAccount): void {
+    this._loadTokens(serviceAccount);
+  }
+
+  private _hideToken(serviceAccount: ServiceAccount): void {
+    this._tokenMap.get(serviceAccount.id)?.unsubscribe.next();
+    this._tokenMap.get(serviceAccount.id)?.unsubscribe.complete();
+    this._tokenMap.delete(serviceAccount.id);
   }
 }

--- a/src/app/serviceaccount/component.ts
+++ b/src/app/serviceaccount/component.ts
@@ -135,7 +135,11 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
     return this._tokenMap.get(id)?.initializing;
   }
 
-  getTokenList(id: string): ServiceAccountToken[] {
+  getTokenList(id: string): TokenList {
+    return this._tokenMap.get(id);
+  }
+
+  getTokens(id: string): ServiceAccountToken[] {
     return this._tokenMap.get(id)?.tokens;
   }
 
@@ -213,19 +217,16 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
       this._tokenMap.set(serviceAccount.id, new TokenList());
     }
 
-    this._tokenMap.get(serviceAccount.id).visible = true;
-    const tokenList = this._tokenMap.get(serviceAccount.id);
+    this.getTokenList(serviceAccount.id).visible = true;
     merge(
       timer(0, this._refreshTime * this._appConfig.getRefreshTimeBase()),
       this._tokenMap.get(serviceAccount.id).onChange
     )
-      .pipe(takeUntil(tokenList.unsubscribe))
+      .pipe(takeUntil(this.getTokenList(serviceAccount.id).unsubscribe))
       .pipe(switchMap(() => this._serviceAccountService.getTokens(this._selectedProject.id, serviceAccount)))
       .subscribe(tokens => {
-        tokenList.tokens = tokens;
-        tokenList.initializing = false;
-
-        this._tokenMap.set(serviceAccount.id, tokenList);
+        this.getTokenList(serviceAccount.id).tokens = tokens;
+        this.getTokenList(serviceAccount.id).initializing = false;
       });
   }
 

--- a/src/app/serviceaccount/create-dialog/component.ts
+++ b/src/app/serviceaccount/create-dialog/component.ts
@@ -54,7 +54,7 @@ export class CreateServiceAccountDialogComponent implements OnInit {
       .subscribe(() => {
         this._matDialogRef.close(true);
         this._notificationService.success(
-          `The ${model.name} service account was created in the ${this.project.name} project`
+          `Created the ${model.name} service account in the ${this.project.name} project`
         );
       });
   }

--- a/src/app/serviceaccount/edit-dialog/component.ts
+++ b/src/app/serviceaccount/edit-dialog/component.ts
@@ -58,7 +58,7 @@ export class EditServiceAccountDialogComponent implements OnInit {
       .pipe(take(1))
       .subscribe(() => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The ${this.serviceaccount.name} service account was updated`);
+        this._notificationService.success(`Updated the ${this.serviceaccount.name} service account`);
       });
   }
 }

--- a/src/app/serviceaccount/template.html
+++ b/src/app/serviceaccount/template.html
@@ -123,7 +123,7 @@ limitations under the License.
             [attr.colspan]="displayedColumns.length">
           <div class="km-serviceaccount-token-wrapper">
             <km-serviceaccount-token [serviceaccount]="element"
-                                     [serviceaccountTokens]="getTokenList(element.id)"
+                                     [serviceaccountTokens]="getTokens(element.id)"
                                      [isInitializing]="isTokenInitializing(element.id)"
                                      (onUpdate)="onTokenChange(element.id)"></km-serviceaccount-token>
           </div>

--- a/src/app/serviceaccount/template.html
+++ b/src/app/serviceaccount/template.html
@@ -42,7 +42,7 @@ limitations under the License.
             class="km-header-cell"></th>
         <td mat-cell
             *matCellDef="let element">
-          <i [ngClass]="isShowToken[element.id] ? 'km-icon-mask km-icon-arrow-up' : 'km-icon-mask km-icon-arrow-down'"></i>
+          <i [ngClass]="isTokenVisible(element.id) ? 'km-icon-mask km-icon-arrow-up' : 'km-icon-mask km-icon-arrow-down'"></i>
         </td>
       </ng-container>
 
@@ -123,8 +123,9 @@ limitations under the License.
             [attr.colspan]="displayedColumns.length">
           <div class="km-serviceaccount-token-wrapper">
             <km-serviceaccount-token [serviceaccount]="element"
-                                     [serviceaccountTokens]="tokenList[element.id]"
-                                     [isInitializing]="isTokenInitializing[element.id]"></km-serviceaccount-token>
+                                     [serviceaccountTokens]="getTokenList(element.id)"
+                                     [isInitializing]="isTokenInitializing(element.id)"
+                                     (onUpdate)="onTokenChange(element.id)"></km-serviceaccount-token>
           </div>
         </td>
       </ng-container>
@@ -137,8 +138,8 @@ limitations under the License.
           class="km-mat-row km-pointer"
           (click)="toggleToken(row)"></tr>
       <tr mat-row
-          *matRowDef="let row; let i=index; columns: toggledColumns;"
-          [ngClass]="isShowToken[row.id] ? '' : 'km-hidden'"
+          *matRowDef="let row; let i=index; columns: toggleableColumns;"
+          [ngClass]="isTokenVisible(row.id) ? '' : 'km-hidden'"
           class="km-mat-row"></tr>
     </table>
 

--- a/src/app/serviceaccount/token/add/component.ts
+++ b/src/app/serviceaccount/token/add/component.ts
@@ -140,7 +140,7 @@ export class ServiceAccountTokenDialog implements OnInit {
       .subscribe(
         token => {
           this._notificationService.success(
-            `The ${token.name} token was added to the ${this._data.serviceAccount.name} service account`
+            `Added the ${token.name} token to the ${this._data.serviceAccount.name} service account`
           );
 
           this._tokenDialogService.token = token.token;
@@ -164,7 +164,7 @@ export class ServiceAccountTokenDialog implements OnInit {
       .pipe(take(1))
       .subscribe(
         _ => {
-          this._notificationService.success(`The ${this._data.token.name} token was updated`);
+          this._notificationService.success(`Updated the ${this._data.token.name} token`);
           this._dialogRef.close();
         },
         _ => {},
@@ -183,7 +183,7 @@ export class ServiceAccountTokenDialog implements OnInit {
       .pipe(take(1))
       .subscribe(
         token => {
-          this._notificationService.success(`The ${this._data.token.name} token was regenerated`);
+          this._notificationService.success(`Regenerated the ${this._data.token.name} token`);
           this._tokenDialogService.token = token.token;
         },
         _ => {},

--- a/src/app/serviceaccount/token/component.ts
+++ b/src/app/serviceaccount/token/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, OnInit, ViewChild} from '@angular/core';
+import {Component, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {MatSort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
@@ -41,6 +41,7 @@ export class ServiceAccountTokenComponent implements OnInit {
   @Input() serviceaccount: ServiceAccount;
   @Input() serviceaccountTokens: ServiceAccountToken[];
   @Input() isInitializing: boolean;
+  @Output() onUpdate = new EventEmitter<void>();
   displayedColumns: string[] = ['name', 'expiry', 'creationDate', 'actions'];
   dataSource = new MatTableDataSource<ServiceAccountToken>();
   @ViewChild(MatSort, {static: true}) sort: MatSort;
@@ -90,7 +91,11 @@ export class ServiceAccountTokenComponent implements OnInit {
       } as ServiceAccountTokenDialogData,
     };
 
-    this._matDialog.open(ServiceAccountTokenDialog, config);
+    this._matDialog
+      .open(ServiceAccountTokenDialog, config)
+      .afterClosed()
+      .pipe(take(1))
+      .subscribe(() => this.onUpdate.next());
   }
 
   regenerateToken(token: ServiceAccountToken): void {
@@ -143,6 +148,7 @@ export class ServiceAccountTokenComponent implements OnInit {
           `Removed the ${token.name} token from the ${this.serviceaccount.name} service account`
         );
         this._googleAnalyticsService.emitEvent('serviceAccountTokenOverview', 'ServiceAccountTokenDeleted');
+        this.onUpdate.next();
       });
   }
 }

--- a/src/app/serviceaccount/token/component.ts
+++ b/src/app/serviceaccount/token/component.ts
@@ -140,7 +140,7 @@ export class ServiceAccountTokenComponent implements OnInit {
       .pipe(take(1))
       .subscribe(() => {
         this._notificationService.success(
-          `The ${token.name} token was removed from the ${this.serviceaccount.name} service account`
+          `Removed the ${token.name} token from the ${this.serviceaccount.name} service account`
         );
         this._googleAnalyticsService.emitEvent('serviceAccountTokenOverview', 'ServiceAccountTokenDeleted');
       });

--- a/src/app/settings/admin/admins/component.ts
+++ b/src/app/settings/admin/admins/component.ts
@@ -105,7 +105,7 @@ export class AdminsComponent implements OnInit, OnChanges {
       .setAdmin(admin)
       .pipe(take(1))
       .subscribe(() => {
-        this._notificationService.success(`The ${admin.name} user was deleted from admin group`);
+        this._notificationService.success(`Removed the ${admin.name} user from the admin group`);
         this._settingsService.refreshAdmins();
       });
   }

--- a/src/app/settings/admin/bucket-settings/destinations/component.ts
+++ b/src/app/settings/admin/bucket-settings/destinations/component.ts
@@ -134,7 +134,7 @@ export class DestinationsComponent implements OnInit {
       .pipe(switchMap(_ => this._backupService.deleteBackupDestination(this.seed.name, destination.destinationName)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success(`The destination ${destination.destinationName} was deleted`);
+        this._notificationService.success(`Deleting the ${destination.destinationName} destination`);
         this._datacenterService.refreshAdminSeeds();
       });
   }

--- a/src/app/settings/admin/component.ts
+++ b/src/app/settings/admin/component.ts
@@ -51,7 +51,7 @@ export class AdminSettingsComponent implements OnInit, OnDestroy {
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {
         if (this.apiSettings && !_.isEqual(this.apiSettings, this._settingsService.defaultAdminSettings)) {
-          this._notificationService.success('The settings update was applied');
+          this._notificationService.success('Updated the admin settings');
         }
         this._applySettings(settings);
       }

--- a/src/app/settings/admin/defaults/component.ts
+++ b/src/app/settings/admin/defaults/component.ts
@@ -49,7 +49,7 @@ export class DefaultsAndLimitsComponent implements OnInit, OnDestroy {
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {
         if (this.apiSettings && !_.isEqual(this.apiSettings, this._settingsService.defaultAdminSettings)) {
-          this._notificationService.success('The settings update was applied');
+          this._notificationService.success('Updated the admin settings');
         }
         this._applySettings(settings);
       }

--- a/src/app/settings/admin/dynamic-datacenters/component.ts
+++ b/src/app/settings/admin/dynamic-datacenters/component.ts
@@ -163,7 +163,7 @@ export class DynamicDatacentersComponent implements OnInit, OnDestroy, OnChanges
       .createDatacenter(model)
       .pipe(take(1))
       .subscribe(datacenter => {
-        this._notificationService.success(`The ${datacenter.metadata.name} datacenter was created`);
+        this._notificationService.success(`Created the ${datacenter.metadata.name} datacenter`);
         this._datacenterService.refreshDatacenters();
       });
   }
@@ -191,7 +191,7 @@ export class DynamicDatacentersComponent implements OnInit, OnDestroy, OnChanges
       .patchDatacenter(original.spec.seed, original.metadata.name, edited)
       .pipe(take(1))
       .subscribe(datacenter => {
-        this._notificationService.success(`The ${datacenter.metadata.name} datacenter was updated`);
+        this._notificationService.success(`Updated the ${datacenter.metadata.name} datacenter`);
         this._datacenterService.refreshDatacenters();
       });
   }
@@ -212,7 +212,7 @@ export class DynamicDatacentersComponent implements OnInit, OnDestroy, OnChanges
       .pipe(switchMap(_ => this._datacenterService.deleteDatacenter(datacenter)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success(`The ${datacenter.metadata.name} datacenter was deleted`);
+        this._notificationService.success(`Deleting the ${datacenter.metadata.name} datacenter`);
         this._datacenterService.refreshDatacenters();
       });
   }

--- a/src/app/settings/admin/interface/component.ts
+++ b/src/app/settings/admin/interface/component.ts
@@ -49,7 +49,7 @@ export class InterfaceComponent implements OnInit, OnDestroy {
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {
         if (this.apiSettings && !_.isEqual(this.apiSettings, this._settingsService.defaultAdminSettings)) {
-          this._notificationService.success('The settings update was applied');
+          this._notificationService.success('Updated the admin settings');
         }
         this._applySettings(settings);
       }

--- a/src/app/settings/admin/opa/constraint-templates/component.ts
+++ b/src/app/settings/admin/opa/constraint-templates/component.ts
@@ -139,7 +139,7 @@ export class ConstraintTemplatesComponent implements OnInit, OnChanges, OnDestro
       .pipe(switchMap(_ => this._opaService.deleteConstraintTemplate(constraintTemplate.name)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success(`The constraint template ${constraintTemplate.name} was deleted`);
+        this._notificationService.success(`Deleting the ${constraintTemplate.name} constraint template`);
         this._opaService.refreshConstraintTemplates();
       });
   }

--- a/src/app/settings/admin/opa/constraint-templates/constraint-template-dialog/component.ts
+++ b/src/app/settings/admin/opa/constraint-templates/constraint-template-dialog/component.ts
@@ -119,7 +119,7 @@ export class ConstraintTemplateDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(result => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The constraint template ${result.name} was created`);
+        this._notificationService.success(`Created the ${result.name} constraint template`);
         this._opaService.refreshConstraintTemplates();
       });
   }
@@ -130,7 +130,7 @@ export class ConstraintTemplateDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(result => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The constraint template ${result.name} was updated`);
+        this._notificationService.success(`Updated the ${result.name} constraint template`);
         this._opaService.refreshConstraintTemplates();
       });
   }

--- a/src/app/settings/admin/opa/default-constraints/component.ts
+++ b/src/app/settings/admin/opa/default-constraints/component.ts
@@ -132,7 +132,7 @@ export class DefaultConstraintComponent implements OnInit, OnChanges, OnDestroy 
       .patchDefaultConstraint(constraint.name, patch)
       .pipe(take(1))
       .subscribe(result => {
-        this._notificationService.success(`The default constraint ${result.name} was updated`);
+        this._notificationService.success(`Updated the ${result.name} default constraint`);
         this._opaService.refreshConstraint();
       });
   }
@@ -178,7 +178,7 @@ export class DefaultConstraintComponent implements OnInit, OnChanges, OnDestroy 
       .pipe(switchMap(_ => this._opaService.deleteDefaultConstraint(defaultConstraint.name)))
       .pipe(take(1))
       .subscribe(_ => {
-        this._notificationService.success(`The default constraint ${defaultConstraint.name} was deleted`);
+        this._notificationService.success(`Deleting the ${defaultConstraint.name} default constraint`);
         this._opaService.refreshDefaultConstraints();
       });
   }

--- a/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/component.ts
+++ b/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/component.ts
@@ -117,7 +117,7 @@ export class DefaultConstraintDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(result => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The default constraint ${result.name} was created`);
+        this._notificationService.success(`Created the ${result.name} default constraint`);
         this._opaService.refreshConstraint();
       });
   }
@@ -128,7 +128,7 @@ export class DefaultConstraintDialog implements OnInit, OnDestroy {
       .pipe(take(1))
       .subscribe(result => {
         this._matDialogRef.close(true);
-        this._notificationService.success(`The default constraint ${result.name} was updated`);
+        this._notificationService.success(`Updated the ${result.name} default constraint`);
         this._opaService.refreshConstraint();
       });
   }

--- a/src/app/settings/admin/presets/edit-dialog/component.ts
+++ b/src/app/settings/admin/presets/edit-dialog/component.ts
@@ -56,7 +56,7 @@ export class EditPresetDialogComponent implements OnInit, OnDestroy {
         const idx = this.data.preset.providers.findIndex(p => p.name === provider);
         this.data.preset.providers[idx].enabled = enabled;
         this._notificationService.success(
-          `${enabled ? 'Enabled' : 'Disabled'} ${provider} provider for preset ${this.data.preset.name}`
+          `${enabled ? 'Enabled' : 'Disabled'} the ${provider} provider for the preset ${this.data.preset.name}`
         );
       });
   }

--- a/src/app/settings/user/component.ts
+++ b/src/app/settings/user/component.ts
@@ -56,7 +56,7 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
     this._userService.currentUserSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {
         if (this.apiSettings) {
-          this._notificationService.success('An external settings update was applied');
+          this._notificationService.success('Updated the user settings');
         }
         this.apiSettings = settings;
         this.settings = _.cloneDeep(this.apiSettings);

--- a/src/app/shared/components/add-external-cluster-dialog/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/component.ts
@@ -110,7 +110,7 @@ export class AddExternalClusterDialogComponent implements OnInit, OnDestroy {
         next: cluster => {
           this._creating = false;
           this._matDialogRef.close();
-          this._notificationService.success(`The ${cluster.name} cluster was added`);
+          this._notificationService.success(`Added the ${cluster.name} cluster`);
           this._router.navigate([`/projects/${this.projectId}/clusters/external/${cluster.id}`]);
         },
         error: () => (this._creating = false),

--- a/src/app/shared/components/add-project-dialog/component.ts
+++ b/src/app/shared/components/add-project-dialog/component.ts
@@ -49,7 +49,7 @@ export class AddProjectDialogComponent implements OnInit {
 
     this._projectService.create({name: this.form.controls.name.value, labels: this.labels}).subscribe(project => {
       this._matDialogRef.close(project);
-      this._notificationService.success(`The ${project.name} project was added`);
+      this._notificationService.success(`Added the ${project.name} project`);
     });
   }
 }

--- a/src/app/shared/entity/backup.ts
+++ b/src/app/shared/entity/backup.ts
@@ -94,8 +94,10 @@ type BackupStatusPhase = string;
 export const BackupStatusPhaseCompleted = 'Completed';
 
 export class EtcdRestore {
+  // ObjectMeta
+  creationTimestamp?: Date;
+  deletionTimestamp?: Date;
   name?: string;
-
   spec: EtcdRestoreSpec;
   status: EtcdRestoreStatus;
 }

--- a/src/app/shared/entity/backup.ts
+++ b/src/app/shared/entity/backup.ts
@@ -94,7 +94,6 @@ type BackupStatusPhase = string;
 export const BackupStatusPhaseCompleted = 'Completed';
 
 export class EtcdRestore {
-  // ObjectMeta
   creationTimestamp?: Date;
   deletionTimestamp?: Date;
   name?: string;

--- a/src/app/sshkey/component.ts
+++ b/src/app/sshkey/component.ts
@@ -168,7 +168,7 @@ export class SSHKeyComponent implements OnInit, OnChanges, OnDestroy {
       .pipe(switchMap(_ => this._sshKeyService.delete(sshKey.id, this.project.id)))
       .pipe(take(1))
       .subscribe(() => {
-        this._notificationService.success(`The ${sshKey.name} SSH key was removed from the ${this.project.id} project`);
+        this._notificationService.success(`Removed the ${sshKey.name} SSH key from the ${this.project.id} project`);
         this._googleAnalyticsService.emitEvent('sshKeyOverview', 'SshKeyDeleted');
       });
   }

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -117,7 +117,7 @@ export class WizardComponent implements OnInit, OnDestroy {
       .create(this.project.id, createCluster)
       .pipe(
         tap(cluster => {
-          this._notificationService.success(`The ${createCluster.cluster.name} cluster was created`);
+          this._notificationService.success(`Created the ${createCluster.cluster.name} cluster`);
           this._googleAnalyticsService.emitEvent('clusterCreation', 'clusterCreated');
           createdCluster = cluster;
         })
@@ -144,7 +144,7 @@ export class WizardComponent implements OnInit, OnDestroy {
           this._router.navigate([`/projects/${this.project.id}/clusters/${createdCluster.id}`]);
           keys.forEach(key =>
             this._notificationService.success(
-              `The ${key.name} SSH key was added to cluster ${createCluster.cluster.name}`
+              `Added the ${key.name} SSH key to the cluster ${createCluster.cluster.name}`
             )
           );
         },


### PR DESCRIPTION
### What this PR does / why we need it
- Updated in general the way we construct the notification messages to `[action] the [resource name] [resource type]`
- Updated all async delete/remove messages to use deleting/removing form as we cannot guarantee that the resource will be actually deleted after showing the notification.
- Fixed an issue with the project switch on cluster list view where the reload animation was not triggered.
- Fixed an issue with the subscription leak on the SA list view and refactored the logic.

API part: https://github.com/kubermatic/kubermatic/pull/8908

#### ~~TODO~~
~~Finish reviewing the resource refresh after showing the notification. It also requires a `deletionTimestamp` handling. Some of the resources do not provide the proper `deletionTimestamp` as the API does not return it. It will require further API review and update.~~


### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #4042
Fixes #4161

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
