### PR TITLE
Add option to get kubeconfig for external clusters

### DIFF
--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -137,6 +137,10 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
     return this.cluster?.status?.state === ExternalClusterState.Running;
   }
 
+  downloadKubeconfig(): void {
+    window.open(this._clusterService.getExternalKubeconfigURL(this.projectID, this.cluster.id), '_blank');
+  }
+
   hasUpgrades(): boolean {
     return this.isRunning() && this.provider !== ExternalClusterProvider.EKS;
   }

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -29,6 +29,16 @@ limitations under the License.
         <span>Disconnect</span>
       </button>
       <div fxFlex></div>
+      <button color="alternative"
+              fxLayoutAlign="center center"
+              mat-flat-button
+              type="button"
+              kmThrottleClick
+              (throttleClick)="downloadKubeconfig()"
+              [disabled]="!isRunning()">
+        <i class="km-icon-mask km-icon-download"></i>
+        <span>Get Kubeconfig</span>
+      </button>
     </div>
   </div>
 

--- a/src/app/core/services/cluster.ts
+++ b/src/app/core/services/cluster.ts
@@ -235,6 +235,10 @@ export class ClusterService {
     return `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/kubeconfig`;
   }
 
+  getExternalKubeconfigURL(projectID: string, clusterID: string): string {
+    return `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters/${clusterID}/kubeconfig`;
+  }
+
   getDashboardProxyURL(projectID: string, clusterID: string): string {
     return `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/dashboard/proxy`;
   }


### PR DESCRIPTION
### What this PR does / why we need it
Adds a button for https://github.com/kubermatic/kubermatic/pull/8122.

### Which issue(s) this PR fixes
Closes https://github.com/kubermatic/dashboard/issues/4146.

### Release note
```release-note
Add option to get kubeconfig for external clusters.
```
