### PR TITLE
[release/v2.18] Bump release version to v2.18.6

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -67,6 +67,7 @@ presubmits:
         repo: kubermatic
         base_ref: master
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+        clone_depth: 0
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"
@@ -120,6 +121,7 @@ presubmits:
         repo: kubermatic
         base_ref: master
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+        clone_depth: 0
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -67,7 +67,6 @@ presubmits:
         repo: kubermatic
         base_ref: master
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-        clone_depth: 0
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"
@@ -121,7 +120,6 @@ presubmits:
         repo: kubermatic
         base_ref: master
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-        clone_depth: 0
     labels:
       preset-alibaba: "true"
       preset-anexia: "true"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -65,7 +65,7 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: master
+        base_ref: "release/v2.18"
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-alibaba: "true"
@@ -118,7 +118,7 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: master
+        base_ref: "release/v2.18"
         clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-alibaba: "true"

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ ifeq (${HUMAN_VERSION},)
 	TARGET_BRANCH=$(or ${PULL_BASE_REF},${CURRENT_BRANCH})
 
 	ifeq (${TARGET_BRANCH},master)
-	HUMAN_VERSION=v2.18.5-dev-g$(shell git rev-parse --short HEAD)
+	HUMAN_VERSION=v2.18.6-dev-g$(shell git rev-parse --short HEAD)
 	else
-	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.18.5-dev-g$(shell git rev-parse --short HEAD))
+	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.18.6-dev-g$(shell git rev-parse --short HEAD))
 	endif
 endif
 

--- a/hack/e2e/fixtures/kubermatic.yaml
+++ b/hack/e2e/fixtures/kubermatic.yaml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: operator.kubermatic.io/v1alpha1
+apiVersion: kubermatic.k8c.io/v1
 kind: KubermaticConfiguration
 metadata:
   name: e2e

--- a/hack/e2e/fixtures/kubermatic.yaml
+++ b/hack/e2e/fixtures/kubermatic.yaml
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kubermatic.k8c.io/v1
+apiVersion: operator.kubermatic.io/v1alpha1
 kind: KubermaticConfiguration
 metadata:
   name: e2e

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -28,7 +28,9 @@ if [[ ${TARGET_BRANCH} == release* ]]; then
   fi
   export KUBERMATIC_VERSION=${TAG_VERSION}
   # Try to switch to the same target branch in the kubermatic/kubermatic repo
+  git remote -v
   git fetch
+  git show-ref
   ! git checkout "${TARGET_BRANCH}"
 fi
 

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -27,11 +27,6 @@ if [[ ${TARGET_BRANCH} == release* ]]; then
     TAG_VERSION=latest
   fi
   export KUBERMATIC_VERSION=${TAG_VERSION}
-  # Try to switch to the same target branch in the kubermatic/kubermatic repo
-  git remote -v
-  git fetch
-  git show-ref
-  ! git checkout "${TARGET_BRANCH}"
 fi
 
 REPOSUFFIX=""

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -73,7 +73,7 @@ fi
 # Build binaries and load the Docker images into the kind cluster
 echodate "Building binaries for $KUBERMATIC_VERSION"
 TEST_NAME="Build Kubermatic binaries"
-KUBERMATICDOCKERTAG=latest UIDOCKERTAG=latest make kubermatic-installer
+KUBERMATICDOCKERTAG=$KUBERMATIC_VERSION UIDOCKERTAG=latest make kubermatic-installer
 
 TEST_NAME="Deploy Kubermatic"
 echodate "Deploying Kubermatic [${KUBERMATIC_VERSION}]..."

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -27,7 +27,8 @@ if [[ ${TARGET_BRANCH} == release* ]]; then
     TAG_VERSION=latest
   fi
   export KUBERMATIC_VERSION=${TAG_VERSION}
-  # Switch to the same target branch in the kubermatic/kubermatic repo
+  # Try to switch to the same target branch in the kubermatic/kubermatic repo
+  git fetch
   ! git checkout "${TARGET_BRANCH}"
 fi
 

--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -27,6 +27,8 @@ if [[ ${TARGET_BRANCH} == release* ]]; then
     TAG_VERSION=latest
   fi
   export KUBERMATIC_VERSION=${TAG_VERSION}
+  # Switch to the same target branch in the kubermatic/kubermatic repo
+  ! git checkout "${TARGET_BRANCH}"
 fi
 
 REPOSUFFIX=""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "v2.18.5",
+  "version": "v2.18.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kubermatic-dashboard",
   "private": true,
   "type": "module",
-  "version": "v2.18.5",
+  "version": "v2.18.6",
   "description": "Kubermatic Dashboard",
   "repository": "https://github.com/kubermatic/dashboard",
   "license": "proprietary",


### PR DESCRIPTION
### What this PR does / why we need it

Bumps version to `v2.18.6`. No changes to `release/v2.18` have happened since `v2.18.5`.

Please approve if there are no pending backports to `release/v2.18` you would like to get out.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
