### PR TITLE
Disable OIDC kubeconfig flag if feature gate OIDCKubeCfgEndpoint is disabled

### DIFF
--- a/src/app/core/services/feature-gate.ts
+++ b/src/app/core/services/feature-gate.ts
@@ -21,6 +21,7 @@ import {catchError, shareReplay, switchMap} from 'rxjs/operators';
 
 export interface FeatureGates {
   konnectivityService?: boolean;
+  OIDCKubeCfgEndpoint?: boolean;
 }
 
 @Injectable({

--- a/src/app/core/services/feature-gate.ts
+++ b/src/app/core/services/feature-gate.ts
@@ -21,7 +21,7 @@ import {catchError, shareReplay, switchMap} from 'rxjs/operators';
 
 export interface FeatureGates {
   konnectivityService?: boolean;
-  OIDCKubeCfgEndpoint?: boolean;
+  oidcKubeCfgEndpoint?: boolean;
 }
 
 @Injectable({

--- a/src/app/settings/admin/interface/component.ts
+++ b/src/app/settings/admin/interface/component.ts
@@ -52,7 +52,7 @@ export class InterfaceComponent implements OnInit, OnDestroy {
 
     this._featureGatesService.featureGates
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(featureGates => (this.isOIDCKubeCfgEndpointEnabled = !!featureGates?.OIDCKubeCfgEndpoint));
+      .subscribe(featureGates => (this.isOIDCKubeCfgEndpointEnabled = !!featureGates?.oidcKubeCfgEndpoint));
 
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {

--- a/src/app/settings/admin/interface/component.ts
+++ b/src/app/settings/admin/interface/component.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Component, OnDestroy, OnInit} from '@angular/core';
+import {FeatureGateService} from '@app/core/services/feature-gate';
 import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
@@ -37,14 +38,21 @@ export class InterfaceComponent implements OnInit, OnDestroy {
   private _settingsChange = new Subject<void>();
   private _unsubscribe = new Subject<void>();
 
+  isOIDCKubeCfgEndpointEnabled = false;
+
   constructor(
     private readonly _userService: UserService,
     private readonly _settingsService: SettingsService,
-    private readonly _notificationService: NotificationService
+    private readonly _notificationService: NotificationService,
+    private readonly _featureGatesService: FeatureGateService
   ) {}
 
   ngOnInit(): void {
     this._userService.currentUser.pipe(take(1)).subscribe(user => (this.user = user));
+
+    this._featureGatesService.featureGates
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(featureGates => (this.isOIDCKubeCfgEndpointEnabled = !!featureGates?.OIDCKubeCfgEndpoint));
 
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       if (!_.isEqual(settings, this.apiSettings)) {

--- a/src/app/settings/admin/interface/template.html
+++ b/src/app/settings/admin/interface/template.html
@@ -92,10 +92,12 @@ limitations under the License.
              class="entry-label">
           <span>Enable OIDC Kubeconfig</span>
           <div class="km-icon-info km-pointer"
-               matTooltip="Use OIDC provider as a proxy for kubeconfig download."></div>
+               matTooltip="Use OIDC provider as a proxy for kubeconfig download. Requires OIDCKubeCfgEndpoint feature gate to be enabled."></div>
         </div>
         <mat-checkbox [(ngModel)]="settings.enableOIDCKubeconfig"
+                      [disabled]="!isOIDCKubeCfgEndpointEnabled"
                       (change)="onSettingsChange()"
+                      [matTooltip]="!isOIDCKubeCfgEndpointEnabled ? 'OIDCKubeCfgEndpoint feature gates needs to enabled.' : null"
                       id="km-enable-oidc-setting"></mat-checkbox>
         <km-spinner-with-confirmation [isSaved]="isEqual(settings.enableOIDCKubeconfig, apiSettings.enableOIDCKubeconfig)"></km-spinner-with-confirmation>
       </div>

--- a/src/app/settings/admin/interface/template.html
+++ b/src/app/settings/admin/interface/template.html
@@ -97,7 +97,7 @@ limitations under the License.
         <mat-checkbox [(ngModel)]="settings.enableOIDCKubeconfig"
                       [disabled]="!isOIDCKubeCfgEndpointEnabled"
                       (change)="onSettingsChange()"
-                      [matTooltip]="!isOIDCKubeCfgEndpointEnabled ? 'OIDCKubeCfgEndpoint feature gates needs to enabled.' : null"
+                      [matTooltip]="!isOIDCKubeCfgEndpointEnabled ? 'OIDCKubeCfgEndpoint feature gates needs to enabled in KubermaticConfiguration.' : null"
                       id="km-enable-oidc-setting"></mat-checkbox>
         <km-spinner-with-confirmation [isSaved]="isEqual(settings.enableOIDCKubeconfig, apiSettings.enableOIDCKubeconfig)"></km-spinner-with-confirmation>
       </div>


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

### What this PR does / why we need it
Disable OIDC kubeconfig flag if feature gate OIDCKubeCfgEndpoint is disabled.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4193

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
