### PR TITLE
changing the default OS disk size to 30

### DIFF
--- a/src/app/node-data/basic/provider/azure/component.ts
+++ b/src/app/node-data/basic/provider/azure/component.ts
@@ -73,7 +73,7 @@ enum ZoneState {
 })
 export class AzureBasicNodeDataComponent extends BaseFormValidator implements OnInit, OnDestroy {
   private _sizeChanges = new EventEmitter<boolean>();
-  private readonly _defaultDiskSize = 0;
+  private readonly _defaultDiskSize = 30;
 
   readonly Controls = Controls;
 

--- a/src/app/node-data/basic/provider/azure/template.html
+++ b/src/app/node-data/basic/provider/azure/template.html
@@ -57,12 +57,13 @@ limitations under the License.
   <km-number-stepper [formControlName]="Controls.OSDiskSize"
                      mode="errors"
                      label="OS Disk Size in GB"
-                     hint="Leave 0 to use default value.">
+                     min="30"
+                     hint="Leave 30 to use default value.">
   </km-number-stepper>
 
   <km-number-stepper [formControlName]="Controls.DataDiskSize"
                      mode="errors"
                      label="Data Disk Size in GB"
-                     hint="Leave 0 to use default value.">
+                     hint="Leave 30 to use default value.">
   </km-number-stepper>
 </form>


### PR DESCRIPTION
### What this PR does / why we need it
changing the default value for the OS disk size in MD for Azure Provider from 0 to 30GB 
### Which issue(s) this PR fixes
when creating a machine with lower than 30GB it fails in machine-controller that minimal size for OS disk is 30GB.

“closes #4201”

```release-note
NONE
```
