### PR TITLE
[release/v2.18] Bump release version to v2.18.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ ifeq (${HUMAN_VERSION},)
 	TARGET_BRANCH=$(or ${PULL_BASE_REF},${CURRENT_BRANCH})
 
 	ifeq (${TARGET_BRANCH},master)
-	HUMAN_VERSION=v2.18.6-dev-g$(shell git rev-parse --short HEAD)
+	HUMAN_VERSION=v2.18.7-dev-g$(shell git rev-parse --short HEAD)
 	else
-	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.18.6-dev-g$(shell git rev-parse --short HEAD))
+	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.18.7-dev-g$(shell git rev-parse --short HEAD))
 	endif
 endif
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "v2.18.6",
+  "version": "v2.18.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "v2.17.0",
+      "version": "v2.18.7",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kubermatic-dashboard",
   "private": true,
   "type": "module",
-  "version": "v2.18.6",
+  "version": "v2.18.7",
   "description": "Kubermatic Dashboard",
   "repository": "https://github.com/kubermatic/dashboard",
   "license": "proprietary",


### PR DESCRIPTION
### What this PR does / why we need it

We need another KKP release `v2.18.7` to fix some issues with `nodeport-proxy-envoy` introduced with `v2.18.6`.

Bumps version to v2.18.7.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
