### PR TITLE
Require spot instance max price

### DIFF
--- a/src/app/node-data/extended/provider/aws/component.ts
+++ b/src/app/node-data/extended/provider/aws/component.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
-import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import {NodeDataService} from '@core/services/node-data/service';
 import {pushDown} from '@shared/animations/push';
 import {NodeCloudSpec, NodeSpec} from '@shared/entity/node';
@@ -87,6 +87,19 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
     )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._nodeDataService.nodeData = this._getNodeData()));
+
+    this.form
+      .get(Controls.IsSpotInstance)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(checked => {
+        checked
+          ? this.form
+              .get(Controls.SpotInstanceMaxPrice)
+              .setValidators([KmValidators.largerThan(0), Validators.required])
+          : this.form.get(Controls.SpotInstanceMaxPrice).setValidators(KmValidators.largerThan(0));
+        this.form.get(Controls.SpotInstanceMaxPrice).setValue(undefined);
+        this.form.get(Controls.SpotInstanceMaxPrice).updateValueAndValidity();
+      });
   }
 
   onTagsChange(tags: object): void {

--- a/src/app/node-data/extended/provider/aws/template.html
+++ b/src/app/node-data/extended/provider/aws/template.html
@@ -39,6 +39,7 @@ limitations under the License.
                        hint="Maximum price you are willing to pay per instance hour. Your instance runs when your maximum price is greater than the Spot Instance price."
                        type="decimal"
                        min="0.0001"
+                       [required]="isSpotInstance"
                        step="0.01">
     </km-number-stepper>
 


### PR DESCRIPTION
### What this PR does / why we need it
Require from user to provide max spot instance price if spot instance checkbox is checked.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
