### PR TITLE
Default unset settings returned from PATCH endpoint too

### DIFF
--- a/src/app/core/services/settings.ts
+++ b/src/app/core/services/settings.ts
@@ -21,7 +21,7 @@ import {Admin, Member} from '@shared/entity/member';
 import {Report} from '@shared/entity/metering';
 import {AdminSettings, CustomLink, DEFAULT_ADMIN_SETTINGS} from '@shared/entity/settings';
 import {BehaviorSubject, EMPTY, iif, merge, Observable, of, Subject, timer} from 'rxjs';
-import {catchError, delay, retryWhen, shareReplay, switchMap, tap} from 'rxjs/operators';
+import {catchError, delay, map, retryWhen, shareReplay, switchMap, tap} from 'rxjs/operators';
 import {webSocket} from 'rxjs/webSocket';
 
 @Injectable({
@@ -103,7 +103,9 @@ export class SettingsService {
 
   patchAdminSettings(patch: any): Observable<AdminSettings> {
     const url = `${this._restRoot}/admin/settings`;
-    return this._httpClient.patch<AdminSettings>(url, patch);
+    return this._httpClient
+      .patch<AdminSettings>(url, patch)
+      .pipe(map(settings => this._defaultAdminSettings(settings)));
   }
 
   get customLinks(): Observable<CustomLink[]> {

--- a/src/app/core/services/user.ts
+++ b/src/app/core/services/user.ts
@@ -101,7 +101,9 @@ export class UserService {
 
   patchCurrentUserSettings(patch: UserSettings): Observable<UserSettings> {
     const url = `${this.restRoot}/me/settings`;
-    return this._httpClient.patch<UserSettings>(url, patch);
+    return this._httpClient
+      .patch<UserSettings>(url, patch)
+      .pipe(map(userSettings => this._defaultUserSettings(userSettings)));
   }
 
   getCurrentUserGroup(projectID: string): Observable<string> {


### PR DESCRIPTION
### What this PR does / why we need it
We use PATCH endpoint response to set the settings too and without defaulting it was setting only initialized (already changed) fields. Now, if the field is not set it will be defaulted in the service.

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/dashboard/issues/4232.

### Release note
```release-note
Fixed settings defaulting after first settings update.
```
