### PR TITLE
fixing font weight for Add token Button

### DIFF
--- a/src/app/serviceaccount/token/style.scss
+++ b/src/app/serviceaccount/token/style.scss
@@ -14,6 +14,12 @@
 
 @use 'variables';
 
+.mat-flat-button {
+  span {
+    font-weight: 600;
+  }
+}
+
 .km-empty-list-msg {
   border-radius: variables.$border-radius;
   border-style: solid;


### PR DESCRIPTION
### What this PR does / why we need it
The button text looks too light compared to the plus icon next to it.
so the PR fix the text font weight to looks more like the plus icon next to it 

“closes #4234”

```release-note
NONE
```
