### PR TITLE
Fix an issue with continuous polling the azure sizes in the dialog mode

### DIFF
--- a/src/app/core/services/node-data/provider/azure.ts
+++ b/src/app/core/services/node-data/provider/azure.ts
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 import {NodeDataMode} from '@app/node-data/config';
-import {NodeDataService} from '@core/services/node-data/service';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {DatacenterService} from '@core/services/datacenter';
+import {NodeDataService} from '@core/services/node-data/service';
 import {ProjectService} from '@core/services/project';
+import {AzureService} from '@core/services/provider/azure';
 import {PresetsService} from '@core/services/wizard/presets';
 import {Cluster} from '@shared/entity/cluster';
 import {AzureSizes, AzureZones} from '@shared/entity/provider/azure';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {Observable, of, onErrorResumeNext} from 'rxjs';
 import {catchError, debounceTime, filter, switchMap, take, tap} from 'rxjs/operators';
-import {AzureService} from '@core/services/provider/azure';
 
 export class NodeDataAzureProvider {
   private readonly _debounce = 500;
@@ -79,7 +79,7 @@ export class NodeDataAzureProvider {
       case NodeDataMode.Dialog: {
         let selectedProject: string;
         return this._projectService.selectedProject
-          .pipe(debounceTime(this._debounce))
+          .pipe(take(1))
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(switchMap(_ => this._azureService.getSizes(selectedProject, this._clusterSpecService.cluster.id)))
@@ -91,8 +91,7 @@ export class NodeDataAzureProvider {
 
               return onErrorResumeNext(of([]));
             })
-          )
-          .pipe(take(1));
+          );
       }
     }
   }


### PR DESCRIPTION
### What this PR does / why we need it
Updated the code so that the sizes will be downloaded only once and there will be no additional requests.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4257

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
