### PR TITLE
Fix an issue with preset creation when domain is provided

### DIFF
--- a/src/app/shared/entity/preset.ts
+++ b/src/app/shared/entity/preset.ts
@@ -74,7 +74,10 @@ export class CreatePresetSpec {
   enabled?: boolean;
 
   provider(): NodeProvider {
-    const providerKey = Object.keys(this).find(key => !_.isEmpty(this[key]) && _.isObject(this[key]));
+    const providerKey = Object.keys(this).find(
+      key => !_.isEmpty(this[key]) && _.isObject(this[key]) && !_.isArray(this[key])
+    );
+
     return providerKey ? NodeProviderConstants.newNodeProvider(providerKey) : NodeProvider.NONE;
   }
 }


### PR DESCRIPTION
### What this PR does / why we need it
There has been an issue with preset creation due to the required emails type change.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
