### PR TITLE
Update the MLA admin settings logic

### DIFF
--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -264,7 +264,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
 
   private _enforce(control: Controls, isEnforced: boolean): void {
     if (isEnforced) {
-      this.form.get(control).setValue(true);
       this.form.get(control).disable();
     }
   }

--- a/src/app/settings/admin/defaults/template.html
+++ b/src/app/settings/admin/defaults/template.html
@@ -93,7 +93,7 @@ limitations under the License.
             </mat-checkbox>
             <mat-checkbox [(ngModel)]="settings.mlaOptions.loggingEnforced"
                           (change)="onSettingsChange()"
-                          fxFlexAlign=" center">Enforce
+                          fxFlexAlign=" center">Enforce Default
             </mat-checkbox>
             <km-spinner-with-confirmation [isSaved]="isMLALoggingEqual()"></km-spinner-with-confirmation>
           </div>
@@ -115,7 +115,7 @@ limitations under the License.
             </mat-checkbox>
             <mat-checkbox [(ngModel)]="settings.mlaOptions.monitoringEnforced"
                           (change)="onSettingsChange()"
-                          fxFlexAlign=" center">Enforce
+                          fxFlexAlign=" center">Enforce Default
             </mat-checkbox>
             <km-spinner-with-confirmation [isSaved]="isMLAMonitoringEqual()"></km-spinner-with-confirmation>
           </div>

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -335,7 +335,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
   private _enforce(control: Controls, isEnforced: boolean): void {
     if (isEnforced) {
-      this.form.get(control).setValue(true);
       this.form.get(control).disable();
     }
   }


### PR DESCRIPTION
### What this PR does / why we need it
Current enforce checkboxes were both checking and disabling the related fields instead of only disabling them. I have updated the logic to match other settings.

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
