### PR TITLE
Remove debounce from provider settings form and fix subscription leak

### DIFF
--- a/src/app/cluster/details/cluster/edit-provider-settings/alibaba-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/alibaba-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {merge, Subject} from 'rxjs';
-import {debounceTime, takeUntil} from 'rxjs/operators';
+import {takeUntil} from 'rxjs/operators';
 
 enum Control {
   AccessKeyID = 'accessKeyID',
@@ -29,7 +29,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class AlibabaProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -43,7 +42,6 @@ export class AlibabaProviderSettingsComponent implements OnInit, OnDestroy {
     });
 
     merge(this.form.get(Control.AccessKeyID).valueChanges, this.form.get(Control.AccessKeySecret).valueChanges)
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/anexia-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/anexia-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   Token = 'token',
@@ -28,7 +28,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class AnexiaProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -43,7 +42,6 @@ export class AnexiaProviderSettingsComponent implements OnInit, OnDestroy {
     this.form
       .get(Control.Token)
       .valueChanges.pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/aws-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/aws-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {merge, Subject} from 'rxjs';
-import {debounceTime, takeUntil} from 'rxjs/operators';
+import {takeUntil} from 'rxjs/operators';
 
 enum Control {
   AccessKeyID = 'accessKeyID',
@@ -32,7 +32,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class AWSProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -58,7 +57,6 @@ export class AWSProviderSettingsComponent implements OnInit, OnDestroy {
       this.form.get(Control.AssumeRoleARN).valueChanges,
       this.form.get(Control.AssumeRoleExternalID).valueChanges
     )
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
 

--- a/src/app/cluster/details/cluster/edit-provider-settings/azure-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/azure-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {merge, Subject} from 'rxjs';
-import {debounceTime, takeUntil} from 'rxjs/operators';
+import {takeUntil} from 'rxjs/operators';
 
 enum Control {
   ClientID = 'clientID',
@@ -31,7 +31,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class AzureProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -52,7 +51,6 @@ export class AzureProviderSettingsComponent implements OnInit, OnDestroy {
       this.form.get(Control.SubscriptionID).valueChanges,
       this.form.get(Control.TenantID).valueChanges
     )
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {MatDialogRef} from '@angular/material/dialog';
 import {ClusterService} from '@core/services/cluster';
 import {NotificationService} from '@core/services/notification';
@@ -24,7 +24,7 @@ import {takeUntil} from 'rxjs/operators';
   selector: 'km-edit-provider-settings',
   templateUrl: './template.html',
 })
-export class EditProviderSettingsComponent implements OnInit {
+export class EditProviderSettingsComponent implements OnInit, OnDestroy {
   private _unsubscribe = new Subject<void>();
   private providerSettingsPatch: ProviderSettingsPatch = {
     isValid: false,
@@ -47,6 +47,11 @@ export class EditProviderSettingsComponent implements OnInit {
     this._clusterService.providerSettingsPatchChanges$
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(patch => (this.providerSettingsPatch = patch));
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
   }
 
   providerDisplayName(cluster: Cluster): string {

--- a/src/app/cluster/details/cluster/edit-provider-settings/digitalocean-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/digitalocean-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   Token = 'token',
@@ -28,7 +28,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class DigitaloceanProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _tokenLength = 64;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
@@ -48,7 +47,6 @@ export class DigitaloceanProviderSettingsComponent implements OnInit, OnDestroy 
     this.form
       .get(Control.Token)
       .valueChanges.pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/equinix-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/equinix-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {AVAILABLE_EQUINIX_BILLING_CYCLES, ProviderSettingsPatch} from '@shared/entity/cluster';
 import {merge, Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   ApiKey = 'apiKey',
@@ -33,7 +33,6 @@ export class EquinixProviderSettingsComponent implements OnInit, OnDestroy {
   private readonly _billingCycleMaxLen = 64;
   private readonly _apiKeyMaxLen = 64;
   private readonly _projectIDMaxLen = 64;
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   @Input() billingCycle: string;
@@ -60,7 +59,6 @@ export class EquinixProviderSettingsComponent implements OnInit, OnDestroy {
       this.form.get(Control.BillingCycle).valueChanges
     )
       .pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/gcp-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/gcp-provider-settings/component.ts
@@ -18,7 +18,7 @@ import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {encode, isValid} from 'js-base64';
 import {Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   ServiceAccount = 'serviceAccount',
@@ -29,7 +29,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class GCPProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -44,7 +43,6 @@ export class GCPProviderSettingsComponent implements OnInit, OnDestroy {
     this.form
       .get(Control.ServiceAccount)
       .valueChanges.pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/hetzner-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/hetzner-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   Token = 'token',
@@ -28,7 +28,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class HetznerProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -43,7 +42,6 @@ export class HetznerProviderSettingsComponent implements OnInit, OnDestroy {
     this.form
       .get(Control.Token)
       .valueChanges.pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/kubevirt-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/kubevirt-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {AbstractControl, FormBuilder, FormGroup} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   Kubeconfig = 'kubeconfig',
@@ -28,7 +28,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class KubevirtProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -47,7 +46,6 @@ export class KubevirtProviderSettingsComponent implements OnInit, OnDestroy {
     this.form
       .get(Control.Kubeconfig)
       .valueChanges.pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/nutanix-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/nutanix-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 export enum Controls {
   Username = 'username',
@@ -32,7 +32,6 @@ export enum Controls {
   templateUrl: './template.html',
 })
 export class NutanixProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Controls = Controls;
   form: FormGroup;
@@ -50,7 +49,6 @@ export class NutanixProviderSettingsComponent implements OnInit, OnDestroy {
 
     this.form.valueChanges
       .pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/openstack-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/openstack-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {merge, Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   Username = 'username',
@@ -29,7 +29,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class OpenstackProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -44,7 +43,6 @@ export class OpenstackProviderSettingsComponent implements OnInit, OnDestroy {
 
     merge(this.form.get(Control.Username).valueChanges, this.form.get(Control.Password).valueChanges)
       .pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }

--- a/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/component.ts
+++ b/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ClusterService} from '@core/services/cluster';
 import {ProviderSettingsPatch} from '@shared/entity/cluster';
 import {merge, Subject} from 'rxjs';
-import {debounceTime, distinctUntilChanged, takeUntil} from 'rxjs/operators';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Control {
   InfraManagementUsername = 'infraManagementUsername',
@@ -31,7 +31,6 @@ enum Control {
   templateUrl: './template.html',
 })
 export class VSphereProviderSettingsComponent implements OnInit, OnDestroy {
-  private readonly _debounceTime = 500;
   private readonly _unsubscribe = new Subject<void>();
   readonly Control = Control;
   form: FormGroup;
@@ -53,7 +52,6 @@ export class VSphereProviderSettingsComponent implements OnInit, OnDestroy {
       this.form.get(Control.Password).valueChanges
     )
       .pipe(distinctUntilChanged())
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._clusterService.changeProviderSettingsPatch(this._getProviderSettingsPatch()));
   }


### PR DESCRIPTION
### Which issue(s) this PR fixes
Closes https://github.com/kubermatic/dashboard/issues/4283. The dialog and the form work but there was 500ms debounce, so once the form was filled it took 500ms to validate. Debounce in that case is not required as we are not connecting to any API and without it the UI will be nicer to use.

### Release note
```release-note
NONE
```
