### PR TITLE
Add allowed IP range override support and update the azure os disk size default for RHEL

### DIFF
--- a/src/app/node-data/basic/provider/azure/component.ts
+++ b/src/app/node-data/basic/provider/azure/component.ts
@@ -22,17 +22,18 @@ import {
   OnInit,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {ClusterSpecService} from '@core/services/cluster-spec';
 import {NodeDataService} from '@core/services/node-data/service';
 import {PresetsService} from '@core/services/wizard/presets';
 import {AzureNodeSpec, NodeCloudSpec, NodeSpec} from '@shared/entity/node';
 import {AzureSizes, AzureZones} from '@shared/entity/provider/azure';
+import {OperatingSystem} from '@shared/model/NodeProviderConstants';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {compare} from '@shared/utils/common';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import _ from 'lodash';
 import {merge, Observable} from 'rxjs';
 import {filter, switchMap, takeUntil, tap} from 'rxjs/operators';
-import {ClusterSpecService} from '@core/services/cluster-spec';
 
 enum Controls {
   Size = 'size',
@@ -107,7 +108,7 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
       [Controls.Size]: this._builder.control('', Validators.required),
       [Controls.Zone]: this._builder.control(''),
       [Controls.ImageID]: this._builder.control(''),
-      [Controls.OSDiskSize]: this._builder.control(this._defaultDiskSize),
+      [Controls.OSDiskSize]: this._builder.control(this.defaultOSDiskSize()),
       [Controls.DataDiskSize]: this._builder.control(this._defaultDiskSize),
     });
 
@@ -117,6 +118,11 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
     this._sizesObservable.pipe(takeUntil(this._unsubscribe)).subscribe(this._setDefaultSize.bind(this));
 
     this._presets.presetChanges.pipe(takeUntil(this._unsubscribe)).subscribe(this._clearSize.bind(this));
+
+    this._nodeDataService.operatingSystemChanges
+      .pipe(tap(_ => this.form.get(Controls.OSDiskSize).setValue(this.defaultOSDiskSize())))
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => this._cdr.detectChanges());
 
     this._sizeChanges
       .pipe(tap(_ => this._clearZone()))
@@ -176,6 +182,11 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
     return `${s.name} (${s.numberOfCores} vCPU,${gpu} ${s.memoryInMB} MB RAM)`;
   }
 
+  defaultOSDiskSize(): number {
+    const defaultDiskSizeRHEL = 64;
+    return this._nodeDataService.operatingSystem === OperatingSystem.RHEL ? defaultDiskSizeRHEL : this._defaultDiskSize;
+  }
+
   private _init(): void {
     if (this._nodeDataService.nodeData.spec.cloud.azure) {
       const selectedZones = this._nodeDataService.nodeData.spec.cloud.azure.zones;
@@ -184,7 +195,7 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
       this.form.get(Controls.ImageID).setValue(this._nodeDataService.nodeData.spec.cloud.azure.imageID);
       this.form
         .get(Controls.OSDiskSize)
-        .setValue(this._nodeDataService.nodeData.spec.cloud.azure.osDiskSize || this._defaultDiskSize);
+        .setValue(this._nodeDataService.nodeData.spec.cloud.azure.osDiskSize || this.defaultOSDiskSize());
       this.form
         .get(Controls.DataDiskSize)
         .setValue(this._nodeDataService.nodeData.spec.cloud.azure.dataDiskSize || this._defaultDiskSize);

--- a/src/app/node-data/basic/provider/azure/template.html
+++ b/src/app/node-data/basic/provider/azure/template.html
@@ -55,14 +55,14 @@ limitations under the License.
   </mat-form-field>
 
   <km-number-stepper [formControlName]="Controls.OSDiskSize"
-                     mode="errors"
+                     mode="all"
                      label="OS Disk Size in GB"
                      min="30"
-                     hint="Leave 30 to use default value.">
+                     hint="Leave {{this.defaultOSDiskSize()}} to use default value.">
   </km-number-stepper>
 
   <km-number-stepper [formControlName]="Controls.DataDiskSize"
-                     mode="errors"
+                     mode="all"
                      label="Data Disk Size in GB"
                      hint="Leave 30 to use default value.">
   </km-number-stepper>

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -337,6 +337,26 @@ limitations under the License.
           <div value>{{cluster.spec.clusterNetwork.services.cidrBlocks.join(', ')}}</div>
         </km-property>
 
+        <km-property *ngIf="cluster.spec.cloud?.aws?.nodePortsAllowedIPRange">
+          <div key>Allowed IP Range for NodePorts</div>
+          <div value>{{cluster.spec.cloud.aws.nodePortsAllowedIPRange}}</div>
+        </km-property>
+
+        <km-property *ngIf="cluster.spec.cloud?.azure?.nodePortsAllowedIPRange">
+          <div key>Allowed IP Range for NodePorts</div>
+          <div value>{{cluster.spec.cloud.azure.nodePortsAllowedIPRange}}</div>
+        </km-property>
+
+        <km-property *ngIf="cluster.spec.cloud?.gcp?.nodePortsAllowedIPRange">
+          <div key>Allowed IP Range for NodePorts</div>
+          <div value>{{cluster.spec.cloud.gcp.nodePortsAllowedIPRange}}</div>
+        </km-property>
+
+        <km-property *ngIf="cluster.spec.cloud?.openstack?.nodePortsAllowedIPRange">
+          <div key>Allowed IP Range for NodePorts</div>
+          <div value>{{cluster.spec.cloud.openstack.nodePortsAllowedIPRange}}</div>
+        </km-property>
+
         <km-property-boolean *ngIf="cluster.spec.clusterNetwork?.konnectivityEnabled"
                              label="Konnectivity"
                              [value]="cluster.spec.clusterNetwork?.konnectivityEnabled">

--- a/src/app/shared/components/openstack-credentials/application/component.ts
+++ b/src/app/shared/components/openstack-credentials/application/component.ts
@@ -82,9 +82,7 @@ export class OpenstackApplicationCredentialsComponent extends BaseFormValidator 
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ =>
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.openstack).every(value => !value)
-        )
+        this._presets.enablePresets(OpenstackCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.openstack))
       );
 
     this.form.reset();

--- a/src/app/shared/components/openstack-credentials/component.ts
+++ b/src/app/shared/components/openstack-credentials/component.ts
@@ -30,6 +30,7 @@ import {
 } from '@app/wizard/step/provider-settings/provider/extended/openstack/service';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {PresetsService} from '@core/services/wizard/presets';
+import {OpenstackCloudSpec} from '@shared/entity/cluster';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import {debounceTime, filter, takeUntil, tap} from 'rxjs/operators';
@@ -115,9 +116,7 @@ export class OpenstackCredentialsComponent extends BaseFormValidator implements 
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ =>
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.openstack).every(value => !value)
-        )
+        this._presets.enablePresets(OpenstackCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.openstack))
       );
   }
 

--- a/src/app/shared/components/openstack-credentials/default/component.ts
+++ b/src/app/shared/components/openstack-credentials/default/component.ts
@@ -127,9 +127,7 @@ export class OpenstackDefaultCredentialsComponent extends BaseFormValidator impl
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ =>
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.openstack).every(value => !value)
-        )
+        this._presets.enablePresets(OpenstackCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.openstack))
       );
 
     merge(

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {MachineDeployment} from '@shared/entity/machine-deployment';
+import _ from 'lodash';
 
 export enum Provider {
   Alibaba = 'alibaba',
@@ -111,12 +112,20 @@ export class CloudSpec {
   anexia?: AnexiaCloudSpec;
 }
 
+export class ExtraCloudSpecOptions {
+  constructor(public nodePortsAllowedIPRange?: string) {}
+
+  static new(spec: AWSCloudSpec | GCPCloudSpec | AzureCloudSpec | OpenstackCloudSpec): ExtraCloudSpecOptions {
+    return new ExtraCloudSpecOptions(spec.nodePortsAllowedIPRange);
+  }
+}
+
 export class AlibabaCloudSpec {
   accessKeyID: string;
   accessKeySecret: string;
 }
 
-export class AWSCloudSpec {
+export class AWSCloudSpec extends ExtraCloudSpecOptions {
   accessKeyID: string;
   secretAccessKey: string;
   assumeRoleARN: string;
@@ -126,9 +135,13 @@ export class AWSCloudSpec {
   securityGroupID: string;
   instanceProfileName: string;
   roleARN: string;
+
+  static isEmpty(spec: AWSCloudSpec): boolean {
+    return _.difference(Object.keys(spec), Object.keys(ExtraCloudSpecOptions.new(spec))).every(key => !spec[key]);
+  }
 }
 
-export class AzureCloudSpec {
+export class AzureCloudSpec extends ExtraCloudSpecOptions {
   clientID: string;
   clientSecret: string;
   resourceGroup: string;
@@ -141,6 +154,13 @@ export class AzureCloudSpec {
   vnet: string;
   loadBalancerSKU: string;
   assignAvailabilitySet: boolean;
+
+  static isEmpty(spec: AzureCloudSpec): boolean {
+    const optionalFields = ['assignAvailabilitySet'];
+    return _.difference(Object.keys(spec), [...Object.keys(ExtraCloudSpecOptions.new(spec)), ...optionalFields]).every(
+      key => !spec[key]
+    );
+  }
 }
 
 export class BringYourOwnCloudSpec {}
@@ -157,10 +177,14 @@ export class FakeCloudSpec {
   token: string;
 }
 
-export class GCPCloudSpec {
+export class GCPCloudSpec extends ExtraCloudSpecOptions {
   network: string;
   serviceAccount: string;
   subnetwork: string;
+
+  static isEmpty(spec: GCPCloudSpec): boolean {
+    return _.difference(Object.keys(spec), Object.keys(ExtraCloudSpecOptions.new(spec))).every(key => !spec[key]);
+  }
 }
 
 export class HetznerCloudSpec {
@@ -191,7 +215,7 @@ export class NutanixCSIConfig {
   ssSegmentedIscsiNetwork?: boolean;
 }
 
-export class OpenstackCloudSpec {
+export class OpenstackCloudSpec extends ExtraCloudSpecOptions {
   useToken?: boolean;
   applicationCredentialID?: string;
   applicationCredentialSecret?: string;
@@ -204,6 +228,10 @@ export class OpenstackCloudSpec {
   securityGroups: string;
   floatingIPPool: string;
   subnetID: string;
+
+  static isEmpty(spec: OpenstackCloudSpec): boolean {
+    return _.difference(Object.keys(spec), Object.keys(ExtraCloudSpecOptions.new(spec))).every(key => !spec[key]);
+  }
 }
 
 export class EquinixCloudSpec {

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -119,6 +119,16 @@ limitations under the License.
             Invalid pattern. Use CIDR notation, i.e. 192.168.1.0/24.
           </mat-error>
         </mat-form-field>
+        <mat-form-field *ngIf="isAllowedIPRangeSupported()">
+          <mat-label>Allowed IP Range</mat-label>
+          <input matInput
+                 [formControlName]="Controls.AllowedIPRange"
+                 type="text"
+                 autocomplete="off">
+          <mat-error *ngIf="form.get(Controls.AllowedIPRange).hasError('pattern')">
+            Invalid pattern. Use CIDR notation, i.e. 192.168.1.0/24.
+          </mat-error>
+        </mat-form-field>
         <mat-checkbox *ngIf="isKonnectivityEnabled"
                       [formControlName]="Controls.Konnectivity">
           Konnectivity

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -120,7 +120,7 @@ limitations under the License.
           </mat-error>
         </mat-form-field>
         <mat-form-field *ngIf="isAllowedIPRangeSupported()">
-          <mat-label>Allowed IP Range</mat-label>
+          <mat-label>Allowed IP Range for NodePorts</mat-label>
           <input matInput
                  [formControlName]="Controls.AllowedIPRange"
                  type="text"

--- a/src/app/wizard/step/provider-settings/provider/basic/aws/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/aws/component.ts
@@ -108,12 +108,9 @@ export class AWSProviderBasicComponent extends BaseFormValidator implements OnIn
 
     this.form.valueChanges
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.AWS))
-      .pipe(debounceTime(this._debounceTime))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ =>
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.aws).every(value => !value)
-        )
+        this._presets.enablePresets(AWSCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.aws))
       );
 
     merge(this._clusterSpecService.providerChanges, this._clusterSpecService.datacenterChanges)

--- a/src/app/wizard/step/provider-settings/provider/basic/azure/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/azure/component.ts
@@ -67,13 +67,9 @@ export class AzureProviderBasicComponent extends BaseFormValidator implements On
     this.form.valueChanges
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.AZURE))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(_ => {
-        this._presets.enablePresets(
-          Object.keys(this._clusterSpecService.cluster.spec.cloud.azure)
-            .filter(key => key !== 'assignAvailabilitySet')
-            .every(key => !this._clusterSpecService.cluster.spec.cloud.azure[key])
-        );
-      });
+      .subscribe(_ =>
+        this._presets.enablePresets(AzureCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.azure))
+      );
 
     this._presets.presetChanges
       .pipe(takeUntil(this._unsubscribe))

--- a/src/app/wizard/step/provider-settings/provider/basic/gcp/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/gcp/component.ts
@@ -67,9 +67,7 @@ export class GCPProviderBasicComponent extends BaseFormValidator implements OnIn
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.GCP))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ =>
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.gcp).every(value => !value)
-        )
+        this._presets.enablePresets(GCPCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.gcp))
       );
 
     merge(this._clusterSpecService.providerChanges, this._clusterSpecService.datacenterChanges)

--- a/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
@@ -107,9 +107,7 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ =>
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.openstack).every(value => !value)
-        )
+        this._presets.enablePresets(OpenstackCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.openstack))
       );
 
     merge(this.form.get(Controls.Domain).valueChanges.pipe(distinctUntilChanged()))

--- a/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/aws/component.ts
@@ -48,7 +48,7 @@ enum Controls {
   ],
 })
 export class AWSProviderExtendedComponent extends BaseFormValidator implements OnInit, OnDestroy {
-  private readonly _debounceTime = 1000;
+  private readonly _debounceTime = 500;
   readonly Controls = Controls;
   isLoadingSecurityGroups = false;
   securityGroups: string[] = [];
@@ -79,9 +79,7 @@ export class AWSProviderExtendedComponent extends BaseFormValidator implements O
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.AWS))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => {
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.aws).every(value => !value)
-        );
+        this._presets.enablePresets(AWSCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.aws));
       });
 
     this._clusterSpecService.clusterChanges

--- a/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/azure/component.ts
@@ -98,13 +98,9 @@ export class AzureProviderExtendedComponent extends BaseFormValidator implements
     this.form.valueChanges
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.AZURE))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(_ => {
-        this._presets.enablePresets(
-          Object.keys(this._clusterSpecService.cluster.spec.cloud.azure)
-            .filter(key => key !== 'assignAvailabilitySet')
-            .every(key => !this._clusterSpecService.cluster.spec.cloud.azure[key])
-        );
-      });
+      .subscribe(_ =>
+        this._presets.enablePresets(AzureCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.azure))
+      );
 
     this._presets.presetChanges.pipe(takeUntil(this._unsubscribe)).subscribe(preset =>
       Object.values(Controls)

--- a/src/app/wizard/step/provider-settings/provider/extended/gcp/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/gcp/component.ts
@@ -26,6 +26,7 @@ import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {PresetsService} from '@core/services/wizard/presets';
 import {FilteredComboboxComponent} from '@shared/components/combobox/component';
+import {GCPCloudSpec} from '@shared/entity/cluster';
 import {GCPNetwork, GCPSubnetwork} from '@shared/entity/provider/gcp';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
@@ -107,9 +108,7 @@ export class GCPProviderExtendedComponent extends BaseFormValidator implements O
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.GCP))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ =>
-        this._presets.enablePresets(
-          Object.values(this._clusterSpecService.cluster.spec.cloud.gcp).every(value => !value)
-        )
+        this._presets.enablePresets(GCPCloudSpec.isEmpty(this._clusterSpecService.cluster.spec.cloud.gcp))
       );
 
     this._clusterSpecService.clusterChanges


### PR DESCRIPTION
### What this PR does / why we need it
- Refactored the preset enable/disable logic
- Added support for the allowed IP range override to the second wizard step for the supported providers
- Updated default os disk size for the Azure provider when RHEL OS is selected

![image](https://user-images.githubusercontent.com/2285385/158188760-d747759f-b99f-43b1-959d-4fa899851aa1.png)

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #3924
Fixes #4259

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Added allowed IP range override support to the GCP, Azure, AWS, and OpenStack providers.
Updated OS default disk size to 64GB for the Azure provider when RHEL OS is selected.
```
