### PR TITLE
ajust clear notification

### DIFF
--- a/src/app/core/components/notification-panel/template.html
+++ b/src/app/core/components/notification-panel/template.html
@@ -49,6 +49,7 @@ limitations under the License.
       </button>
     </div>
     <div class="notification-list"
+         fxLayout="column"
          fxFlex>
       <div *ngFor="let notification of notifications"
            @slideOut


### PR DESCRIPTION
### What this PR does / why we need it

when we clear the notifications the animation for  it first make it look like columns then it clear them,, so this PR fix it so the animation wouldn't change the arrange of the notification before clear them 

"closes #4233 "

-->
```release-note
NONE
```
