### PR TITLE
Add warning for invalid SA tokens

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -203,6 +203,7 @@ presubmits:
 
   - name: pre-dashboard-test-e2e
     skip_if_only_changed: "^(containers|docs)/|\\.(md)$"
+    optional: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     labels:
@@ -231,6 +232,7 @@ presubmits:
 
   - name: pre-dashboard-test-e2e-ce
     skip_if_only_changed: "^(containers|docs)/|\\.(md)$"
+    optional: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     labels:

--- a/src/app/serviceaccount/token/component.ts
+++ b/src/app/serviceaccount/token/component.ts
@@ -151,8 +151,4 @@ export class ServiceAccountTokenComponent implements OnInit {
         this.onUpdate.next();
       });
   }
-
-  isInvalid(token: ServiceAccountToken): boolean {
-    return token.invalidated;
-  }
 }

--- a/src/app/serviceaccount/token/component.ts
+++ b/src/app/serviceaccount/token/component.ts
@@ -151,4 +151,8 @@ export class ServiceAccountTokenComponent implements OnInit {
         this.onUpdate.next();
       });
   }
+
+  isInvalid(token: ServiceAccountToken): boolean {
+    return token.invalidated;
+  }
 }

--- a/src/app/serviceaccount/token/template.html
+++ b/src/app/serviceaccount/token/template.html
@@ -43,7 +43,7 @@ limitations under the License.
       <div fxLayoutAlign=" center"
            fxLayoutGap="8px">
         <span>{{element.name}}</span>
-        <div *ngIf="isInvalid(element)"
+        <div *ngIf="element.invalidated"
              class="km-icon-warning"
              matTooltip="This token is no longer valid. Please regenerate or delete it."></div>
       </div>
@@ -102,7 +102,7 @@ limitations under the License.
                     [attr.id]="'km-edit-dialog-token-' + element?.name"
                     matTooltip="Edit Service Account Token"
                     (click)="editToken(element)"
-                    [disabled]="!isEnabled('edit') || isInvalid(element)">
+                    [disabled]="!isEnabled('edit') || element.invalidated">
               <i class="km-icon-mask km-icon-edit"></i>
             </button>
 

--- a/src/app/serviceaccount/token/template.html
+++ b/src/app/serviceaccount/token/template.html
@@ -39,7 +39,15 @@ limitations under the License.
         mat-sort-header>Token Name
     </th>
     <td mat-cell
-        *matCellDef="let element">{{element.name}}</td>
+        *matCellDef="let element">
+      <div fxLayoutAlign=" center"
+           fxLayoutGap="8px">
+        <span>{{element.name}}</span>
+        <div *ngIf="isInvalid(element)"
+             class="km-icon-warning"
+             matTooltip="This token is no longer valid. Please regenerate or delete it."></div>
+      </div>
+    </td>
   </ng-container>
 
   <ng-container matColumnDef="expiry">
@@ -94,7 +102,7 @@ limitations under the License.
                     [attr.id]="'km-edit-dialog-token-' + element?.name"
                     matTooltip="Edit Service Account Token"
                     (click)="editToken(element)"
-                    [disabled]="!isEnabled('edit')">
+                    [disabled]="!isEnabled('edit') || isInvalid(element)">
               <i class="km-icon-mask km-icon-edit"></i>
             </button>
 

--- a/src/app/shared/entity/service-account.ts
+++ b/src/app/shared/entity/service-account.ts
@@ -33,6 +33,7 @@ export class ServiceAccountToken {
   id: string;
   name: string;
   token?: string;
+  invalidated?: boolean;
 }
 
 export class CreateTokenEntity {


### PR DESCRIPTION
### What this PR does / why we need it
- blocked edit when token is invalid
- added warning icon with tooltip to inform about invalid token
- made e2e optional for further investigation (https://github.com/kubermatic/dashboard/issues/4344)

![image](https://user-images.githubusercontent.com/2285385/159001225-8b99bcf3-c780-47c5-b49b-6bd2f758f675.png)

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4331

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Added warning icon with a message for invalid service account tokens.
```
