### PR TITLE
Update external cluster statuses

### DIFF
--- a/src/app/shared/entity/external-cluster.ts
+++ b/src/app/shared/entity/external-cluster.ts
@@ -79,14 +79,14 @@ export class ExternalCloudSpec {
 }
 
 export enum ExternalClusterState {
-  Provisioning = 'PROVISIONING',
-  Running = 'RUNNING',
-  Reconciling = 'RECONCILING',
-  Stopping = 'STOPPING',
-  Stopped = 'STOPPED',
-  Deleting = 'DELETING',
-  Error = 'ERROR',
-  Unknown = 'UNKNOWN',
+  Provisioning = 'Provisioning',
+  Running = 'Running',
+  Reconciling = 'Reconciling',
+  Stopping = 'Stopping',
+  Stopped = 'Stopped',
+  Deleting = 'Deleting',
+  Error = 'Error',
+  Unknown = 'Unknown',
 }
 
 export class ExternalClusterStatus {


### PR DESCRIPTION
### What this PR does / why we need it
To keep in sync with https://github.com/kubermatic/kubermatic/pull/9408.

### Release note
```release-note
NONE
```
