### PR TITLE
support Redirects to external cluster view 

### DIFF
--- a/cypress/integration/stories/external-cluster.spec.ts
+++ b/cypress/integration/stories/external-cluster.spec.ts
@@ -78,9 +78,9 @@ describe('External Cluster Story', () => {
     ClustersPage.getDisconnectConfirmBtn().click();
   });
 
-  it('should verify that there are no clusters', () => {
+  it('should verify that there are no external clusters', () => {
     ClustersPage.visit();
-    ClustersPage.verifyNoClusters();
+    ClustersPage.verifyNoExternalClusters();
   });
 
   it('should go to the projects page', () => {

--- a/cypress/pages/clusters.po.ts
+++ b/cypress/pages/clusters.po.ts
@@ -259,6 +259,17 @@ export class ClustersPage {
     cy.get('div').should(Condition.Contain, 'No clusters available.');
   }
 
+  static verifyNoExternalClusters(): void {
+    if (Mocks.enabled()) {
+      cy.intercept({method: RequestType.GET, path: Endpoint.ExternalClusters}, []);
+    }
+
+    this.waitForRefresh();
+    this.verifyUrl();
+
+    cy.get('div').should(Condition.Contain, 'No external clusters available.');
+  }
+
   static verifyClustersCount(count: number): void {
     this.waitForRefresh();
     this.verifyUrl();

--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -32,6 +32,7 @@ import {forkJoin, of, Subject, timer} from 'rxjs';
 import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {ExternalMachineDeployment} from '@shared/entity/external-machine-deployment';
 import {MasterVersion} from '@shared/entity/cluster';
+import {ClusterListTab} from '@app/cluster/list/component';
 
 @Component({
   selector: 'km-external-cluster-details',
@@ -179,7 +180,9 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
 
   disconnect(): void {
     this._clusterService.showDisconnectClusterDialog(this.cluster, this.projectID).subscribe(_ => {
-      this._router.navigate(['/projects/' + this.projectID + '/clusters']);
+      this._router.navigate(['/projects/' + this.projectID + '/clusters'], {
+        fragment: `${ClusterListTab.ExternalCluster}`,
+      });
       this._notificationService.success(`Disconnected the ${this.cluster.name} cluster`);
     });
   }

--- a/src/app/cluster/list/component.ts
+++ b/src/app/cluster/list/component.ts
@@ -16,6 +16,12 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import {Subject} from 'rxjs';
 import {SettingsService} from '@core/services/settings';
 import {map, takeUntil} from 'rxjs/operators';
+import {ActivatedRoute} from '@angular/router';
+
+export enum ClusterListTab {
+  Cluster,
+  ExternalCluster,
+}
 
 @Component({
   selector: 'km-clusters',
@@ -25,8 +31,9 @@ import {map, takeUntil} from 'rxjs/operators';
 export class ClustersComponent implements OnInit, OnDestroy {
   private _unsubscribe: Subject<void> = new Subject<void>();
   areExternalClustersEnabled = false;
+  clusterIndex = this._route.snapshot.fragment;
 
-  constructor(private readonly _settingsService: SettingsService) {}
+  constructor(private readonly _settingsService: SettingsService, private readonly _route: ActivatedRoute) {}
 
   ngOnInit(): void {
     this._settingsService.adminSettings

--- a/src/app/cluster/list/template.html
+++ b/src/app/cluster/list/template.html
@@ -16,7 +16,8 @@ limitations under the License.
 
 <ng-container [ngSwitch]="areExternalClustersEnabled">
   <mat-tab-group *ngSwitchCase="true"
-                 animationDuration="0ms">
+                 animationDuration="0ms"
+                 [selectedIndex]="clusterIndex">
     <mat-tab label="Clusters">
       <div class="container">
         <km-cluster-list></km-cluster-list>


### PR DESCRIPTION
### What this PR does / why we need it

At the moment after disconnecting external cluster users get redirected to the cluster list view. It displays always the first tab, so the internal clusters. this PR redirect the user to the external cluster list view .

"closes #4265 "

```release-note
NONE
```
