### PR TITLE
Add metering report removal action to the report list component.

### DIFF
--- a/src/app/core/services/settings.ts
+++ b/src/app/core/services/settings.ts
@@ -18,7 +18,6 @@ import {AppConfigService} from '@app/config.service';
 import {Auth} from '@core/services/auth/service';
 import {environment} from '@environments/environment';
 import {Admin, Member} from '@shared/entity/member';
-import {Report} from '@shared/entity/metering';
 import {AdminSettings, CustomLink, DEFAULT_ADMIN_SETTINGS} from '@shared/entity/settings';
 import {BehaviorSubject, EMPTY, iif, merge, Observable, of, Subject, timer} from 'rxjs';
 import {catchError, delay, map, retryWhen, shareReplay, switchMap} from 'rxjs/operators';
@@ -41,7 +40,6 @@ export class SettingsService {
   private _usersRefresh$ = new Subject<void>();
   private _customLinks$: Observable<CustomLink[]>;
   private _customLinksRefresh$ = new Subject<void>();
-  private _reports$ = new Map<string, Observable<Report[]>>();
   private _refreshTimer$ = timer(0, this._appConfigService.getRefreshTimeBase() * this._refreshTime);
 
   constructor(
@@ -149,26 +147,5 @@ export class SettingsService {
 
   refreshUsers(): void {
     this._usersRefresh$.next();
-  }
-
-  reports(scheduleName: string): Observable<Report[]> {
-    if (!this._reports$.get(scheduleName)) {
-      const reports$ = this._refreshTimer$
-        .pipe(switchMap(() => this._getReports(scheduleName)))
-        .pipe(shareReplay({refCount: true, bufferSize: 1}));
-      this._reports$.set(scheduleName, reports$);
-    }
-
-    return this._reports$.get(scheduleName);
-  }
-
-  private _getReports(scheduleName: string): Observable<Report[]> {
-    const url = `${this._restRoot}/admin/metering/reports`;
-    return this._httpClient.get<Report[]>(url, {params: {configuration_name: scheduleName}});
-  }
-
-  reportDownload(reportName: string, scheduleName: string): Observable<string> {
-    const url = `${this._restRoot}/admin/metering/reports/${reportName}`;
-    return this._httpClient.get<string>(url, {params: {configuration_name: scheduleName}});
   }
 }

--- a/src/app/dynamic/enterprise/metering/schedule-config/report-list/component.spec.ts
+++ b/src/app/dynamic/enterprise/metering/schedule-config/report-list/component.spec.ts
@@ -25,7 +25,6 @@ import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterTestingModule} from '@angular/router/testing';
 import {AppConfigService} from '@app/config.service';
 import {Auth} from '@app/core/services/auth/service';
-import {SettingsService} from '@app/core/services/settings';
 import {UserService} from '@app/core/services/user';
 import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering';
 import {SharedModule} from '@app/shared/module';
@@ -38,7 +37,7 @@ import {MeteringReportListComponent} from './component';
 describe('MeteringReportListComponent', () => {
   let component: MeteringReportListComponent;
   let fixture: ComponentFixture<MeteringReportListComponent>;
-  let settingsService: SettingsService;
+  let meteringService: MeteringService;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -67,7 +66,7 @@ describe('MeteringReportListComponent', () => {
         size: 5559,
       },
     ];
-    settingsService = fixture.debugElement.injector.get(SettingsService);
+    meteringService = fixture.debugElement.injector.get(MeteringService);
   });
 
   it('should create metering report list component', () => {
@@ -75,10 +74,10 @@ describe('MeteringReportListComponent', () => {
   });
 
   it('should trigger report download', () => {
-    const spySettingsSvc = jest.spyOn(settingsService, 'reportDownload');
+    const spyMeteringSvc = jest.spyOn(meteringService, 'reportDownload');
     fixture.detectChanges();
     const downloadReportBtn = fixture.debugElement.query(By.css('#km-download-report-button'));
     downloadReportBtn.triggerEventHandler('throttleClick', null);
-    expect(spySettingsSvc).toHaveBeenCalledWith(component.reports[0].name, component.scheduleName);
+    expect(spyMeteringSvc).toHaveBeenCalledWith(component.reports[0].name, component.scheduleName);
   });
 });

--- a/src/app/dynamic/enterprise/metering/schedule-config/report-list/template.html
+++ b/src/app/dynamic/enterprise/metering/schedule-config/report-list/template.html
@@ -114,7 +114,7 @@ END OF TERMS AND CONDITIONS
             *matCellDef="let element">
           <div class="km-table-actions"
                fxLayoutAlign="end">
-            <ng-container *ngIf="isFetchingReport(element)">
+            <ng-container *ngIf="isProcessingReport(element)">
               <mat-spinner color="accent"
                            class="km-spinner"
                            fxFlexAlign=" center"
@@ -124,9 +124,14 @@ END OF TERMS AND CONDITIONS
             <button id="km-download-report-button"
                     mat-icon-button
                     kmThrottleClick
-                    (throttleClick)="download(element)"
-                    [disabled]="!canDownload(element)">
+                    (throttleClick)="download(element.name)">
               <i class="km-icon-mask km-icon-download"></i>
+            </button>
+
+            <button mat-icon-button
+                    kmThrottleClick
+                    (throttleClick)="remove(element.name)">
+              <i class="km-icon-mask km-icon-delete"></i>
             </button>
           </div>
         </td>

--- a/src/test/services/metering-mock.ts
+++ b/src/test/services/metering-mock.ts
@@ -14,6 +14,7 @@
 
 import {Injectable} from '@angular/core';
 import {MeteringReportConfiguration} from '@app/shared/entity/datacenter';
+import {Report} from '@app/shared/entity/metering';
 import {fakeScheduleConfiguration} from '@test/data/metering';
 import {EMPTY, Observable, of, Subject} from 'rxjs';
 
@@ -30,6 +31,14 @@ export class MeteringMockService {
   }
 
   addScheduleConfiguration(_: MeteringReportConfiguration): Observable<any> {
+    return EMPTY;
+  }
+
+  reports(_: string): Observable<Report[]> {
+    return EMPTY;
+  }
+
+  reportDownload(_1: string, _2: string): Observable<string> {
     return EMPTY;
   }
 }


### PR DESCRIPTION
### What this PR does / why we need it
Metering report list component now supports remove report action. 
I also decided to move all report related methods from setting service to metering service.

### Which issue(s) this PR fixes
Fixes #4429 

### Release note
```release-note
Enable metering report removal
```
