### PR TITLE
Give correct Kubernetes version that removes Docker support

### DIFF
--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -172,7 +172,7 @@ limitations under the License.
               <mat-option [value]="containerRuntime.Docker">docker</mat-option>
             </mat-select>
             <mat-error *ngIf="control(Controls.ContainerRuntime).hasError('dockerVersionCompatibility')">
-              Docker is not supported since v1.22.0.
+              Docker is not supported since v1.24.
             </mat-error>
           </mat-form-field>
         </div>


### PR DESCRIPTION


### What this PR does / why we need it

The message shown to users was out of sync with the actual constraint (message said 1.22, but constraint is 1.24), so this updates the error message shown in the UI when trying to deploy Kubernetes 1.24 with Docker.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
