### PR TITLE
Show updated config instead of default values in edit machine deployment dialog 

### DIFF
--- a/src/app/node-data/basic/provider/alibaba/component.ts
+++ b/src/app/node-data/basic/provider/alibaba/component.ts
@@ -205,20 +205,17 @@ export class AlibabaBasicNodeDataComponent extends BaseFormValidator implements 
   }
 
   private _onInstanceTypeLoading(): void {
-    this._clearInstanceType();
     this.instanceTypeLabel = InstanceTypeState.Loading;
     this._cdr.detectChanges();
   }
 
   private _onZoneLoading(): void {
-    this._clearZone();
     this.zoneLabel = ZoneState.Loading;
     this._cdr.detectChanges();
   }
 
   private _onVSwitchLoading(): void {
     this.isLoadingVSwitches = true;
-    this._clearVSwitch();
     this._cdr.detectChanges();
   }
 

--- a/src/app/node-data/basic/provider/anexia/component.ts
+++ b/src/app/node-data/basic/provider/anexia/component.ts
@@ -147,13 +147,11 @@ export class AnexiaBasicNodeDataComponent extends BaseFormValidator implements O
 
   private _onVlanLoading(): void {
     this.isLoadingVlans = true;
-    this._clearVlan();
     this._cdr.detectChanges();
   }
 
   private _onTemplateLoading(): void {
     this.isLoadingTemplates = true;
-    this._clearTemplate();
     this._cdr.detectChanges();
   }
 

--- a/src/app/node-data/basic/provider/aws/component.ts
+++ b/src/app/node-data/basic/provider/aws/component.ts
@@ -294,13 +294,11 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
   }
 
   private _onSizeLoading(): void {
-    this._clearSize();
     this.sizeLabel = SizeState.Loading;
     this._cdr.detectChanges();
   }
 
   private _onSubnetLoading(): void {
-    this._clearSubnet();
     this.subnetLabel = SubnetState.Loading;
     this._cdr.detectChanges();
   }

--- a/src/app/node-data/basic/provider/gcp/component.ts
+++ b/src/app/node-data/basic/provider/gcp/component.ts
@@ -205,7 +205,6 @@ export class GCPBasicNodeDataComponent extends BaseFormValidator implements OnIn
   }
 
   private _onZoneLoading(): void {
-    this._clearZone();
     this.zoneLabel = ZoneState.Loading;
     this._cdr.detectChanges();
   }
@@ -232,7 +231,6 @@ export class GCPBasicNodeDataComponent extends BaseFormValidator implements OnIn
   }
 
   private _onDiskTypeLoading(): void {
-    this._clearDiskTypes();
     this.diskTypeLabel = DiskTypeState.Loading;
     this._cdr.detectChanges();
   }
@@ -261,7 +259,6 @@ export class GCPBasicNodeDataComponent extends BaseFormValidator implements OnIn
   }
 
   private _onMachineTypeLoading(): void {
-    this._clearMachineType();
     this.machineTypeLabel = MachineTypeState.Loading;
     this._cdr.detectChanges();
   }

--- a/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -200,7 +200,6 @@ export class KubeVirtBasicNodeDataComponent
   }
 
   private _onFlavorLoading(): void {
-    this._clearFlavor();
     this.flavorLabel = FlavorsState.Loading;
     this._cdr.detectChanges();
   }
@@ -232,7 +231,6 @@ export class KubeVirtBasicNodeDataComponent
   }
 
   private _onStorageClassLoading(): void {
-    this._clearStorageClass();
     this.storageClassLabel = StorageClassState.Loading;
     this._cdr.detectChanges();
   }

--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -237,7 +237,6 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
   }
 
   private _onFlavorLoading(): void {
-    this._clearFlavor();
     this.flavorsLabel = FlavorState.Loading;
     this._cdr.detectChanges();
   }
@@ -262,7 +261,6 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
   }
 
   private _onAvailabilityZoneLoading(): void {
-    this._clearAvailabilityZone();
     this.availabilityZonesLabel = AvailabilityZoneState.Loading;
     this._cdr.detectChanges();
   }


### PR DESCRIPTION

Signed-off-by: Waseem Abbas <waseemabbas8261@gmail.com>

### What this PR does / why we need it
Edit machine deployment dialog was displaying default values in combobox elements instead of what was configured. This has been fixed by removing `_clearX` method calls when combobox options are loading.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Fixes #4472 

### Special notes for your reviewer
<!-- Remove if not needed -->
Reason for removing these clear method calls:
- `_onXLoading` method is called when combobox options are loading
- `_onXLoading` method calls `_clearX` method
- `_clearX` method calls `reset` method of combobox
- Combobox emits `changed` event with `null` value
- `null` value gets assigned to property in `_nodeDataService.nodeData.spec.cloud.X` hence replacing original value
- Combobox options finish loading so `_setDefaultX` is called
- `_setDefaultX` method loads value from `_nodeDataService.nodeData.spec.cloud.X` which was set to `null` in previous step
- `_setDefaultX` method sets default value in combobox so original configured value is never shown

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
