### PR TITLE
Only consider MachineDeployment running if replicas are updated

### DIFF
--- a/src/app/shared/utils/health-status.ts
+++ b/src/app/shared/utils/health-status.ts
@@ -71,7 +71,11 @@ export function getNodeHealthStatus(n: Node): HealthStatus {
 export function getMachineDeploymentHealthStatus(md: MachineDeployment): HealthStatus {
   if (md.deletionTimestamp) {
     return new HealthStatus('Deleting', StatusIcon.Error);
-  } else if (md.status && md.status.availableReplicas === md.spec.replicas) {
+  } else if (
+    md.status &&
+    md.status.availableReplicas === md.spec.replicas &&
+    md.status.availableReplicas === md.status.updatedReplicas
+  ) {
     return new HealthStatus('Running', StatusIcon.Running);
   } else if (md.status && md.status.updatedReplicas !== md.spec.replicas) {
     return new HealthStatus('Updating', StatusIcon.Pending);


### PR DESCRIPTION
### What this PR does / why we need it

MachineDeployment health in the dashboard does not consider whether replicas where updated. That can result in incorrect UI information during a MachineDeployment upgrade (it should be showing that the MachineDeployment is updating, but as long as enough old Machines are still available, it will not).

This PR includes `md.status.updatedReplicas` in the if condition for status "Running".

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
MachineDeployment health is only considered "Running" if replicas are all updated
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>