### PR TITLE
4529 display multiple internal IPs in node details of machine deployment

### DIFF
--- a/src/app/cluster/details/cluster/node-list/component.ts
+++ b/src/app/cluster/details/cluster/node-list/component.ts
@@ -25,7 +25,7 @@ import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialo
 import {Cluster} from '@shared/entity/cluster';
 import {Member} from '@shared/entity/member';
 import {NodeMetrics} from '@shared/entity/metrics';
-import {getOperatingSystem, getOperatingSystemLogoClass, Node, VSphereTag} from '@shared/entity/node';
+import {getOperatingSystem, getOperatingSystemLogoClass, Node, NodeIPAddress, VSphereTag} from '@shared/entity/node';
 import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member';
 import {NodeUtils} from '@shared/utils/node';
@@ -176,7 +176,7 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
     return NodeUtils.getFormattedNodeMemory(memory);
   }
 
-  getAddresses(node: Node): object {
+  getAddresses(node: Node): NodeIPAddress {
     return NodeUtils.getAddresses(node);
   }
 

--- a/src/app/cluster/details/cluster/node-list/style.scss
+++ b/src/app/cluster/details/cluster/node-list/style.scss
@@ -36,16 +36,6 @@ i.km-icon-warning {
   margin-left: 5px;
 }
 
-.mat-column-name,
-.node-info {
-  align-items: center;
-  display: flex;
-}
-
-.mat-column-name {
-  height: 50px;
-}
-
 .node-details {
   box-shadow: variables.$border-box-shadow-inset;
   padding: variables.$item-details-padding;

--- a/src/app/cluster/details/cluster/node-list/style.scss
+++ b/src/app/cluster/details/cluster/node-list/style.scss
@@ -26,9 +26,9 @@
   }
 }
 
-.node-ip-addresses {
-  display: block;
-  line-height: 20px;
+.node-ip-addresses-spacing {
+  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
 i.km-icon-info,

--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -55,18 +55,12 @@ limitations under the License.
         </th>
         <td mat-cell
             *matCellDef="let element">
-          <ng-container *ngIf="!element.spec.cloud.aws">
-            {{element.name}}
-            <i class="km-icon-info km-pointer"
-               matTooltip="{{getInfo(element)}}"
-               *ngIf="showInfo(element)"></i>
-          </ng-container>
-          <ng-container *ngIf="element.spec.cloud.aws">
-            {{getNodeName(element)}}
-            <i class="km-icon-info km-pointer"
-               matTooltip="{{getInfo(element)}}"
-               *ngIf="showInfo(element)"></i>
-          </ng-container>
+          <div fxLayoutAlign=" center">
+            {{element.spec.cloud.aws ? getNodeName(element) : element.name}}
+            <i *ngIf="showInfo(element)"
+               class="km-icon-info km-pointer"
+               matTooltip="{{getInfo(element)}}"></i>
+          </div>
           <ng-container *ngIf="element.status.errorMessage">
             <i [matTooltip]="element.status.errorMessage"
                class="km-icon-warning"></i>

--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -91,7 +91,6 @@ limitations under the License.
                  [ngClass]="{'node-ip-addresses-spacing': (addresses.externalIP && addresses.internalIPs.length) || addresses.internalIPs.length > 1}">
               <div *ngIf="!!addresses.internalIPs.length"
                    fxLayout="row"
-                   fxLayoutAlign=" center"
                    fxLayoutGap="5px">
                 <span>Int. IP:</span>
                 <div fxLayout="column">

--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -91,24 +91,34 @@ limitations under the License.
         </th>
         <td mat-cell
             *matCellDef="let element">
-          <span class="node-ip-addresses"
-                *ngIf="!!element.status.addresses && !!getAddresses(element).InternalIP">
-            Int.IP:
-            <span class="km-copy"
-                  [cbContent]="getAddresses(element).InternalIP"
-                  (click)="$event.stopPropagation()"
-                  ngxClipboard
-                  matTooltip="click to copy">{{getAddresses(element).InternalIP}}</span>
-          </span>
-          <span class="node-ip-addresses"
-                *ngIf="!!element.status.addresses && !!getAddresses(element).ExternalIP">
-            Ext.IP:
-            <span class="km-copy"
-                  [cbContent]="getAddresses(element).ExternalIP"
-                  (click)="$event.stopPropagation()"
-                  ngxClipboard
-                  matTooltip="click to copy">{{getAddresses(element).ExternalIP}}</span>
-          </span>
+          <ng-container *ngIf="element.status.addresses && getAddresses(element) as addresses">
+            <div fxLayout="column"
+                 fxLayoutGap="5px"
+                 [ngClass]="{'node-ip-addresses-spacing': (addresses.externalIP && addresses.internalIPs.length) || addresses.internalIPs.length > 1}">
+              <div *ngIf="!!addresses.internalIPs.length"
+                   fxLayout="row"
+                   fxLayoutAlign=" center"
+                   fxLayoutGap="5px">
+                <span>Int.IP:</span>
+                <div fxLayout="column">
+                  <span *ngFor="let internalIP of addresses.internalIPs"
+                        class="km-copy"
+                        [cbContent]="internalIP"
+                        (click)="$event.stopPropagation()"
+                        ngxClipboard
+                        matTooltip="click to copy">{{internalIP}}</span>
+                </div>
+              </div>
+              <div *ngIf="!!addresses.externalIP">
+                Ext.IP:
+                <span class="km-copy"
+                      [cbContent]="addresses.externalIP"
+                      (click)="$event.stopPropagation()"
+                      ngxClipboard
+                      matTooltip="click to copy">{{addresses.externalIP}}</span>
+              </div>
+            </div>
+          </ng-container>
         </td>
       </ng-container>
 

--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -93,7 +93,7 @@ limitations under the License.
                    fxLayout="row"
                    fxLayoutAlign=" center"
                    fxLayoutGap="5px">
-                <span>Int.IP:</span>
+                <span>Int. IP:</span>
                 <div fxLayout="column">
                   <span *ngFor="let internalIP of addresses.internalIPs"
                         class="km-copy"
@@ -104,7 +104,7 @@ limitations under the License.
                 </div>
               </div>
               <div *ngIf="!!addresses.externalIP">
-                Ext.IP:
+                Ext. IP:
                 <span class="km-copy"
                       [cbContent]="addresses.externalIP"
                       (click)="$event.stopPropagation()"

--- a/src/app/cluster/details/external-cluster/external-node-list/component.ts
+++ b/src/app/cluster/details/external-cluster/external-node-list/component.ts
@@ -19,7 +19,7 @@ import {MatTableDataSource} from '@angular/material/table';
 import {UserService} from '@core/services/user';
 import {ExternalCluster} from '@shared/entity/external-cluster';
 import {NodeMetrics} from '@shared/entity/metrics';
-import {Node} from '@shared/entity/node';
+import {Node, NodeIPAddress} from '@shared/entity/node';
 import {NodeUtils} from '@shared/utils/node';
 import _ from 'lodash';
 import {Subject} from 'rxjs';
@@ -87,7 +87,7 @@ export class ExternalNodeListComponent implements OnInit, OnChanges, OnDestroy {
     return NodeUtils.getFormattedNodeMemory(memory);
   }
 
-  getAddresses(node: Node): object {
+  getAddresses(node: Node): NodeIPAddress {
     return NodeUtils.getAddresses(node);
   }
 

--- a/src/app/cluster/details/external-cluster/external-node-list/style.scss
+++ b/src/app/cluster/details/external-cluster/external-node-list/style.scss
@@ -22,9 +22,10 @@
   }
 }
 
-.node-ip-addresses {
-  display: block;
-  line-height: 20px;
+
+.node-ip-addresses-spacing {
+  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
 i.km-icon-info {

--- a/src/app/cluster/details/external-cluster/external-node-list/style.scss
+++ b/src/app/cluster/details/external-cluster/external-node-list/style.scss
@@ -26,7 +26,6 @@
   }
 }
 
-
 .node-ip-addresses-spacing {
   margin-bottom: 10px;
   margin-top: 10px;

--- a/src/app/cluster/details/external-cluster/external-node-list/style.scss
+++ b/src/app/cluster/details/external-cluster/external-node-list/style.scss
@@ -20,6 +20,10 @@
       padding-left: 30px;
     }
   }
+
+  .health-status {
+    margin-top: 10px;
+  }
 }
 
 
@@ -30,12 +34,6 @@
 
 i.km-icon-info {
   margin-left: 5px;
-}
-
-.mat-column-name {
-  align-items: center;
-  display: flex;
-  height: 50px;
 }
 
 .node-details {

--- a/src/app/cluster/details/external-cluster/external-node-list/template.html
+++ b/src/app/cluster/details/external-cluster/external-node-list/template.html
@@ -76,24 +76,35 @@ limitations under the License.
         </th>
         <td mat-cell
             *matCellDef="let element">
-          <span class="node-ip-addresses"
-                *ngIf="!!element.status.addresses && !!getAddresses(element).InternalIP">
-            Int.IP:
-            <span class="km-copy"
-                  [cbContent]="getAddresses(element).InternalIP"
-                  (click)="$event.stopPropagation()"
-                  ngxClipboard
-                  matTooltip="click to copy">{{getAddresses(element).InternalIP}}</span>
-          </span>
-          <span class="node-ip-addresses"
-                *ngIf="!!element.status.addresses && !!getAddresses(element).ExternalIP">
-            Ext.IP:
-            <span class="km-copy"
-                  [cbContent]="getAddresses(element).ExternalIP"
-                  (click)="$event.stopPropagation()"
-                  ngxClipboard
-                  matTooltip="click to copy">{{getAddresses(element).ExternalIP}}</span>
-          </span>
+          <ng-container *ngIf="element.status.addresses && getAddresses(element) as addresses">
+            <div fxLayout="column"
+                 fxLayoutGap="5px"
+                 [ngClass]="{'node-ip-addresses-spacing': (addresses.externalIP && addresses.internalIPs.length) || addresses.internalIPs.length > 1}">
+              <div *ngIf="!!addresses.internalIPs.length"
+                   fxLayout="row"
+                   fxLayoutAlign=" center"
+                   fxLayoutGap="5px">
+                <span>Int.IP:</span>
+                <div fxLayout="column">
+                  <span *ngFor="let internalIP of addresses.internalIPs"
+                        class="km-copy"
+                        [cbContent]="internalIP"
+                        (click)="$event.stopPropagation()"
+                        ngxClipboard
+                        matTooltip="click to copy">{{internalIP}}</span>
+                </div>
+              </div>
+              <div *ngIf="!!addresses.externalIP">
+                Ext.IP:
+                <span class="km-copy"
+                      [cbContent]="addresses.externalIP"
+                      (click)="$event.stopPropagation()"
+                      ngxClipboard
+                      matTooltip="click to copy">{{addresses.externalIP}}</span>
+              </div>
+
+            </div>
+          </ng-container>
         </td>
       </ng-container>
 

--- a/src/app/cluster/details/external-cluster/external-node-list/template.html
+++ b/src/app/cluster/details/external-cluster/external-node-list/template.html
@@ -83,7 +83,6 @@ limitations under the License.
                  [ngClass]="{'node-ip-addresses-spacing': (addresses.externalIP && addresses.internalIPs.length) || addresses.internalIPs.length > 1}">
               <div *ngIf="!!addresses.internalIPs.length"
                    fxLayout="row"
-                   fxLayoutAlign=" center"
                    fxLayoutGap="5px">
                 <span>Int. IP:</span>
                 <div fxLayout="column">

--- a/src/app/cluster/details/external-cluster/external-node-list/template.html
+++ b/src/app/cluster/details/external-cluster/external-node-list/template.html
@@ -43,7 +43,8 @@ limitations under the License.
         <td mat-cell
             *matCellDef="let element">
           <i [matTooltip]="getNodeHealthStatus(element).message"
-             [ngClass]="getNodeHealthStatus(element).icon"></i>
+             [ngClass]="getNodeHealthStatus(element).icon"
+             class="health-status"></i>
         </td>
       </ng-container>
 

--- a/src/app/cluster/details/external-cluster/external-node-list/template.html
+++ b/src/app/cluster/details/external-cluster/external-node-list/template.html
@@ -85,7 +85,7 @@ limitations under the License.
                    fxLayout="row"
                    fxLayoutAlign=" center"
                    fxLayoutGap="5px">
-                <span>Int.IP:</span>
+                <span>Int. IP:</span>
                 <div fxLayout="column">
                   <span *ngFor="let internalIP of addresses.internalIPs"
                         class="km-copy"
@@ -96,7 +96,7 @@ limitations under the License.
                 </div>
               </div>
               <div *ngIf="!!addresses.externalIP">
-                Ext.IP:
+                Ext. IP:
                 <span class="km-copy"
                       [cbContent]="addresses.externalIP"
                       (click)="$event.stopPropagation()"

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -120,6 +120,11 @@ export class NodeAddress {
   address: string;
 }
 
+export class NodeIPAddress {
+  internalIPs: string[] = [];
+  externalIP: string;
+}
+
 export class NodeSystemInfo {
   kernelVersion: string;
   kubeletVersion: string;

--- a/src/app/shared/utils/node.ts
+++ b/src/app/shared/utils/node.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Node} from '../entity/node';
+import {Node, NodeIPAddress} from '../entity/node';
 
 export class NodeUtils {
   static getFormattedNodeMemory(memory: string): string {
@@ -38,13 +38,13 @@ export class NodeUtils {
     return nodeCapacity ? `${nodeCapacity} ${prefixes[i - 1]}` : 'unknown';
   }
 
-  static getAddresses(node: Node): object {
-    const addresses = {};
+  static getAddresses(node: Node): NodeIPAddress {
+    const addresses = new NodeIPAddress();
     for (const i in node.status.addresses) {
       if (node.status.addresses[i].type === 'InternalIP') {
-        addresses['InternalIP'] = node.status.addresses[i].address;
+        addresses.internalIPs = [...addresses.internalIPs, node.status.addresses[i].address];
       } else if (node.status.addresses[i].type === 'ExternalIP') {
-        addresses['ExternalIP'] = node.status.addresses[i].address;
+        addresses.externalIP = node.status.addresses[i].address;
       }
     }
     return addresses;


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds functionality to display multiple Internal IPs in node details of a machine deployment.

![screenshot-localhost_8000-2022 06 07-12_09_58](https://user-images.githubusercontent.com/13975988/172326597-b820bcaf-4a7a-4274-b5bb-3e4d424716e5.png)

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#4529 

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
