### PR TITLE
Remove `approved` label for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,5 @@ updates:
     labels:
       - dependencies
       - release-note-none
-      - approved
       - ok-to-test
 


### PR DESCRIPTION
Signed-off-by: Waseem Abbas <waseemabbas8261@gmail.com>

### What this PR does / why we need it
`approved` label from `dependabot.yml` has been removed so that someone from the owners list has to manually `/approve` it and PRs by dependabot are not merged automatically by just the addition of `/lgtm` label.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
