### PR TITLE
External Clusters Machine Deployment Nodes Details Fix

### DIFF
--- a/src/app/cluster/details/external-cluster/external-machine-deployment-details/component.ts
+++ b/src/app/cluster/details/external-cluster/external-machine-deployment-details/component.ts
@@ -80,9 +80,21 @@ export class ExternalMachineDeploymentDetailsComponent implements OnInit, OnDest
         switchMap(_ =>
           forkJoin([
             this._clusterService.externalMachineDeployment(this.projectID, this._clusterID, this._machineDeploymentID),
-            this._clusterService.externalClusterNodes(this.projectID, this._clusterID),
-            this._clusterService.externalClusterEvents(this.projectID, this._clusterID),
-            this._clusterService.externalClusterNodesMetrics(this.projectID, this._clusterID),
+            this._clusterService.externalMachineDeploymentNodes(
+              this.projectID,
+              this._clusterID,
+              this._machineDeploymentID
+            ),
+            this._clusterService.externalMachineDeploymentNodesEvents(
+              this.projectID,
+              this._clusterID,
+              this._machineDeploymentID
+            ),
+            this._clusterService.externalMachineDeploymentNodesMetrics(
+              this.projectID,
+              this._clusterID,
+              this._machineDeploymentID
+            ),
           ])
         )
       )

--- a/src/app/core/services/cluster.spec.ts
+++ b/src/app/core/services/cluster.spec.ts
@@ -1,0 +1,87 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
+import {TestBed} from '@angular/core/testing';
+import {lastValueFrom} from 'rxjs';
+import {MatDialogModule} from '@angular/material/dialog';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
+import {RouterTestingModule} from '@angular/router/testing';
+
+import {AppConfigService} from '@app/config.service';
+
+import {environment} from '@environments/environment';
+
+import {fakeProject} from '@test/data/project';
+import {RequestType} from '@shared/types/request-type';
+import {machineDeploymentsFake} from '@test/data/node';
+import {fakeDigitaloceanCluster} from '@test/data/cluster';
+import {AppConfigMockService} from '@test/services/app-config-mock';
+
+import {ClusterService} from './cluster';
+
+describe('ClusterService', () => {
+  let service: ClusterService;
+  let httpController: HttpTestingController;
+
+  const mockMachineDeploymentID = machineDeploymentsFake()[0].id;
+  const mockClusterID = fakeDigitaloceanCluster().id;
+  const mockProjectID = fakeProject().id;
+
+  const newRestRoot = environment.newRestRoot;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ClusterService, {provide: AppConfigService, useClass: AppConfigMockService}],
+      imports: [HttpClientTestingModule, MatDialogModule, MatSnackBarModule, RouterTestingModule],
+    });
+    httpController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(ClusterService);
+  });
+
+  afterEach(() => {
+    httpController.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should dispatch correct URL with GET request when externalMachineDeploymentNodes() is called', () => {
+    lastValueFrom(service.externalMachineDeploymentNodes(mockProjectID, mockClusterID, mockMachineDeploymentID));
+    const req = httpController.expectOne(
+      `${newRestRoot}/projects/${mockProjectID}/kubernetes/clusters/${mockClusterID}/machinedeployments/${mockMachineDeploymentID}/nodes`
+    );
+    expect(req.request.method).toBe(RequestType.GET);
+    req.flush({});
+  });
+
+  it('should dispatch correct URL with GET request when externalMachineDeploymentNodesMetrics() is called', () => {
+    lastValueFrom(service.externalMachineDeploymentNodesMetrics(mockProjectID, mockClusterID, mockMachineDeploymentID));
+    const req = httpController.expectOne(
+      `${newRestRoot}/projects/${mockProjectID}/kubernetes/clusters/${mockClusterID}/machinedeployments/${mockMachineDeploymentID}/nodes/metrics`
+    );
+    expect(req.request.method).toBe(RequestType.GET);
+    req.flush({});
+  });
+
+  it('should dispatch correct URL with GET request when externalMachineDeploymentNodesEvents() is called', () => {
+    lastValueFrom(service.externalMachineDeploymentNodesEvents(mockProjectID, mockClusterID, mockMachineDeploymentID));
+    const req = httpController.expectOne(
+      `${newRestRoot}/projects/${mockProjectID}/kubernetes/clusters/${mockClusterID}/machinedeployments/${mockMachineDeploymentID}/nodes/events`
+    );
+    expect(req.request.method).toBe(RequestType.GET);
+    req.flush({});
+  });
+});

--- a/src/app/core/services/cluster.ts
+++ b/src/app/core/services/cluster.ts
@@ -227,6 +227,15 @@ export class ClusterService {
     return this._http.get<NodeMetrics[]>(url).pipe(catchError(() => of<NodeMetrics[]>([])));
   }
 
+  externalMachineDeploymentNodesMetrics(
+    projectID: string,
+    clusterID: string,
+    machineDeploymentID: string
+  ): Observable<NodeMetrics[]> {
+    const url = `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters/${clusterID}/machinedeployments/${machineDeploymentID}/nodes/metrics`;
+    return this._http.get<NodeMetrics[]>(url).pipe(catchError(() => of<NodeMetrics[]>([])));
+  }
+
   events(projectID: string, clusterID: string): Observable<Event[]> {
     const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/events`;
     return this._http.get<Event[]>(url).pipe(catchError(() => of<Event[]>([])));
@@ -263,6 +272,15 @@ export class ClusterService {
     return this._http.get<Event[]>(url).pipe(catchError(() => of<Event[]>()));
   }
 
+  externalMachineDeploymentNodesEvents(
+    projectID: string,
+    clusterID: string,
+    machineDeploymentID: string
+  ): Observable<Event[]> {
+    const url = `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters/${clusterID}/machinedeployments/${machineDeploymentID}/nodes/events`;
+    return this._http.get<Event[]>(url).pipe(catchError(() => of<Event[]>()));
+  }
+
   externalClusterNodes(projectID: string, clusterID: string): Observable<Node[]> {
     const url = `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters/${clusterID}/nodes`;
     return this._http.get<Node[]>(url).pipe(catchError(() => of<Node[]>()));
@@ -282,6 +300,15 @@ export class ClusterService {
     return this._http
       .get<ExternalMachineDeployment>(url)
       .pipe(catchError(() => of<ExternalMachineDeployment>({} as ExternalMachineDeployment)));
+  }
+
+  externalMachineDeploymentNodes(
+    projectID: string,
+    clusterID: string,
+    machineDeploymentID: string
+  ): Observable<Node[]> {
+    const url = `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters/${clusterID}/machinedeployments/${machineDeploymentID}/nodes`;
+    return this._http.get<Node[]>(url).pipe(catchError(() => of<Node[]>()));
   }
 
   patchExternalMachineDeployment(

--- a/src/app/shared/types/request-type.ts
+++ b/src/app/shared/types/request-type.ts
@@ -1,0 +1,20 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export enum RequestType {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  PATCH = 'PATCH',
+}


### PR DESCRIPTION
### What this PR does / why we need it

Fixes bug where on the machine deployment details page the nodes where not specific to the machine deployment selected, the page was showing all the node 

`URL: https://dev.kubermatic.io/projects/<project-id>/clusters/external/<cluster-id>/md/<node-group>`

#### Before
![image](https://user-images.githubusercontent.com/56511988/172956042-ada420a1-3e01-43d1-80b5-3f92d252d06b.png)

#### After
![image](https://user-images.githubusercontent.com/56511988/172956446-353b6cd6-8080-4bf6-8064-330feaeac509.png)


### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

closes #4540 

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Bug fix: on the machine deployment details page, show the correct nodes instead of all nodes
```
