### PR TITLE
Revert `swagger-ui` version to `4.8.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "rxjs": "7.5.5",
         "rxjs-compat": "6.6.7",
         "semver": "7.3.7",
-        "swagger-ui": "4.12.0",
+        "swagger-ui": "4.8.1",
         "zone.js": "0.11.5"
       },
       "devDependencies": {
@@ -95,7 +95,8 @@
         "typescript": "4.6.4"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.15.0",
+        "npm": ">=8.5.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -23720,9 +23721,9 @@
       }
     },
     "node_modules/swagger-ui": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-4.12.0.tgz",
-      "integrity": "sha512-ffNcDTQFWu5dEzJywQ4QEcgQZlBaHaeYCjifuWePds8anzqCZXVpeJSD7RCirUs+8D051YevRSu3ZjqNUNyvrQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-4.8.1.tgz",
+      "integrity": "sha512-HUJwPHgnZakmsR9DCfaMfOMgAbALsW+kbRrkbm0carjkw7XBNigpKntmGnPw7uIcL+spcvsxt7FQ3Rraznf1uQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.16.8",
         "@braintree/sanitize-url": "=6.0.0",
@@ -23754,7 +23755,7 @@
         "reselect": "^4.1.5",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.18.5",
+        "swagger-client": "^3.18.4",
         "url-parse": "^1.5.8",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -43631,9 +43632,9 @@
       }
     },
     "swagger-ui": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-4.12.0.tgz",
-      "integrity": "sha512-ffNcDTQFWu5dEzJywQ4QEcgQZlBaHaeYCjifuWePds8anzqCZXVpeJSD7RCirUs+8D051YevRSu3ZjqNUNyvrQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui/-/swagger-ui-4.8.1.tgz",
+      "integrity": "sha512-HUJwPHgnZakmsR9DCfaMfOMgAbALsW+kbRrkbm0carjkw7XBNigpKntmGnPw7uIcL+spcvsxt7FQ3Rraznf1uQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.16.8",
         "@braintree/sanitize-url": "=6.0.0",
@@ -43665,7 +43666,7 @@
         "reselect": "^4.1.5",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.18.5",
+        "swagger-client": "^3.18.4",
         "url-parse": "^1.5.8",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "rxjs": "7.5.5",
     "rxjs-compat": "6.6.7",
     "semver": "7.3.7",
-    "swagger-ui": "4.12.0",
+    "swagger-ui": "4.8.1",
     "zone.js": "0.11.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Signed-off-by: Waseem Abbas <waseemabbas8261@gmail.com>

### What this PR does / why we need it
`swagger-ui` version was bumped to `4.12.0` which broke the swagger rest-api page so this PR reverts the version to `4.8.1`

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
