### PR TITLE
Pre-select rocky linux while editing machine deployment

### DIFF
--- a/src/app/cluster/details/cluster/machine-deployment-details/template.html
+++ b/src/app/cluster/details/cluster/machine-deployment-details/template.html
@@ -181,8 +181,8 @@ limitations under the License.
           <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rhel"
                                [value]="machineDeployment.spec.template.operatingSystem.rhel.distUpgradeOnBoot"
                                label="Upgrade system on the first boot"></km-property-boolean>
-          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockylinux"
-                               [value]="machineDeployment.spec.template.operatingSystem.rockylinux.distUpgradeOnBoot"
+          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockyLinux"
+                               [value]="machineDeployment.spec.template.operatingSystem.rockyLinux.distUpgradeOnBoot"
                                label="Upgrade system on the first boot"></km-property-boolean>
           <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.flatcar"
                                [value]="machineDeployment.spec.template.operatingSystem.flatcar.disableAutoUpdate"

--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -437,9 +437,9 @@ limitations under the License.
                                  label="Upgrade system on first boot"
                                  [value]="element.spec.operatingSystem.rhel.distUpgradeOnBoot">
             </km-property-boolean>
-            <km-property-boolean *ngIf="!!element.spec.operatingSystem.rockylinux"
+            <km-property-boolean *ngIf="!!element.spec.operatingSystem.rockyLinux"
                                  label="Upgrade system on first boot"
-                                 [value]="element.spec.operatingSystem.rockylinux.distUpgradeOnBoot">
+                                 [value]="element.spec.operatingSystem.rockyLinux.distUpgradeOnBoot">
             </km-property-boolean>
             <km-property-boolean *ngIf="element.spec.cloud.digitalocean"
                                  label="Backups"

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -54,7 +54,7 @@ export class NodeService {
     patch.spec.template.operatingSystem.ubuntu = patch.spec.template.operatingSystem.ubuntu || null;
     patch.spec.template.operatingSystem.centos = patch.spec.template.operatingSystem.centos || null;
     patch.spec.template.operatingSystem.flatcar = patch.spec.template.operatingSystem.flatcar || null;
-    patch.spec.template.operatingSystem.rockylinux = patch.spec.template.operatingSystem.rockylinux || null;
+    patch.spec.template.operatingSystem.rockyLinux = patch.spec.template.operatingSystem.rockyLinux || null;
     patch.spec.template.operatingSystem.sles = patch.spec.template.operatingSystem.sles || null;
 
     return patch;

--- a/src/app/node-data/basic/provider/nutanix/component.ts
+++ b/src/app/node-data/basic/provider/nutanix/component.ts
@@ -222,7 +222,7 @@ export class NutanixBasicNodeDataComponent extends BaseFormValidator implements 
       case OperatingSystem.Flatcar:
         return this._images?.flatcar;
       case OperatingSystem.RockyLinux:
-        return this._images?.rockylinux;
+        return this._images?.rockyLinux;
       default:
         return this._images?.ubuntu;
     }

--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -302,7 +302,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
       case OperatingSystem.Flatcar:
         return this._images.flatcar;
       case OperatingSystem.RockyLinux:
-        return this._images.rockylinux;
+        return this._images.rockyLinux;
       default:
         return this._images.ubuntu;
     }

--- a/src/app/node-data/basic/provider/vsphere/component.ts
+++ b/src/app/node-data/basic/provider/vsphere/component.ts
@@ -136,7 +136,7 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
         this._defaultTemplate = this._templates.flatcar;
         break;
       case OperatingSystem.RockyLinux:
-        this._defaultTemplate = this._templates.rockylinux;
+        this._defaultTemplate = this._templates.rockyLinux;
         break;
       default:
         this._defaultTemplate = '';
@@ -154,7 +154,7 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
       return OperatingSystem.SLES;
     } else if (this._templates.flatcar) {
       return OperatingSystem.Flatcar;
-    } else if (this._templates.rockylinux) {
+    } else if (this._templates.rockyLinux) {
       return OperatingSystem.RockyLinux;
     }
     return undefined;

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -99,7 +99,7 @@ limitations under the License.
         </mat-button-toggle>
         <mat-button-toggle [value]="OperatingSystem.RockyLinux"
                            *ngIf="isOperatingSystemSupported(OperatingSystem.RockyLinux)">
-          <i class="km-os-image-rockylinux"></i>
+          <i class="km-os-image-rockyLinux"></i>
           Rocky Linux
         </mat-button-toggle>
       </mat-button-toggle-group>

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -99,7 +99,7 @@ limitations under the License.
         </mat-button-toggle>
         <mat-button-toggle [value]="OperatingSystem.RockyLinux"
                            *ngIf="isOperatingSystemSupported(OperatingSystem.RockyLinux)">
-          <i class="km-os-image-rockyLinux"></i>
+          <i class="km-os-image-rocky-linux"></i>
           Rocky Linux
         </mat-button-toggle>
       </mat-button-toggle-group>

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -484,9 +484,9 @@ limitations under the License.
                                label="Upgrade system on the first boot"
                                [value]="machineDeployment.spec.template.operatingSystem.rhel.distUpgradeOnBoot">
           </km-property-boolean>
-          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockylinux?.distUpgradeOnBoot"
+          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockyLinux?.distUpgradeOnBoot"
                                label="Upgrade system on the first boot"
-                               [value]="machineDeployment.spec.template.operatingSystem.rockylinux.distUpgradeOnBoot">
+                               [value]="machineDeployment.spec.template.operatingSystem.rockyLinux.distUpgradeOnBoot">
           </km-property-boolean>
           <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.flatcar?.disableAutoUpdate"
                                label="Disable system auto-update"

--- a/src/app/shared/entity/datacenter.ts
+++ b/src/app/shared/entity/datacenter.ts
@@ -54,7 +54,7 @@ export class DatacenterOperatingSystemOptions {
   sles?: string;
   rhel?: string;
   flatcar?: string;
-  rockylinux?: string;
+  rockyLinux?: string;
 }
 
 export class AnexiaDatacenterSpec {

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -403,7 +403,7 @@ export function getOperatingSystemLogoClass(spec: NodeSpec): string {
   } else if (spec.operatingSystem.flatcar) {
     return 'flatcar';
   } else if (spec.operatingSystem.rockyLinux) {
-    return 'rockyLinux';
+    return 'rocky-linux';
   }
   return '';
 }

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -67,7 +67,7 @@ export class OperatingSystemSpec {
   sles?: SLESSpec;
   rhel?: RHELSpec;
   flatcar?: FlatcarSpec;
-  rockylinux?: RockyLinuxSpec;
+  rockyLinux?: RockyLinuxSpec;
 
   static getOperatingSystem(spec: OperatingSystemSpec): OperatingSystem {
     return Object.keys(spec).find(key => spec[key] !== undefined) as OperatingSystem;
@@ -385,7 +385,7 @@ export function getOperatingSystem(spec: NodeSpec): string {
     return 'RHEL';
   } else if (spec.operatingSystem.flatcar) {
     return 'Flatcar';
-  } else if (spec.operatingSystem.rockylinux) {
+  } else if (spec.operatingSystem.rockyLinux) {
     return 'Rocky Linux';
   }
   return '';
@@ -402,7 +402,7 @@ export function getOperatingSystemLogoClass(spec: NodeSpec): string {
     return 'rhel';
   } else if (spec.operatingSystem.flatcar) {
     return 'flatcar';
-  } else if (spec.operatingSystem.rockylinux) {
+  } else if (spec.operatingSystem.rockyLinux) {
     return 'rockylinux';
   }
   return '';

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -403,7 +403,7 @@ export function getOperatingSystemLogoClass(spec: NodeSpec): string {
   } else if (spec.operatingSystem.flatcar) {
     return 'flatcar';
   } else if (spec.operatingSystem.rockyLinux) {
-    return 'rockylinux';
+    return 'rockyLinux';
   }
   return '';
 }

--- a/src/app/shared/model/NodeProviderConstants.ts
+++ b/src/app/shared/model/NodeProviderConstants.ts
@@ -88,7 +88,7 @@ export namespace NodeProviderConstants {
       return OperatingSystem.RHEL;
     } else if (spec.operatingSystem.flatcar) {
       return OperatingSystem.Flatcar;
-    } else if (spec.operatingSystem.rockylinux) {
+    } else if (spec.operatingSystem.rockyLinux) {
       return OperatingSystem.RockyLinux;
     }
     return '';

--- a/src/app/shared/model/NodeProviderConstants.ts
+++ b/src/app/shared/model/NodeProviderConstants.ts
@@ -48,7 +48,7 @@ export enum OperatingSystem {
   SLES = 'sles',
   RHEL = 'rhel',
   Flatcar = 'flatcar',
-  RockyLinux = 'rockylinux',
+  RockyLinux = 'rockyLinux',
 }
 
 export namespace NodeProviderConstants {

--- a/src/assets/css/_images.scss
+++ b/src/assets/css/_images.scss
@@ -456,7 +456,7 @@
   @include mixins.background-image('/assets/images/os/flatcar.svg', 24px);
 }
 
-.km-os-image-rockylinux {
+.km-os-image-rockyLinux {
   @include mixins.background-image('/assets/images/os/rocky-linux.svg', 24px);
 }
 

--- a/src/assets/css/_images.scss
+++ b/src/assets/css/_images.scss
@@ -456,7 +456,7 @@
   @include mixins.background-image('/assets/images/os/flatcar.svg', 24px);
 }
 
-.km-os-image-rockyLinux {
+.km-os-image-rocky-linux {
   @include mixins.background-image('/assets/images/os/rocky-linux.svg', 24px);
 }
 


### PR DESCRIPTION
Signed-off-by: Talha Jamil TJ <talha.jamil@kubermatic.com>

### What this PR does / why we need it

fixes the spelling of rocky linux from "rockylinux" to "rockyLinux" in **OperatingSystem** enum

Now while editing machine deployments **Rocky Linux** will be selected by default

<img width="673" alt="image" src="https://user-images.githubusercontent.com/56511988/173573011-ccb9fa25-ddb1-4951-9fb8-4b33b047d26f.png">

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #4571 

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
NONE
```
