### PR TITLE
Add an option to specify "Operating System Profile" when creating machine deployments

### DIFF
--- a/src/app/core/services/feature-gate.ts
+++ b/src/app/core/services/feature-gate.ts
@@ -21,6 +21,7 @@ import {catchError, shareReplay, switchMap} from 'rxjs/operators';
 
 export interface FeatureGates {
   konnectivityService?: boolean;
+  operatingSystemManager?: boolean;
 }
 
 @Injectable({

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -97,6 +97,7 @@ export class NodeService {
       data: {
         initialClusterData: cluster,
         initialNodeData: {
+          operatingSystemProfile: md.annotations['k8c.io/operating-system-profile'],
           count: md.spec.replicas,
           name: md.name,
           spec: md.spec.template,

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -29,7 +29,7 @@ export class NodeService {
   private readonly _notificationService: NotificationService;
 
   private static _getMachineDeploymentEntity(nodeData: NodeData): MachineDeployment {
-    return {
+    const machineDeployment: MachineDeployment = {
       name: nodeData.name,
       spec: {
         template: nodeData.spec,
@@ -37,6 +37,12 @@ export class NodeService {
         dynamicConfig: nodeData.dynamicConfig,
       },
     };
+    if (nodeData.operatingSystemProfile) {
+      machineDeployment.annotations = {
+        'k8c.io/operating-system-profile': nodeData.operatingSystemProfile,
+      };
+    }
+    return machineDeployment;
   }
 
   private static _createPatch(data: DialogDataOutput): MachineDeploymentPatch {

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -104,7 +104,7 @@ export class NodeService {
       data: {
         initialClusterData: cluster,
         initialNodeData: {
-          operatingSystemProfile: md.annotations[OPERATING_SYSTEM_PROFILE_ANNOTATION],
+          operatingSystemProfile: md.annotations?.[OPERATING_SYSTEM_PROFILE_ANNOTATION],
           count: md.spec.replicas,
           name: md.name,
           spec: md.spec.template,

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -23,7 +23,7 @@ import {NodeData} from '@shared/model/NodeSpecChange';
 import {Observable, of} from 'rxjs';
 import {catchError, filter, mergeMap, switchMap, take} from 'rxjs/operators';
 import {MachineDeploymentService} from '@core/services/machine-deployment';
-import {OPERATING_SYSTEM_PROFILE} from '@shared/entity/machine-deployment';
+import {OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@shared/entity/machine-deployment';
 
 @Injectable()
 export class NodeService {
@@ -40,7 +40,7 @@ export class NodeService {
     };
     if (nodeData.operatingSystemProfile) {
       machineDeployment.annotations = {
-        [OPERATING_SYSTEM_PROFILE]: nodeData.operatingSystemProfile,
+        [OPERATING_SYSTEM_PROFILE_ANNOTATION]: nodeData.operatingSystemProfile,
       };
     }
     return machineDeployment;
@@ -104,7 +104,7 @@ export class NodeService {
       data: {
         initialClusterData: cluster,
         initialNodeData: {
-          operatingSystemProfile: md.annotations[OPERATING_SYSTEM_PROFILE],
+          operatingSystemProfile: md.annotations[OPERATING_SYSTEM_PROFILE_ANNOTATION],
           count: md.spec.replicas,
           name: md.name,
           spec: md.spec.template,

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -23,6 +23,7 @@ import {NodeData} from '@shared/model/NodeSpecChange';
 import {Observable, of} from 'rxjs';
 import {catchError, filter, mergeMap, switchMap, take} from 'rxjs/operators';
 import {MachineDeploymentService} from '@core/services/machine-deployment';
+import {OPERATING_SYSTEM_PROFILE} from '@shared/entity/machine-deployment';
 
 @Injectable()
 export class NodeService {
@@ -39,7 +40,7 @@ export class NodeService {
     };
     if (nodeData.operatingSystemProfile) {
       machineDeployment.annotations = {
-        'k8c.io/operating-system-profile': nodeData.operatingSystemProfile,
+        [OPERATING_SYSTEM_PROFILE]: nodeData.operatingSystemProfile,
       };
     }
     return machineDeployment;
@@ -103,7 +104,7 @@ export class NodeService {
       data: {
         initialClusterData: cluster,
         initialNodeData: {
-          operatingSystemProfile: md.annotations['k8c.io/operating-system-profile'],
+          operatingSystemProfile: md.annotations[OPERATING_SYSTEM_PROFILE],
           count: md.spec.replicas,
           name: md.name,
           spec: md.spec.template,

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -50,6 +50,7 @@ enum Controls {
   ProviderBasic = 'providerBasic',
   ProviderExtended = 'providerExtended',
   Kubelet = 'kubelet',
+  OperatingSystemProfile = 'operating system profile',
 }
 
 @Component({
@@ -118,6 +119,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
       [Controls.RhelOfflineToken]: this._builder.control(''),
       [Controls.ProviderBasic]: this._builder.control(''),
       [Controls.ProviderExtended]: this._builder.control(''),
+      [Controls.OperatingSystemProfile]: this._builder.control(this._nodeDataService.nodeData.operatingSystemProfile),
     });
 
     if (this.isDialogView()) {
@@ -151,7 +153,8 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     merge(
       this.form.get(Controls.Name).valueChanges,
       this.form.get(Controls.Count).valueChanges,
-      this.form.get(Controls.DynamicConfig).valueChanges
+      this.form.get(Controls.DynamicConfig).valueChanges,
+      this.form.get(Controls.OperatingSystemProfile).valueChanges
     )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._nodeDataService.nodeData = this._getNodeData()));
@@ -328,10 +331,14 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   }
 
   private _getNodeData(): NodeData {
-    return {
+    const nodeData: NodeData = {
       count: this.form.get(Controls.Count).value,
       name: this.form.get(Controls.Name).value,
       dynamicConfig: this.form.get(Controls.DynamicConfig).value,
-    } as NodeData;
+    };
+    if (this.form.get(Controls.OperatingSystemProfile).value) {
+      nodeData.operatingSystemProfile = this.form.get(Controls.OperatingSystemProfile).value;
+    }
+    return nodeData;
   }
 }

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -89,13 +89,13 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   get providerDisplayName(): string {
     return NodeProviderConstants.displayName(this.provider);
   }
-
-  get isDynamicKubletConfigSupported(): boolean {
-    return this._clusterSpecService.cluster.spec.version < this.endOfDynamicKubeletConfigSupportVersion;
-  }
   
   get showOperatingSystemProfile(): boolean {
     return this._clusterSpecService.cluster.spec.enableOperatingSystemManager && this.isKonnectivityEnabled;
+  }
+
+  get isDynamicKubletConfigSupported(): boolean {
+    return this._clusterSpecService.cluster.spec.version < this.endOfDynamicKubeletConfigSupportVersion;
   }
 
   constructor(

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -82,17 +82,18 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   @Input() showExtended = false;
   labels: object = {};
   taints: Taint[] = [];
-  FeatureGateOperatingSystemMangerEnabled: boolean;
+  featureGateOperatingSystemManagerEnabled: boolean;
   dialogEditMode = false;
   endOfDynamicKubeletConfigSupportVersion: string = END_OF_DYNAMIC_KUBELET_CONFIG_SUPPORT_VERSION;
 
   get providerDisplayName(): string {
     return NodeProviderConstants.displayName(this.provider);
   }
-  
+
   get showOperatingSystemProfile(): boolean {
     return (
-      this._clusterSpecService.cluster.spec.enableOperatingSystemManager && this.FeatureGateOperatingSystemMangerEnabled
+      this._clusterSpecService.cluster.spec.enableOperatingSystemManager &&
+      this.featureGateOperatingSystemManagerEnabled
     );
   }
 
@@ -189,7 +190,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
 
     this._featureGatesService.featureGates
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(featureGates => (this.FeatureGateOperatingSystemMangerEnabled = featureGates.operatingSystemManager));
+      .subscribe(featureGates => (this.featureGateOperatingSystemManagerEnabled = featureGates.operatingSystemManager));
   }
 
   ngOnDestroy(): void {

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -129,6 +129,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
 
     if (this.dialogEditMode) {
       this.form.get(Controls.Name).disable();
+      this.form.get(Controls.OperatingSystemProfile).disable();
     }
 
     this._init();

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -82,7 +82,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   @Input() showExtended = false;
   labels: object = {};
   taints: Taint[] = [];
-  isKonnectivityEnabled: boolean;
+  FeatureGateOperatingSystemMangerEnabled: boolean;
   dialogEditMode = false;
   endOfDynamicKubeletConfigSupportVersion: string = END_OF_DYNAMIC_KUBELET_CONFIG_SUPPORT_VERSION;
 
@@ -91,7 +91,9 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   }
   
   get showOperatingSystemProfile(): boolean {
-    return this._clusterSpecService.cluster.spec.enableOperatingSystemManager && this.isKonnectivityEnabled;
+    return (
+      this._clusterSpecService.cluster.spec.enableOperatingSystemManager && this.FeatureGateOperatingSystemMangerEnabled
+    );
   }
 
   get isDynamicKubletConfigSupported(): boolean {
@@ -105,7 +107,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     private readonly _datacenterService: DatacenterService,
     private readonly _nodeDataService: NodeDataService,
     private readonly _settingsService: SettingsService,
-    private readonly __featureGatesService: FeatureGateService,
+    private readonly _featureGatesService: FeatureGateService,
     private readonly _cdr: ChangeDetectorRef
   ) {
     super();
@@ -185,9 +187,9 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
       this.form.get(Controls.Count).setValue(replicas);
     });
 
-    this.__featureGatesService.featureGates
+    this._featureGatesService.featureGates
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(featureGates => (this.isKonnectivityEnabled = featureGates?.konnectivityService));
+      .subscribe(featureGates => (this.FeatureGateOperatingSystemMangerEnabled = featureGates.operatingSystemManager));
   }
 
   ngOnDestroy(): void {

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -119,7 +119,9 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
       [Controls.RhelOfflineToken]: this._builder.control(''),
       [Controls.ProviderBasic]: this._builder.control(''),
       [Controls.ProviderExtended]: this._builder.control(''),
-      [Controls.OperatingSystemProfile]: this._builder.control(this._nodeDataService.nodeData.operatingSystemProfile),
+      [Controls.OperatingSystemProfile]: this._builder.control(this._nodeDataService.nodeData.operatingSystemProfile, [
+        KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
+      ]),
     });
 
     if (this.isDialogView()) {
@@ -332,14 +334,11 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   }
 
   private _getNodeData(): NodeData {
-    const nodeData: NodeData = {
+    return {
       count: this.form.get(Controls.Count).value,
       name: this.form.get(Controls.Name).value,
       dynamicConfig: this.form.get(Controls.DynamicConfig).value,
-    };
-    if (this.form.get(Controls.OperatingSystemProfile).value) {
-      nodeData.operatingSystemProfile = this.form.get(Controls.OperatingSystemProfile).value;
-    }
-    return nodeData;
+      operatingSystemProfile: this.form.get(Controls.OperatingSystemProfile).value,
+    } as NodeData;
   }
 }

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -175,7 +175,7 @@ limitations under the License.
       <input [formControlName]="Controls.OperatingSystemProfile"
              matInput
              type="text">
-      <mat-hint *ngIf="!dialogEditMode">leave this field blanc to use default operating system profile</mat-hint>
+      <mat-hint *ngIf="!dialogEditMode">Leave this field blank to use default operating system profile</mat-hint>
       <mat-error *ngIf="form.get(Controls.OperatingSystemProfile).hasError( 'pattern')">
         OSP can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
       </mat-error>

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -175,7 +175,7 @@ limitations under the License.
       <input [formControlName]="Controls.OperatingSystemProfile"
              matInput
              type="text">
-      <mat-hint>Use this field to override the default operating system profile used for this machine deployment.</mat-hint>
+      <mat-hint *ngIf="!dialogEditMode">Use this field to override the default operating system profile used for this machine deployment.</mat-hint>
     </mat-form-field>
 
     <km-label-form [ngClass]="isDialogView() ? 'additional-margin' : ''"

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -170,6 +170,14 @@ limitations under the License.
                              [formControlName]="Controls.ProviderExtended"></km-extended-node-data>
     </div>
 
+    <mat-form-field>
+      <mat-label>Operating System Profile</mat-label>
+      <input [formControlName]="Controls.OperatingSystemProfile"
+             matInput
+             type="text">
+      <mat-hint>Use this field to override the default operating system profile used for this machine deployment.</mat-hint>
+    </mat-form-field>
+
     <km-label-form [ngClass]="isDialogView() ? 'additional-margin' : ''"
                    title="Node Labels"
                    [labels]="labels"

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -170,12 +170,12 @@ limitations under the License.
                              [formControlName]="Controls.ProviderExtended"></km-extended-node-data>
     </div>
 
-    <mat-form-field>
+    <mat-form-field *ngIf="showOperatingSystemProfile">
       <mat-label>Operating System Profile</mat-label>
       <input [formControlName]="Controls.OperatingSystemProfile"
              matInput
              type="text">
-      <mat-hint *ngIf="!dialogEditMode">Use this field to override the default operating system profile used for this machine deployment.</mat-hint>
+      <mat-hint *ngIf="!dialogEditMode">leave this field blanc to use default operating system profile</mat-hint>
       <mat-error *ngIf="form.get(Controls.OperatingSystemProfile).hasError( 'pattern')">
         OSP can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
       </mat-error>

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -175,7 +175,7 @@ limitations under the License.
       <input [formControlName]="Controls.OperatingSystemProfile"
              matInput
              type="text">
-      <mat-hint *ngIf="!dialogEditMode">Leave this field blank to use default operating system profile</mat-hint>
+      <mat-hint *ngIf="!dialogEditMode">Leave this field blank to use default operating system profile.</mat-hint>
       <mat-error *ngIf="form.get(Controls.OperatingSystemProfile).hasError( 'pattern')">
         OSP can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
       </mat-error>

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -176,6 +176,9 @@ limitations under the License.
              matInput
              type="text">
       <mat-hint *ngIf="!dialogEditMode">Use this field to override the default operating system profile used for this machine deployment.</mat-hint>
+      <mat-error *ngIf="form.get(Controls.OperatingSystemProfile).hasError( 'pattern')">
+        OSP can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
+      </mat-error>
     </mat-form-field>
 
     <km-label-form [ngClass]="isDialogView() ? 'additional-margin' : ''"

--- a/src/app/shared/components/cluster-summary/component.ts
+++ b/src/app/shared/components/cluster-summary/component.ts
@@ -24,6 +24,7 @@ import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plugin';
 import _ from 'lodash';
 import {convertArrayToObject} from '@shared/utils/common';
+import {OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@shared/entity/machine-deployment';
 
 @Component({
   selector: 'km-cluster-summary',
@@ -37,6 +38,7 @@ export class ClusterSummaryComponent {
   @Input() seedSettings: SeedSettings;
   @Input() flipLayout = false;
   @Input() showNumbering = false;
+  operatingSystemProfileAnnotation = OPERATING_SYSTEM_PROFILE_ANNOTATION;
 
   private _sshKeys: SSHKey[] = [];
 
@@ -66,6 +68,10 @@ export class ClusterSummaryComponent {
 
   get operatingSystemLogoClass(): string {
     return getOperatingSystemLogoClass(this.machineDeployment.spec.template);
+  }
+
+  get operatingSystemProfile(): string {
+    return this.machineDeployment.annotations?.[this.operatingSystemProfileAnnotation];
   }
 
   get isMLAEnabled(): boolean {

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -468,6 +468,11 @@ limitations under the License.
             </div>
           </km-property>
 
+          <km-property *ngIf="operatingSystemProfile">
+            <div key>Operating System Profile</div>
+            <div value>{{operatingSystemProfile}}</div>
+          </km-property>
+
           <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.ubuntu?.distUpgradeOnBoot"
                                label="Upgrade system on the first boot"
                                [value]="machineDeployment.spec.template.operatingSystem.ubuntu.distUpgradeOnBoot">

--- a/src/app/shared/entity/machine-deployment.ts
+++ b/src/app/shared/entity/machine-deployment.ts
@@ -58,3 +58,5 @@ export class NodeSpecPatch {
   labels?: object;
   taints?: Taint[];
 }
+
+export const OPERATING_SYSTEM_PROFILE = 'k8c.io/operating-system-profile';

--- a/src/app/shared/entity/machine-deployment.ts
+++ b/src/app/shared/entity/machine-deployment.ts
@@ -59,4 +59,4 @@ export class NodeSpecPatch {
   taints?: Taint[];
 }
 
-export const OPERATING_SYSTEM_PROFILE = 'k8c.io/operating-system-profile';
+export const OPERATING_SYSTEM_PROFILE_ANNOTATION = 'k8c.io/operating-system-profile';

--- a/src/app/shared/entity/machine-deployment.ts
+++ b/src/app/shared/entity/machine-deployment.ts
@@ -15,6 +15,7 @@
 import {NodeCloudSpec, NodeSpec, NodeVersionInfo, OperatingSystemSpec, Taint} from './node';
 
 export class MachineDeployment {
+  annotations?: object;
   creationTimestamp?: Date;
   deletionTimestamp?: Date;
   id?: string;

--- a/src/app/shared/model/NodeSpecChange.ts
+++ b/src/app/shared/model/NodeSpecChange.ts
@@ -15,6 +15,7 @@
 import {NodeCloudSpec, NodeSpec} from '../entity/node';
 
 export class NodeData {
+  operatingSystemProfile?: string;
   name?: string;
   spec?: NodeSpec;
   count?: number;

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -149,7 +149,7 @@ export class WizardComponent implements OnInit, OnDestroy {
   }
 
   private _getCreateClusterModel(cluster: Cluster, nodeData: NodeData): CreateClusterModel {
-    return {
+    const clusterModel: CreateClusterModel = {
       cluster: {
         name: cluster.name,
         labels: cluster.labels,
@@ -157,9 +157,6 @@ export class WizardComponent implements OnInit, OnDestroy {
         credential: cluster.credential,
       },
       nodeDeployment: {
-        annotations: {
-          'k8c.io/operating-system-profile': nodeData.operatingSystemProfile,
-        },
         name: nodeData.name,
         spec: {
           template: nodeData.spec,
@@ -168,6 +165,12 @@ export class WizardComponent implements OnInit, OnDestroy {
         },
       },
     };
+    if (nodeData.operatingSystemProfile) {
+      clusterModel.nodeDeployment.annotations = {
+        'k8c.io/operating-system-profile': nodeData.operatingSystemProfile,
+      };
+    }
+    return clusterModel;
   }
 
   private _initForm(steps: WizardStep[]): void {

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -157,6 +157,9 @@ export class WizardComponent implements OnInit, OnDestroy {
         credential: cluster.credential,
       },
       nodeDeployment: {
+        annotations: {
+          'k8c.io/operating-system-profile': nodeData.operatingSystemProfile,
+        },
         name: nodeData.name,
         spec: {
           template: nodeData.spec,

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -42,7 +42,7 @@ export class WizardComponent implements OnInit, OnDestroy {
   form: FormGroup;
   project = {} as Project;
   creating = false;
-  operatingSystemProfile = OPERATING_SYSTEM_PROFILE_ANNOTATION;
+  operatingSystemProfileAnnotation = OPERATING_SYSTEM_PROFILE_ANNOTATION;
   readonly stepRegistry = StepRegistry;
 
   @ViewChild('stepper', {static: true}) private readonly _stepper: MatStepper;
@@ -167,9 +167,9 @@ export class WizardComponent implements OnInit, OnDestroy {
         },
       },
     };
-    if (nodeData.operatingSystemProfile) {
+    if (nodeData.operatingSystemProfile && cluster.spec.enableOperatingSystemManager) {
       clusterModel.nodeDeployment.annotations = {
-        [this.operatingSystemProfile]: nodeData.operatingSystemProfile,
+        [this.operatingSystemProfileAnnotation]: nodeData.operatingSystemProfile,
       };
     }
     return clusterModel;

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -26,7 +26,7 @@ import {WizardService} from '@core/services/wizard/wizard';
 import {SaveClusterTemplateDialogComponent} from '@shared/components/save-cluster-template/component';
 import {Cluster, CreateClusterModel} from '@shared/entity/cluster';
 import {Project} from '@shared/entity/project';
-import {OPERATING_SYSTEM_PROFILE} from '@shared/entity/machine-deployment';
+import {OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@shared/entity/machine-deployment';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {Observable, Subject, take} from 'rxjs';
 import {filter, switchMap, takeUntil} from 'rxjs/operators';
@@ -42,7 +42,7 @@ export class WizardComponent implements OnInit, OnDestroy {
   form: FormGroup;
   project = {} as Project;
   creating = false;
-  operatingSystemProfile = OPERATING_SYSTEM_PROFILE;
+  operatingSystemProfile = OPERATING_SYSTEM_PROFILE_ANNOTATION;
   readonly stepRegistry = StepRegistry;
 
   @ViewChild('stepper', {static: true}) private readonly _stepper: MatStepper;

--- a/src/app/wizard/component.ts
+++ b/src/app/wizard/component.ts
@@ -26,6 +26,7 @@ import {WizardService} from '@core/services/wizard/wizard';
 import {SaveClusterTemplateDialogComponent} from '@shared/components/save-cluster-template/component';
 import {Cluster, CreateClusterModel} from '@shared/entity/cluster';
 import {Project} from '@shared/entity/project';
+import {OPERATING_SYSTEM_PROFILE} from '@shared/entity/machine-deployment';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {Observable, Subject, take} from 'rxjs';
 import {filter, switchMap, takeUntil} from 'rxjs/operators';
@@ -41,6 +42,7 @@ export class WizardComponent implements OnInit, OnDestroy {
   form: FormGroup;
   project = {} as Project;
   creating = false;
+  operatingSystemProfile = OPERATING_SYSTEM_PROFILE;
   readonly stepRegistry = StepRegistry;
 
   @ViewChild('stepper', {static: true}) private readonly _stepper: MatStepper;
@@ -167,7 +169,7 @@ export class WizardComponent implements OnInit, OnDestroy {
     };
     if (nodeData.operatingSystemProfile) {
       clusterModel.nodeDeployment.annotations = {
-        'k8c.io/operating-system-profile': nodeData.operatingSystemProfile,
+        [this.operatingSystemProfile]: nodeData.operatingSystemProfile,
       };
     }
     return clusterModel;

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -102,6 +102,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   masterVersions: MasterVersion[] = [];
   admissionPlugins: AdmissionPlugin[] = [];
   labels: object;
+  operatingSystemManagerEnabled: boolean;
   podNodeSelectorAdmissionPluginConfig: object;
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
   proxyMode = ProxyMode;
@@ -131,9 +132,10 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   ngOnInit(): void {
-    this._featureGatesService.featureGates
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(featureGates => (this.isKonnectivityEnabled = !!featureGates?.konnectivityService));
+    this._featureGatesService.featureGates.pipe(takeUntil(this._unsubscribe)).subscribe(featureGates => {
+      this.isKonnectivityEnabled = !!featureGates?.konnectivityService;
+      this.operatingSystemManagerEnabled = featureGates?.operatingSystemManager;
+    });
 
     this.form = this._builder.group({
       [Controls.Name]: this._builder.control('', [

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -102,7 +102,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   masterVersions: MasterVersion[] = [];
   admissionPlugins: AdmissionPlugin[] = [];
   labels: object;
-  operatingSystemManagerEnabled: boolean;
+  operatingSystemManagerFeatureEnabled: boolean;
   podNodeSelectorAdmissionPluginConfig: object;
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
   proxyMode = ProxyMode;
@@ -134,7 +134,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   ngOnInit(): void {
     this._featureGatesService.featureGates.pipe(takeUntil(this._unsubscribe)).subscribe(featureGates => {
       this.isKonnectivityEnabled = !!featureGates?.konnectivityService;
-      this.operatingSystemManagerEnabled = featureGates?.operatingSystemManager;
+      this.operatingSystemManagerFeatureEnabled = featureGates?.operatingSystemManager;
     });
 
     this.form = this._builder.group({

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -290,7 +290,7 @@ limitations under the License.
               </mat-checkbox>
             </ng-container>
 
-            <mat-checkbox *ngIf="operatingSystemManagerEnabled"
+            <mat-checkbox *ngIf="operatingSystemManagerFeatureEnabled"
                           [formControlName]="Controls.OperatingSystemManager">
               Operating System Manager
               <span class="km-label-primary">Experimental</span>

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -290,7 +290,8 @@ limitations under the License.
               </mat-checkbox>
             </ng-container>
 
-            <mat-checkbox [formControlName]="Controls.OperatingSystemManager">
+            <mat-checkbox *ngIf="operatingSystemManagerEnabled"
+                          [formControlName]="Controls.OperatingSystemManager">
               Operating System Manager
               <span class="km-label-primary">Experimental</span>
               <i class="km-icon-info km-pointer"

--- a/src/app/wizard/step/summary/component.ts
+++ b/src/app/wizard/step/summary/component.ts
@@ -22,6 +22,7 @@ import {SSHKey} from '@shared/entity/ssh-key';
 import {Subject} from 'rxjs';
 import {take, switchMap, takeUntil, tap} from 'rxjs/operators';
 import {MachineDeployment} from '@shared/entity/machine-deployment';
+import {OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@shared/entity/machine-deployment';
 
 @Component({
   selector: 'km-wizard-summary-step',
@@ -63,7 +64,7 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
 
   get machineDeployment(): MachineDeployment {
     const data = this._nodeDataService.nodeData;
-    return {
+    const md: MachineDeployment = {
       name: data.name,
       spec: {
         template: data.spec,
@@ -71,6 +72,12 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
         dynamicConfig: data.dynamicConfig,
       },
     };
+    if (data.operatingSystemProfile && this._clusterSpecService.cluster.spec.enableOperatingSystemManager) {
+      md.annotations = {
+        [OPERATING_SYSTEM_PROFILE_ANNOTATION]: data.operatingSystemProfile,
+      };
+    }
+    return md;
   }
 
   get sshKeys(): string[] {


### PR DESCRIPTION
### What this PR does / why we need it
adding new field to add operating system profile when creating new MD  
### Which issue(s) this PR fixes
"closes #4580"

```release-note
Allow the user to specify the operating system profile when creating machine deployment.
```
