### PR TITLE
update to Go 1.18

### DIFF
--- a/.prow/build-image.yaml
+++ b/.prow/build-image.yaml
@@ -22,7 +22,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           imagePullPolicy: Always
           command:
             - /bin/bash
@@ -50,7 +50,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           imagePullPolicy: Always
           command:
             - /bin/bash

--- a/.prow/tests-e2e.yaml
+++ b/.prow/tests-e2e.yaml
@@ -44,7 +44,7 @@ presubmits:
       preset-scratch-tmpfs: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.2.0
+        - image: quay.io/kubermatic/chrome-headless:v1.3.0
           imagePullPolicy: Always
           command:
             - make
@@ -100,7 +100,7 @@ presubmits:
       preset-scratch-tmpfs: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.2.0
+        - image: quay.io/kubermatic/chrome-headless:v1.3.0
           imagePullPolicy: Always
           command:
             - make
@@ -136,7 +136,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.2.0
+        - image: quay.io/kubermatic/chrome-headless:v1.3.0
           imagePullPolicy: Always
           command:
             - make
@@ -165,7 +165,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.2.0
+        - image: quay.io/kubermatic/chrome-headless:v1.3.0
           imagePullPolicy: Always
           command:
             - make

--- a/.prow/tests-unit.yaml
+++ b/.prow/tests-unit.yaml
@@ -20,7 +20,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.2.0
+        - image: quay.io/kubermatic/chrome-headless:v1.3.0
           command:
             - make
             - test-headless

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic-labs/boilerplate:v0.2.0
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           command:
             - ./hack/verify-boilerplate.sh
           resources:
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           command:
             - make
             - verify-go
@@ -51,7 +51,7 @@ presubmits:
     clone_uri: 'ssh://git@github.com/kubermatic/dashboard.git'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
           command:
             - make
             - check

--- a/containers/chrome-headless/Dockerfile
+++ b/containers/chrome-headless/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.17-node-16-kind-0.12-8
+FROM quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
 
 LABEL maintainer="support@kubermatic.com"
 

--- a/containers/chrome-headless/release.sh
+++ b/containers/chrome-headless/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v1.2.0
+TAG=v1.3.0
 
 set -euo pipefail
 

--- a/containers/custom-dashboard/Dockerfile
+++ b/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-1
+FROM quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-7
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci


### PR DESCRIPTION
### What this PR does / why we need it
This simply updates all build related things from Go 1.17 to Go 1.18. As the dashboard is 99% client-side, this should not have a noticable effect.

### Release note
```release-note
Update to Go 1.18
```
