### PR TITLE
allow arbitrary cluster names

### DIFF
--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -40,7 +40,6 @@ import {Observable, Subject} from 'rxjs';
 import {startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import * as semver from 'semver';
 import {FeatureGateService} from '@core/services/feature-gate';
-import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 
 enum Controls {
   Name = 'name',
@@ -110,7 +109,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.Name]: new FormControl(this.cluster.name, [
         Validators.required,
         Validators.minLength(this._nameMinLen),
-        KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
       ]),
       [Controls.ContainerRuntime]: new FormControl(this.cluster.spec.containerRuntime || ContainerRuntime.Containerd, [
         Validators.required,

--- a/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -36,9 +36,6 @@ limitations under the License.
         <mat-error *ngIf="form.get(Controls.Name).hasError('minlength')">
           Name must be at least {{form.get(Controls.Name).getError('minlength').requiredLength}} characters.
         </mat-error>
-        <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
-          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
-        </mat-error>
       </mat-form-field>
 
       <mat-form-field class="km-dropdown-with-suffix"

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -46,7 +46,7 @@ limitations under the License.
         <i class="km-icon-randomize"></i>
       </button>
       <mat-hint *ngIf="!dialogEditMode">Leave this field blank to use automatic name generation.</mat-hint>
-      <mat-error *ngIf="form.get(Controls.Name).hasError( 'pattern')">
+      <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
         Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
       </mat-error>
     </mat-form-field>

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -21,7 +21,6 @@ import {
   Validator,
   Validators,
 } from '@angular/forms';
-import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 import {ClusterService} from '@core/services/cluster';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {DatacenterService} from '@core/services/datacenter';
@@ -139,7 +138,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.Name]: this._builder.control('', [
         Validators.required,
         Validators.minLength(this._minNameLength),
-        KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
       ]),
       [Controls.Version]: this._builder.control('', [Validators.required]),
       [Controls.ContainerRuntime]: this._builder.control(ContainerRuntime.Containerd, [Validators.required]),

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -47,9 +47,6 @@ limitations under the License.
         <mat-error *ngIf="form.get(Controls.Name).hasError('minlength')">
           Name must be at least {{ control(Controls.Name).getError('minlength').requiredLength }} characters.
         </mat-error>
-        <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
-          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
-        </mat-error>
       </mat-form-field>
 
       <mat-card-header class="km-no-padding">


### PR DESCRIPTION
### What this PR does / why we need it
There is no technical reason to restrict the human readable name for clusters. Those names are only used for display purposes, so this PR simply removes the pattern validation for them.

### Which issue(s) this PR fixes
Fixes https://github.com/kubermatic/kubermatic/issues/6190

### Release note
```release-note
Allow arbitrary human readable cluster names
```
