### PR TITLE
Remove IPv6 control for DigitalOcean cloud provider

### DIFF
--- a/cypress/fixtures/digitalocean/machinedeployment.json
+++ b/cypress/fixtures/digitalocean/machinedeployment.json
@@ -12,7 +12,6 @@
         "digitalocean": {
           "size": "s-2vcpu-2gb",
           "backups": false,
-          "ipv6": false,
           "monitoring": false,
           "tags": [
             "kubernetes",

--- a/cypress/fixtures/digitalocean/machinedeployments.json
+++ b/cypress/fixtures/digitalocean/machinedeployments.json
@@ -13,7 +13,6 @@
           "digitalocean": {
             "size": "s-2vcpu-2gb",
             "backups": false,
-            "ipv6": false,
             "monitoring": false,
             "tags": [
               "kubernetes",

--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -446,10 +446,6 @@ limitations under the License.
                                  [value]="element.spec.cloud.digitalocean.backups">
             </km-property-boolean>
             <km-property-boolean *ngIf="element.spec.cloud.digitalocean"
-                                 label="IPv6"
-                                 [value]="element.spec.cloud.digitalocean.ipv6">
-            </km-property-boolean>
-            <km-property-boolean *ngIf="element.spec.cloud.digitalocean"
                                  label="Monitoring"
                                  [value]="element.spec.cloud.digitalocean.monitoring">
             </km-property-boolean>

--- a/src/app/node-data/extended/provider/digitalocean/component.ts
+++ b/src/app/node-data/extended/provider/digitalocean/component.ts
@@ -23,7 +23,6 @@ import {BaseFormValidator} from '@shared/validators/base-form.validator';
 
 enum Controls {
   Backups = 'backups',
-  IPv6 = 'ipv6',
   Monitoring = 'monitoring',
   Tags = 'tags',
 }
@@ -61,7 +60,6 @@ export class DigitalOceanExtendedNodeDataComponent extends BaseFormValidator imp
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.Backups]: this._builder.control(false),
-      [Controls.IPv6]: this._builder.control(false),
       [Controls.Monitoring]: this._builder.control(false),
       [Controls.Tags]: this._builder.control(''),
     });
@@ -69,11 +67,7 @@ export class DigitalOceanExtendedNodeDataComponent extends BaseFormValidator imp
     this._init();
     this._nodeDataService.nodeData = this._getNodeData();
 
-    merge(
-      this.form.get(Controls.Backups).valueChanges,
-      this.form.get(Controls.IPv6).valueChanges,
-      this.form.get(Controls.Monitoring).valueChanges
-    )
+    merge(this.form.get(Controls.Backups).valueChanges, this.form.get(Controls.Monitoring).valueChanges)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._nodeDataService.nodeData = this._getNodeData()));
   }
@@ -89,7 +83,6 @@ export class DigitalOceanExtendedNodeDataComponent extends BaseFormValidator imp
         cloud: {
           digitalocean: {
             backups: this.form.get(Controls.Backups).value,
-            ipv6: this.form.get(Controls.IPv6).value,
             monitoring: this.form.get(Controls.Monitoring).value,
           },
         } as NodeCloudSpec,
@@ -107,7 +100,6 @@ export class DigitalOceanExtendedNodeDataComponent extends BaseFormValidator imp
       this.onTagsChange(this._nodeDataService.nodeData.spec.cloud.digitalocean.tags);
 
       this.form.get(Controls.Backups).setValue(this.nodeData.spec.cloud.digitalocean.backups);
-      this.form.get(Controls.IPv6).setValue(this.nodeData.spec.cloud.digitalocean.ipv6);
       this.form.get(Controls.Monitoring).setValue(this.nodeData.spec.cloud.digitalocean.monitoring);
     }
   }

--- a/src/app/node-data/extended/provider/digitalocean/template.html
+++ b/src/app/node-data/extended/provider/digitalocean/template.html
@@ -25,10 +25,6 @@ limitations under the License.
                 [formControlName]="Controls.Monitoring"
                 fxFlex>Monitoring</mat-checkbox>
 
-  <mat-checkbox id="ipv6"
-                [formControlName]="Controls.IPv6"
-                fxFlex>IPv6</mat-checkbox>
-
   <km-chip-list class="tag-list"
                 title="Provider Tags"
                 [tags]="tags"

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -831,10 +831,6 @@ limitations under the License.
                                    label="Monitoring"
                                    [value]="machineDeployment.spec.template.cloud?.digitalocean?.monitoring">
               </km-property-boolean>
-              <km-property-boolean *ngIf="machineDeployment.spec.template.cloud?.digitalocean?.ipv6"
-                                   label="IPv6"
-                                   [value]="machineDeployment.spec.template.cloud?.digitalocean?.ipv6">
-              </km-property-boolean>
             </ng-container>
 
             <!-- GCP Node Options -->

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -184,7 +184,6 @@ export class AzureNodeSpec {
 export class DigitaloceanNodeSpec {
   size: string;
   backups: boolean;
-  ipv6: boolean;
   monitoring: boolean;
   tags: string[];
 }
@@ -281,7 +280,6 @@ export function getDefaultNodeProviderSpec(provider: string): object {
       return {
         size: '',
         backups: false,
-        ipv6: false,
         monitoring: false,
         tags: [],
       } as DigitaloceanNodeSpec;

--- a/src/test/data/node.ts
+++ b/src/test/data/node.ts
@@ -26,7 +26,6 @@ export function nodeFake(): Node {
         digitalocean: {
           size: 's-1vcpu-1gb',
           backups: false,
-          ipv6: false,
           monitoring: false,
           tags: [],
         },
@@ -139,7 +138,6 @@ export function machineDeploymentsFake(): MachineDeployment[] {
             digitalocean: {
               size: '4gb',
               backups: null,
-              ipv6: null,
               monitoring: null,
               tags: null,
             },
@@ -169,7 +167,6 @@ export function machineDeploymentsFake(): MachineDeployment[] {
             digitalocean: {
               size: '2gb',
               backups: null,
-              ipv6: null,
               monitoring: null,
               tags: null,
             },
@@ -199,7 +196,6 @@ export function nodesFake(): Node[] {
           digitalocean: {
             size: '4gb',
             backups: null,
-            ipv6: null,
             monitoring: null,
             tags: null,
           },
@@ -253,7 +249,6 @@ export function nodesFake(): Node[] {
           digitalocean: {
             size: 's-1vcpu-1gb',
             backups: false,
-            ipv6: false,
             monitoring: false,
             tags: [],
           },


### PR DESCRIPTION
### What this PR does / why we need it
This PR removes IPv6 control from extended settings of DigitalOcean cloud provider in create cluster wizard and edit cluster dialog.

![172796580-fddf2ad0-e38a-482a-9a66-e0156070c175](https://user-images.githubusercontent.com/13975988/175012146-05ed8327-f025-4b43-a176-042feac7b49f.png)


### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
#4566 

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
DigitalOcean: Option to configure IPv6 has been removed from node settings since it can now be configured using dual-stack network configuration in cluster creation wizard.
```
