### PR TITLE
kubelet version selector fallback case fix

### DIFF
--- a/src/app/node-data/kubelet-version/component.ts
+++ b/src/app/node-data/kubelet-version/component.ts
@@ -102,7 +102,7 @@ export class KubeletVersionNodeDataComponent extends BaseFormValidator implement
     }
 
     // As a fallback simply use the newest version available
-    this.form.get(Controls.Kubelet).setValue(this.versions.pop());
+    this.form.get(Controls.Kubelet).setValue(this.versions[this.versions.length - 1]);
   }
 
   private _getNodeDataVersionInfo(version: string): NodeData {


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <olaf.klischat@gmail.com>

### What this PR does / why we need it

One-line fix for the Kubelet version selector dropdown component. In the fallback case, i.e. when the list of possible kubelet upgrade versions from the API contains neither the current ("selected") Kubelet version nor the current control plane version of the cluster, the code is supposed to just select the last one of the list of possible Kubelet upgrade versions. It does this by doing `control.setValue(versions.pop())`. versions.pop() however removes the last element from the list, resulting in a selector that's empty by default and is just missing the last (newest) upgrade version in the dropdown. This PR fixes this to `control.setValue(versions[versions.length - 1])`.

Example with this.versions == ["1.19.12", "1.20.14", "1.21.8"], clusterVersion == "1.21.3", this.selected == "1.21.3" --

without the fix:

![image](https://user-images.githubusercontent.com/283179/175369723-8da5f908-e9e7-4443-b0ab-553cd3303b24.png)

with the fix:

![image](https://user-images.githubusercontent.com/283179/175370232-0acf85df-0912-4184-a222-220c7bb09d09.png)

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
Fixed empty default selection in fallback case of Kubelet version selector
```
