### PR TITLE
Filter subnets and VPCs when dual-stack network is selected for AWS cloud provider

### DIFF
--- a/src/app/node-data/basic/provider/aws/component.ts
+++ b/src/app/node-data/basic/provider/aws/component.ts
@@ -186,6 +186,7 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
   }
 
   onSubnetChange(subnet: string): void {
+    this.selectedSubnet = subnet;
     this._nodeDataService.nodeData.spec.cloud.aws.subnetID = subnet;
     this._nodeDataService.nodeData.spec.cloud.aws.availabilityZone = this._getAZFromSubnet(subnet);
     this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
@@ -263,6 +264,10 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
     this._subnets = subnets;
     this._subnetMap = {};
     this.selectedSubnet = this._nodeDataService.nodeData.spec.cloud.aws.subnetID;
+
+    if (this._subnets.length && !this._subnets.find(subnet => subnet.id === this.selectedSubnet)) {
+      this.selectedSubnet = '';
+    }
 
     if (!this.selectedSubnet && this._subnets.length > 0) {
       const defaultSubnet = this._subnets.find(s => s.isDefaultSubnet);


### PR DESCRIPTION
### What this PR does / why we need it
Only list subnets and VPCs that support IPv6 when dual-stack networking is enabled for AWS.

### Which issue(s) this PR fixes
<!--
Use one of the GitHub's keywords to link connected Issues/PRs.
Keyword list: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Closes #4474 

### Special notes for your reviewer
<!-- Remove if not needed -->

### Release note
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just leave "NONE".
-->
```release-note
AWS: Only list subnets and VPCs that support IPv6 when dual-stack networking is enabled.
```
