### PR TITLE
Fix default values of CIDR mask size controls

### DIFF
--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -195,8 +195,8 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         IPV6_CIDR_PATTERN_VALIDATOR,
         this._dualStackRequiredIfValidator(Controls.IPv4AllowedIPRange),
       ]),
-      [Controls.IPv4CIDRMaskSize]: this._builder.control(''),
-      [Controls.IPv6CIDRMaskSize]: this._builder.control(''),
+      [Controls.IPv4CIDRMaskSize]: this._builder.control(null),
+      [Controls.IPv6CIDRMaskSize]: this._builder.control(null),
       [Controls.NodeLocalDNSCache]: this._builder.control(false),
     });
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Default values of IPv4 and IPv6 CIDR mask size controls is set to `null` so that form control is not invalid.

**Special notes for your reviewer**:
If value is set to `''` for `number-stepper` component then this is considered an invalid value so form becomes invalid. In order to fix this, value needs to be either `null`/`undefined` or a valid number.

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

