### PR TITLE
Create External Cluster AKS

### DIFF
--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -202,7 +202,7 @@ export class ExternalClusterService {
   }
 
   getGKEZones(): Observable<GKEZone[]> {
-    const url = `${this._newRestRoot}//providers/gke/zones`;
+    const url = `${this._newRestRoot}/providers/gke/zones`;
     return this._http.get<GKEZone[]>(url, {headers: this._getGKEHeaders()}).pipe(catchError(() => of<[]>()));
   }
 

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -14,6 +14,7 @@
 
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
+import {environment} from '@environments/environment';
 import {AKSCluster} from '@shared/entity/provider/aks';
 import {EKSCluster, EKSVpc} from '@shared/entity/provider/eks';
 import {GKECluster, GKEZone} from '@shared/entity/provider/gke';
@@ -21,7 +22,6 @@ import {ExternalCluster, ExternalClusterModel, ExternalClusterProvider} from '@s
 import {PresetList} from '@shared/entity/preset';
 import {BehaviorSubject, Observable, of, throwError} from 'rxjs';
 import {catchError} from 'rxjs/operators';
-import {environment} from '@environments/environment';
 
 @Injectable({providedIn: 'root'})
 export class ExternalClusterService {
@@ -196,6 +196,11 @@ export class ExternalClusterService {
     this.isClusterDetailsStepValid = false;
   }
 
+  getAKSVmSizes(location?: string): Observable<string[]> {
+    const url = `${this._newRestRoot}/providers/aks/vmsizes`;
+    return this._http.get<string[]>(url, {headers: this._getAKSHeaders(location)}).pipe(catchError(() => of<[]>()));
+  }
+
   getGKEZones(): Observable<GKEZone[]> {
     const url = `${this._newRestRoot}//providers/gke/zones`;
     return this._http.get<GKEZone[]>(url, {headers: this._getGKEHeaders()}).pipe(catchError(() => of<[]>()));
@@ -223,6 +228,9 @@ export class ExternalClusterService {
 
     let headers: HttpHeaders;
     switch (this.provider) {
+      case ExternalClusterProvider.AKS:
+        headers = this._getAKSHeaders();
+        break;
       case ExternalClusterProvider.EKS:
         headers = this._getEKSHeaders();
         break;
@@ -236,17 +244,29 @@ export class ExternalClusterService {
     return this._http.post<ExternalCluster>(url, externalClusterModel, {headers}).pipe(catchError(() => of<null>()));
   }
 
-  private _getAKSHeaders(): HttpHeaders {
+  private _getAKSHeaders(location?: string): HttpHeaders {
+    let headers = {};
     if (this._preset) {
-      return new HttpHeaders({Credential: this._preset});
+      headers = {Credential: this._preset};
+      if (location) {
+        headers = {Credential: this._preset, Location: location};
+        return new HttpHeaders(headers);
+      }
+      return new HttpHeaders(headers);
     }
 
-    return new HttpHeaders({
+    headers = {
       TenantID: this._externalCluster.cloud.aks.tenantID,
       SubscriptionID: this._externalCluster.cloud.aks.subscriptionID,
       ClientID: this._externalCluster.cloud.aks.clientID,
       ClientSecret: this._externalCluster.cloud.aks.clientSecret,
-    });
+    };
+
+    if (location) {
+      headers['Location'] = location;
+    }
+
+    return new HttpHeaders(headers);
   }
 
   private _getEKSHeaders(vpcId?: string): HttpHeaders {

--- a/src/app/external-cluster-wizard/component.ts
+++ b/src/app/external-cluster-wizard/component.ts
@@ -35,7 +35,7 @@ import {ExternalClusterWizardStep, StepRegistry, WizardSteps} from './config';
 export class ExternalClusterWizardComponent implements OnInit, OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
   readonly stepRegistry = StepRegistry;
-  readonly externalProviders = [ExternalClusterProvider.EKS, ExternalClusterProvider.GKE];
+  readonly externalProviders = [ExternalClusterProvider.AKS, ExternalClusterProvider.EKS, ExternalClusterProvider.GKE];
   form: FormGroup;
   project = {} as Project;
 
@@ -74,6 +74,7 @@ export class ExternalClusterWizardComponent implements OnInit, OnDestroy {
         return !this._externalClusterService.isCredentialsStepValid;
       case StepRegistry.ExternalClusterDetails:
         if (
+          this.selectedProvider === ExternalClusterProvider.AKS ||
           this.selectedProvider === ExternalClusterProvider.EKS ||
           this.selectedProvider === ExternalClusterProvider.GKE
         ) {

--- a/src/app/external-cluster-wizard/module.ts
+++ b/src/app/external-cluster-wizard/module.ts
@@ -20,6 +20,7 @@ import {NodeDataModule} from '../node-data/module';
 import {ExternalClusterWizardComponent} from './component';
 import {ExternalClusterStepComponent} from '@app/external-cluster-wizard/steps/external-cluster/component';
 import {EKSClusterSettingsComponent} from '@app/external-cluster-wizard/steps/external-cluster/provider/eks/component';
+import {AKSClusterSettingsComponent} from '@app/external-cluster-wizard/steps/external-cluster/provider/aks/component';
 import {GKEClusterSettingsComponent} from '@app/external-cluster-wizard/steps/external-cluster/provider/gke/component';
 import {ExternalClusterWizardService} from '@core/services/external-cluster-wizard/external-cluster-wizard';
 
@@ -27,6 +28,7 @@ const components = [
   ExternalClusterWizardComponent,
   ExternalClusterStepComponent,
   EKSClusterSettingsComponent,
+  AKSClusterSettingsComponent,
   GKEClusterSettingsComponent,
 ];
 

--- a/src/app/external-cluster-wizard/steps/external-cluster/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/component.ts
@@ -20,6 +20,7 @@ import {filter, takeUntil} from 'rxjs/operators';
 import {StepBase} from '../base';
 
 enum Controls {
+  AKSExternalCluster = 'AKSExternalCluster',
   EKSExternalCluster = 'EKSExternalCluster',
   GKEExternalCluster = 'GKEExternalCluster',
 }
@@ -69,6 +70,7 @@ export class ExternalClusterStepComponent
 
   private _initForm() {
     this.form = this._builder.group({
+      [Controls.AKSExternalCluster]: this._builder.control(''),
       [Controls.EKSExternalCluster]: this._builder.control(''),
       [Controls.GKEExternalCluster]: this._builder.control(''),
     });

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -1,0 +1,213 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import {Component, forwardRef, Input, OnDestroy, OnInit} from '@angular/core';
+import {
+  ControlValueAccessor,
+  FormBuilder,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  Validator,
+  Validators,
+} from '@angular/forms';
+import {MatCheckboxChange} from '@angular/material/checkbox';
+import {StepBase} from '@app/external-cluster-wizard/steps/base';
+import {ExternalClusterService} from '@core/services/external-cluster';
+import {NameGeneratorService} from '@core/services/name-generator';
+import {ErrorType} from '@shared/types/error-type';
+import {Observable} from 'rxjs';
+import {debounceTime, finalize, switchMap, takeUntil} from 'rxjs/operators';
+import {ExternalCloudSpec, ExternalClusterModel, ExternalClusterSpec} from '@shared/entity/external-cluster';
+import {
+  AgentPoolBasics,
+  AKSCloudSpec,
+  AKSClusterSpec,
+  AKSMachineDeploymentCloudSpec,
+  AKSNodegroupScalingConfig,
+} from '@shared/entity/provider/aks';
+import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
+
+enum Controls {
+  Name = 'name',
+  Location = 'location',
+  KubernetesVersion = 'kubernetesVersion',
+  NodeResourceGroup = 'nodeResourceGroup',
+  NodePoolName = 'nodePoolName',
+  Count = 'count',
+  VmSize = 'vmSize',
+  Mode = 'mode',
+  EnableAutoScaling = 'enableAutoScaling',
+  MaxCount = 'maxCount',
+  MinCount = 'minCount',
+}
+
+@Component({
+  selector: 'km-aks-cluster-settings',
+  templateUrl: './template.html',
+  styleUrls: ['./style.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => AKSClusterSettingsComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => AKSClusterSettingsComponent),
+      multi: true,
+    },
+  ],
+})
+export class AKSClusterSettingsComponent
+  extends StepBase
+  implements OnInit, OnDestroy, ControlValueAccessor, Validator
+{
+  readonly Controls = Controls;
+  readonly ErrorType = ErrorType;
+  readonly AUTOSCALING_MIN_VALUE = 1;
+  readonly AUTOSCALING_MAX_VALUE = 1000;
+
+  isLoadingVmSizes: boolean;
+  vmSizes: string[] = [];
+
+  @Input() projectID: string;
+
+  private readonly _debounceTime = 500;
+
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _externalClusterService: ExternalClusterService,
+    private readonly _nameGenerator: NameGeneratorService
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this._initForm();
+    this._initSubscriptions();
+  }
+
+  ngOnDestroy(): void {
+    this.reset();
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  generateName(): void {
+    this.control(Controls.Name).setValue(this._nameGenerator.generateName());
+  }
+
+  onEnableAutoScalingChange(evt: MatCheckboxChange) {
+    if (!evt.checked) {
+      this.form.patchValue({
+        [Controls.MaxCount]: null,
+        [Controls.MinCount]: null,
+      });
+
+      this.control(Controls.MaxCount).clearValidators();
+      this.control(Controls.MaxCount).updateValueAndValidity();
+      this.control(Controls.MinCount).clearValidators();
+      this.control(Controls.MinCount).updateValueAndValidity();
+    }
+  }
+
+  private _initForm(): void {
+    const MIN_COUNT_DEFAULT_VALUE = 1;
+    const MAX_COUNT_DEFAULT_VALUE = 5;
+    const DEFAULT_MODE = 'System';
+
+    this.form = this._builder.group({
+      [Controls.Name]: this._builder.control('', [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]),
+      [Controls.Location]: this._builder.control('', Validators.required),
+      [Controls.NodeResourceGroup]: this._builder.control('', Validators.required),
+      [Controls.KubernetesVersion]: this._builder.control('', Validators.required),
+      [Controls.NodePoolName]: this._builder.control('', Validators.required),
+      [Controls.Count]: this._builder.control(1, Validators.required),
+      [Controls.VmSize]: this._builder.control('', Validators.required),
+      [Controls.Mode]: this._builder.control(DEFAULT_MODE),
+      [Controls.EnableAutoScaling]: this._builder.control(true),
+      [Controls.MaxCount]: this._builder.control(MAX_COUNT_DEFAULT_VALUE, [
+        Validators.required,
+        Validators.max(this.AUTOSCALING_MAX_VALUE),
+      ]),
+      [Controls.MinCount]: this._builder.control(MIN_COUNT_DEFAULT_VALUE, [
+        Validators.required,
+        Validators.min(this.AUTOSCALING_MIN_VALUE),
+      ]),
+    });
+
+    this.control(Controls.Mode).disable();
+  }
+
+  private _initSubscriptions(): void {
+    this.form.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => {
+      this._updateExternalClusterModel();
+      this._externalClusterService.isClusterDetailsStepValid = this.form.valid;
+    });
+
+    this.control(Controls.Location)
+      .valueChanges.pipe(debounceTime(this._debounceTime))
+      .pipe(switchMap(location => this._getAKSVmSizes(location)))
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe((vmSizes: string[]) => {
+        this.vmSizes = vmSizes;
+      });
+  }
+
+  private _getAKSVmSizes(location?: string): Observable<string[]> {
+    this.isLoadingVmSizes = true;
+    return this._externalClusterService.getAKSVmSizes(location).pipe(
+      takeUntil(this._unsubscribe),
+      finalize(() => (this.isLoadingVmSizes = false))
+    );
+  }
+
+  private _updateExternalClusterModel(): void {
+    const config = {
+      name: this.controlValue(Controls.Name),
+      cloud: {
+        aks: {
+          ...this._externalClusterService.externalCluster.cloud.aks,
+          name: this.controlValue(Controls.Name),
+          resourceGroup: this.controlValue(Controls.NodeResourceGroup),
+        } as AKSCloudSpec,
+      } as ExternalCloudSpec,
+      spec: {
+        aksclusterSpec: {
+          kubernetesVersion: this.controlValue(Controls.KubernetesVersion),
+          location: this.controlValue(Controls.Location),
+          machineDeploymentSpec: {
+            name: this.controlValue(Controls.NodePoolName),
+            basicSettings: {
+              mode: this.controlValue(Controls.Mode),
+              vmSize: this.controlValue(Controls.VmSize)?.main,
+              count: this.controlValue(Controls.Count),
+              enableAutoScaling: this.controlValue(Controls.EnableAutoScaling),
+            } as AgentPoolBasics,
+          } as AKSMachineDeploymentCloudSpec,
+        } as AKSClusterSpec,
+        version: this.controlValue(Controls.KubernetesVersion),
+      } as ExternalClusterSpec,
+    } as ExternalClusterModel;
+
+    if (this.controlValue(Controls.EnableAutoScaling)) {
+      config.spec.aksclusterSpec.machineDeploymentSpec.basicSettings.scalingConfig = {
+        maxCount: this.controlValue(Controls.MaxCount),
+        minCount: this.controlValue(Controls.MinCount),
+      } as AKSNodegroupScalingConfig;
+    } else {
+      delete config.spec.aksclusterSpec?.machineDeploymentSpec?.basicSettings.scalingConfig;
+    }
+    this._externalClusterService.externalCluster = config;
+  }
+}

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/style.scss
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/style.scss
@@ -1,0 +1,58 @@
+// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@use 'variables';
+
+.edit-cluster-form {
+  margin-bottom: 30px;
+}
+
+km-label-form:not(.pod-node-selector-config) {
+  margin-top: 30px;
+}
+
+mat-checkbox {
+  i {
+    margin: 4px 8px;
+  }
+}
+
+mat-button-toggle-group[group='auditLogging'] {
+  margin: 0 10px;
+
+  mat-button-toggle {
+    margin: 0 0 0 -1px;
+    max-height: 28px;
+    min-height: 28px;
+    min-width: unset;
+
+    &.mat-button-toggle-checked {
+      z-index: 1;
+    }
+
+    &:not(:first-of-type),
+    &:not(:last-of-type) {
+      border-radius: 0;
+    }
+
+    &:first-of-type {
+      border-radius: variables.$border-radius 0 0 variables.$border-radius;
+      margin: 0;
+    }
+
+    &:last-of-type {
+      border-radius: 0 variables.$border-radius variables.$border-radius 0;
+    }
+  }
+}

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/style.scss
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/style.scss
@@ -1,4 +1,4 @@
-// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,47 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@use 'variables';
-
-.edit-cluster-form {
-  margin-bottom: 30px;
-}
-
-km-label-form:not(.pod-node-selector-config) {
-  margin-top: 30px;
-}
-
 mat-checkbox {
   i {
     margin: 4px 8px;
-  }
-}
-
-mat-button-toggle-group[group='auditLogging'] {
-  margin: 0 10px;
-
-  mat-button-toggle {
-    margin: 0 0 0 -1px;
-    max-height: 28px;
-    min-height: 28px;
-    min-width: unset;
-
-    &.mat-button-toggle-checked {
-      z-index: 1;
-    }
-
-    &:not(:first-of-type),
-    &:not(:last-of-type) {
-      border-radius: 0;
-    }
-
-    &:first-of-type {
-      border-radius: variables.$border-radius 0 0 variables.$border-radius;
-      margin: 0;
-    }
-
-    &:last-of-type {
-      border-radius: 0 variables.$border-radius variables.$border-radius 0;
-    }
   }
 }

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
@@ -65,7 +65,7 @@ limitations under the License.
       </mat-hint>
 
       <mat-error *ngIf="form.get(Controls.KubernetesVersion).hasError(ErrorType.Required)">
-        Version is <strong>required</strong>.
+        Kubernetes Version is <strong>required</strong>.
       </mat-error>
     </mat-form-field>
 
@@ -82,15 +82,15 @@ limitations under the License.
     </mat-form-field>
 
     <mat-form-field>
-      <mat-label>Resource group</mat-label>
+      <mat-label>Resource Group</mat-label>
       <input matInput
+             required
              type="text"
              autocomplete="off"
-             [formControlName]="Controls.NodeResourceGroup"
-             required="true" />
+             [formControlName]="Controls.NodeResourceGroup" />
       <mat-hint>Enter name of the resource group containing agent pool nodes.</mat-hint>
       <mat-error *ngIf="form.get(Controls.NodeResourceGroup).hasError(ErrorType.Required)">
-        Resource group is <strong>required</strong>.
+        Resource Group is <strong>required</strong>.
       </mat-error>
     </mat-form-field>
   </div>
@@ -121,9 +121,9 @@ limitations under the License.
              type="text"
              autocomplete="off"
              [formControlName]="Controls.NodePoolName" />
-      <mat-hint>Enter Node pool name. It must contain only lowercase letters and numbers.</mat-hint>
+      <mat-hint>Enter node pool name. It must contain only lowercase letters and numbers.</mat-hint>
       <mat-error *ngIf="form.get(Controls.NodePoolName).hasError(ErrorType.Required)">
-        Pool name is <strong>required</strong>.
+        Node Pool Name is <strong>required</strong>.
       </mat-error>
     </mat-form-field>
 
@@ -149,8 +149,7 @@ limitations under the License.
     <div fxLayout="column"
          fxFlex="100"
          fxLayoutGap="10px">
-      <mat-checkbox matTooltip=""
-                    [formControlName]="Controls.EnableAutoScaling"
+      <mat-checkbox [formControlName]="Controls.EnableAutoScaling"
                     (change)="onEnableAutoScalingChange($event)">
         Enable Auto Scaling
         <i class="km-icon-info km-pointer"
@@ -161,7 +160,7 @@ limitations under the License.
     <ng-container *ngIf="form.get(Controls.EnableAutoScaling).value">
       <km-number-stepper label="Max Count"
                          mode="all"
-                         hint="The maximum number of nodes for auto-scaling and max can be less than equal to 1000"
+                         hint="The maximum number of nodes for auto-scaling. Maximum value can be 1000."
                          [required]="true"
                          [min]="form.get(Controls.MinCount).value"
                          [max]="1000"
@@ -170,7 +169,7 @@ limitations under the License.
 
       <km-number-stepper label="Min Count"
                          mode="all"
-                         hint="The minimum number of nodes for auto-scaling. Min count be can 1"
+                         hint="The minimum number of nodes for auto-scaling. Minimum value can be 1"
                          [required]="true"
                          [min]="1"
                          [max]="form.get(Controls.MaxCount).value"

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
@@ -1,0 +1,181 @@
+<!--
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<form [formGroup]="form"
+      fxLayout="row"
+      fxLayoutGap="30px"
+      fxLayout.md="column"
+      fxLayoutGap.md="30px"
+      fxLayout.sm="column"
+      fxLayoutGap.sm="30px">
+  <div fxFlex="50%"
+       fxLayout="column"
+       fxLayoutGap="8px">
+    <mat-card-header class="km-no-padding">
+      <mat-card-title>Cluster</mat-card-title>
+    </mat-card-header>
+
+    <mat-form-field>
+      <mat-label>Name</mat-label>
+      <input matInput
+             type="text"
+             autocomplete="off"
+             [formControlName]="Controls.Name" />
+      <button mat-icon-button
+              type="button"
+              matSuffix
+              class="km-randomize-btn"
+              matTooltip="Generate name"
+              (click)="generateName()">
+        <i class="km-icon-randomize"></i>
+      </button>
+      <mat-hint>Enter a unique name for this cluster</mat-hint>
+      <mat-error *ngIf="form.get(Controls.Name).hasError(ErrorType.Required)">
+        Name is <strong>required</strong>.
+      </mat-error>
+      <mat-error *ngIf="form.get(Controls.Name).hasError(ErrorType.Pattern)">
+        Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Kubernetes Version</mat-label>
+      <input [formControlName]="Controls.KubernetesVersion"
+             matInput
+             type="text"
+             autocomplete="off" />
+
+      <mat-hint>
+        Set the kubernetes version. See list of
+        <a href="https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli"
+           rel="noopener noreferrer"
+           target="_blank">supported versions</a>.
+      </mat-hint>
+
+      <mat-error *ngIf="form.get(Controls.KubernetesVersion).hasError(ErrorType.Required)">
+        Version is <strong>required</strong>.
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Location</mat-label>
+      <input matInput
+             type="text"
+             autocomplete="off"
+             [formControlName]="Controls.Location" />
+      <mat-hint>Enter a region name for your cluster.</mat-hint>
+      <mat-error *ngIf="form.get(Controls.Location).hasError(ErrorType.Required)">
+        Location is <strong>required</strong>.
+      </mat-error>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>Resource group</mat-label>
+      <input matInput
+             type="text"
+             autocomplete="off"
+             [formControlName]="Controls.NodeResourceGroup"
+             required="true" />
+      <mat-hint>Enter name of the resource group containing agent pool nodes.</mat-hint>
+      <mat-error *ngIf="form.get(Controls.NodeResourceGroup).hasError(ErrorType.Required)">
+        Resource group is <strong>required</strong>.
+      </mat-error>
+    </mat-form-field>
+  </div>
+
+  <div fxFlex="50%"
+       fxLayout="column"
+       fxLayoutGap="8px">
+    <mat-card-header class="km-no-padding">
+      <mat-card-title>Node Pool Setting</mat-card-title>
+    </mat-card-header>
+
+    <km-autocomplete label="VM Size"
+                     required="true"
+                     [isLoading]="isLoadingVmSizes"
+                     [options]="vmSizes"
+                     [formControlName]="Controls.VmSize">
+      <ng-container hint>
+        VM size availability varies by region.
+        <a href="https://docs.microsoft.com/azure/aks/quotas-skus-regions"
+           rel="noopener noreferrer"
+           target="_blank">supported versions</a>.
+      </ng-container>
+    </km-autocomplete>
+
+    <mat-form-field>
+      <mat-label>Node Pool Name</mat-label>
+      <input matInput
+             type="text"
+             autocomplete="off"
+             [formControlName]="Controls.NodePoolName" />
+      <mat-hint>Enter Node pool name. It must contain only lowercase letters and numbers.</mat-hint>
+      <mat-error *ngIf="form.get(Controls.NodePoolName).hasError(ErrorType.Required)">
+        Pool name is <strong>required</strong>.
+      </mat-error>
+    </mat-form-field>
+
+    <km-number-stepper [formControlName]="Controls.Count"
+                       label="Count"
+                       mode="all"
+                       required="true"
+                       [hint]="form.get(Controls.EnableAutoScaling).value ?
+                        'Number of agents (VMs) to host docker containers can be between min and max auto scaling config' :
+                        'Number of agents (VMs) to host docker containers' "
+                       [min]="form.get(Controls.MinCount).value"
+                       [max]="form.get(Controls.MaxCount).value">
+    </km-number-stepper>
+
+    <mat-form-field>
+      <mat-label>Mode</mat-label>
+      <input matInput
+             type="text"
+             autocomplete="off"
+             [formControlName]="Controls.Mode" />
+    </mat-form-field>
+
+    <div fxLayout="column"
+         fxFlex="100"
+         fxLayoutGap="10px">
+      <mat-checkbox matTooltip=""
+                    [formControlName]="Controls.EnableAutoScaling"
+                    (change)="onEnableAutoScalingChange($event)">
+        Enable Auto Scaling
+        <i class="km-icon-info km-pointer"
+           matTooltip="Indicates whether to enable auto scaling.This option is recommended so that cluster sized correctly for the current running workloads."></i>
+      </mat-checkbox>
+    </div>
+
+    <ng-container *ngIf="form.get(Controls.EnableAutoScaling).value">
+      <km-number-stepper label="Max Count"
+                         mode="all"
+                         hint="The maximum number of nodes for auto-scaling and max can be less than equal to 1000"
+                         [required]="true"
+                         [min]="form.get(Controls.MinCount).value"
+                         [max]="1000"
+                         [formControlName]="Controls.MaxCount">
+      </km-number-stepper>
+
+      <km-number-stepper label="Min Count"
+                         mode="all"
+                         hint="The minimum number of nodes for auto-scaling. Min count be can 1"
+                         [required]="true"
+                         [min]="1"
+                         [max]="form.get(Controls.MaxCount).value"
+                         [formControlName]="Controls.MinCount">
+      </km-number-stepper>
+    </ng-container>
+  </div>
+</form>

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
@@ -65,7 +65,7 @@ limitations under the License.
            target="_blank">supported versions</a>.
       </mat-hint>
       <mat-error *ngIf="form.get(Controls.Version).hasError('required')">
-        Kubernetes version is <strong>required</strong>.
+        Kubernetes Version is <strong>required</strong>.
       </mat-error>
     </mat-form-field>
 

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -59,7 +59,7 @@ limitations under the License.
              [formControlName]="Controls.Version" />
       <mat-hint>Set the kubernetes version.</mat-hint>
       <mat-error *ngIf="form.get(Controls.Version).hasError('required')">
-        kubernetes Version is <strong>required</strong>.
+        Kubernetes Version is <strong>required</strong>.
       </mat-error>
     </mat-form-field>
 
@@ -90,7 +90,7 @@ limitations under the License.
                      [isLoading]="isLoadingZones"
                      [options]="zones"
                      [formControlName]="Controls.Zone">
-      <ng-container hint>Chose from Zones List.</ng-container>
+      <ng-container hint>Select from Zones List.</ng-container>
     </km-autocomplete>
 
   </div>

--- a/src/app/external-cluster-wizard/steps/external-cluster/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/template.html
@@ -15,9 +15,10 @@ limitations under the License.
 -->
 <div [ngSwitch]="selectedProvider"
      fxLayout="column">
+  <km-aks-cluster-settings *ngSwitchCase="Provider.AKS"
+                           [formControl]="form.get(Controls.AKSExternalCluster)"></km-aks-cluster-settings>
   <km-eks-cluster-settings *ngSwitchCase="Provider.EKS"
                            [formControl]="form.get(Controls.EKSExternalCluster)"></km-eks-cluster-settings>
   <km-gke-cluster-settings *ngSwitchCase="Provider.GKE"
                            [formControl]="form.get(Controls.GKEExternalCluster)"></km-gke-cluster-settings>
-
 </div>

--- a/src/app/external-cluster-wizard/template.html
+++ b/src/app/external-cluster-wizard/template.html
@@ -40,7 +40,6 @@ limitations under the License.
       <div [ngSwitch]="step.name"
            id="{{step.id}}-step"
            class="wizard-step">
-
         <ng-container *ngSwitchCase="stepRegistry.Provider">
           <km-select-external-cluster-provider [providers]="externalProviders"
                                                (providerChange)="onProviderChanged($event)"></km-select-external-cluster-provider>

--- a/src/app/project-overview/create-resource-panel/component.ts
+++ b/src/app/project-overview/create-resource-panel/component.ts
@@ -100,8 +100,12 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
     this._isOpen = !this._isOpen;
   }
 
-  createCluster(): void {
+  openClusterWizard(): void {
     this._router.navigate([`/projects/${this.project.id}/wizard`]);
+  }
+
+  openExternalClusterWizard(): void {
+    this._router.navigate([`/projects/${this.project.id}/external-cluster-wizard`]);
   }
 
   createClusterFromTemplate(): void {
@@ -116,7 +120,7 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
       .subscribe(_ => this.refreshClusters.next());
   }
 
-  createExternalCluster(): void {
+  importExternalCluster(): void {
     this.close();
     const dialog = this._matDialog.open(AddExternalClusterDialogComponent);
     dialog.componentInstance.projectId = this.project.id;

--- a/src/app/project-overview/create-resource-panel/template.html
+++ b/src/app/project-overview/create-resource-panel/template.html
@@ -27,10 +27,20 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="createCluster()">
+         (click)="openClusterWizard()">
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
-      <span>Cluster</span>
+      <span>Create Cluster</span>
+    </div>
+    <div class="entry"
+         [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"
+         fxLayoutAlign=" center"
+         fxLayoutGap="14px"
+         matRipple
+         (click)="openExternalClusterWizard()">
+      <i class="km-icon-mask km-icon-cluster"
+         [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
+      <span>Create External Cluster</span>
     </div>
     <div class="entry"
          [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"
@@ -47,10 +57,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="createExternalCluster()">
+         (click)="importExternalCluster()">
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
-      <span>External Cluster</span>
+      <span>Import External Cluster</span>
     </div>
     <div class="entry"
          [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"

--- a/src/app/project-overview/create-resource-panel/template.html
+++ b/src/app/project-overview/create-resource-panel/template.html
@@ -37,6 +37,16 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
+         (click)="importExternalCluster()">
+      <i class="km-icon-mask km-icon-cluster"
+         [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
+      <span>Import External Cluster</span>
+    </div>
+    <div class="entry"
+         [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"
+         fxLayoutAlign=" center"
+         fxLayoutGap="14px"
+         matRipple
          (click)="openExternalClusterWizard()">
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
@@ -51,16 +61,6 @@ limitations under the License.
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Cluster from Template</span>
-    </div>
-    <div class="entry"
-         [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"
-         fxLayoutAlign=" center"
-         fxLayoutGap="14px"
-         matRipple
-         (click)="importExternalCluster()">
-      <i class="km-icon-mask km-icon-cluster"
-         [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
-      <span>Import External Cluster</span>
     </div>
     <div class="entry"
          [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"

--- a/src/app/shared/entity/external-cluster.ts
+++ b/src/app/shared/entity/external-cluster.ts
@@ -14,9 +14,9 @@
 
 import _ from 'lodash';
 import {StatusIcon} from '@shared/utils/health-status';
+import {AKSCloudSpec, AKSClusterSpec} from './provider/aks';
 import {GKECloudSpec, GKEClusterSpec} from './provider/gke';
 import {EKSCloudSpec, EKSClusterSpec} from './provider/eks';
-import {AKSCloudSpec} from './provider/aks';
 
 export enum ExternalClusterProvider {
   Custom = 'custom',
@@ -84,6 +84,7 @@ export class ExternalCluster {
 }
 
 export class ExternalClusterSpec {
+  aksclusterSpec?: AKSClusterSpec;
   eksclusterSpec?: EKSClusterSpec;
   gkeclusterSpec?: GKEClusterSpec;
   version?: string;

--- a/src/app/shared/entity/provider/aks.ts
+++ b/src/app/shared/entity/provider/aks.ts
@@ -26,3 +26,67 @@ export class AKSCloudSpec {
   clientSecret?: string;
   resourceGroup?: string;
 }
+
+export class AKSClusterSpec {
+  location: string;
+  kubernetesVersion: string;
+  nodeResourceGroup?: string;
+  enableRBAC?: boolean;
+  managedAAD?: boolean;
+  dnsPrefix?: string;
+  fqdnSubdomain?: string;
+  fqdn?: string;
+  privateFQDN?: string;
+  machineDeploymentSpec?: AKSMachineDeploymentCloudSpec;
+  networkProfile?: AKSNetworkProfile;
+}
+
+export class AKSMachineDeploymentCloudSpec {
+  name: string;
+  basicSettings: AgentPoolBasics;
+  optionalSettings?: AgentPoolOptionalSettings;
+  configuration?: AgentPoolConfig;
+}
+
+export class AgentPoolBasics {
+  count: number;
+  vmSize: string;
+  mode?: string;
+  orchestratorVersion?: string;
+  availabilityZones?: string[];
+  enableAutoScaling?: boolean;
+  scalingConfig?: AKSNodegroupScalingConfig;
+  osDiskSizeGB?: number;
+}
+
+export class AKSNodegroupScalingConfig {
+  maxCount?: number;
+  minCount?: number;
+}
+
+export class AgentPoolOptionalSettings {
+  nodeLabels?: {[key: string]: string | undefined};
+  nodeTaints?: string[];
+}
+
+export class AgentPoolConfig {
+  osDiskType?: string;
+  maxPods?: number;
+  osType?: string;
+  enableNodePublicIP?: boolean;
+  maxSurge?: string;
+  vnetSubnetID?: string;
+  podSubnetID?: string;
+}
+
+export class AKSNetworkProfile {
+  podCidr?: string;
+  serviceCidr?: string;
+  dnsServiceIP?: string;
+  dockerBridgeCidr?: string;
+  networkPlugin?: string;
+  networkPolicy?: string;
+  networkMode?: string;
+  outboundType?: string;
+  loadBalancerSku?: string;
+}

--- a/src/app/shared/types/error-type.ts
+++ b/src/app/shared/types/error-type.ts
@@ -1,0 +1,21 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export enum ErrorType {
+  Required = 'required',
+  Min = 'min',
+  Max = 'max',
+  Pattern = 'pattern',
+  Number = 'number',
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

This feature allows to Create External Cluster of type AKS provider from UI. This feature is accessible under Clusters and navigating to External Clusters tab.

**Select Provider:**

<img width="1437" alt="AKS-Select-Provider" src="https://user-images.githubusercontent.com/17727069/179087382-80bc551c-557b-42c0-82e0-21549020c3a6.png">

**Credentials:**

<img width="1439" alt="AKS-Select-Credentials" src="https://user-images.githubusercontent.com/17727069/179087531-c9ee1971-037c-401d-a4bf-4b1eaeb80e94.png">

**Cluster Details Step:**

<img width="1423" alt="AKS-Cluster-Details" src="https://user-images.githubusercontent.com/17727069/179087542-9496d4c0-fc17-427f-aa5a-1fc540509965.png">


**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4569 

**Special notes for your reviewer**:

**Important:**
Currently, When you will try to create AKS cluster UI hangs as Backend is not responding status but external is created to cloud provider and issue is on KKP side where POD fails to return status to Frontend that needs to be investigated and figured out.

However once you press **Create External Cluster** button you can come back to 
- "Import" external cluster dialog 
- Select AKS external. Provider
- Select Preset
- You will see NEW AKS provider that was created via Wizard.

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for creating AKS External Cluster
```

