### PR TITLE
add-project-landing-page-option

### DIFF
--- a/src/app/core/services/project.ts
+++ b/src/app/core/services/project.ts
@@ -93,9 +93,13 @@ export class ProjectService {
   }
 
   selectProject(project: Project): Promise<boolean> {
+    let projectLandingPage: string;
     if (project?.status === ProjectStatus.Active) {
       this.onProjectChange.emit(project);
-      return this._router.navigate([`/projects/${project.id}/overview`]);
+      this._userService.currentUser.subscribe(settings => {
+        projectLandingPage = settings.userSettings.useClustersView ? 'clusters' : 'overview';
+      });
+      return this._router.navigate([`/projects/${project.id}/${projectLandingPage}`]);
     }
 
     return this._router.navigate(['/projects']);

--- a/src/app/project-overview/component.ts
+++ b/src/app/project-overview/component.ts
@@ -33,6 +33,7 @@ import {ClusterTemplate} from '@shared/entity/cluster-template';
 import {BackupService} from '@core/services/backup';
 import {EtcdBackupConfig} from '@shared/entity/backup';
 import {Health} from '@shared/entity/health';
+import {CookieService} from 'ngx-cookie-service';
 
 @Component({
   selector: 'km-project-overview',
@@ -57,6 +58,7 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
   private _projectChange = new Subject<void>();
   private _unsubscribe = new Subject<void>();
   private readonly _refreshTime = 15;
+  firstVisite: string;
 
   constructor(
     private readonly _projectService: ProjectService,
@@ -67,7 +69,8 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
     private readonly _memberService: MemberService,
     private readonly _serviceAccountService: ServiceAccountService,
     private readonly _settingsService: SettingsService,
-    private readonly _appConfigService: AppConfigService
+    private readonly _appConfigService: AppConfigService,
+    private readonly _cookieService: CookieService
   ) {}
 
   ngOnInit(): void {
@@ -80,6 +83,7 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
     this._loadSSHKeys();
     this._loadMembers();
     this._loadServiceAccounts();
+    this._checkFirstVisit();
   }
 
   ngOnDestroy(): void {
@@ -189,5 +193,15 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
       .pipe(switchMap(() => (this.project ? this._serviceAccountService.get(this.project.id) : EMPTY)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(serviceAccounts => (this.serviceAccounts = serviceAccounts));
+  }
+
+  private _checkFirstVisit(): void {
+    this._cookieService.get('firstVisit')
+      ? this.hideFirstVisitMessage()
+      : this._cookieService.set('firstVisit', 'visited', null, '/', 'localhost', false, 'Lax');
+  }
+
+  hideFirstVisitMessage(): void {
+    this.firstVisite = this._cookieService.get('firstVisit');
   }
 }

--- a/src/app/project-overview/style.scss
+++ b/src/app/project-overview/style.scss
@@ -27,3 +27,13 @@
     padding: 0 30px;
   }
 }
+
+.first-visit-message {
+  margin-bottom: 20px;
+  padding: 10px;
+
+  i {
+    position: fixed;
+    right: 40px;
+  }
+}

--- a/src/app/project-overview/template.html
+++ b/src/app/project-overview/template.html
@@ -13,7 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
+<mat-card class="first-visit-message km-text"
+          *ngIf="!firstVisite">
+  Welcome to the new Project Overview! You can change your project landing page in
+  <a class="km-text-muted"
+     href="/account">User Settings.</a>
+  <i class="km-icon-close km-pointer"
+     (click)="hideFirstVisitMessage()"></i>
+</mat-card>
 <div fxLayout="column"
      fxLayoutGap="20px">
   <mat-card>

--- a/src/app/project/component.ts
+++ b/src/app/project/component.ts
@@ -174,8 +174,8 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
       this._sortProjectOwners();
       this.dataSource.data = this.projects;
 
-      if (this._shouldRedirectToCluster()) {
-        this._redirectToCluster();
+      if (this._shouldRedirectToProjectLandingPage()) {
+        this._redirectToProjectLandingPage();
       }
       this.isInitializing = false;
       this.selectDefaultProject();
@@ -494,14 +494,15 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
       });
   }
 
-  private _shouldRedirectToCluster(): boolean {
+  private _shouldRedirectToProjectLandingPage(): boolean {
     const autoredirect: boolean = this._cookieService.get(this._cookie.autoredirect) === 'true';
     this._cookieService.delete(this._cookie.autoredirect, '/');
     return this.projects.length === 1 && autoredirect;
   }
 
-  private _redirectToCluster(): void {
-    this._router.navigate([`/projects/${this.projects[0].id}/clusters`]);
+  private _redirectToProjectLandingPage(): void {
+    const projectLandingPage = this._apiSettings.useClustersView ? 'clusters' : 'overview';
+    this._router.navigate([`/projects/${this.projects[0].id}/${projectLandingPage}`]);
   }
 
   private _isPaginatorVisible(): boolean {

--- a/src/app/settings/user/component.ts
+++ b/src/app/settings/user/component.ts
@@ -38,6 +38,7 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
   user: Member;
   settings: UserSettings; // Local settings copy. User can edit it.
   apiSettings: UserSettings; // Original settings from the API. Cannot be edited by the user.
+  selectedProjectLandingPage: string;
 
   private readonly _debounceTime = 1000;
   private _settingsChange = new Subject<void>();
@@ -60,6 +61,7 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
         }
         this.apiSettings = settings;
         this.settings = _.cloneDeep(this.apiSettings);
+        this.selectedProjectLandingPage = this.settings.useClustersView ? 'Clusters' : 'ProjectOverView';
       }
     });
 
@@ -82,6 +84,11 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
+  }
+
+  changingLandingPage(landingPage: string): void {
+    landingPage === 'Clusters' ? (this.settings.useClustersView = true) : (this.settings.useClustersView = false);
+    this.onSettingsChange();
   }
 
   onSettingsChange(): void {

--- a/src/app/settings/user/style.scss
+++ b/src/app/settings/user/style.scss
@@ -48,6 +48,26 @@
   }
 }
 
+.project-overview-button {
+  @include mixins.size(170px, 45px, $force: true);
+
+  i {
+    margin-right: 10px;
+    min-height: 28px;
+    min-width: 28px;
+  }
+}
+
+.clusters-button {
+  @include mixins.size(110px, 45px, $force: true);
+
+  i {
+    margin-right: 10px;
+    min-height: 28px;
+    min-width: 28px;
+  }
+}
+
 .km-pointer {
   margin-left: 8px;
 }

--- a/src/app/settings/user/template.html
+++ b/src/app/settings/user/template.html
@@ -98,6 +98,26 @@ limitations under the License.
         <km-spinner-with-confirmation [isSaved]="isEqual(settings.selectedProjectID, apiSettings.selectedProjectID)"
                                       fxFlexAlign=" center"></km-spinner-with-confirmation>
       </div>
+      <div fxLayout="row">
+        <div class="entry-label"
+             fxLayoutAlign=" center">Project Landing Page
+        </div>
+        <mat-button-toggle-group [(value)]="selectedProjectLandingPage"
+                                 (change)="changingLandingPage($event.value)">
+          <mat-button-toggle class="project-overview-button"
+                             value="ProjectOverView">
+            <i class="km-icon-mask km-icon-projects-card"></i>
+            Project Overview
+          </mat-button-toggle>
+          <mat-button-toggle class="clusters-button"
+                             value="Clusters">
+            <i class="km-icon-mask km-icon-cluster"></i>
+            Clusters
+          </mat-button-toggle>
+        </mat-button-toggle-group>
+        <km-spinner-with-confirmation [isSaved]="isEqual(settings.useClustersView, apiSettings.useClustersView)"
+                                      fxFlexAlign=" center"></km-spinner-with-confirmation>
+      </div>
     </div>
   </mat-card-content>
 </mat-card>

--- a/src/app/shared/entity/settings.ts
+++ b/src/app/shared/entity/settings.ts
@@ -22,6 +22,7 @@ export interface UserSettings {
   collapseSidenav?: boolean;
   displayAllProjectsForAdmin?: boolean;
   lastSeenChangelogVersion?: string;
+  useClustersView?: boolean;
 }
 
 export interface AdminSettings {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
adding a new option in user settings to select the project landing page so it appear first when you open project ,(clusters page or project overview page) and also show a message on the first time the user open the project overview page to inform the user with this option

**Which issue(s) this PR fixes** :
Fixes #4510

```release-note
NONE
```

