### PR TITLE
Check k8s dashboard health

### DIFF
--- a/src/app/cluster/details/cluster/component.ts
+++ b/src/app/cluster/details/cluster/component.ts
@@ -116,6 +116,10 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     return Object.keys(AdmissionPlugin);
   }
 
+  get kubernetesDashboardHealth(): boolean {
+    return this.health?.kubernetesDashboard === HealthState.Up;
+  }
+
   constructor(
     private readonly _route: ActivatedRoute,
     private readonly _router: Router,

--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -42,7 +42,7 @@ limitations under the License.
             class="km-share-kubeconfig-btn"
             color="alternative"
             (click)="shareConfigDialog()"
-            [disabled]="!isClusterRunning"
+            [disabled]="!kubernetesDashboardHealth"
             *ngIf="isShareConfigEnabled() | async">
       <i class="km-icon-mask km-icon-share"></i>
       <span>Share</span>
@@ -50,7 +50,7 @@ limitations under the License.
     <km-button color="alternative"
                icon="km-icon-download"
                label="Get Kubeconfig"
-               [disabled]="!isClusterRunning"
+               [disabled]="!kubernetesDashboardHealth"
                [observable]="getObservable()"
                (next)="onNext($event)">
     </km-button>
@@ -69,7 +69,7 @@ limitations under the License.
        [href]="getProxyURL()"
        target="_blank"
        mat-flat-button
-       [disabled]="!isClusterRunning"
+       [disabled]="!kubernetesDashboardHealth"
        *ngIf="(settings.adminSettings | async)?.enableDashboard">
       <i class="km-icon-mask km-icon-external-link"></i>
       <span>Open Dashboard</span>

--- a/src/app/shared/entity/health.ts
+++ b/src/app/shared/entity/health.ts
@@ -26,6 +26,8 @@ export class Health {
   alertmanagerConfig?: HealthState;
   logging?: HealthState;
   monitoring?: HealthState;
+  kubernetesDashboard?: HealthState;
+  operatingSystemManager?: HealthState;
 
   static allHealthy(health: Health): boolean {
     const supported = [
@@ -62,6 +64,8 @@ export enum HealthType {
   AlertmanagerConfig = 'alertmanagerConfig',
   Logging = 'logging',
   Monitoring = 'monitoring',
+  KubernetesDashboard = 'kubernetesDashboard',
+  OperatingSystemManager = 'operatingSystemManager',
 }
 
 export namespace HealthState {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
the current behavior for the open dashboard button is that the button will be available only when all cluster components health is up so in this PR we change the availability for the open dashboard button according to the k8s dashboard health ,  
also the same for kubeconfig and share buttons 

Fixes #4579

```release-note
NONE
```

