### PR TITLE
Delete External Cluster MD 

### DIFF
--- a/src/app/cluster/details/external-cluster/external-machine-deployment-details/template.html
+++ b/src/app/cluster/details/external-cluster/external-machine-deployment-details/template.html
@@ -38,6 +38,14 @@ limitations under the License.
                 [disabled]="!isEditEnabled()">
           <i class="km-icon-mask km-icon-edit"></i>
         </button>
+
+        <button mat-icon-button
+                color="tertiary"
+                matTooltip="Delete Machine Deployment"
+                (click)="showDeleteDialog();"
+                [disabled]="!isDeleteEnabled()">
+          <i class="km-icon-mask km-icon-delete"></i>
+        </button>
       </div>
 
     </mat-card-header>

--- a/src/app/cluster/details/external-cluster/external-machine-deployment-list/template.html
+++ b/src/app/cluster/details/external-cluster/external-machine-deployment-list/template.html
@@ -132,9 +132,17 @@ limitations under the License.
                 <button mat-icon-button
                         class="machine-deployment-action"
                         matTooltip="Update number of replicas"
-                        (click)="updateReplicas(element); $event.stopPropagation()"
+                        (click)="updateReplicas(element, $event);"
                         [disabled]="!isEditEnabled()">
                   <i class="km-icon-mask km-icon-edit"></i>
+                </button>
+
+                <button mat-icon-button
+                        class="machine-deployment-action"
+                        matTooltip="Delete Machine Deployment"
+                        [disabled]="!isDeleteEnabled()"
+                        (click)="showDeleteDialog(element, $event);">
+                  <i class="km-icon-mask km-icon-delete"></i>
                 </button>
               </ng-container>
             </ng-container>

--- a/src/app/core/module.ts
+++ b/src/app/core/module.ts
@@ -58,6 +58,7 @@ import {AuthInterceptor, CheckTokenInterceptor, ErrorNotificationsInterceptor, L
 import {ClusterTemplateService} from '@core/services/cluster-templates';
 import {ServiceAccountService} from '@core/services/service-account';
 import {MachineDeploymentService} from '@core/services/machine-deployment';
+import {ExternalMachineDeploymentService} from '@core/services/external-machine-deployment';
 import {AlibabaService} from '@core/services/provider/alibaba';
 import {AnexiaService} from '@core/services/provider/anexia';
 import {AWSService} from '@core/services/provider/aws';
@@ -117,6 +118,7 @@ const services = [
   BackupService,
   ServiceAccountService,
   MachineDeploymentService,
+  ExternalMachineDeploymentService,
   AlibabaService,
   AnexiaService,
   AWSService,

--- a/src/app/core/services/external-machine-deployment.ts
+++ b/src/app/core/services/external-machine-deployment.ts
@@ -1,0 +1,77 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {Observable, of} from 'rxjs';
+import {catchError, map, mergeMap, take} from 'rxjs/operators';
+import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
+import {NotificationService} from '@core/services/notification';
+import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
+import {ExternalCluster} from '@shared/entity/external-cluster';
+import {ExternalMachineDeployment} from '@shared/entity/external-machine-deployment';
+import {environment} from '@environments/environment';
+
+@Injectable()
+export class ExternalMachineDeploymentService {
+  private readonly _restRoot: string = environment.newRestRoot;
+
+  constructor(
+    private readonly _httpClient: HttpClient,
+    private readonly _matDialog: MatDialog,
+    private readonly _notificationService: NotificationService
+  ) {}
+
+  showExternalMachineDeploymentDeleteDialog(
+    projectID: string,
+    cluster: ExternalCluster,
+    md: ExternalMachineDeployment
+  ): Observable<boolean> {
+    const dialogConfig: MatDialogConfig = {
+      data: {
+        title: 'Delete Machine Deployment',
+        message: `Delete <b>${md.name}</b> machine deployment of <b>${cluster.name}</b> cluster permanently?`,
+        confirmLabel: 'Delete',
+      },
+    };
+    const dialogRef = this._matDialog.open(ConfirmationDialogComponent, dialogConfig);
+    return dialogRef.afterClosed().pipe(
+      mergeMap((isConfirmed: boolean): Observable<boolean> => {
+        if (isConfirmed) {
+          return this._deleteExternalMachineDeployment(projectID, cluster.id, md.id).pipe(
+            map(data => {
+              this._notificationService.success(`Deleting the ${md.name} machine deployment`);
+              return Boolean(data);
+            }),
+            catchError(() => {
+              this._notificationService.error(`Could not delete the ${md.name} machine deployment`);
+              return of(false);
+            }),
+            take(1)
+          );
+        }
+        return of(false);
+      })
+    );
+  }
+
+  private _deleteExternalMachineDeployment(
+    projectID: string,
+    clusterId: string,
+    machineDeploymentId: string
+  ): Observable<Record<string, never>> {
+    const url = `${this._restRoot}/projects/${projectID}/kubernetes/clusters/${clusterId}/machinedeployments/${machineDeploymentId}`;
+    return this._httpClient.delete<Record<string, never>>(url);
+  }
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

This PR allows to Delete External Cluster machine deployment from External cluster details page and External Cluster Machine Deployment details page.

**External cluster details page:**

https://user-images.githubusercontent.com/17727069/177599481-3f08cc4b-9eef-481d-a5ce-b155bde405e1.mp4

**External Cluster Machine Deployment details page**

https://user-images.githubusercontent.com/17727069/177599547-d828a99b-1a00-4e99-953f-04558ab76eb0.mp4


**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes # https://github.com/kubermatic/dashboard/issues/4629

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for deleting machine deployments of External Cluster (EKS,AKS,GKE)
```

