### PR TITLE
Add validations for backup destination names in seed

### DIFF
--- a/src/app/settings/admin/bucket-settings/destinations/destination-dialog/component.ts
+++ b/src/app/settings/admin/bucket-settings/destinations/destination-dialog/component.ts
@@ -19,6 +19,7 @@ import {DatacenterService} from '@core/services/datacenter';
 import {NotificationService} from '@core/services/notification';
 import {AdminSeed, BackupDestination, DestinationDetails, Destinations} from '@shared/entity/datacenter';
 import {Observable, Subject} from 'rxjs';
+import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 
 export interface DestinationDialogData {
   title: string;
@@ -68,7 +69,7 @@ export class DestinationDialog implements OnInit, OnDestroy {
     this.form = this._builder.group({
       [Controls.DestinationName]: this._builder.control(
         this.data.mode === Mode.Edit ? this.data.destination.destinationName : '',
-        [Validators.required]
+        [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]
       ),
       [Controls.Bucket]: this._builder.control(this.data.mode === Mode.Edit ? this.data.destination.bucketName : '', [
         Validators.required,

--- a/src/app/settings/admin/bucket-settings/destinations/destination-dialog/template.html
+++ b/src/app/settings/admin/bucket-settings/destinations/destination-dialog/template.html
@@ -27,6 +27,9 @@ limitations under the License.
              type="text"
              autocomplete="off"
              required>
+      <mat-error *ngIf="form.get(Controls.DestinationName).hasError('pattern')">
+        Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex>


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This is a follow-up for https://github.com/kubermatic/kubermatic/pull/9717 which adds validation at the front-end for destination name for backups.

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validations for backup destination names
```

