### PR TITLE
Fix the functionality to add/edit backup destinations

### DIFF
--- a/src/app/settings/admin/bucket-settings/destinations/destination-dialog/component.ts
+++ b/src/app/settings/admin/bucket-settings/destinations/destination-dialog/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Inject, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {DatacenterService} from '@core/services/datacenter';
@@ -20,6 +20,7 @@ import {NotificationService} from '@core/services/notification';
 import {AdminSeed, BackupDestination, DestinationDetails, Destinations} from '@shared/entity/datacenter';
 import {Observable, Subject} from 'rxjs';
 import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
+import _ from 'lodash';
 
 export interface DestinationDialogData {
   title: string;
@@ -46,6 +47,7 @@ export enum Controls {
   selector: 'km-destination-dialog',
   templateUrl: './template.html',
   styleUrls: ['style.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DestinationDialog implements OnInit, OnDestroy {
   readonly Controls = Controls;
@@ -117,10 +119,10 @@ export class DestinationDialog implements OnInit, OnDestroy {
       [Controls.Endpoint]: this.form.get(Controls.Endpoint).value,
     };
 
-    const destination: Destinations = this.data.seed.spec.etcdBackupRestore?.destinations || {};
+    const destination: Destinations = _.cloneDeep(this.data.seed.spec.etcdBackupRestore?.destinations || {});
     destination[this.form.get(Controls.DestinationName).value] = destinationDetails;
 
-    const configuration: AdminSeed = this.data.seed;
+    const configuration: AdminSeed = _.cloneDeep(this.data.seed);
     if (!configuration.spec.etcdBackupRestore) {
       configuration.spec.etcdBackupRestore = {destinations: {}, defaultDestination: ''};
     }


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
This PR fixes the broken functionality for adding new “Backup Destinations”. `destination` and `configuration` in `getObservable` method were being shallow cloned and thus retaining object references. Which leads to a map that adds each input character as a key and thus breaks everything. They should be deep cloned, which fixes the issues.

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:
The bug:

![Screenshot 2022-07-07 at 10 19 26 PM](https://user-images.githubusercontent.com/18264334/178950751-c49c14de-ea52-4169-99ab-be1252f279a6.png)
![Screenshot 2022-07-07 at 10 20 02 PM](https://user-images.githubusercontent.com/18264334/178950781-a65ca7f9-29e5-44b5-8ee9-708337743962.png)

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

