### PR TITLE
Extend external cluster specification 

### DIFF
--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -76,6 +76,14 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
     private readonly _notificationService: NotificationService
   ) {}
 
+  get subnetIds(): string[] {
+    return this.cluster?.spec?.eksclusterSpec?.vpcConfigRequest?.subnetIds;
+  }
+
+  get securityGroupIds(): string[] {
+    return this.cluster?.spec?.eksclusterSpec?.vpcConfigRequest?.securityGroupIds;
+  }
+
   ngOnInit(): void {
     this.projectID = this._activatedRoute.snapshot.paramMap.get(PathParam.ProjectID);
     const clusterID = this._activatedRoute.snapshot.paramMap.get(PathParam.ClusterID);

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -117,10 +117,36 @@ limitations under the License.
         </km-property>
 
         <!-- specification for AKS -->
-        <ng-container>
-          <km-property *ngIf="provider === Provider.AKS">
+        <ng-container *ngIf="provider === Provider.AKS">
+          <km-property>
+            <div key>Location</div>
+            <div value>{{cluster?.spec?.aksclusterSpec?.location}}</div>
+          </km-property>
+          <km-property>
             <div key>Resource Group</div>
             <div value>{{cluster?.cloud?.aks?.resourceGroup}}</div>
+          </km-property>
+          <km-property>
+            <div key>Cluster Version</div>
+            <div value>{{cluster?.spec?.aksclusterSpec?.kubernetesVersion}}</div>
+          </km-property>
+          <km-property>
+            <div key>DNS Prefix</div>
+            <div value>{{cluster?.spec?.aksclusterSpec?.dnsPrefix}}</div>
+          </km-property>
+          <km-property>
+            <div key>Enable RBAC</div>
+            <div value>{{cluster?.spec?.aksclusterSpec?.enableRBAC}}</div>
+          </km-property>
+          <km-property>
+            <div key>FQDN</div>
+            <div value>{{cluster?.spec?.aksclusterSpec?.fqdn}}</div>
+          </km-property>
+          <km-property *ngIf="cluster.spec?.aksclusterSpec?.networkProfile">
+            <div key>Network Profile</div>
+            <div value>
+              <km-labels [labels]="cluster.spec?.aksclusterSpec?.networkProfile"></km-labels>
+            </div>
           </km-property>
         </ng-container>
 
@@ -135,7 +161,11 @@ limitations under the License.
             <div value>{{cluster?.spec?.eksclusterSpec?.version}}</div>
           </km-property>
           <km-property>
-            <div key>subnet Ids</div>
+            <div key>VpcId</div>
+            <div value>{{cluster?.spec?.eksclusterSpec?.vpcConfigRequest?.vpcId}}</div>
+          </km-property>
+          <km-property>
+            <div key>Subnet Ids</div>
             <div value>
               <mat-chip-list *ngIf="subnetIds.length > 0">
                 <div *ngFor="let subnetId of subnetIds">
@@ -147,7 +177,7 @@ limitations under the License.
             </div>
           </km-property>
           <km-property>
-            <div key>security Group Ids</div>
+            <div key>Security Group Ids</div>
             <div value>
               <mat-chip-list *ngIf="securityGroupIds.length > 0">
                 <div *ngFor="let securityGroupId of securityGroupIds">
@@ -156,6 +186,12 @@ limitations under the License.
                   </mat-chip>
                 </div>
               </mat-chip-list>
+            </div>
+          </km-property>
+          <km-property *ngIf="cluster.spec?.eksclusterSpec?.kubernetesNetworkConfig">
+            <div key>Kubernetes Network Config</div>
+            <div value>
+              <km-labels [labels]="cluster.spec?.eksclusterSpec?.kubernetesNetworkConfig"></km-labels>
             </div>
           </km-property>
         </ng-container>
@@ -171,12 +207,16 @@ limitations under the License.
             <div value>{{cluster?.spec?.gkeclusterSpec?.initialClusterVersion}}</div>
           </km-property>
           <km-property>
-            <div key>cluster Ipv4 Cidr</div>
+            <div key>Cluster Ipv4 CIDR</div>
             <div value>{{cluster?.spec?.gkeclusterSpec?.clusterIpv4Cidr}}</div>
           </km-property>
           <km-property>
-            <div key>default Max Pods Constraint</div>
+            <div key>Default Max Pods Constraint</div>
             <div value>{{cluster?.spec?.gkeclusterSpec?.defaultMaxPodsConstraint}}</div>
+          </km-property>
+          <km-property>
+            <div key>Sub Network</div>
+            <div value>{{cluster?.spec?.gkeclusterSpec?.subnetwork}}</div>
           </km-property>
         </ng-container>
         <!--  -->

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -109,8 +109,8 @@ limitations under the License.
             <span class="km-provider-logo km-provider-logo-{{provider}}"></span>
           </div>
         </km-property>
-        <km-property>
-          <div key>Created</div>
+        <km-property *ngIf="cluster.labels?.isImported === 'true'">
+          <div key>Imported</div>
           <div value>
             <km-relative-time [date]="cluster.creationTimestamp"></km-relative-time>
           </div>
@@ -152,6 +152,12 @@ limitations under the License.
 
         <!-- specification for EKS -->
         <ng-container *ngIf="provider === Provider.EKS">
+          <km-property>
+            <div key>Created</div>
+            <div value>
+              <km-relative-time [date]="cluster?.spec?.eksclusterSpec?.createdAt"></km-relative-time>
+            </div>
+          </km-property>
           <km-property>
             <div key>Region</div>
             <div value>{{cluster?.cloud?.eks?.region}}</div>
@@ -198,6 +204,12 @@ limitations under the License.
 
         <!-- specification for GKE -->
         <ng-container *ngIf="provider === Provider.GKE">
+          <km-property>
+            <div key>Created</div>
+            <div value>
+              <km-relative-time [date]="cluster?.spec?.gkeclusterSpec?.createTime"></km-relative-time>
+            </div>
+          </km-property>
           <km-property>
             <div key>Zone</div>
             <div value>{{cluster?.cloud?.gke?.zone}}</div>

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -109,24 +109,77 @@ limitations under the License.
             <span class="km-provider-logo km-provider-logo-{{provider}}"></span>
           </div>
         </km-property>
-        <km-property *ngIf="provider === Provider.AKS">
-          <div key>Resource Group</div>
-          <div value>{{cluster?.cloud?.aks?.resourceGroup}}</div>
-        </km-property>
-        <km-property *ngIf="provider === Provider.EKS">
-          <div key>Region</div>
-          <div value>{{cluster?.cloud?.eks?.region}}</div>
-        </km-property>
-        <km-property *ngIf="provider === Provider.GKE">
-          <div key>Zone</div>
-          <div value>{{cluster?.cloud?.gke?.zone}}</div>
-        </km-property>
         <km-property>
           <div key>Created</div>
           <div value>
             <km-relative-time [date]="cluster.creationTimestamp"></km-relative-time>
           </div>
         </km-property>
+
+        <!-- specification for AKS -->
+        <ng-container>
+          <km-property *ngIf="provider === Provider.AKS">
+            <div key>Resource Group</div>
+            <div value>{{cluster?.cloud?.aks?.resourceGroup}}</div>
+          </km-property>
+        </ng-container>
+
+        <!-- specification for EKS -->
+        <ng-container *ngIf="provider === Provider.EKS">
+          <km-property>
+            <div key>Region</div>
+            <div value>{{cluster?.cloud?.eks?.region}}</div>
+          </km-property>
+          <km-property>
+            <div key>Cluster Version</div>
+            <div value>{{cluster?.spec?.eksclusterSpec?.version}}</div>
+          </km-property>
+          <km-property>
+            <div key>subnet Ids</div>
+            <div value>
+              <mat-chip-list *ngIf="subnetIds.length > 0">
+                <div *ngFor="let subnetId of subnetIds">
+                  <mat-chip>
+                    <div>{{subnetId}}</div>
+                  </mat-chip>
+                </div>
+              </mat-chip-list>
+            </div>
+          </km-property>
+          <km-property>
+            <div key>security Group Ids</div>
+            <div value>
+              <mat-chip-list *ngIf="securityGroupIds.length > 0">
+                <div *ngFor="let securityGroupId of securityGroupIds">
+                  <mat-chip>
+                    <div>{{securityGroupId}}</div>
+                  </mat-chip>
+                </div>
+              </mat-chip-list>
+            </div>
+          </km-property>
+        </ng-container>
+
+        <!-- specification for GKE -->
+        <ng-container *ngIf="provider === Provider.GKE">
+          <km-property>
+            <div key>Zone</div>
+            <div value>{{cluster?.cloud?.gke?.zone}}</div>
+          </km-property>
+          <km-property>
+            <div key>Cluster Version</div>
+            <div value>{{cluster?.spec?.gkeclusterSpec?.initialClusterVersion}}</div>
+          </km-property>
+          <km-property>
+            <div key>cluster Ipv4 Cidr</div>
+            <div value>{{cluster?.spec?.gkeclusterSpec?.clusterIpv4Cidr}}</div>
+          </km-property>
+          <km-property>
+            <div key>default Max Pods Constraint</div>
+            <div value>{{cluster?.spec?.gkeclusterSpec?.defaultMaxPodsConstraint}}</div>
+          </km-property>
+        </ng-container>
+        <!--  -->
         <km-property *ngIf="cluster.labels">
           <div key>Labels</div>
           <div value>


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
 add extra detail for external cluster specification in the external cluster page

**Which issue(s) this PR fixes** :
Fixes #4673 

```release-note
add extra detail in external cluster page
```

