### PR TITLE
Add IPv6 subnet ID and IPv6 subnet pool for OpenStack cluster provider

### DIFF
--- a/src/app/core/services/wizard/provider/openstack.ts
+++ b/src/app/core/services/wizard/provider/openstack.ts
@@ -20,6 +20,7 @@ import {
   OpenstackNetwork,
   OpenstackSecurityGroup,
   OpenstackSubnet,
+  OpenstackSubnetPool,
   OpenstackTenant,
 } from '@shared/entity/provider/openstack';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
@@ -240,6 +241,29 @@ export class Openstack extends Provider {
 
     const url = `${this._restRoot}/providers/openstack/subnets?network_id=${network}`;
     return this._http.get<OpenstackSubnet[]>(url, {headers: this._headers});
+  }
+
+  subnetPools(ipVersion: number, onLoadingCb: () => void = null): Observable<OpenstackSubnetPool[]> {
+    if (this._usingApplicationCredentials) {
+      this._setRequiredHeaders(
+        Openstack.Header.ApplicationCredentialID,
+        Openstack.Header.ApplicationCredentialSecret,
+        Openstack.Header.Datacenter
+      );
+
+      this._cleanupOptionalHeaders();
+    }
+
+    if (!this._hasRequiredHeaders() || !ipVersion) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._newRestRoot}/providers/openstack/subnetpools?ip_version=${ipVersion}`;
+    return this._http.get<OpenstackSubnetPool[]>(url, {headers: this._headers});
   }
 
   availabilityZones(onLoadingCb: () => void = null): Observable<OpenstackAvailabilityZone[]> {

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -168,8 +168,16 @@ limitations under the License.
             <div value>{{cluster.spec.cloud?.openstack.floatingIPPool}}</div>
           </km-property>
           <km-property *ngIf="cluster.spec.cloud?.openstack.subnetID">
-            <div key>Subnet ID</div>
+            <div key>IPv4 Subnet ID</div>
             <div value>{{cluster.spec.cloud?.openstack.subnetID}}</div>
+          </km-property>
+          <km-property *ngIf="cluster.spec.cloud?.openstack.ipv6SubnetID">
+            <div key>IPv6 Subnet ID</div>
+            <div value>{{cluster.spec.cloud?.openstack.ipv6SubnetID}}</div>
+          </km-property>
+          <km-property *ngIf="cluster.spec.cloud?.openstack.ipv6SubnetPool">
+            <div key>IPv6 Subnet Pool</div>
+            <div value>{{cluster.spec.cloud?.openstack.ipv6SubnetPool}}</div>
           </km-property>
         </ng-container>
 

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -245,6 +245,8 @@ export class OpenstackCloudSpec extends ExtraCloudSpecOptions {
   securityGroups: string;
   floatingIPPool: string;
   subnetID: string;
+  ipv6SubnetID: string;
+  ipv6SubnetPool: string;
 
   static isEmpty(spec: OpenstackCloudSpec): boolean {
     return _.difference(Object.keys(spec), Object.keys(ExtraCloudSpecOptions.new(spec))).every(key => !spec[key]);

--- a/src/app/shared/entity/provider/openstack.ts
+++ b/src/app/shared/entity/provider/openstack.ts
@@ -42,6 +42,7 @@ export class OpenstackFloatingIPPool {
 export class OpenstackSubnet {
   id: string;
   name: string;
+  ipVersion: number;
 }
 
 export class OpenstackSecurityGroup {
@@ -56,4 +57,12 @@ export class OpenstackOptionalFields {
 
 export class OpenstackAvailabilityZone {
   name: string;
+}
+
+export class OpenstackSubnetPool {
+  id: string;
+  name: string;
+  ipVersion: number;
+  isDefault: boolean;
+  prefixes?: string[];
 }

--- a/src/app/wizard/step/provider-settings/provider/extended/openstack/application/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/openstack/application/template.html
@@ -48,21 +48,58 @@ limitations under the License.
     </div>
   </km-combobox>
 
-  <km-combobox #subnetIDCombobox
+  <km-combobox #ipv4SubnetIDCombobox
                [required]="false"
                [grouped]="false"
                [isDisabled]="isPresetSelected"
-               [valueFormatter]="subnetIDDisplayName.bind(this)"
-               [options]="subnetIDs"
-               [hint]="getHint(Controls.SubnetID)"
-               [formControlName]="Controls.SubnetID"
-               (changed)="onSubnetIDChange($event)"
-               [label]="subnetIDsLabel"
-               inputLabel="Select subnet id..."
+               [valueFormatter]="ipv4SubnetIDDisplayName.bind(this)"
+               [options]="ipv4SubnetIDs"
+               [hint]="getHint(Controls.IPv4SubnetID)"
+               [formControlName]="Controls.IPv4SubnetID"
+               (changed)="onIPv4SubnetIDChange($event)"
+               [label]="ipv4SubnetIDsLabel"
+               inputLabel="Select IPv4 subnet ID..."
                filterBy="name"
                selectBy="id">
     <div *option="let subnet">
       {{subnet.name}} ({{subnet.id}})
     </div>
   </km-combobox>
+
+  <ng-container *ngIf="isDualStackNetworkSelected">
+    <km-combobox #ipv6SubnetIDCombobox
+                 [required]="false"
+                 [grouped]="false"
+                 [isDisabled]="isPresetSelected"
+                 [valueFormatter]="ipv6SubnetIDDisplayName.bind(this)"
+                 [options]="ipv6SubnetIDs"
+                 [hint]="getHint(Controls.IPv6SubnetID)"
+                 [formControlName]="Controls.IPv6SubnetID"
+                 (changed)="onIPv6SubnetIDChange($event)"
+                 [label]="ipv6SubnetIDsLabel"
+                 inputLabel="Select IPv6 subnet ID..."
+                 filterBy="name"
+                 selectBy="id">
+      <div *option="let subnet">
+        {{subnet.name}} ({{subnet.id}})
+      </div>
+    </km-combobox>
+
+    <km-combobox #ipv6SubnetPoolCombobox
+                 [required]="false"
+                 [grouped]="false"
+                 [isDisabled]="isPresetSelected"
+                 [options]="ipv6SubnetPools"
+                 [hint]="getHint(Controls.IPv6SubnetPool)"
+                 [formControlName]="Controls.IPv6SubnetPool"
+                 (changed)="onIPv6SubnetPoolChange($event)"
+                 [label]="ipv6SubnetPoolsLabel"
+                 inputLabel="Select IPv6 subnet pool..."
+                 filterBy="name"
+                 selectBy="name">
+      <div *option="let subnetPool">
+        {{subnetPool.name}}
+      </div>
+    </km-combobox>
+  </ng-container>
 </form>

--- a/src/app/wizard/step/provider-settings/provider/extended/openstack/default/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/openstack/default/component.ts
@@ -23,39 +23,37 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {OpenstackCredentialsTypeService} from '@app/wizard/step/provider-settings/provider/extended/openstack/service';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {PresetsService} from '@core/services/wizard/presets';
 import {FilteredComboboxComponent} from '@shared/components/combobox/component';
-import {OpenstackNetwork, OpenstackSecurityGroup, OpenstackSubnet} from '@shared/entity/provider/openstack';
+import {Cluster} from '@shared/entity/cluster';
+import {
+  OpenstackNetwork,
+  OpenstackSecurityGroup,
+  OpenstackSubnet,
+  OpenstackSubnetPool,
+} from '@shared/entity/provider/openstack';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import _ from 'lodash';
 import {EMPTY, merge, Observable, onErrorResumeNext} from 'rxjs';
 import {catchError, debounceTime, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {OpenstackCredentialsTypeService} from '../service';
+import {IPVersion} from '../shared/types/ip-version';
+import {
+  IPv4SubnetIDState,
+  IPv6SubnetIDState,
+  IPv6SubnetPoolState,
+  NetworkState,
+  SecurityGroupState,
+} from '../shared/types/state';
 
 enum Controls {
   SecurityGroup = 'securityGroup',
   Network = 'network',
-  SubnetID = 'subnetID',
-}
-
-enum SecurityGroupState {
-  Ready = 'Security Group',
-  Loading = 'Loading...',
-  Empty = 'No Security Groups Available',
-}
-
-enum NetworkState {
-  Ready = 'Network',
-  Loading = 'Loading...',
-  Empty = 'No Networks Available',
-}
-
-enum SubnetIDState {
-  Ready = 'Subnet ID',
-  Loading = 'Loading...',
-  Empty = 'No Subnet IDs Available',
+  IPv4SubnetID = 'ipv4SubnetID',
+  IPv6SubnetID = 'ipv6SubnetID',
+  IPv6SubnetPool = 'ipv6SubnetPool',
 }
 
 @Component({
@@ -83,8 +81,12 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
   private readonly _networkCombobox: FilteredComboboxComponent;
   @ViewChild('securityGroupCombobox')
   private readonly _securityGroupCombobox: FilteredComboboxComponent;
-  @ViewChild('subnetIDCombobox')
-  private readonly _subnetIDCombobox: FilteredComboboxComponent;
+  @ViewChild('ipv4SubnetIDCombobox')
+  private readonly _ipv4SubnetIDCombobox: FilteredComboboxComponent;
+  @ViewChild('ipv6SubnetIDCombobox')
+  private readonly _ipv6SubnetIDCombobox: FilteredComboboxComponent;
+  @ViewChild('ipv6SubnetPoolCombobox')
+  private readonly _ipv6SubnetPoolCombobox: FilteredComboboxComponent;
   private readonly _debounceTime = 500;
   readonly Controls = Controls;
   isPresetSelected = false;
@@ -92,8 +94,13 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
   securityGroupsLabel = SecurityGroupState.Empty;
   networks: OpenstackNetwork[] = [];
   networksLabel = NetworkState.Empty;
-  subnetIDs: OpenstackSubnet[] = [];
-  subnetIDsLabel = SubnetIDState.Empty;
+  ipv4SubnetIDs: OpenstackSubnet[] = [];
+  ipv4SubnetIDsLabel = IPv4SubnetIDState.Empty;
+  ipv6SubnetIDs: OpenstackSubnet[] = [];
+  ipv6SubnetIDsLabel = IPv6SubnetIDState.Empty;
+  ipv6SubnetPools: OpenstackSubnetPool[] = [];
+  ipv6SubnetPoolsLabel = IPv6SubnetPoolState.Empty;
+  isDualStackNetworkSelected: boolean;
 
   constructor(
     private readonly _builder: FormBuilder,
@@ -109,7 +116,9 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
     this.form = this._builder.group({
       [Controls.SecurityGroup]: this._builder.control(''),
       [Controls.Network]: this._builder.control(''),
-      [Controls.SubnetID]: this._builder.control(''),
+      [Controls.IPv4SubnetID]: this._builder.control(''),
+      [Controls.IPv6SubnetID]: this._builder.control(''),
+      [Controls.IPv6SubnetPool]: this._builder.control(''),
     });
 
     this._presets.presetChanges.pipe(takeUntil(this._unsubscribe)).subscribe(preset =>
@@ -122,6 +131,20 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
     this._credentialsTypeService.credentialsTypeChanges
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this.form.reset());
+
+    this._clusterSpecService.clusterChanges
+      .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
+      .pipe(map(cluster => Cluster.isDualStackNetworkSelected(cluster)))
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe({
+        next: isDualStackNetworkSelected => {
+          this.isDualStackNetworkSelected = isDualStackNetworkSelected;
+          if (!this.isDualStackNetworkSelected) {
+            this._ipv6SubnetIDCombobox?.reset();
+            this._ipv6SubnetPoolCombobox?.reset();
+          }
+        },
+      });
   }
 
   ngAfterViewInit(): void {
@@ -152,6 +175,16 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
       .pipe(switchMap(_ => this._subnetIDListObservable()))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(this._loadSubnetIDs.bind(this));
+
+    merge(this._clusterSpecService.clusterChanges, this._credentialsTypeService.credentialsTypeChanges)
+      .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
+      .pipe(debounceTime(this._debounceTime))
+      .pipe(filter(_ => Cluster.isDualStackNetworkSelected(this._clusterSpecService.cluster)))
+      .pipe(tap(_ => (!this._hasRequiredCredentials() ? this._clearNetwork() : null)))
+      .pipe(filter(_ => this._hasRequiredCredentials()))
+      .pipe(switchMap(_ => this._subnetPoolListObservable()))
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(this._loadSubnetPools.bind(this));
   }
 
   onSecurityGroupChange(securityGroup: string): void {
@@ -162,16 +195,26 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
     this._clusterSpecService.cluster.spec.cloud.openstack.network = network;
   }
 
-  onSubnetIDChange(subnetID: string): void {
+  onIPv4SubnetIDChange(subnetID: string): void {
     this._clusterSpecService.cluster.spec.cloud.openstack.subnetID = subnetID;
+  }
+
+  onIPv6SubnetIDChange(subnetID: string): void {
+    this._clusterSpecService.cluster.spec.cloud.openstack.ipv6SubnetID = subnetID;
+  }
+
+  onIPv6SubnetPoolChange(subnetPool: string): void {
+    this._clusterSpecService.cluster.spec.cloud.openstack.ipv6SubnetPool = subnetPool;
   }
 
   getHint(control: Controls): string {
     switch (control) {
       case Controls.SecurityGroup:
       case Controls.Network:
+      case Controls.IPv6SubnetPool:
         return this._hasRequiredCredentials() ? '' : 'Please enter your credentials first.';
-      case Controls.SubnetID:
+      case Controls.IPv4SubnetID:
+      case Controls.IPv6SubnetID:
         return this._canLoadSubnet() ? '' : 'Please enter your credentials and network first.';
     }
   }
@@ -181,8 +224,13 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
     this._unsubscribe.complete();
   }
 
-  subnetIDDisplayName(id: string): string {
-    const subnetID = this.subnetIDs.find(subnetID => subnetID.id === id);
+  ipv4SubnetIDDisplayName(id: string): string {
+    const subnetID = this.ipv4SubnetIDs.find(subnetID => subnetID.id === id);
+    return subnetID ? `${subnetID.name} (${subnetID.id})` : '';
+  }
+
+  ipv6SubnetIDDisplayName(id: string): string {
+    const subnetID = this.ipv6SubnetIDs.find(subnetID => subnetID.id === id);
     return subnetID ? `${subnetID.name} (${subnetID.id})` : '';
   }
 
@@ -199,8 +247,18 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
   }
 
   private _loadSubnetIDs(subnetIDs: OpenstackSubnet[]): void {
-    this.subnetIDs = subnetIDs;
-    this.subnetIDsLabel = !_.isEmpty(this.subnetIDs) ? SubnetIDState.Ready : SubnetIDState.Empty;
+    this.ipv4SubnetIDs = subnetIDs.filter(subnetID => subnetID.ipVersion === IPVersion.IPv4);
+    this.ipv6SubnetIDs = subnetIDs.filter(subnetID => subnetID.ipVersion === IPVersion.IPv6);
+    this.ipv4SubnetIDsLabel = !_.isEmpty(this.ipv4SubnetIDs) ? IPv4SubnetIDState.Ready : IPv4SubnetIDState.Empty;
+    this.ipv6SubnetIDsLabel = !_.isEmpty(this.ipv6SubnetIDs) ? IPv6SubnetIDState.Ready : IPv6SubnetIDState.Empty;
+    this._cdr.detectChanges();
+  }
+
+  private _loadSubnetPools(subnetPools: OpenstackSubnetPool[]): void {
+    this.ipv6SubnetPools = subnetPools;
+    this.ipv6SubnetPoolsLabel = !_.isEmpty(this.ipv6SubnetPools)
+      ? IPv6SubnetPoolState.Ready
+      : IPv6SubnetPoolState.Empty;
     this._cdr.detectChanges();
   }
 
@@ -312,15 +370,50 @@ export class OpenstackProviderExtendedDefaultCredentialsComponent
   }
 
   private _clearSubnetID(): void {
-    this.subnetIDs = [];
-    this._subnetIDCombobox.reset();
-    this.subnetIDsLabel = SubnetIDState.Empty;
+    this.ipv4SubnetIDs = [];
+    this._ipv4SubnetIDCombobox.reset();
+    this._ipv6SubnetIDCombobox?.reset();
+    this.ipv4SubnetIDsLabel = IPv4SubnetIDState.Empty;
+    this.ipv6SubnetIDsLabel = IPv6SubnetIDState.Empty;
     this._cdr.detectChanges();
   }
 
   private _onSubnetIDLoading(): void {
     this._clearSubnetID();
-    this.subnetIDsLabel = SubnetIDState.Loading;
+    this.ipv4SubnetIDsLabel = IPv4SubnetIDState.Loading;
+    this.ipv6SubnetIDsLabel = IPv6SubnetIDState.Loading;
+    this._cdr.detectChanges();
+  }
+
+  private _subnetPoolListObservable(): Observable<OpenstackSubnetPool[]> {
+    return this._presets
+      .provider(NodeProvider.OPENSTACK)
+      .domain(this._clusterSpecService.cluster.spec.cloud.openstack.domain)
+      .username(this._clusterSpecService.cluster.spec.cloud.openstack.username)
+      .password(this._clusterSpecService.cluster.spec.cloud.openstack.password)
+      .project(this._clusterSpecService.cluster.spec.cloud.openstack.project)
+      .projectID(this._clusterSpecService.cluster.spec.cloud.openstack.projectID)
+      .datacenter(this._clusterSpecService.cluster.spec.cloud.dc)
+      .subnetPools(IPVersion.IPv6, this._onSubnetPoolLoading.bind(this))
+      .pipe(map(subnetPools => _.sortBy(subnetPools, s => s.name.toLowerCase())))
+      .pipe(
+        catchError(() => {
+          this._clearSubnetPool();
+          return onErrorResumeNext(EMPTY);
+        })
+      );
+  }
+
+  private _clearSubnetPool(): void {
+    this.ipv6SubnetPools = [];
+    this._ipv6SubnetPoolCombobox?.reset();
+    this.ipv6SubnetPoolsLabel = IPv6SubnetPoolState.Empty;
+    this._cdr.detectChanges();
+  }
+
+  private _onSubnetPoolLoading(): void {
+    this._clearSubnetPool();
+    this.ipv6SubnetPoolsLabel = IPv6SubnetPoolState.Loading;
     this._cdr.detectChanges();
   }
 

--- a/src/app/wizard/step/provider-settings/provider/extended/openstack/default/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/openstack/default/template.html
@@ -48,21 +48,58 @@ limitations under the License.
     </div>
   </km-combobox>
 
-  <km-combobox #subnetIDCombobox
+  <km-combobox #ipv4SubnetIDCombobox
                [required]="false"
                [grouped]="false"
                [isDisabled]="isPresetSelected"
-               [valueFormatter]="subnetIDDisplayName.bind(this)"
-               [options]="subnetIDs"
-               [hint]="getHint(Controls.SubnetID)"
-               [formControlName]="Controls.SubnetID"
-               (changed)="onSubnetIDChange($event)"
-               [label]="subnetIDsLabel"
-               inputLabel="Select subnet id..."
+               [valueFormatter]="ipv4SubnetIDDisplayName.bind(this)"
+               [options]="ipv4SubnetIDs"
+               [hint]="getHint(Controls.IPv4SubnetID)"
+               [formControlName]="Controls.IPv4SubnetID"
+               (changed)="onIPv4SubnetIDChange($event)"
+               [label]="ipv4SubnetIDsLabel"
+               inputLabel="Select IPv4 subnet ID..."
                filterBy="name"
                selectBy="id">
     <div *option="let subnet">
       {{subnet.name}} ({{subnet.id}})
     </div>
   </km-combobox>
+
+  <ng-container *ngIf="isDualStackNetworkSelected">
+    <km-combobox #ipv6SubnetIDCombobox
+                 [required]="false"
+                 [grouped]="false"
+                 [isDisabled]="isPresetSelected"
+                 [valueFormatter]="ipv6SubnetIDDisplayName.bind(this)"
+                 [options]="ipv6SubnetIDs"
+                 [hint]="getHint(Controls.IPv6SubnetID)"
+                 [formControlName]="Controls.IPv6SubnetID"
+                 (changed)="onIPv6SubnetIDChange($event)"
+                 [label]="ipv6SubnetIDsLabel"
+                 inputLabel="Select IPv6 subnet ID..."
+                 filterBy="name"
+                 selectBy="id">
+      <div *option="let subnet">
+        {{subnet.name}} ({{subnet.id}})
+      </div>
+    </km-combobox>
+
+    <km-combobox #ipv6SubnetPoolCombobox
+                 [required]="false"
+                 [grouped]="false"
+                 [isDisabled]="isPresetSelected"
+                 [options]="ipv6SubnetPools"
+                 [hint]="getHint(Controls.IPv6SubnetPool)"
+                 [formControlName]="Controls.IPv6SubnetPool"
+                 (changed)="onIPv6SubnetPoolChange($event)"
+                 [label]="ipv6SubnetPoolsLabel"
+                 inputLabel="Select IPv6 subnet pool..."
+                 filterBy="name"
+                 selectBy="name">
+      <div *option="let subnetPool">
+        {{subnetPool.name}}
+      </div>
+    </km-combobox>
+  </ng-container>
 </form>

--- a/src/app/wizard/step/provider-settings/provider/extended/openstack/shared/types/ip-version.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/openstack/shared/types/ip-version.ts
@@ -1,0 +1,18 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export enum IPVersion {
+  IPv4 = 4,
+  IPv6 = 6,
+}

--- a/src/app/wizard/step/provider-settings/provider/extended/openstack/shared/types/state.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/openstack/shared/types/state.ts
@@ -1,0 +1,43 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export enum SecurityGroupState {
+  Ready = 'Security Group',
+  Loading = 'Loading...',
+  Empty = 'No Security Groups Available',
+}
+
+export enum NetworkState {
+  Ready = 'Network',
+  Loading = 'Loading...',
+  Empty = 'No Networks Available',
+}
+
+export enum IPv4SubnetIDState {
+  Ready = 'IPv4 Subnet ID',
+  Loading = 'Loading...',
+  Empty = 'No IPv4 Subnet IDs Available',
+}
+
+export enum IPv6SubnetIDState {
+  Ready = 'IPv6 Subnet ID',
+  Loading = 'Loading...',
+  Empty = 'No IPv6 Subnet IDs Available',
+}
+
+export enum IPv6SubnetPoolState {
+  Ready = 'IPv6 Subnet Pool',
+  Loading = 'Loading...',
+  Empty = 'No IPv6 Subnet Pools Available',
+}

--- a/src/test/data/cluster.ts
+++ b/src/test/data/cluster.ts
@@ -171,6 +171,8 @@ export function fakeOpenstackCluster(): Cluster {
           project: 'test-tenant',
           projectID: '',
           subnetID: 'test-subnet-id',
+          ipv6SubnetID: '',
+          ipv6SubnetPool: '',
         },
         providerName: 'openstack',
       },


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Add IPv6 subnet ID and IPv6 subnet pool for OpenStack cluster provider.

![screenshot-localhost_8000-2022 07 15-16_41_10](https://user-images.githubusercontent.com/13975988/179217727-05c9ffdb-e94f-4cc2-9132-3cfa75343acc.png)


**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4469 

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add IPv6 subnet ID and IPv6 subnet pool for OpenStack cluster provider.
```

