### PR TITLE
Delete external cluster from the cloud provider

### DIFF
--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -32,6 +32,7 @@ import {switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {ExternalMachineDeployment} from '@shared/entity/external-machine-deployment';
 import {MasterVersion} from '@shared/entity/cluster';
 import {ClusterListTab} from '@app/cluster/list/component';
+import {ExternalClusterService} from '@core/services/external-cluster';
 
 @Component({
   selector: 'km-external-cluster-details',
@@ -65,6 +66,7 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
     private readonly _router: Router,
     private readonly _matDialog: MatDialog,
     private readonly _clusterService: ClusterService,
+    private readonly _externalClusterService: ExternalClusterService,
     private readonly _userService: UserService,
     private readonly _appConfigService: AppConfigService
   ) {}
@@ -173,6 +175,6 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   disconnect(): void {
-    this._clusterService.showDisconnectClusterDialog(this.cluster, this.projectID);
+    this._externalClusterService.showDisconnectClusterDialog(this.cluster, this.projectID);
   }
 }

--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -33,6 +33,7 @@ import {ExternalMachineDeployment} from '@shared/entity/external-machine-deploym
 import {MasterVersion} from '@shared/entity/cluster';
 import {ClusterListTab} from '@app/cluster/list/component';
 import {ExternalClusterService} from '@core/services/external-cluster';
+import {ExternalClusterDeleteConfirmationComponent} from '@app/cluster/details/external-cluster/external-cluster-delete-confirmation/component';
 
 @Component({
   selector: 'km-external-cluster-details',
@@ -174,7 +175,23 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
     return MemberUtils.hasPermission(this._user, this._currentGroupConfig, 'cluster', Permission.Delete);
   }
 
-  disconnect(): void {
+  disconnectCluster(): void {
     this._externalClusterService.showDisconnectClusterDialog(this.cluster, this.projectID);
+  }
+
+  deleteClusterDialog(): void {
+    const modal = this._matDialog.open(ExternalClusterDeleteConfirmationComponent);
+    modal.componentInstance.projectID = this.projectID;
+    modal.componentInstance.cluster = this.cluster;
+    modal
+      .afterClosed()
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(isDeleted => {
+        if (isDeleted) {
+          this._router.navigate(['/projects/' + this.projectID + '/clusters'], {
+            fragment: `${ClusterListTab.ExternalCluster}`,
+          });
+        }
+      });
   }
 }

--- a/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/component.ts
+++ b/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/component.ts
@@ -1,0 +1,80 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AfterContentChecked, Component, ElementRef, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {MatDialogRef} from '@angular/material/dialog';
+import {GoogleAnalyticsService} from '@app/google-analytics.service';
+import {NotificationService} from '@core/services/notification';
+import {AdminSettings} from '@shared/entity/settings';
+import {ClipboardService} from 'ngx-clipboard';
+import {Observable, Subject} from 'rxjs';
+import {take} from 'rxjs/operators';
+import {ExternalCluster} from '@shared/entity/external-cluster';
+import {ExternalClusterService} from '@core/services/external-cluster';
+import {ClusterService} from '@core/services/cluster';
+
+@Component({
+  selector: 'km-external-cluster-delete-confirmation',
+  templateUrl: './template.html',
+  styleUrls: ['style.scss'],
+})
+export class ExternalClusterDeleteConfirmationComponent implements OnInit, OnDestroy, AfterContentChecked {
+  @Input() projectID: string;
+  @Input() cluster: ExternalCluster;
+  @ViewChild('clusterNameInput', {static: true}) clusterNameInputRef: ElementRef;
+  inputName = '';
+  settings: AdminSettings;
+  private readonly _unsubscribe = new Subject<void>();
+
+  constructor(
+    private readonly _clusterService: ClusterService,
+    private readonly _clipboardService: ClipboardService,
+    private readonly _dialogRef: MatDialogRef<ExternalClusterDeleteConfirmationComponent>,
+    private readonly _externalClusterService: ExternalClusterService,
+    private readonly _googleAnalyticsService: GoogleAnalyticsService,
+    private readonly _notificationService: NotificationService
+  ) {}
+
+  ngOnInit(): void {
+    this._googleAnalyticsService.emitEvent('clusterOverview', 'deleteClusterDialogOpened');
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  ngAfterContentChecked(): void {
+    this.clusterNameInputRef.nativeElement.focus();
+  }
+
+  onChange(event: any): void {
+    this.inputName = event.target.value;
+  }
+
+  copy(clipboard: string): void {
+    this._clipboardService.copy(clipboard);
+  }
+
+  getObservable(): Observable<void> {
+    return this._externalClusterService.deleteExternalCluster(this.projectID, this.cluster.id, 'delete').pipe(take(1));
+  }
+
+  onNext(): void {
+    this._dialogRef.close(true);
+    this._googleAnalyticsService.emitEvent('clusterOverview', 'clusterDeleted');
+    this._notificationService.success(`Deleting the ${this.cluster.name} cluster`);
+    this._clusterService.refreshExternalClusters();
+  }
+}

--- a/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/style.scss
+++ b/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/style.scss
@@ -1,0 +1,25 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.delete-cluster-checkbox {
+  margin-bottom: 8px;
+}
+
+.mat-form-field {
+  margin-top: 8px;
+}
+
+.km-icon-warning {
+  margin: 0 14.4px 0 0;
+}

--- a/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
+++ b/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<km-dialog-title>Delete Cluster</km-dialog-title>
+<km-dialog-title>Delete External Cluster</km-dialog-title>
 <mat-dialog-content>
   <p>Delete
     <b (click)="copy(cluster.name)"
@@ -24,32 +24,32 @@ limitations under the License.
 
   <mat-form-field>
     <mat-label>Cluster Name</mat-label>
-    <input id="km-delete-cluster-dialog-input"
+    <input id="km-delete-external-cluster-dialog-input"
            required
            matInput
            type="text"
            title="Cluster name"
-           (blur)="onChange($event)"
-           (keyup)="onChange($event)"
+           [(ngModel)]="inputName"
            #clusterNameInput>
   </mat-form-field>
 
 
-  <div *ngIf="hasMachineDeployments"
+  <div *ngIf="warningMessage"
        fxLayoutAlign=" start"
        class="warning-container">
     <i class="km-icon-warning"></i>
     <div class="km-text dynamic-kubelet-config-warning">
-      {{errorMessage}}
+      <p [innerHTML]="warningMessage"></p>
     </div>
   </div>
 </mat-dialog-content>
 
 <mat-dialog-actions>
-  <km-button id="km-delete-cluster-dialog-delete-btn"
+  <km-button id="km-delete-external-cluster-dialog-delete-btn"
              icon="km-icon-delete"
              label="Delete Cluster"
-             [disabled]="inputName !== cluster.name || !hasMachineDeployments"
+             [disabled]="inputName !== cluster.name || isLoadingMachineDeployments"
+             [matTooltip]="isLoadingMachineDeployments ? 'Loading Machine Deployments': null"
              [observable]="getObservable()"
              (next)="onNext()">
   </km-button>

--- a/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
+++ b/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
@@ -1,0 +1,46 @@
+<!--
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<km-dialog-title>Delete Cluster</km-dialog-title>
+<mat-dialog-content>
+  <p>Delete
+    <b (click)="copy(cluster.name)"
+       matTooltip="Click to copy"
+       class="km-copy">{{cluster.name}}</b>
+    cluster permanently?
+  </p>
+
+  <mat-form-field>
+    <mat-label>Cluster Name</mat-label>
+    <input id="km-delete-cluster-dialog-input"
+           required
+           matInput
+           type="text"
+           title="Cluster name"
+           (blur)="onChange($event)"
+           (keyup)="onChange($event)"
+           #clusterNameInput>
+  </mat-form-field>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <km-button id="km-delete-cluster-dialog-delete-btn"
+             icon="km-icon-delete"
+             label="Delete Cluster"
+             [disabled]="inputName !== cluster.name"
+             [observable]="getObservable()"
+             (next)="onNext()">
+  </km-button>
+</mat-dialog-actions>

--- a/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
+++ b/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
@@ -33,13 +33,23 @@ limitations under the License.
            (keyup)="onChange($event)"
            #clusterNameInput>
   </mat-form-field>
+
+
+  <div *ngIf="hasMachineDeployments"
+       fxLayoutAlign=" start"
+       class="warning-container">
+    <i class="km-icon-warning"></i>
+    <div class="km-text dynamic-kubelet-config-warning">
+      {{errorMessage}}
+    </div>
+  </div>
 </mat-dialog-content>
 
 <mat-dialog-actions>
   <km-button id="km-delete-cluster-dialog-delete-btn"
              icon="km-icon-delete"
              label="Delete Cluster"
-             [disabled]="inputName !== cluster.name"
+             [disabled]="inputName !== cluster.name || !hasMachineDeployments"
              [observable]="getObservable()"
              (next)="onNext()">
   </km-button>

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -25,14 +25,24 @@ limitations under the License.
               matTooltip="Go back to the cluster list">
         <i class="km-icon-arrow-left"></i>
       </button>
-      <button id="km-delete-cluster-btn"
+      <button id="km-disconnect-external-cluster-btn"
               mat-flat-button
               color="tertiary"
               fxLayoutAlign="center center"
-              (click)="disconnect()"
+              (click)="disconnectCluster()"
               [disabled]="!canDisconnect()">
         <i class="km-icon-mask km-icon-disconnect"></i>
         <span>Disconnect</span>
+      </button>
+
+      <button id="km-delete-external-cluster-btn"
+              mat-flat-button
+              color="tertiary"
+              fxLayoutAlign="center center"
+              [disabled]="!canDisconnect()"
+              (click)="deleteClusterDialog()">
+        <i class="km-icon-mask km-icon-delete"></i>
+        <span>Delete</span>
       </button>
       <div fxFlex></div>
       <button color="alternative"

--- a/src/app/cluster/list/external-cluster/component.ts
+++ b/src/app/cluster/list/external-cluster/component.ts
@@ -38,6 +38,7 @@ import {
   ExternalClusterProvider,
   ExternalClusterState,
 } from '@shared/entity/external-cluster';
+import {ExternalClusterDeleteConfirmationComponent} from '@app/cluster/details/external-cluster/external-cluster-delete-confirmation/component';
 
 @Component({
   selector: 'km-external-cluster-list',
@@ -187,6 +188,14 @@ export class ExternalClusterListComponent implements OnInit, OnChanges, OnDestro
     event.stopPropagation();
 
     this._clusterService.showDisconnectClusterDialog(cluster, this._selectedProject.id);
+  }
+
+  deleteClusterDialog(cluster: ExternalCluster, event: Event): void {
+    event.stopPropagation();
+
+    const modal = this._matDialog.open(ExternalClusterDeleteConfirmationComponent);
+    modal.componentInstance.projectID = this._selectedProject.id;
+    modal.componentInstance.cluster = cluster;
   }
 
   isPaginatorVisible(): boolean {

--- a/src/app/cluster/list/external-cluster/component.ts
+++ b/src/app/cluster/list/external-cluster/component.ts
@@ -39,6 +39,7 @@ import {
   ExternalClusterState,
 } from '@shared/entity/external-cluster';
 import {ExternalClusterDeleteConfirmationComponent} from '@app/cluster/details/external-cluster/external-cluster-delete-confirmation/component';
+import {ExternalClusterService} from '@core/services/external-cluster';
 
 @Component({
   selector: 'km-external-cluster-list',
@@ -63,6 +64,7 @@ export class ExternalClusterListComponent implements OnInit, OnChanges, OnDestro
 
   constructor(
     private readonly _clusterService: ClusterService,
+    private readonly _externalClusterService: ExternalClusterService,
     private readonly _projectService: ProjectService,
     private readonly _userService: UserService,
     private readonly _router: Router,
@@ -186,8 +188,7 @@ export class ExternalClusterListComponent implements OnInit, OnChanges, OnDestro
 
   disconnectClusterDialog(cluster: ExternalCluster, event: Event): void {
     event.stopPropagation();
-
-    this._clusterService.showDisconnectClusterDialog(cluster, this._selectedProject.id);
+    this._externalClusterService.showDisconnectClusterDialog(cluster, this._selectedProject.id);
   }
 
   deleteClusterDialog(cluster: ExternalCluster, event: Event): void {

--- a/src/app/cluster/list/external-cluster/template.html
+++ b/src/app/cluster/list/external-cluster/template.html
@@ -131,6 +131,16 @@ limitations under the License.
                   <i class="km-icon-mask km-icon-disconnect"></i>
                 </button>
               </ng-container>
+
+              <ng-container *ngSwitchCase="false">
+                <button mat-icon-button
+                        [attr.id]="'km-delete-cluster-' + element.name"
+                        matTooltip="Delete Cluster"
+                        (click)="deleteClusterDialog(element, $event)"
+                        [disabled]="!can(Permission.Delete)">
+                  <i class="km-icon-mask km-icon-delete"></i>
+                </button>
+              </ng-container>
             </ng-container>
           </div>
         </td>

--- a/src/app/cluster/list/external-cluster/template.html
+++ b/src/app/cluster/list/external-cluster/template.html
@@ -130,9 +130,6 @@ limitations under the License.
                         [disabled]="!can(Permission.Delete)">
                   <i class="km-icon-mask km-icon-disconnect"></i>
                 </button>
-              </ng-container>
-
-              <ng-container *ngSwitchCase="false">
                 <button mat-icon-button
                         [attr.id]="'km-delete-cluster-' + element.name"
                         matTooltip="Delete Cluster"

--- a/src/app/cluster/module.ts
+++ b/src/app/cluster/module.ts
@@ -69,6 +69,7 @@ import {ClustersComponent} from '@app/cluster/list/component';
 import {ReplicasDialogComponent} from '@app/cluster/details/external-cluster/replicas-dialog/component';
 import {NutanixProviderSettingsComponent} from '@app/cluster/details/cluster/edit-provider-settings/nutanix-provider-settings/component';
 import {VMwareCloudDirectorProviderSettingsComponent} from '@app/cluster/details/cluster/edit-provider-settings/vmware-cloud-director-provider-settings/component';
+import {ExternalClusterDeleteConfirmationComponent} from '@app/cluster/details/external-cluster/external-cluster-delete-confirmation/component';
 
 const components: any[] = [
   ClusterDetailsComponent,
@@ -83,6 +84,7 @@ const components: any[] = [
   MachineNetworksDisplayComponent,
   RBACComponent,
   ClusterDeleteConfirmationComponent,
+  ExternalClusterDeleteConfirmationComponent,
   VersionChangeDialogComponent,
   EditClusterComponent,
   RevokeTokenComponent,

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -244,6 +244,14 @@ export class ExternalClusterService {
     return this._http.post<ExternalCluster>(url, externalClusterModel, {headers}).pipe(catchError(() => of<null>()));
   }
 
+  deleteExternalCluster(projectID: string, clusterID: string, action: string): Observable<void> {
+    const url = `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters/${clusterID}`;
+    const headers = new HttpHeaders({
+      Action: action,
+    });
+    return this._http.delete<void>(url, {headers: headers});
+  }
+
   private _getAKSHeaders(location?: string): HttpHeaders {
     let headers = {};
     if (this._preset) {

--- a/src/app/shared/entity/external-cluster.ts
+++ b/src/app/shared/entity/external-cluster.ts
@@ -18,6 +18,11 @@ import {AKSCloudSpec, AKSClusterSpec} from './provider/aks';
 import {GKECloudSpec, GKEClusterSpec} from './provider/gke';
 import {EKSCloudSpec, EKSClusterSpec} from './provider/eks';
 
+export enum DeleteExternalClusterAction {
+  Delete = 'delete',
+  Disconnect = 'disconnect',
+}
+
 export enum ExternalClusterProvider {
   Custom = 'custom',
   AKS = 'aks',


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR adds functionality to delete external cluster(AKS/EKS/GKE) from cloud provider

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

- Delete external cluster

https://user-images.githubusercontent.com/17727069/179901663-d9e02537-6c1d-421c-9883-373c1b11acef.mp4

- When no **nodegroups** are attached user can't delete the external cluster unitl nodegroups are removed and just warning is shown to notify to user.

![nodegroups-attached](https://user-images.githubusercontent.com/17727069/179901729-aa757b83-0903-419e-9641-5b8284cd19bd.png)


Fixes #4627 

**Special notes for your reviewer**:

- Adds code improvement by moving `Disconnect` functionality  

**Notes:**

[Allows user to delete External Cluster from the Cloud Provider #10330](https://github.com/kubermatic/kubermatic/pull/10330)

> By default the cluster will `Disconnect` which means the KKP cluster object will be deleted cluster still exists on the provider, but is no longer connected/imported in KKP.

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Add support to delete external cluster AKS/EKS/GKE
```

