### PR TITLE
Enable OSM by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Dashboard for the Kubermatic Kubernetes Platform
-[![codecov](https://codecov.io/gh/kubermatic/dashboard/branch/master/graph/badge.svg?token=njXM3OrmAM)](https://codecov.io/gh/kubermatic/dashboard)
 
+[![codecov](https://codecov.io/gh/kubermatic/dashboard/branch/master/graph/badge.svg?token=njXM3OrmAM)](https://codecov.io/gh/kubermatic/dashboard)
 
 ## Overview & More information
 
 This repo contains the Dashboard for the Kubermatic Kubernetes Platform. For more information regarding overview, installation and user guides check [Kubermatic Kubernetes Platform repo][5] & [Kubermatic Kubernetes Platform docs website][21].
 
 ## Editions
+
 There are two editions of Kubermatic Kubernetes Platform:
 
 Kubermatic Kubernetes Platform Community Edition (CE) is available freely under the Apache License, Version 2.0.
 Kubermatic Kubernetes Platform Enterprise Edition (EE) includes premium features that are most useful for organizations with large-scale Kubernetes installations with more than 50 clusters. To access the Enterprise Edition and get official support please become a subscriber.
 
 ## Licensing
+
 See the [LICENSE](LICENSE) file for licensing information as it pertains to files in this repository.
 
 ## Troubleshooting
@@ -30,7 +32,6 @@ Feedback and discussion are available on [the mailing list][11].
 * Please familiarize yourself with the [Code of Conduct][4] before contributing.
 * See [CONTRIBUTING.md][2] and [Development.md][3] for instructions on the developer certificate of origin that we require.
 * Read how [we're using ZenHub][13] for project and roadmap planning
-
 
 ### Pull requests
 

--- a/src/app/cluster/details/cluster/component.ts
+++ b/src/app/cluster/details/cluster/component.ts
@@ -339,10 +339,6 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   getDownloadURL(): Observable<string> {
-    if (!this.isClusterAPIRunning) {
-      return of('');
-    }
-
     return this.settings.adminSettings.pipe(
       switchMap(settings =>
         iif(

--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -42,7 +42,6 @@ limitations under the License.
             class="km-share-kubeconfig-btn"
             color="alternative"
             (click)="shareConfigDialog()"
-            [disabled]="!kubernetesDashboardHealth"
             *ngIf="isShareConfigEnabled() | async">
       <i class="km-icon-mask km-icon-share"></i>
       <span>Share</span>
@@ -50,7 +49,6 @@ limitations under the License.
     <km-button color="alternative"
                icon="km-icon-download"
                label="Get Kubeconfig"
-               [disabled]="!kubernetesDashboardHealth"
                [observable]="getObservable()"
                (next)="onNext($event)">
     </km-button>
@@ -59,6 +57,7 @@ limitations under the License.
             type="button"
             (click)="addNode()"
             [fxHide]="nodeDc?.spec?.provider === 'bringyourown'"
+            [matTooltip]="isAddMachineDeploymentsEnabled() ? '' : !isClusterRunning ? 'Cluster is not healthy' : 'You do not have permission to perform this action'"
             [disabled]="!isAddMachineDeploymentsEnabled()">
       <i class="km-icon-mask km-icon-add"></i>
       <span>Add Machine Deployment</span>
@@ -70,6 +69,7 @@ limitations under the License.
        target="_blank"
        mat-flat-button
        [disabled]="!kubernetesDashboardHealth"
+       [matTooltip]="kubernetesDashboardHealth ? '' : 'Kubernetes Dashboard is not running'"
        *ngIf="(settings.adminSettings | async)?.enableDashboard">
       <i class="km-icon-mask km-icon-external-link"></i>
       <span>Open Dashboard</span>
@@ -221,8 +221,13 @@ limitations under the License.
                                 [healthState]="health?.controller"></km-property-health>
             <km-property-health label="Machine Controller"
                                 [healthState]="health?.machineController"></km-property-health>
+            <km-property-health *ngIf="cluster.spec.enableOperatingSystemManager"
+                                label="Operating System Manager"
+                                [healthState]="health?.operatingSystemManager"></km-property-health>
             <km-property-health label="User Controller Manager"
                                 [healthState]="health?.userClusterControllerManager"></km-property-health>
+            <km-property-health label="Kubernetes Dashboard"
+                                [healthState]="health?.kubernetesDashboard"></km-property-health>
           </div>
 
           <div fxFlex="33"
@@ -361,13 +366,6 @@ limitations under the License.
           <div fxFlex="33"
                class="container-spacing">
             <div class="section-header">Misc</div>
-            <div fxLayout="row">
-              <km-property-boolean label="Operating System Manager"
-                                   [value]="cluster.spec.enableOperatingSystemManager">
-              </km-property-boolean>
-              <span class="km-label-primary secondary">experimental</span>
-            </div>
-
             <div fxLayout="row">
               <km-property-boolean label="Audit Logging"
                                    [value]="cluster.spec.auditLogging?.enabled">

--- a/src/app/core/services/feature-gate.ts
+++ b/src/app/core/services/feature-gate.ts
@@ -21,7 +21,6 @@ import {catchError, shareReplay, switchMap} from 'rxjs/operators';
 
 export interface FeatureGates {
   konnectivityService?: boolean;
-  operatingSystemManager?: boolean;
 }
 
 @Injectable({

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -25,7 +25,6 @@ import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angula
 import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {DatacenterService} from '@core/services/datacenter';
-import {FeatureGateService} from '@core/services/feature-gate';
 import {NameGeneratorService} from '@core/services/name-generator';
 import {NodeDataService} from '@core/services/node-data/service';
 import {SettingsService} from '@core/services/settings';
@@ -82,7 +81,6 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   @Input() showExtended = false;
   labels: object = {};
   taints: Taint[] = [];
-  featureGateOperatingSystemManagerEnabled: boolean;
   dialogEditMode = false;
   endOfDynamicKubeletConfigSupportVersion: string = END_OF_DYNAMIC_KUBELET_CONFIG_SUPPORT_VERSION;
 
@@ -91,10 +89,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   }
 
   get showOperatingSystemProfile(): boolean {
-    return (
-      this._clusterSpecService.cluster.spec.enableOperatingSystemManager &&
-      this.featureGateOperatingSystemManagerEnabled
-    );
+    return this._clusterSpecService.cluster.spec.enableOperatingSystemManager;
   }
 
   get isDynamicKubletConfigSupported(): boolean {
@@ -108,7 +103,6 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     private readonly _datacenterService: DatacenterService,
     private readonly _nodeDataService: NodeDataService,
     private readonly _settingsService: SettingsService,
-    private readonly _featureGatesService: FeatureGateService,
     private readonly _cdr: ChangeDetectorRef
   ) {
     super();
@@ -187,10 +181,6 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
       const replicas = this.dialogEditMode ? this._nodeDataService.nodeData.count : settings.defaultNodeCount;
       this.form.get(Controls.Count).setValue(replicas);
     });
-
-    this._featureGatesService.featureGates
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(featureGates => (this.featureGateOperatingSystemManagerEnabled = featureGates.operatingSystemManager));
   }
 
   ngOnDestroy(): void {

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -113,7 +113,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   masterVersions: MasterVersion[] = [];
   admissionPlugins: AdmissionPlugin[] = [];
   labels: object;
-  operatingSystemManagerFeatureEnabled: boolean;
   podNodeSelectorAdmissionPluginConfig: object;
   asyncLabelValidators = [AsyncValidators.RestrictedLabelKeyName(ResourceType.Cluster)];
   proxyMode = ProxyMode;
@@ -147,7 +146,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   ngOnInit(): void {
     this._featureGatesService.featureGates.pipe(takeUntil(this._unsubscribe)).subscribe(featureGates => {
       this.isKonnectivityEnabled = !!featureGates?.konnectivityService;
-      this.operatingSystemManagerFeatureEnabled = featureGates?.operatingSystemManager;
     });
 
     this.form = this._builder.group({
@@ -157,7 +155,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.AuditLogging]: this._builder.control(false),
       [Controls.AuditPolicyPreset]: this._builder.control(''),
       [Controls.UserSSHKeyAgent]: this._builder.control(true),
-      [Controls.OperatingSystemManager]: this._builder.control(false),
+      [Controls.OperatingSystemManager]: this._builder.control(true),
       [Controls.OPAIntegration]: this._builder.control(false),
       [Controls.Konnectivity]: this._builder.control(true),
       [Controls.MLALogging]: this._builder.control(false),

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -379,12 +379,10 @@ limitations under the License.
               </mat-checkbox>
             </ng-container>
 
-            <mat-checkbox *ngIf="operatingSystemManagerFeatureEnabled"
-                          [formControlName]="Controls.OperatingSystemManager">
+            <mat-checkbox [formControlName]="Controls.OperatingSystemManager">
               Operating System Manager
-              <span class="km-label-primary">Experimental</span>
               <i class="km-icon-info km-pointer"
-                 matTooltip="Enable to use OSM for creating and managing the configuration that are needed to configure worker nodes. This is an experimental feature and usage in production environment is not recommended."></i>
+                 matTooltip="Enable to use OSM for creating and managing worker node configurations. Disable this to use legacy machine-controller userdata, its usage in production environment is not recommended."></i>
             </mat-checkbox>
 
             <km-label-form title="Labels"


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
This PR does the following things:

- Enable Operating System Manager by default in the `Cluster Settings` step in the cluster creation wizard.
- Remove usage of the `experimental` keyword with OSM
- Display health status for OSM and Kubernetes dashboard on cluster summary page.
- Some other fixes

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Operating System Manager is enabled by default for new clusters.
```