### PR TITLE
migrate to yq4

### DIFF
--- a/hack/e2e/run-tests.sh
+++ b/hack/e2e/run-tests.sh
@@ -42,7 +42,7 @@ if [ $CYPRESS_MOCKS != "true" ]; then
   source hack/e2e/setup-kubermatic-in-kind.sh
 
   export CYPRESS_SEED_NAME="${SEED_NAME}"
-  export CYPRESS_KUBECONFIG_ENCODED="$(kind get kubeconfig --name="$KIND_CLUSTER_NAME" --internal | yq r - -j -I=0 | base64 -w0)"
+  export CYPRESS_KUBECONFIG_ENCODED="$(kind get kubeconfig --name="$KIND_CLUSTER_NAME" --internal | base64 -w0)"
   export CYPRESS_USERNAME="roxy@kubermatic.com"
   export CYPRESS_USERNAME_2="roxy2@kubermatic.com"
   export CYPRESS_PASSWORD="password"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
It's time to migrate to yq4. See https://mikefarah.gitbook.io/yq/upgrading-from-v3 for more information.

I chose to make it explicit what version we're using for now, in order to slowly get rid of yq3 over the next few PRs. It is a bit annoying that devs would need a  `yq4` binary on their machines, but I suspect many have v3 and v4 around, like I do.

I have no idea why exactly we had to YAML-to-JSON the kubeconfig, and also why it should not have been encoded. So I simply removed `yq` here alltogether.

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

