### PR TITLE
Remove delete functionality for imported cluster

### DIFF
--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -35,7 +35,8 @@ limitations under the License.
         <span>Disconnect</span>
       </button>
 
-      <button id="km-delete-external-cluster-btn"
+      <button *ngIf="!cluster?.labels || cluster.labels['isImported'] !== 'true'"
+              id="km-delete-external-cluster-btn"
               mat-flat-button
               color="tertiary"
               fxLayoutAlign="center center"

--- a/src/app/cluster/list/external-cluster/template.html
+++ b/src/app/cluster/list/external-cluster/template.html
@@ -130,7 +130,8 @@ limitations under the License.
                         [disabled]="!can(Permission.Delete)">
                   <i class="km-icon-mask km-icon-disconnect"></i>
                 </button>
-                <button mat-icon-button
+                <button *ngIf="!element?.labels || element?.labels['isImported'] !== 'true'"
+                        mat-icon-button
                         [attr.id]="'km-delete-cluster-' + element.name"
                         matTooltip="Delete Cluster"
                         (click)="deleteClusterDialog(element, $event)"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

This PR doesn't show `delete` icon  when cluster is `imported`:

- on List page
- on Details page

https://user-images.githubusercontent.com/17727069/180807427-59936c98-4137-44b5-93c9-e04fecfd31a9.mp4



**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

```txt
{
    "isImported": "true" || "false"
    "project-id": "jgm2x2q9rc"
}
```
Since `string` value is returned from Backend so had to implicit check of string on UI

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. 
-->
```release-note
NONE
```

