### PR TITLE
Skip polling for machine deployments when cluster is marked for deletion

### DIFF
--- a/src/app/cluster/list/cluster/component.ts
+++ b/src/app/cluster/list/cluster/component.ts
@@ -139,7 +139,7 @@ export class ClusterListComponent implements OnInit, OnChanges, OnDestroy {
                     .pipe(tap(health => (this.health[cluster.id] = health)))
                     .pipe(
                       switchMap(_ =>
-                        Health.allHealthy(this.health[cluster.id])
+                        Health.allHealthy(this.health[cluster.id]) && !cluster.deletionTimestamp
                           ? this._machineDeploymentService.list(cluster.id, this._selectedProject.id)
                           : of([])
                       )


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:
On the list cluster view, we keep polling for machine deployments even if the cluster is marked for deletion. This is just a wasteful API call that results in an undesired error message.

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

![Screenshot 2022-07-25 at 10 58 24 PM](https://user-images.githubusercontent.com/18264334/180844317-18aada06-3e50-4391-9dac-517c37153c11.png)


**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

