### PR TITLE
Configure pod affinity/anti-affinity and node affinity preset settings

### DIFF
--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -304,6 +304,28 @@ limitations under the License.
                 <div key>Secondary Disk {{i + 1}}</div>
                 <div value>{{disk.storageClassName}}, {{disk.size}}</div>
               </km-property>
+              <km-property *ngIf="element.spec.cloud.kubevirt?.podAffinityPreset">
+                <div key>Pod Affinity Preset</div>
+                <div value>{{element.spec.cloud.kubevirt.podAffinityPreset}}</div>
+              </km-property>
+              <km-property *ngIf="element.spec.cloud.kubevirt.podAntiAffinityPreset">
+                <div key>Pod Anti-Affinity Preset</div>
+                <div value>{{element.spec.cloud.kubevirt.podAntiAffinityPreset}}</div>
+              </km-property>
+              <ng-container *ngIf="element.spec.cloud.kubevirt.nodeAffinityPreset as nodeAffinityPreset">
+                <km-property>
+                  <div key>Node Affinity Preset</div>
+                  <div value>{{nodeAffinityPreset.Type}}</div>
+                </km-property>
+                <km-property *ngIf="nodeAffinityPreset.Key">
+                  <div key>Node Affinity Preset Key</div>
+                  <div value>{{nodeAffinityPreset.Key}}</div>
+                </km-property>
+                <km-property *ngIf="nodeAffinityPreset.Values?.length">
+                  <div key>Node Affinity Preset Values</div>
+                  <div value>{{nodeAffinityPreset.Values.join(', ')}}</div>
+                </km-property>
+              </ng-container>
             </ng-container>
 
             <km-property *ngIf="element.spec.cloud.vsphere">

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -144,4 +144,58 @@ limitations under the License.
        class="no-secondary-disks-msg km-text-muted">
     No secondary disks configured. Use the add button above to configure up to three disks.
   </div>
+
+  <ng-container *ngTemplateOutlet="selectAffinityPreset; context: {label: 'Pod Affinity Preset', controlName: Controls.PodAffinityPreset, resetCallback: resetPodAffinityPresetControl.bind(this)}"></ng-container>
+
+  <ng-container *ngTemplateOutlet="selectAffinityPreset; context: {label: 'Pod Anti-Affinity Preset', controlName: Controls.PodAntiAffinityPreset, resetCallback: resetPodAntiAffinityPresetControl.bind(this)}"></ng-container>
+
+  <ng-container *ngTemplateOutlet="selectAffinityPreset; context: {label: 'Node Affinity Preset Type', controlName: Controls.NodeAffinityPreset, resetCallback: resetNodeAffinityPresetControl.bind(this)}"></ng-container>
+
+  <mat-form-field fxFlex>
+    <mat-label>Node Affinity Preset Key</mat-label>
+    <input matInput
+           [id]="Controls.NodeAffinityPresetKey"
+           [formControlName]="Controls.NodeAffinityPresetKey"
+           type="text"
+           autocomplete="off">
+  </mat-form-field>
+
+  <km-chip-list label="Node Affinity Preset Values"
+                [tags]="nodeAffinityPresetValues"
+                (onChange)="onNodeAffinityPresetValuesChange($event)"
+                [formControlName]="Controls.NodeAffinityPresetValues"
+                [disabled]="form.get(Controls.NodeAffinityPresetValues).disabled"
+                placeholder="Add values..."
+                fxFlex></km-chip-list>
+
+  <ng-template #selectAffinityPreset
+               let-label="label"
+               let-controlName="controlName"
+               let-resetCallback="resetCallback">
+    <mat-form-field fxFlex
+                    class="km-dropdown-with-suffix">
+      <mat-label>{{label}}</mat-label>
+      <mat-select [formControlName]="controlName"
+                  class="km-select-ellipsis"
+                  disableOptionCentering>
+        <mat-option *ngFor="let preset of affinityPresetOptions"
+                    [value]="preset">
+          {{preset}}
+        </mat-option>
+        <mat-select-trigger fxLayout="row">
+          <div fxLayoutAlign="start">{{form.get(controlName).value}}</div>
+
+          <div fxLayoutAlign="end"
+               class="km-select-trigger-button-wrapper">
+            <button matSuffix
+                    mat-icon-button
+                    aria-label="Clear"
+                    (click)="resetCallback(); $event.stopPropagation()">
+              <i class="km-icon-mask km-icon-remove"></i>
+            </button>
+          </div>
+        </mat-select-trigger>
+      </mat-select>
+    </mat-form-field>
+  </ng-template>
 </form>

--- a/src/app/shared/components/chip-list/component.ts
+++ b/src/app/shared/components/chip-list/component.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {COMMA, ENTER, SPACE} from '@angular/cdk/keycodes';
-import {Component, EventEmitter, forwardRef, Input, OnDestroy, Output} from '@angular/core';
+import {Component, EventEmitter, forwardRef, Input, OnChanges, OnDestroy, Output, SimpleChanges} from '@angular/core';
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -52,13 +52,14 @@ enum Controls {
     },
   ],
 })
-export class ChipListComponent implements OnDestroy, ControlValueAccessor, Validator {
+export class ChipListComponent implements OnChanges, OnDestroy, ControlValueAccessor, Validator {
   private _unsubscribe = new Subject<void>();
   readonly controls = Controls;
   @Input() title: string;
   @Input() label: string;
   @Input() description = 'Use comma, enter or space key as the separator.';
   @Input() placeholder: string;
+  @Input() disabled: boolean;
   @Input('kmPatternError') patternError = 'Invalid pattern';
   @Input('kmPattern') pattern: string;
   @Input() tags: string[] = [];
@@ -70,10 +71,23 @@ export class ChipListComponent implements OnDestroy, ControlValueAccessor, Valid
 
   ngOnInit(): void {
     this.form = this._builder.group({[Controls.Tags]: this._builder.control(this.tags, this._validators())});
+    if (this.disabled) {
+      this.form.get(Controls.Tags).disable();
+    }
     this.onChange.pipe(takeUntil(this._unsubscribe)).subscribe(_ => {
       this.form.get(Controls.Tags).setValue(this.tags);
       this.form.get(Controls.Tags).updateValueAndValidity();
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.disabled && this.form) {
+      if (this.disabled) {
+        this.form.get(Controls.Tags).disable();
+      } else if (this.form.get(Controls.Tags).disabled) {
+        this.form.get(Controls.Tags).enable();
+      }
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -749,6 +749,28 @@ limitations under the License.
                 <div key>Secondary Disk {{i + 1}}</div>
                 <div value>{{disk.storageClassName}}, {{disk.size}}</div>
               </km-property>
+              <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.podAffinityPreset">
+                <div key>Pod Affinity Preset</div>
+                <div value>{{machineDeployment.spec.template.cloud?.kubevirt.podAffinityPreset}}</div>
+              </km-property>
+              <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.podAntiAffinityPreset">
+                <div key>Pod Anti-Affinity Preset</div>
+                <div value>{{machineDeployment.spec.template.cloud?.kubevirt.podAntiAffinityPreset}}</div>
+              </km-property>
+              <ng-container *ngIf="machineDeployment.spec.template.cloud?.kubevirt.nodeAffinityPreset as nodeAffinityPreset">
+                <km-property>
+                  <div key>Node Affinity Preset</div>
+                  <div value>{{nodeAffinityPreset.Type}}</div>
+                </km-property>
+                <km-property *ngIf="nodeAffinityPreset.Key">
+                  <div key>Node Affinity Preset Key</div>
+                  <div value>{{nodeAffinityPreset.Key}}</div>
+                </km-property>
+                <km-property *ngIf="nodeAffinityPreset.Values?.length">
+                  <div key>Node Affinity Preset Values</div>
+                  <div value>{{nodeAffinityPreset.Values.join(', ')}}</div>
+                </km-property>
+              </ng-container>
             </ng-container>
 
             <!-- Nutanix Nodes -->

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {KubeVirtAffinityPreset} from '@shared/entity/provider/kubevirt';
 import {VMwareCloudDirectorIPAllocationMode} from '@shared/entity/provider/vmware-cloud-director';
 import {NodeProvider, OperatingSystem} from '../model/NodeProviderConstants';
 
@@ -219,11 +220,20 @@ export class KubeVirtNodeSpec {
   primaryDiskStorageClassName: string;
   primaryDiskSize: string;
   secondaryDisks?: KubeVirtSecondaryDisk[];
+  podAffinityPreset?: KubeVirtAffinityPreset;
+  podAntiAffinityPreset?: KubeVirtAffinityPreset;
+  nodeAffinityPreset?: KubeVirtNodeAffinityPreset;
 }
 
 export class KubeVirtSecondaryDisk {
   size: string;
   storageClassName: string;
+}
+
+export class KubeVirtNodeAffinityPreset {
+  Type: KubeVirtAffinityPreset;
+  Key?: string;
+  Values?: string[];
 }
 
 export class OpenstackNodeSpec {

--- a/src/app/shared/entity/provider/kubevirt.ts
+++ b/src/app/shared/entity/provider/kubevirt.ts
@@ -21,3 +21,8 @@ export class KubeVirtVMInstancePreset {
 export class KubeVirtStorageClass {
   name: string;
 }
+
+export enum KubeVirtAffinityPreset {
+  Hard = 'hard',
+  Soft = 'soft',
+}


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Configure pod affinity/anti-affinity and node affinity preset settings for KubeVirt provider.

![screenshot-localhost_8000-2022 07 26-14_24_37](https://user-images.githubusercontent.com/13975988/180987374-d6737d36-d261-4412-a1d6-f5b94a6fb482.png)


**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4433 

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Configure pod affinity/anti-affinity and node affinity preset settings for KubeVirt provider.
```

