### PR TITLE
Remove kubevirt specific check in Cluster Spec service

### DIFF
--- a/src/app/core/services/cluster-spec.ts
+++ b/src/app/core/services/cluster-spec.ts
@@ -55,16 +55,6 @@ export class ClusterSpecService {
       );
     }
 
-    // Copy kubevirt pre-allocated data volumes using different customizer, it
-    // will overwrite destination array with source array instead of ignoring the changes.
-    if (cluster.spec?.cloud?.kubevirt?.preAllocatedDataVolumes) {
-      this._cluster.spec.cloud.kubevirt.preAllocatedDataVolumes = _.mergeWith(
-        this._cluster.spec.cloud.kubevirt.preAllocatedDataVolumes,
-        cluster.spec.cloud.kubevirt.preAllocatedDataVolumes,
-        (dest, src) => (_.isArray(dest) && _.isArray(src) ? src : undefined)
-      );
-    }
-
     this.clusterChanges.emit(this._cluster);
   }
 

--- a/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
@@ -17,13 +17,7 @@ import {FormArray, FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} fr
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {PresetsService} from '@core/services/wizard/presets';
 import {ComboboxControls} from '@shared/components/combobox/component';
-import {
-  CloudSpec,
-  Cluster,
-  ClusterSpec,
-  KubeVirtCloudSpec,
-  KubeVirtPreAllocatedDataVolume,
-} from '@shared/entity/cluster';
+import {Cluster, KubeVirtPreAllocatedDataVolume} from '@shared/entity/cluster';
 import {KubeVirtStorageClass} from '@shared/entity/provider/kubevirt';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
@@ -113,7 +107,12 @@ export class KubeVirtProviderExtendedComponent extends BaseFormValidator impleme
       .pipe(debounceTime(this._debounceTime))
       .pipe(distinctUntilChanged())
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(_ => (this._clusterSpecService.cluster = this._getCluster()));
+      .subscribe(_ => {
+        const preAllocatedDataVolumes = this._preAllocatedDataVolumes;
+        this._clusterSpecService.cluster.spec.cloud.kubevirt.preAllocatedDataVolumes = preAllocatedDataVolumes.length
+          ? preAllocatedDataVolumes
+          : null;
+      });
   }
 
   ngOnDestroy(): void {
@@ -203,19 +202,6 @@ export class KubeVirtProviderExtendedComponent extends BaseFormValidator impleme
   private _clearCredentials(): void {
     this._preset = '';
     this._kubeconfig = '';
-  }
-
-  private _getCluster(): Cluster {
-    const preAllocatedDataVolumes = this._preAllocatedDataVolumes;
-    return {
-      spec: {
-        cloud: {
-          kubevirt: {
-            preAllocatedDataVolumes: preAllocatedDataVolumes.length ? preAllocatedDataVolumes : null,
-          } as KubeVirtCloudSpec,
-        } as CloudSpec,
-      } as ClusterSpec,
-    } as Cluster;
   }
 
   private get _preAllocatedDataVolumes(): KubeVirtPreAllocatedDataVolume[] {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Instead of adding a kubevirt specific check in `cluster-spec` service, its better to set `preAllocatedDataVolumes` directly in cluster spec object.

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

