### PR TITLE
Use `Gi` unit for pre-allocated data volume disk size

### DIFF
--- a/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
@@ -222,7 +222,7 @@ export class KubeVirtProviderExtendedComponent extends BaseFormValidator impleme
     return this.preAllocatedDataVolumesFormArray.controls.map(perAllocatedDataVolumeFormGroup => {
       return {
         name: perAllocatedDataVolumeFormGroup.get(Controls.PreAllocatedDataVolumeName).value,
-        size: `${+perAllocatedDataVolumeFormGroup.get(Controls.PreAllocatedDataVolumeSize).value}GB`,
+        size: `${+perAllocatedDataVolumeFormGroup.get(Controls.PreAllocatedDataVolumeSize).value}Gi`,
         storageClass: perAllocatedDataVolumeFormGroup.get(Controls.PreAllocatedDataVolumeStorageClass).value[
           ComboboxControls.Select
         ],


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Use `Gi` unit for pre-allocated data volume disk size

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #


**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

