### PR TITLE
Incorrect number of secondary disks

### DIFF
--- a/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -159,6 +159,16 @@ export class KubeVirtBasicNodeDataComponent
     this.form.valueChanges
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._nodeDataService.nodeData = this._getNodeData()));
+
+    this.form
+      .get(Controls.SecondaryDisks)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => {
+        const secondaryDisks = this._secondaryDisks;
+        this._nodeDataService.nodeData.spec.cloud.kubevirt.secondaryDisks = secondaryDisks?.length
+          ? secondaryDisks
+          : null;
+      });
   }
 
   ngAfterViewChecked(): void {
@@ -318,7 +328,6 @@ export class KubeVirtBasicNodeDataComponent
     const flavor = this.form.get(Controls.VMFlavor).value[ComboboxControls.Select];
     const cpus = this.form.get(Controls.CPUs).value;
     const memory = this.form.get(Controls.Memory).value;
-    const secondaryDisks = this._secondaryDisks;
     const nodeAffinityPreset = this.form.get(Controls.NodeAffinityPreset).value;
     const nodeAffinityPresetData: KubeVirtNodeAffinityPreset = !nodeAffinityPreset
       ? null
@@ -340,7 +349,6 @@ export class KubeVirtBasicNodeDataComponent
               ComboboxControls.Select
             ],
             primaryDiskSize: `${this.form.get(Controls.PrimaryDiskSize).value}Gi`,
-            secondaryDisks: secondaryDisks?.length ? secondaryDisks : null,
             podAffinityPreset: this.form.get(Controls.PodAffinityPreset).value,
             podAntiAffinityPreset: this.form.get(Controls.PodAntiAffinityPreset).value,
             nodeAffinityPreset: nodeAffinityPresetData,

--- a/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -321,6 +321,12 @@ export class KubeVirtBasicNodeDataComponent
       this.form.get(Controls.NodeAffinityPreset).setValue(this._initialData.nodeAffinityPreset?.Type);
       this.form.get(Controls.NodeAffinityPresetKey).setValue(this._initialData.nodeAffinityPreset?.Key);
       this.nodeAffinityPresetValues = this._initialData.nodeAffinityPreset?.Values || [];
+
+      if (this._initialData.secondaryDisks?.length) {
+        this._initialData.secondaryDisks.forEach(disk => {
+          this.addSecondaryDisk(disk.storageClassName, disk.size.match(/\d+/)[0]);
+        });
+      }
     }
   }
 

--- a/src/app/shared/components/combobox/component.ts
+++ b/src/app/shared/components/combobox/component.ts
@@ -144,5 +144,6 @@ export class FilteredComboboxComponent extends BaseFormValidator implements OnIn
 
   writeValue(value: string | string[]) {
     this.form.get(ComboboxControls.Select).setValue(value, {emitEvent: false});
+    this.selected = value;
   }
 }


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR fixes 2 issues:

1. When removing secondary disks from initial nodes step in wizard, value was not being updated in `nodeData`.
2. Secondary Disks were not shown in edit machine deployment dialog.

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4721 

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Display configured secondary disks in edit machine deployment dialog.
```

