### PR TITLE
Hide members and prevent API call when ownership is other than `owner`

### DIFF
--- a/src/app/core/services/project.ts
+++ b/src/app/core/services/project.ts
@@ -110,8 +110,7 @@ export class ProjectService {
     if (project?.status === ProjectStatus.Active) {
       this.onProjectChange.emit(project);
       this._userService.currentUser.pipe(take(1)).subscribe(settings => {
-        projectLandingPage = settings.userSettings.useClustersView ? View.Clusters : View.Overview;
-
+        projectLandingPage = settings.userSettings?.useClustersView ? View.Clusters : View.Overview;
         this._router.navigateByUrl(`/projects/${project.id}/${projectLandingPage}`);
       });
     } else {

--- a/src/app/project-overview/members-overview/component.ts
+++ b/src/app/project-overview/members-overview/component.ts
@@ -24,6 +24,7 @@ import {Member} from '@shared/entity/member';
 export class MembersOverviewComponent {
   @Input() project: Project;
   @Input() members: Member[] = [];
+  @Input() showMembers = true;
 
   get ownerNames(): string {
     return this.project?.owners

--- a/src/app/project-overview/members-overview/template.html
+++ b/src/app/project-overview/members-overview/template.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <mat-card>
   <mat-card-header>
-    <mat-card-title>Owners & Members</mat-card-title>
+    <mat-card-title>{{showMembers ? 'Owners & Members' : 'Owners'}}</mat-card-title>
   </mat-card-header>
   <mat-card-content fxLayoutGap="10px grid">
     <div fxLayout="row"
@@ -25,7 +25,8 @@ limitations under the License.
       <i class="km-icon-mask km-icon-owner"></i>
       <div>{{ownerNames}}</div>
     </div>
-    <div fxLayout="row"
+    <div *ngIf="showMembers"
+         fxLayout="row"
          fxLayoutAlign=" center"
          fxLayoutGap="15px">
       <i class="km-icon-mask km-icon-member"></i>

--- a/src/app/project-overview/template.html
+++ b/src/app/project-overview/template.html
@@ -119,7 +119,8 @@ limitations under the License.
       <km-providers-overview [clusters]="clusters"
                              [externalClusters]="externalClusters"></km-providers-overview>
       <km-members-overview [project]="project"
-                           [members]="members"></km-members-overview>
+                           [members]="members"
+                           [showMembers]="hasPermission(View.Members)"></km-members-overview>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

**role:** Editor/Viewer 

![viewer:editor case](https://user-images.githubusercontent.com/17727069/181498642-177792ba-5725-492a-867d-8deef1a03201.png)

**role:** Owner:

![owner](https://user-images.githubusercontent.com/17727069/181498624-635fd066-184e-4d53-ac9d-92d09d61764d.png)


**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4723 

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Display owners only when group project binding has role editors/viewers.
```

