### PR TITLE
Add regex to allow cluster template name to only contain alphanumeric characters and dashes

### DIFF
--- a/src/app/shared/components/save-cluster-template/component.ts
+++ b/src/app/shared/components/save-cluster-template/component.ts
@@ -25,6 +25,7 @@ import {ClusterTemplateService} from '@core/services/cluster-templates';
 import {SSHKey} from '@shared/entity/ssh-key';
 import _ from 'lodash';
 import {Observable} from 'rxjs';
+import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
 
 class SaveClusterTemplateDialogData {
   cluster: Cluster;
@@ -57,7 +58,7 @@ export class SaveClusterTemplateDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.form = new FormGroup({
-      [Control.Name]: new FormControl('', [Validators.required]),
+      [Control.Name]: new FormControl('', [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]),
       [Control.Scope]: new FormControl(ClusterTemplateScope.User, [Validators.required]),
     });
 

--- a/src/app/shared/components/save-cluster-template/template.html
+++ b/src/app/shared/components/save-cluster-template/template.html
@@ -33,6 +33,9 @@ limitations under the License.
       <mat-error *ngIf="form.get(control.Name).hasError('required')">
         Name is <strong>required</strong>.
       </mat-error>
+      <mat-error *ngIf="form.get(control.Name).hasError('pattern')">
+        Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
+      </mat-error>
     </mat-form-field>
 
     <label class="km-radio-group-label">Select a Scope</label>


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR adds regex to allow name to contain alphanumeric characters and dashes.


https://user-images.githubusercontent.com/17727069/181500794-b0f280ec-3b31-47b0-8ac0-57dcaa08be54.mp4


**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4477 

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

