### PR TITLE
Support for disabling kubernetes-dashboard for user clusters

### DIFF
--- a/src/app/cluster/details/cluster/component.ts
+++ b/src/app/cluster/details/cluster/component.ts
@@ -117,7 +117,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   get kubernetesDashboardHealth(): boolean {
-    return this.health?.kubernetesDashboard === HealthState.Up;
+    return this.cluster?.spec?.kubernetesDashboard?.enabled && this.health?.kubernetesDashboard === HealthState.Up;
   }
 
   constructor(

--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -54,6 +54,8 @@ enum Controls {
   Konnectivity = 'konnectivity',
   MLALogging = 'loggingEnabled',
   MLAMonitoring = 'monitoringEnabled',
+  OperatingSystemManager = 'enableOperatingSystemManager',
+  KubernetesDashboardEnabled = 'kubernetesDashboardEnabled',
 }
 
 @Component({
@@ -128,6 +130,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       }),
       [Controls.MLALogging]: new FormControl(!!this.cluster.spec.mla && this.cluster.spec.mla.loggingEnabled),
       [Controls.MLAMonitoring]: new FormControl(!!this.cluster.spec.mla && this.cluster.spec.mla.monitoringEnabled),
+      [Controls.OperatingSystemManager]: new FormControl(this.cluster.spec.enableOperatingSystemManager),
+      [Controls.KubernetesDashboardEnabled]: new FormControl(
+        !!this.cluster.spec.kubernetesDashboard && this.cluster.spec.kubernetesDashboard.enabled
+      ),
       [Controls.AdmissionPlugins]: new FormControl(this.cluster.spec.admissionPlugins),
       [Controls.PodNodeSelectorAdmissionPluginConfig]: new FormControl(''),
       [Controls.EventRateLimitConfig]: new FormControl(this.eventRateLimitConfig?.namespace),
@@ -287,6 +293,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         clusterNetwork: {
           konnectivityEnabled: this.form.get(Controls.Konnectivity).value,
         },
+        kubernetesDashboard: {
+          enabled: this.form.get(Controls.KubernetesDashboardEnabled).value,
+        },
+        enableOperatingSystemManager: this.form.get(Controls.OperatingSystemManager).value,
         mla: {
           loggingEnabled: this.form.get(Controls.MLALogging).value,
           monitoringEnabled: this.form.get(Controls.MLAMonitoring).value,

--- a/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -156,6 +156,16 @@ limitations under the License.
            matTooltip="User Cluster Monitoring is enforced by your admin."></i>
       </mat-checkbox>
 
+      <mat-checkbox [formControlName]="Controls.KubernetesDashboardEnabled">
+        Kubernetes Dashboard
+      </mat-checkbox>
+
+      <mat-checkbox [formControlName]="Controls.OperatingSystemManager">
+        Operating System Manager
+        <i class="km-icon-info km-pointer"
+           matTooltip="Disabling this is not recommended in a production environment. Enabling/disabling this will not rotate the machines automatically. The users need to update the Machine Deployments manually."></i>
+      </mat-checkbox>
+
       <km-label-form title="Labels"
                      [(labels)]="labels"
                      [inheritedLabels]="cluster.inheritedLabels"

--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -69,7 +69,7 @@ limitations under the License.
        target="_blank"
        mat-flat-button
        [disabled]="!kubernetesDashboardHealth"
-       [matTooltip]="kubernetesDashboardHealth ? '' : 'Kubernetes Dashboard is not running'"
+       [matTooltip]="kubernetesDashboardHealth ? '' : 'Kubernetes Dashboard is either disabled or not running'"
        *ngIf="(settings.adminSettings | async)?.enableDashboard">
       <i class="km-icon-mask km-icon-external-link"></i>
       <span>Open Dashboard</span>
@@ -226,7 +226,8 @@ limitations under the License.
                                 [healthState]="health?.operatingSystemManager"></km-property-health>
             <km-property-health label="User Controller Manager"
                                 [healthState]="health?.userClusterControllerManager"></km-property-health>
-            <km-property-health label="Kubernetes Dashboard"
+            <km-property-health *ngIf="cluster.spec.kubernetesDashboard?.enabled"
+                                label="Kubernetes Dashboard"
                                 [healthState]="health?.kubernetesDashboard"></km-property-health>
           </div>
 

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -456,6 +456,11 @@ limitations under the License.
                              [value]="cluster.spec.mla?.monitoringEnabled">
         </km-property-boolean>
 
+        <km-property-boolean *ngIf="cluster.spec.kubernetesDashboard?.enabled"
+                             label="Kubernetes Dashboard"
+                             [value]="cluster.spec.kubernetesDashboard?.enabled">
+        </km-property-boolean>
+
         <km-property-boolean *ngIf="cluster.spec.enableOperatingSystemManager"
                              label="Operating System Manager"
                              [value]="cluster.spec.enableOperatingSystemManager">

--- a/src/app/shared/entity/cluster.ts
+++ b/src/app/shared/entity/cluster.ts
@@ -306,6 +306,7 @@ export class ClusterSpec {
   machineNetworks?: MachineNetwork[];
   auditLogging?: AuditLoggingSettings;
   opaIntegration?: OPAIntegration;
+  kubernetesDashboard?: KubernetesDashboard;
   version?: string;
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
@@ -399,6 +400,10 @@ export class AuditLoggingSettings {
   policyPreset?: AuditPolicyPreset;
 }
 
+export class KubernetesDashboard {
+  enabled?: boolean;
+}
+
 export class OPAIntegration {
   enabled: boolean;
 }
@@ -465,10 +470,12 @@ export class ClusterSpecPatch {
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
   useEventRateLimitAdmissionPlugin?: boolean;
+  enableOperatingSystemManager?: boolean;
   eventRateLimitConfig?: EventRateLimitConfig;
   admissionPlugins?: string[];
   opaIntegration?: OPAIntegration;
   clusterNetwork?: ClusterNetwork;
+  kubernetesDashboard?: KubernetesDashboard;
   podNodeSelectorAdmissionPluginConfig?: object;
   auditLogging?: AuditLoggingSettings;
   machineNetworks?: MachineNetwork[];

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -74,6 +74,7 @@ enum Controls {
   OPAIntegration = 'opaIntegration',
   Konnectivity = 'konnectivity',
   MLALogging = 'loggingEnabled',
+  KubernetesDashboardEnabled = 'kubernetesDashboardEnabled',
   MLAMonitoring = 'monitoringEnabled',
   ProxyMode = 'proxyMode',
   IPv4PodsCIDR = 'ipv4PodsCIDR',
@@ -160,6 +161,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.OPAIntegration]: this._builder.control(false),
       [Controls.Konnectivity]: this._builder.control(true),
       [Controls.MLALogging]: this._builder.control(false),
+      [Controls.KubernetesDashboardEnabled]: this._builder.control(true),
       [Controls.MLAMonitoring]: this._builder.control(false),
       [Controls.AdmissionPlugins]: this._builder.control([]),
       [Controls.PodNodeSelectorAdmissionPluginConfig]: this._builder.control(''),
@@ -331,6 +333,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.get(Controls.AuditPolicyPreset).valueChanges,
       this.form.get(Controls.UserSSHKeyAgent).valueChanges,
       this.form.get(Controls.OperatingSystemManager).valueChanges,
+      this.form.get(Controls.KubernetesDashboardEnabled).valueChanges,
       this.form.get(Controls.OPAIntegration).valueChanges,
       this.form.get(Controls.Konnectivity).valueChanges,
       this.form.get(Controls.MLALogging).valueChanges,
@@ -584,6 +587,9 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         },
         opaIntegration: {
           enabled: this.controlValue(Controls.OPAIntegration),
+        },
+        kubernetesDashboard: {
+          enabled: this.controlValue(Controls.KubernetesDashboardEnabled),
         },
         mla: {
           loggingEnabled: this.controlValue(Controls.MLALogging),

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -379,6 +379,10 @@ limitations under the License.
               </mat-checkbox>
             </ng-container>
 
+            <mat-checkbox [formControlName]="Controls.KubernetesDashboardEnabled">
+              Kubernetes Dashboard
+            </mat-checkbox>
+
             <mat-checkbox [formControlName]="Controls.OperatingSystemManager">
               Operating System Manager
               <i class="km-icon-info km-pointer"


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What does this PR do / Why do we need it**:

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4391

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for disabling kubernetes-dashboard for user clusters
```

