### PR TITLE
KubeVirt UI improvements

### DIFF
--- a/src/app/node-data/basic/provider/kubevirt/style.scss
+++ b/src/app/node-data/basic/provider/kubevirt/style.scss
@@ -18,10 +18,6 @@
   margin-top: 4px;
 }
 
-.add-secondary-disk-button {
-  margin-top: -12px;
-}
-
 .no-secondary-disks-msg {
   font-size: variables.$font-size-body;
   padding-bottom: 15px;

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -97,15 +97,18 @@ limitations under the License.
                      required>
   </km-number-stepper>
 
-  <mat-card-header class="km-no-padding">
+  <mat-card-header class="km-no-padding" fxLayoutAlign=" center">
     <mat-card-title>Secondary Disks</mat-card-title>
     <div fxFlex></div>
-    <button mat-icon-button
-            class="add-secondary-disk-button"
+    <button fxLayoutAlign="center center"
+            mat-flat-button
+            type="button"
+            color="quaternary"
             matTooltip="Add secondary disk"
             (click)="addSecondaryDisk()"
             [disabled]="this.secondaryDisksFormArray.length >= this.maxSecondaryDisks">
       <i class="km-icon-mask km-icon-add"></i>
+      <span>Add Disk</span>
     </button>
   </mat-card-header>
 

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -42,7 +42,8 @@ limitations under the License.
     </button>
   </div>
 
-  <km-number-stepper [formControlName]="Controls.CPUs"
+  <km-number-stepper *ngIf="!form.get(Controls.CPUs).disabled; else disabledCPUs"
+                     [formControlName]="Controls.CPUs"
                      mode="errors"
                      label="CPUs"
                      min="1"
@@ -50,7 +51,20 @@ limitations under the License.
                      required>
   </km-number-stepper>
 
-  <km-number-stepper [formControlName]="Controls.Memory"
+  <ng-template #disabledCPUs>
+    <mat-form-field fxFlex>
+      <mat-label>CPUs</mat-label>
+      <input matInput
+             required
+             [value]="selectedFlavorCpus"
+             type="text"
+             disabled
+             autocomplete="off">
+    </mat-form-field>
+  </ng-template>
+
+  <km-number-stepper *ngIf="!form.get(Controls.Memory).disabled; else disabledMemory"
+                     [formControlName]="Controls.Memory"
                      mode="errors"
                      label="Memory (MB)"
                      min="1000"
@@ -58,6 +72,18 @@ limitations under the License.
                      [disabled]="form.get(Controls.Memory).disabled"
                      required>
   </km-number-stepper>
+
+  <ng-template #disabledMemory>
+    <mat-form-field fxFlex>
+      <mat-label>Memory</mat-label>
+      <input matInput
+             required
+             [value]="selectedFlavorMemory"
+             type="text"
+             disabled
+             autocomplete="off">
+    </mat-form-field>
+  </ng-template>
 
   <mat-card-header class="km-no-padding">
     <mat-card-title>Primary Disk</mat-card-title>

--- a/src/app/wizard/step/provider-settings/provider/basic/kubevirt/template.html
+++ b/src/app/wizard/step/provider-settings/provider/basic/kubevirt/template.html
@@ -19,11 +19,12 @@ limitations under the License.
   <mat-form-field fxFlex>
     <mat-label>Kubeconfig</mat-label>
     <textarea matInput
-              rows="3"
+              rows="5"
               required
               [formControlName]="Controls.Kubeconfig"
               [name]="Controls.Kubeconfig"
               autocomplete="off"></textarea>
+    <mat-hint>Base64 encoded YAML or JSON.</mat-hint>
     <mat-error *ngIf="form.get(Controls.Kubeconfig).hasError('required')">
       Kubeconfig is <strong>required</strong>.
     </mat-error>


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
This PR adds following UI improvements for KubeVirt provider:

1. 
![screenshot-localhost_8000-2022 07 29-04_15_55](https://user-images.githubusercontent.com/13975988/181761691-8b35c03d-e940-417b-8194-656b9259e2c4.png)

2. 
![screenshot-localhost_8000-2022 07 29-04_15_05](https://user-images.githubusercontent.com/13975988/181761787-200133b1-bb0f-4fd2-bd17-c377f210e160.png)

3. When VM Flavor is selected then CPUs and Memory of selected flavor are displayed instead of empty fields:


https://user-images.githubusercontent.com/13975988/181762019-37ee7886-ec64-4a90-a7f3-d4921b53ea03.mov



**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4500 

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

