### PR TITLE
Disable OIDC kubeconfig if feature gates is disabled

### DIFF
--- a/src/app/core/services/feature-gate.ts
+++ b/src/app/core/services/feature-gate.ts
@@ -21,6 +21,7 @@ import {catchError, shareReplay, switchMap} from 'rxjs/operators';
 
 export interface FeatureGates {
   konnectivityService?: boolean;
+  oidcKubeCfgEndpoint?: boolean;
 }
 
 @Injectable({

--- a/src/app/settings/admin/interface/template.html
+++ b/src/app/settings/admin/interface/template.html
@@ -95,8 +95,19 @@ limitations under the License.
                matTooltip="Use OIDC provider as a proxy for kubeconfig download."></div>
         </div>
         <mat-checkbox [(ngModel)]="settings.enableOIDCKubeconfig"
+                      [disabled]="!isOIDCKubeCfgEndpointEnabled"
                       (change)="onSettingsChange()"
-                      id="km-enable-oidc-setting"></mat-checkbox>
+                      id="km-enable-oidc-setting">
+          <mat-hint *ngIf="!isOIDCKubeCfgEndpointEnabled">This feature is disabled. Visit the
+            <a
+              href="https://docs.kubermatic.com/kubermatic/master/tutorials_howtos/oidc_provider_configuration/share-_clusters_via_delegated_oidc_authentication/"
+              target="_blank"
+              rel="noopener noreferrer">
+              documentation
+            </a>
+            to learn more.
+          </mat-hint>
+        </mat-checkbox>
         <km-spinner-with-confirmation [isSaved]="isEqual(settings.enableOIDCKubeconfig, apiSettings.enableOIDCKubeconfig)"></km-spinner-with-confirmation>
       </div>
     </div>


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Disable OIDC Kubeconfig setting if `oidcKubeCfgEndpoint` feature gates is disabled.

![screenshot-localhost_8000-2022 07 29-18_35_09](https://user-images.githubusercontent.com/13975988/181773156-c255d5cb-f733-4170-9029-aad3191e2feb.png)


**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4193 

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable OIDC Kubeconfig setting if feature gates is disabled.
```

