### PR TITLE
Add kubernetes versions list in create external cluster 

### DIFF
--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -148,7 +148,7 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   hasUpgrades(): boolean {
-    return this.isRunning() && this.provider !== ExternalClusterProvider.EKS;
+    return this.isRunning();
   }
 
   getStatus(): string {

--- a/src/app/cluster/details/external-cluster/external-machine-deployment-list/template.html
+++ b/src/app/cluster/details/external-cluster/external-machine-deployment-list/template.html
@@ -87,7 +87,7 @@ limitations under the License.
       <ng-container matColumnDef="version">
         <th mat-header-cell
             *matHeaderCellDef
-            class="km-header-cell">kubelet Version
+            class="km-header-cell">Kubelet Version
         </th>
         <td mat-cell
             *matCellDef="let element">v{{element.spec.template.versions?.kubelet}}</td>

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -255,9 +255,9 @@ export class ExternalClusterService {
     return this._http.get<string[]>(url, {headers}).pipe(catchError(() => of<[]>()));
   }
 
-  getEKSKubernetesVersions() {
+  getEKSKubernetesVersions(): Observable<MasterVersion[]> {
     const url = `${this._newRestRoot}/providers/eks/versions`;
-    return this._http.get(url).pipe(catchError(() => of<[]>()));
+    return this._http.get<MasterVersion[]>(url).pipe(catchError(() => of<[]>()));
   }
 
   createExternalCluster(projectID: string, externalClusterModel: ExternalClusterModel): Observable<ExternalCluster> {
@@ -363,21 +363,9 @@ export class ExternalClusterService {
 
     if (this._preset) {
       headers = {Credential: this._preset};
-
-      if (zone) {
-        headers = {...headers, Zone: zone};
-      }
-      if (mode) {
-        headers = {...headers, Mode: mode};
-      }
-      if (releaseChannel) {
-        headers = {...headers, ReleaseChannel: releaseChannel};
-      }
-
-      return new HttpHeaders(headers);
+    } else {
+      headers = {ServiceAccount: this._externalCluster.cloud.gke.serviceAccount};
     }
-
-    headers = {ServiceAccount: this._externalCluster.cloud.gke.serviceAccount};
 
     if (zone) {
       headers = {...headers, Zone: zone};

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -217,6 +217,11 @@ export class ExternalClusterService {
     return this._http.get<string[]>(url, {headers: this._getAKSHeaders(location)}).pipe(catchError(() => of<[]>()));
   }
 
+  getAKSKubernetesVersions() {
+    const url = `${this._newRestRoot}/providers/aks/versions`;
+    return this._http.get(url).pipe(catchError(() => of<[]>()));
+  }
+
   getGKEZones(): Observable<GKEZone[]> {
     const url = `${this._newRestRoot}/providers/gke/zones`;
     return this._http.get<GKEZone[]>(url, {headers: this._getGKEHeaders()}).pipe(catchError(() => of<[]>()));

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -217,9 +217,9 @@ export class ExternalClusterService {
     return this._http.get<string[]>(url, {headers: this._getAKSHeaders(location)}).pipe(catchError(() => of<[]>()));
   }
 
-  getAKSKubernetesVersions() {
+  getAKSKubernetesVersions(): Observable<MasterVersion[]> {
     const url = `${this._newRestRoot}/providers/aks/versions`;
-    return this._http.get(url).pipe(catchError(() => of<[]>()));
+    return this._http.get<MasterVersion[]>(url).pipe(catchError(() => of<[]>()));
   }
 
   getGKEZones(): Observable<GKEZone[]> {

--- a/src/app/core/services/external-machine-deployment.ts
+++ b/src/app/core/services/external-machine-deployment.ts
@@ -119,7 +119,7 @@ export class ExternalMachineDeploymentService {
       .pipe(filter(data => !!data))
       .pipe(
         switchMap((data: ExternalMachineDeployment) => {
-          return this.create(projectID, cluster.id, data);
+          return this.createExternalMachineDeployment(projectID, cluster.id, data);
         })
       );
   }
@@ -157,7 +157,11 @@ export class ExternalMachineDeploymentService {
     );
   }
 
-  create(projectID: string, clusterID: string, md: ExternalMachineDeployment): Observable<ExternalMachineDeployment> {
+  createExternalMachineDeployment(
+    projectID: string,
+    clusterID: string,
+    md: ExternalMachineDeployment
+  ): Observable<ExternalMachineDeployment> {
     const url = `${this._restRoot}/projects/${projectID}/kubernetes/clusters/${clusterID}/machinedeployments`;
     return this._httpClient
       .post<ExternalMachineDeployment>(url, md)

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -182,7 +182,7 @@ export class AKSClusterSettingsComponent
 
     if (this.isDialogView()) {
       const version = this.cluster.spec.version;
-      this.control(Controls.KubernetesVersion).setValue({main: version.slice(1, version.indexOf('-'))});
+      this.control(Controls.KubernetesVersion).setValue({main: version.slice(1)});
       this.control(Controls.Name).clearValidators();
       this.control(Controls.Location).clearValidators();
       this.control(Controls.NodeResourceGroup).clearValidators();
@@ -204,9 +204,8 @@ export class AKSClusterSettingsComponent
         .subscribe((vmSizes: string[]) => {
           this.vmSizes = vmSizes;
         });
+      this._getAKSKubernetesVersions();
     }
-
-    this._getAKSKubernetesVersions();
   }
 
   private _getAKSVmSizes(location: string): Observable<string[]> {
@@ -218,9 +217,15 @@ export class AKSClusterSettingsComponent
   }
 
   private _getAKSKubernetesVersions(): void {
-    this._externalClusterService
-      .getAKSKubernetesVersions()
-      .subscribe((versions: MasterVersion[]) => (this.kubernetesVersions = versions.map(version => version.version)));
+    this._externalClusterService.getAKSKubernetesVersions().subscribe(
+      (versions: MasterVersion[]) =>
+        (this.kubernetesVersions = versions.map(version => {
+          if (version.default) {
+            this.control(Controls.KubernetesVersion).setValue({main: version.version});
+          }
+          return version.version;
+        }))
+    );
   }
 
   private _getAKSVmSizesForMachineDeployment(location?: string): Observable<string[]> {

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -48,6 +48,7 @@ import {
   ExternalMachineDeployment,
   ExternalMachineDeploymentCloudSpec,
 } from '@app/shared/entity/external-machine-deployment';
+import {MasterVersion} from '@app/shared/entity/cluster';
 
 enum Controls {
   Name = 'name',
@@ -99,7 +100,8 @@ export class AKSClusterSettingsComponent
   isLoadingVmSizes: boolean;
   isLoadingNodePoolVersions: boolean;
   vmSizes: string[] = [];
-  nodePoolVersions: string[] = [];
+  nodePoolVersionsForMD: string[] = [];
+  kubernetesVersionsForClusterCreation: string[] = [];
 
   private readonly _debounceTime = 500;
 
@@ -169,6 +171,7 @@ export class AKSClusterSettingsComponent
         Validators.min(this.AUTOSCALING_MIN_VALUE),
       ]),
     });
+    this._getAKSKubernetesVersions();
   }
 
   private _initSubscriptions(): void {
@@ -189,7 +192,7 @@ export class AKSClusterSettingsComponent
       );
       this._getAKSAvailableNodePoolVersionsForCreateMachineDeployment().subscribe(
         (nodePoolVersions: AKSNodePoolVersionForMachineDeployments[]) => {
-          this.nodePoolVersions = nodePoolVersions.map(nodePoolVersion => nodePoolVersion.version);
+          this.nodePoolVersionsForMD = nodePoolVersions.map(nodePoolVersion => nodePoolVersion.version);
         }
       );
     } else {
@@ -209,6 +212,15 @@ export class AKSClusterSettingsComponent
       takeUntil(this._unsubscribe),
       finalize(() => (this.isLoadingVmSizes = false))
     );
+  }
+
+  private _getAKSKubernetesVersions(): void {
+    this._externalClusterService
+      .getAKSKubernetesVersions()
+      .subscribe(
+        (versions: MasterVersion[]) =>
+          (this.kubernetesVersionsForClusterCreation = versions.map(version => version.version))
+      );
   }
 
   private _getAKSVmSizesForMachineDeployment(location?: string): Observable<string[]> {
@@ -234,6 +246,9 @@ export class AKSClusterSettingsComponent
   }
 
   private _updateExternalClusterModel(): void {
+    const positionForIndexOfMethod = 2;
+    const version = this.controlValue(Controls.KubernetesVersion)?.main;
+
     const config = {
       name: this.controlValue(Controls.Name),
       cloud: {
@@ -245,7 +260,7 @@ export class AKSClusterSettingsComponent
       } as ExternalCloudSpec,
       spec: {
         aksclusterSpec: {
-          kubernetesVersion: this.controlValue(Controls.KubernetesVersion),
+          kubernetesVersion: version?.slice(0, version.indexOf('.', positionForIndexOfMethod)),
           location: this.controlValue(Controls.Location),
           machineDeploymentSpec: {
             name: this.controlValue(Controls.NodePoolName),
@@ -257,7 +272,7 @@ export class AKSClusterSettingsComponent
             } as AgentPoolBasics,
           } as AKSMachineDeploymentCloudSpec,
         } as AKSClusterSpec,
-        version: this.controlValue(Controls.KubernetesVersion),
+        version: version?.slice(0, version.indexOf('.', positionForIndexOfMethod)),
       } as ExternalClusterSpec,
     } as ExternalClusterModel;
 

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
@@ -55,7 +55,7 @@ limitations under the License.
       <km-autocomplete *ngIf="!isDialogView()"
                        label="Kubernetes Version"
                        required="true"
-                       [options]="kubernetesVersionsForClusterCreation"
+                       [options]="kubernetesVersions"
                        [formControlName]="Controls.KubernetesVersion">
         <ng-container hint>
           Set the kubernetes version.

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
@@ -52,24 +52,16 @@ limitations under the License.
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field>
-        <mat-label>Kubernetes Version</mat-label>
-        <input [formControlName]="Controls.KubernetesVersion"
-               matInput
-               type="text"
-               autocomplete="off" />
+      <km-autocomplete *ngIf="!isDialogView()"
+                       label="Kubernetes Version"
+                       required="true"
+                       [options]="kubernetesVersionsForClusterCreation"
+                       [formControlName]="Controls.KubernetesVersion">
+        <ng-container hint>
+          Set the kubernetes version.
+        </ng-container>
+      </km-autocomplete>
 
-        <mat-hint>
-          Set the kubernetes version. See list of
-          <a href="https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli"
-             rel="noopener noreferrer"
-             target="_blank">supported versions</a>.
-        </mat-hint>
-
-        <mat-error *ngIf="form.get(Controls.KubernetesVersion).hasError(ErrorType.Required)">
-          Kubernetes Version is <strong>required</strong>.
-        </mat-error>
-      </mat-form-field>
 
       <mat-form-field>
         <mat-label>Location</mat-label>
@@ -140,7 +132,7 @@ limitations under the License.
     <km-autocomplete *ngIf="isDialogView()"
                      label="Kubernetes Version"
                      required="true"
-                     [options]="nodePoolVersions"
+                     [options]="nodePoolVersionsForMD"
                      [formControlName]="Controls.KubernetesVersion">
       <ng-container hint>
         Set the kubernetes version.

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
@@ -135,10 +135,10 @@ export class EKSClusterSettingsComponent
       [Controls.MinSize]: this._builder.control(DEFAULT_MD_MINSIZE),
       [Controls.DesiredSize]: this._builder.control(DEFAULT_MD_DESIRED_SIZE),
     });
-    this._getEKSKubernetesVersions();
   }
 
   private _initSubscriptions(): void {
+    this._getEKSKubernetesVersions();
     this.form.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => {
       this._updateExternalClusterModel();
       this._updateExternalMachineDeployment();
@@ -224,7 +224,7 @@ export class EKSClusterSettingsComponent
   }
 
   private _updateExternalClusterModel(): void {
-    const positionForIndexOfMethod = 2;
+    const indexPosition = 2;
     const version = this.controlValue(Controls.Version)?.main;
     this._externalClusterService.externalCluster = {
       ...this._externalClusterService.externalCluster,
@@ -238,13 +238,13 @@ export class EKSClusterSettingsComponent
       spec: {
         eksclusterSpec: {
           roleArn: this.controlValue(Controls.RoleArn),
-          version: version?.slice(0, version.indexOf('.', positionForIndexOfMethod)),
+          version: version?.slice(0, version.indexOf('.', indexPosition)),
           vpcConfigRequest: {
             subnetIds: this.controlValue(Controls.SubnetIds),
             securityGroupIds: this.controlValue(Controls.SecurityGroupsIds),
           },
         } as EKSClusterSpec,
-        version: version?.slice(0, version.indexOf('.', positionForIndexOfMethod)),
+        version: version?.slice(0, version.indexOf('.', indexPosition)),
       } as ExternalClusterSpec,
     } as ExternalClusterModel;
   }

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
@@ -138,7 +138,6 @@ export class EKSClusterSettingsComponent
   }
 
   private _initSubscriptions(): void {
-    this._getEKSKubernetesVersions();
     this.form.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => {
       this._updateExternalClusterModel();
       this._updateExternalMachineDeployment();
@@ -174,6 +173,8 @@ export class EKSClusterSettingsComponent
         .subscribe((data: string[]) => {
           this.subnetIds = data;
         });
+    } else {
+      this._getEKSKubernetesVersions();
     }
 
     this._externalClusterService.presetChanges.pipe(takeUntil(this._unsubscribe)).subscribe(preset => {
@@ -218,9 +219,15 @@ export class EKSClusterSettingsComponent
   }
 
   private _getEKSKubernetesVersions(): void {
-    this._externalClusterService
-      .getEKSKubernetesVersions()
-      .subscribe((versions: MasterVersion[]) => (this.kubernetesVersions = versions.map(version => version.version)));
+    this._externalClusterService.getEKSKubernetesVersions().subscribe(
+      (versions: MasterVersion[]) =>
+        (this.kubernetesVersions = versions.map(version => {
+          if (version.default) {
+            this.control(Controls.Version).setValue({main: version.version});
+          }
+          return version.version;
+        }))
+    );
   }
 
   private _updateExternalClusterModel(): void {

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
@@ -77,11 +77,21 @@ limitations under the License.
              type="text"
              autocomplete="off"
              [formControlName]="Controls.RoleArn" />
-      <mat-hint>Enter a unique name for your role.</mat-hint>
+      <mat-hint>{{isDialogView() ? 
+        'Enter the IAM role that will be used by the nodes' :        
+        'Enter the IAM role to allow the Kubernetes control plane to manage resources.'}}</mat-hint>
       <mat-error *ngIf="form.get(Controls.RoleArn).hasError('required')">
         Role is <strong>required</strong>.
       </mat-error>
     </mat-form-field>
+
+    <km-number-stepper *ngIf="isDialogView()"
+                       [formControlName]="Controls.DiskSize"
+                       mode="errors"
+                       label="Disk Size in GB"
+                       min="1"
+                       required>
+    </km-number-stepper>
   </div>
 
   <div fxFlex="50%"
@@ -91,7 +101,6 @@ limitations under the License.
     <mat-card-header class="km-no-padding">
       <mat-card-title>Networking</mat-card-title>
     </mat-card-header>
-
 
     <km-autocomplete *ngIf="!isDialogView()"
                      label="VPC"
@@ -109,7 +118,6 @@ limitations under the License.
              [formControlName]="Controls.Vpc" />
     </mat-form-field>
 
-
     <ng-container *ngIf="isDialogView() ? true : form.get(Controls.Vpc).value?.main">
       <km-chip-autocomplete label="Subnet"
                             placeholder="Select Subnet IDs"
@@ -125,12 +133,9 @@ limitations under the License.
                             [formControlName]="Controls.SecurityGroupsIds"></km-chip-autocomplete>
     </ng-container>
     <ng-container *ngIf="isDialogView()">
-      <km-number-stepper [formControlName]="Controls.DiskSize"
-                         mode="errors"
-                         label="Disk Size in GB"
-                         min="1"
-                         required>
-      </km-number-stepper>
+      <mat-card-header class="km-no-padding">
+        <mat-card-title>AutoScaling</mat-card-title>
+      </mat-card-header>
       <km-number-stepper [formControlName]="Controls.DesiredSize"
                          mode="errors"
                          label="Desired Size"

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
@@ -53,22 +53,23 @@ limitations under the License.
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field>
+    <mat-form-field *ngIf="isDialogView()">
       <mat-label>Kubernetes Version</mat-label>
       <input [formControlName]="Controls.Version"
              matInput
              type="text"
              autocomplete="off" />
-      <mat-hint *ngIf="!isDialogView()">
-        Set the kubernetes version. See list of
-        <a href="https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html"
-           rel="noopener noreferrer"
-           target="_blank">supported versions</a>.
-      </mat-hint>
-      <mat-error *ngIf="form.get(Controls.Version).hasError('required')">
-        Kubernetes Version is <strong>required</strong>.
-      </mat-error>
     </mat-form-field>
+
+    <km-autocomplete *ngIf="!isDialogView()"
+                     label="Kubernetes Version"
+                     required="true"
+                     [options]="kubernetesVersions"
+                     [formControlName]="Controls.Version">
+      <ng-container hint>
+        Set the kubernetes version.
+      </ng-container>
+    </km-autocomplete>
 
     <mat-form-field>
       <mat-label>{{isDialogView() ? "Node IAM role" : "Cluster Service Role"}}</mat-label>

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
@@ -44,7 +44,7 @@ limitations under the License.
               (click)="generateName()">
         <i class="km-icon-randomize"></i>
       </button>
-      <mat-hint>Enter a unique name for this cluster</mat-hint>
+      <mat-hint>Enter a unique name for this {{isDialogView() ? 'machine deployment' : 'cluster'}}</mat-hint>
       <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
         Name is <strong>required</strong>.
       </mat-error>

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
@@ -96,6 +96,7 @@ export class GKEClusterSettingsComponent
   readonly DISK_SIZE_DEFAULT_VALUE = 25;
   readonly MAX_REPLICAS_COUNT_DEFAULT_VALUE = 5;
   readonly MIN_REPLICAS_COUNT_DEFAULT_VALUE = 1;
+  readonly ZONE_DEFAULT_VALUE = 'us-central1-c';
 
   zones: string[] = [];
   diskTypes: string[] = [];
@@ -155,9 +156,9 @@ export class GKEClusterSettingsComponent
   private _initForm(): void {
     this.form = this._builder.group({
       [Controls.Name]: this._builder.control('', [Validators.required, GKE_POOL_NAME_VALIDATOR]),
-      [Controls.Zone]: this._builder.control('', Validators.required),
+      [Controls.Zone]: this._builder.control({main: this.ZONE_DEFAULT_VALUE}, Validators.required),
       [Controls.KubernetesVersionMode]: this._builder.control(KubernetesVersionMode.StaticVersion),
-      [Controls.ReleaseChannelOptions]: this._builder.control(''),
+      [Controls.ReleaseChannelOptions]: this._builder.control({main: this.releaseChannelOptions[1]}),
       [Controls.Version]: this._builder.control('', Validators.required),
       [Controls.NodeCount]: this._builder.control(this.MIN_REPLICAS_COUNT_DEFAULT_VALUE, Validators.required),
       [Controls.MachineTypes]: this._builder.control(''),

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/style.scss
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/style.scss
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@use 'variables';
+
 .mat-form-field {
   padding-bottom: 5px;
 }
@@ -19,5 +21,11 @@
 mat-checkbox {
   i {
     margin: 4px 8px;
+  }
+}
+
+mat-radio-button {
+  mat-hint {
+    font-size: variables.$font-size-caption;
   }
 }

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -54,7 +54,19 @@ limitations under the License.
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field>
+
+    <km-autocomplete *ngIf="!isDialogView()"
+                     class="km-dropdown-with-suffix"
+                     label="Zone"
+                     required="true"
+                     [isLoading]="isLoadingZones"
+                     [options]="zones"
+                     [defaultValue]="ZONE_DEFAULT_VALUE"
+                     [formControlName]="Controls.Zone">
+      <ng-container hint>Select from Zones List.</ng-container>
+    </km-autocomplete>
+
+    <mat-form-field *ngIf="isDialogView()">
       <mat-label>Kubernetes Version
       </mat-label>
       <input matInput
@@ -141,18 +153,33 @@ limitations under the License.
        fxLayout="column"
        fxLayoutGap="8px">
 
-    <mat-card-header class="km-no-padding">
-      <mat-card-title>Google Cloud Settings</mat-card-title>
-    </mat-card-header>
+    <label class="km-radio-group-label">Kubernetes Version</label>
+    <mat-radio-group fxFlex
+                     fxLayout="column"
+                     class="km-radio-group"
+                     [formControlName]="Controls.KubernetesVersionMode">
+      <mat-radio-button [value]="KubernetesVersionMode.StaticVersion"
+                        class="km-radio-button">
+        <div class="km-radio-button-title">Static Version</div>
+      </mat-radio-button>
+      <mat-radio-button [value]="KubernetesVersionMode.ReleaseChannel"
+                        class="km-radio-button">
+        <div class="km-radio-button-title">Release Channel</div>
+      </mat-radio-button>
 
-    <km-autocomplete class="km-dropdown-with-suffix"
-                     label="Zone"
-                     required="true"
-                     [isLoading]="isLoadingZones"
-                     [options]="zones"
-                     [formControlName]="Controls.Zone">
-      <ng-container hint>Select from Zones List.</ng-container>
-    </km-autocomplete>
+      <km-autocomplete *ngIf="form.get(Controls.KubernetesVersionMode).value === KubernetesVersionMode.ReleaseChannel"
+                       label="Release Channel"
+                       [options]="releaseChannelOptions"
+                       [formControlName]="Controls.ReleaseChannelOptions">
+      </km-autocomplete>
 
+      <km-autocomplete label="Versions"
+                       [options]="kubernetesVersions"
+                       [formControlName]="Controls.Version">
+        <ng-container hint>
+          Set the kubernetes version.
+        </ng-container>
+      </km-autocomplete>
+    </mat-radio-group>
   </div>
 </form>

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -160,10 +160,12 @@ limitations under the License.
       <mat-radio-button [value]="KubernetesVersionMode.StaticVersion"
                         class="km-radio-button">
         <div class="km-radio-button-title">Static Version</div>
+        <mat-hint>Manually manage the version upgrades.</mat-hint>
       </mat-radio-button>
       <mat-radio-button [value]="KubernetesVersionMode.ReleaseChannel"
                         class="km-radio-button">
         <div class="km-radio-button-title">Release Channel</div>
+        <mat-hint>Let GKE automatically manage the cluster's control plane version.</mat-hint>
       </mat-radio-button>
 
       <km-autocomplete *ngIf="form.get(Controls.KubernetesVersionMode).value === KubernetesVersionMode.ReleaseChannel"

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -61,7 +61,6 @@ limitations under the License.
                      required="true"
                      [isLoading]="isLoadingZones"
                      [options]="zones"
-                     [defaultValue]="ZONE_DEFAULT_VALUE"
                      [formControlName]="Controls.Zone">
       <ng-container hint>Select from Zones List.</ng-container>
     </km-autocomplete>

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -62,7 +62,7 @@ limitations under the License.
                      [isLoading]="isLoadingZones"
                      [options]="zones"
                      [formControlName]="Controls.Zone">
-      <ng-container hint>Select from Zones List.</ng-container>
+      <ng-container hint>Select from Zones list.</ng-container>
     </km-autocomplete>
 
     <mat-form-field *ngIf="isDialogView()">
@@ -174,6 +174,7 @@ limitations under the License.
 
       <km-autocomplete label="Versions"
                        [options]="kubernetesVersions"
+                       required="true"
                        [formControlName]="Controls.Version">
         <ng-container hint>
           Set the kubernetes version.

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -44,7 +44,7 @@ limitations under the License.
               (click)="generateName()">
         <i class="km-icon-randomize"></i>
       </button>
-      <mat-hint>Enter a unique name for this cluster</mat-hint>
+      <mat-hint>Enter a unique name for this {{isDialogView() ? 'machine deployment' : 'cluster'}}</mat-hint>
       <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
         Name is <strong>required</strong>.
       </mat-error>

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -123,7 +123,8 @@ limitations under the License.
                      required>
   </km-number-stepper>
 
-  <mat-card-header class="km-no-padding" fxLayoutAlign=" center">
+  <mat-card-header class="km-no-padding"
+                   fxLayoutAlign=" center">
     <mat-card-title>Secondary Disks</mat-card-title>
     <div fxFlex></div>
     <button fxLayoutAlign="center center"


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
display all the available k8s versions in drop down list when creating new external Cluster.
  
**Which issue(s) this PR fixes** :
Fixes #4741

```release-note
add k8s versions drop down list when creating new external Cluster
```

