### PR TITLE
Fixed quota-widget width on extended view

### DIFF
--- a/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
+++ b/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
@@ -21,39 +21,41 @@
 @use 'mixins';
 @use 'variables';
 
-.km-quota-widget {
+:host {
+  width: 100%;
+}
+
+.km-quota-widget-container {
+  width: 100%;
+
   .km-icon-quota {
     margin-right: 10px;
   }
 
   .mat-card {
     margin: 0;
-    padding: 0;
+    padding: 0 10px 0 0;
+    width: 250px;
 
     .km-icon-quota {
       margin-left: 10px;
     }
   }
 
-  .km-quota-item {
+  km-property {
     padding-top: 9px;
 
     .property-usage-bar {
-      @include mixins.size(60px, 5px, true);
-
       border-radius: variables.$border-radius;
+      height: 5px;
     }
 
     [value] {
       margin: 9px 0;
     }
-
-    &:last-child {
-      margin-right: 5px;
-    }
   }
 
-  .km-detail-view {
+  .km-quota-details {
     left: 0;
     position: absolute;
     top: 59px;
@@ -80,7 +82,9 @@
     }
   }
 
-  .km-extended-view {
+  .km-extended-widget {
+    width: 100%;
+
     .km-quota-heading {
       margin-right: 30px;
 
@@ -89,11 +93,19 @@
       }
     }
 
-    .property-usage-bar {
-      @include mixins.size(140px, 6px, true);
+    .km-icon-quota {
+      @include mixins.size(32px, 32px, true);
+    }
 
-      border-radius: variables.$border-radius;
-      margin: 8px 0;
+    .km-quota-percentages {
+      width: 100%;
+
+      .property-usage-bar {
+        border-radius: variables.$border-radius;
+        height: 6px;
+        margin: 8px 0;
+        min-width: 100px;
+      }
     }
   }
 }

--- a/src/app/dynamic/enterprise/quotas/quota-widget/template.html
+++ b/src/app/dynamic/enterprise/quotas/quota-widget/template.html
@@ -20,20 +20,21 @@
 END OF TERMS AND CONDITIONS
 -->
 
-<div class="km-quota-widget"
+<div class="km-quota-widget-container"
      *ngIf="quotaDetails">
   <ng-container *ngTemplateOutlet="showQuotaWidgetDetails ? quotaWidgetDetails : quotaWidget"></ng-container>
 </div>
 
 <ng-template #quotaWidget>
-  <mat-card *ngIf="showAsCard; else progressQuota">
+  <mat-card *ngIf="showAsCard; else quotaWidgetWithoutCard">
     <mat-card-content>
-      <ng-container *ngTemplateOutlet="progressQuota"></ng-container>
+      <ng-container *ngTemplateOutlet="quotaWidgetWithoutCard"></ng-container>
     </mat-card-content>
   </mat-card>
 
-  <ng-template #progressQuota>
-    <div fxLayout="row"
+  <ng-template #quotaWidgetWithoutCard>
+    <div class="km-quota-widget"
+         fxLayout="row"
          fxLayoutAlign=" center">
       <i *ngIf="showIcon"
          class="km-icon-mask km-icon-quota i-32"></i>
@@ -54,7 +55,7 @@ END OF TERMS AND CONDITIONS
       </ng-container>
     </div>
 
-    <mat-card class="km-detail-view"
+    <mat-card class="km-quota-details"
               *ngIf="showDetails$ | async">
       <mat-card-content fxLayout="column">
         <div class="km-detail-row">Project Quota</div>
@@ -82,9 +83,7 @@ END OF TERMS AND CONDITIONS
     <ng-template #progressBar
                  let-label="label"
                  let-percentage="percentage">
-      <km-property class="km-quota-item"
-                   fxLayout="column"
-                   fxLayoutAlign="center center">
+      <km-property>
         <div key>{{ label }}</div>
         <mat-progress-bar value
                           class="property-usage-bar"
@@ -98,21 +97,20 @@ END OF TERMS AND CONDITIONS
 </ng-template>
 
 <ng-template #quotaWidgetDetails>
-  <div class="km-extended-view"
+  <div class="km-quota-widget km-extended-widget"
        fxLayout="row">
     <div class="km-quota-heading"
          fxLayout="row"
-         fxLayoutGap="5px"
-         fxLayoutAlign="center center">
-      <i class="km-icon-mask km-icon-quota i-32"></i>
+         fxLayoutAlign="space-between center">
+      <i class="km-icon-mask km-icon-quota"></i>
 
       <span>Project Quota</span>
     </div>
 
     <div class="km-quota-percentages"
          fxLayout="row"
-         fxLayoutAlign="space-evenly center"
-         fxLayoutGap="10px">
+         fxLayoutGap="30px"
+         fxLayoutAlign="space-between">
       <ng-container *ngIf="quotaDetails.quota.cpu"
                     [ngTemplateOutlet]="extendedProgress"
                     [ngTemplateOutletContext]="{
@@ -150,20 +148,18 @@ END OF TERMS AND CONDITIONS
                let-total="total"
                let-used="used"
                let-unit="unit">
-    <div fxLayout="column">
-      <km-property>
-        <div key>
-          <span fxFlex>{{label}}</span>
-          <span>{{used ?? 0}}/{{total}} {{unit}}</span>
-        </div>
-        <div value>
-          <mat-progress-bar class="property-usage-bar"
-                            mode="determinate"
-                            [color]="getProgressBarAccent(percentage)"
-                            [value]="percentage ?? 1"
-                            [matTooltip]="percentage ? percentage + '%' : ''"></mat-progress-bar>
-        </div>
-      </km-property>
-    </div>
+    <km-property>
+      <div key>
+        <span fxFlex>{{label}}</span>
+        <span>{{used ?? 0}}/{{total}} {{unit}}</span>
+      </div>
+      <div value>
+        <mat-progress-bar class="property-usage-bar"
+                          mode="determinate"
+                          [color]="getProgressBarAccent(percentage)"
+                          [value]="percentage ?? 1"
+                          [matTooltip]="percentage ? percentage + '%' : ''"></mat-progress-bar>
+      </div>
+    </km-property>
   </ng-template>
 </ng-template>

--- a/src/assets/css/global/_main.scss
+++ b/src/assets/css/global/_main.scss
@@ -618,9 +618,20 @@ km-cni-version {
 }
 
 .km-quota-widget {
-  .km-quota-item {
+  width: 100%;
+
+  km-property {
+    width: 100%;
+
     .container {
       margin: 2px 5px;
+      width: 100%;
+    }
+
+    &:last-child {
+      .container {
+        margin-right: 0;
+      }
     }
   }
 


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes incorrect width of quota widget progress bars on small screens

> Before 
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/56511988/182588168-24dd12cb-3c99-41fe-a5d6-6515eed85b74.png">

> After
<img width="1276" alt="image" src="https://user-images.githubusercontent.com/56511988/182588572-3daa47bd-884e-4a79-9448-0ed83017d20f.png">

Fixes #4750

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

