### PR TITLE
Display Share Kubeconfig button even if OIDC Kubeconfig setting is enabled

### DIFF
--- a/src/app/cluster/details/cluster/component.ts
+++ b/src/app/cluster/details/cluster/component.ts
@@ -571,12 +571,6 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     this._unsubscribe.complete();
   }
 
-  isShareConfigEnabled(): Observable<boolean> {
-    return this.settings.adminSettings.pipe(
-      map(settings => !!this.config.share_kubeconfig && !settings.enableOIDCKubeconfig)
-    );
-  }
-
   isAdmissionPluginEnabled(plugin: string): boolean {
     return this.cluster?.spec?.admissionPlugins?.includes(plugin) || false;
   }

--- a/src/app/cluster/details/cluster/template.html
+++ b/src/app/cluster/details/cluster/template.html
@@ -42,7 +42,7 @@ limitations under the License.
             class="km-share-kubeconfig-btn"
             color="alternative"
             (click)="shareConfigDialog()"
-            *ngIf="isShareConfigEnabled() | async">
+            *ngIf="config.share_kubeconfig">
       <i class="km-icon-mask km-icon-share"></i>
       <span>Share</span>
     </button>


### PR DESCRIPTION
**What does this PR do / Why do we need it**:
Remove condition for hiding Share button if `enableOIDCKubeconfig` setting is enabled and display Share button regardless of `enableOIDCKubeconfig` setting value.

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #4762 

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Display share kubeconfig button even if OIDC Kubeconfig setting is enabled.
```

