### PR TITLE
Remove share kubeconfig button checks from e2e tests

### DIFF
--- a/cypress/integration/v2/stories/admin-settings/defaults.spec.ts
+++ b/cypress/integration/v2/stories/admin-settings/defaults.spec.ts
@@ -100,11 +100,6 @@ describe('Admin Settings - Defaults Story', () => {
 
     // Kubernetes Dashboard settings check
     Pages.Clusters.Details.Buttons.openKubernetesDashboard.should(Condition.Exist);
-
-    // OIDC Kubeconfig settings check
-    // Note: This is actually a workaround to simplify this check as it directly depends
-    // on the OIDC kubeconfig setting. Make sure to have also `share_kubeconfig` set to true.
-    Pages.Clusters.Details.Buttons.shareKubeconfig.should(Condition.Exist);
   });
 
   it('should go to the admin settings and update default values - defaults and limits page', () => {
@@ -151,9 +146,6 @@ describe('Admin Settings - Defaults Story', () => {
 
     // Kubernetes Dashboard settings check
     Pages.Clusters.Details.Buttons.openKubernetesDashboard.should(Condition.NotExist);
-
-    // OIDC Kubeconfig settings check
-    Pages.Clusters.Details.Buttons.shareKubeconfig.should(Condition.NotExist);
   });
 
   it('should delete created project and logout', () => {


### PR DESCRIPTION
**What does this PR do / Why do we need it**:

**Which issue(s) this PR fixes** :<!-- optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged -->

Fixes #

**Special notes for your reviewer**:

**Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

