### PR TITLE
Fix for edit event rate limit

### DIFF
--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -134,7 +134,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.KubernetesDashboardEnabled]: new FormControl(!!this.cluster.spec.kubernetesDashboard?.enabled),
       [Controls.AdmissionPlugins]: new FormControl(this.cluster.spec.admissionPlugins),
       [Controls.PodNodeSelectorAdmissionPluginConfig]: new FormControl(''),
-      [Controls.EventRateLimitConfig]: new FormControl(this.eventRateLimitConfig?.namespace),
+      [Controls.EventRateLimitConfig]: new FormControl(''),
       [Controls.Labels]: new FormControl(''),
     });
 

--- a/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -96,7 +96,7 @@ limitations under the License.
                        formControlName="podNodeSelectorAdmissionPluginConfig"
                        fxFlex="100"></km-label-form>
         <div *ngIf="isPluginEnabled(admissionPlugin.EventRateLimit)">
-          <km-wizard-cluster-event-rate-limit [formControl]="form.get(Controls.EventRateLimitConfig)"></km-wizard-cluster-event-rate-limit>
+          <km-wizard-cluster-event-rate-limit [formControl]="form.get(Controls.EventRateLimitConfig)" [eventRateLimitConfig]="eventRateLimitConfig"></km-wizard-cluster-event-rate-limit>
         </div>
       </div>
 

--- a/src/app/shared/components/event-rate-limit/component.ts
+++ b/src/app/shared/components/event-rate-limit/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
+import {Component, forwardRef, Input, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, FormControl, Validators} from '@angular/forms';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {EventRateLimitConfig} from '@shared/entity/cluster';
@@ -45,6 +45,8 @@ enum Controls {
   ],
 })
 export class EventRateLimitComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  @Input() eventRateLimitConfig: EventRateLimitConfig;
+
   private readonly _debounceTime = 500;
   readonly Controls = Controls;
   private readonly _minValue = 1;
@@ -59,12 +61,15 @@ export class EventRateLimitComponent extends BaseFormValidator implements OnInit
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.QPS]: new FormControl(this._qpsDefault, [Validators.required, Validators.minLength(this._minValue)]),
-      [Controls.Burst]: new FormControl(this._burstDefault, [
+      [Controls.QPS]: new FormControl(this.eventRateLimitConfig?.namespace?.qps || this._qpsDefault, [
         Validators.required,
         Validators.minLength(this._minValue),
       ]),
-      [Controls.CacheSize]: new FormControl(this._cacheSizeDefault, [
+      [Controls.Burst]: new FormControl(this.eventRateLimitConfig?.namespace?.burst || this._burstDefault, [
+        Validators.required,
+        Validators.minLength(this._minValue),
+      ]),
+      [Controls.CacheSize]: new FormControl(this.eventRateLimitConfig?.namespace?.cacheSize || this._cacheSizeDefault, [
         Validators.required,
         Validators.minLength(this._minValue),
       ]),


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Values for `Event rate limit` plugin were not being displayed properly on the edit cluster modal. This bug was there because the values were not being propagated to the `km-wizard-cluster-event-rate-limit` component.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4789

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where the edit cluster view was not loading the correct configuration for the event rate limit plugin.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
