### PR TITLE
Check if plugin is enabled before consuming the event rate limit config

### DIFF
--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -134,7 +134,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.KubernetesDashboardEnabled]: new FormControl(!!this.cluster.spec.kubernetesDashboard?.enabled),
       [Controls.AdmissionPlugins]: new FormControl(this.cluster.spec.admissionPlugins),
       [Controls.PodNodeSelectorAdmissionPluginConfig]: new FormControl(''),
-      [Controls.EventRateLimitConfig]: new FormControl(''),
+      [Controls.EventRateLimitConfig]: new FormControl(),
       [Controls.Labels]: new FormControl(''),
     });
 
@@ -302,14 +302,19 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         usePodNodeSelectorAdmissionPlugin: null,
         usePodSecurityPolicyAdmissionPlugin: null,
         useEventRateLimitAdmissionPlugin: null,
+        eventRateLimitConfig: null,
         admissionPlugins: this.form.get(Controls.AdmissionPlugins).value,
         podNodeSelectorAdmissionPluginConfig: this.podNodeSelectorAdmissionPluginConfig,
-        eventRateLimitConfig: {
-          namespace: this.form.get(Controls.EventRateLimitConfig).value,
-        },
         containerRuntime: this.form.get(Controls.ContainerRuntime).value,
       },
     };
+
+    if (this.isPluginEnabled(this.admissionPlugin.EventRateLimit)) {
+      patch.spec.eventRateLimitConfig = {
+        namespace: this.form.get(Controls.EventRateLimitConfig).value,
+      };
+    }
+
     return this._clusterService.patch(this.projectID, this.cluster.id, patch).pipe(take(1));
   }
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
With https://github.com/kubermatic/dashboard/pull/4442 we changed the behavior of how form changes are synced with the DTOs. As a side effect, in the edit cluster view we were now setting the `spec.eventRateLimitConfig` unconditionally which was incorrect.

This PR ensures that we only propagate those values when the plugin `EventRateLimit` is enabled.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4806

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
