### PR TITLE
KubeVirt UI improvements

### DIFF
--- a/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -172,6 +172,10 @@ limitations under the License.
                      [inheritedLabels]="cluster.inheritedLabels"
                      [asyncKeyValidators]=asyncLabelValidators
                      [formControlName]="Controls.Labels"></km-label-form>
+
+      <ng-container *ngIf="cluster.spec.cloud?.kubevirt?.preAllocatedDataVolumes as dataVolumes">
+        <km-kubevirt-pre-allocated-data-volumes [dataVolumes]="dataVolumes"></km-kubevirt-pre-allocated-data-volumes>
+      </ng-container>
     </form>
   </mat-dialog-content>
   <mat-dialog-actions>

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -97,7 +97,7 @@ limitations under the License.
            [formControlName]="Controls.PrimaryDiskOSImage"
            type="text"
            autocomplete="off">
-    <mat-hint>Use URL or namespace/PVC name format.</mat-hint>
+    <mat-hint>Use URL or Custom Local Disk name.</mat-hint>
     <mat-error *ngIf="form.get(Controls.PrimaryDiskOSImage).hasError('required')">
       Operating system image is <strong>required</strong>.
     </mat-error>
@@ -172,64 +172,80 @@ limitations under the License.
 
   <div *ngIf="secondaryDisksFormArray.length === 0"
        class="no-secondary-disks-msg km-text-muted">
-    No secondary disks configured. Use the add button above to configure up to three disks.
+    Optional disks that will be mounted to the nodes. Configure up to three disks.
   </div>
 
-  <mat-card-header class="km-no-padding">
-    <mat-card-title>Affinity Settings</mat-card-title>
-  </mat-card-header>
+  <km-expansion-panel expandLabel="ADVANCED SCHEDULING SETTINGS"
+                      collapseLabel="ADVANCED SCHEDULING SETTINGS">
+    <ng-container *ngTemplateOutlet="selectAffinityPreset;
+                                      context: {label: 'Pod Affinity Preset',
+                                      controlName: Controls.PodAffinityPreset,
+                                      resetCallback: resetPodAffinityPresetControl.bind(this),
+                                      hint: 'Ensures two tenant nodes to be co-located in a single infrastructure node. Hard and soft values represent required and preferred scheduling.'}">
+    </ng-container>
 
-  <ng-container *ngTemplateOutlet="selectAffinityPreset; context: {label: 'Pod Affinity Preset', controlName: Controls.PodAffinityPreset, resetCallback: resetPodAffinityPresetControl.bind(this)}"></ng-container>
+    <ng-container *ngTemplateOutlet="selectAffinityPreset;
+                                      context: {label: 'Pod Anti-Affinity Preset',
+                                      controlName: Controls.PodAntiAffinityPreset,
+                                      resetCallback: resetPodAntiAffinityPresetControl.bind(this),
+                                      hint: 'Allows you to prevent tenant nodes to be co-located in a single infrastructure node. Hard and soft values represent required and preferred scheduling.'}">
+    </ng-container>
 
-  <ng-container *ngTemplateOutlet="selectAffinityPreset; context: {label: 'Pod Anti-Affinity Preset', controlName: Controls.PodAntiAffinityPreset, resetCallback: resetPodAntiAffinityPresetControl.bind(this)}"></ng-container>
+    <ng-container *ngTemplateOutlet="selectAffinityPreset;
+                                      context: {label: 'Node Affinity Preset Type',
+                                      controlName: Controls.NodeAffinityPreset,
+                                      resetCallback: resetNodeAffinityPresetControl.bind(this),
+                                      hint: 'Ensures that tenant nodes are hosted on particular nodes.'}">
+    </ng-container>
 
-  <ng-container *ngTemplateOutlet="selectAffinityPreset; context: {label: 'Node Affinity Preset Type', controlName: Controls.NodeAffinityPreset, resetCallback: resetNodeAffinityPresetControl.bind(this)}"></ng-container>
-
-  <mat-form-field fxFlex>
-    <mat-label>Node Affinity Preset Key</mat-label>
-    <input matInput
-           [id]="Controls.NodeAffinityPresetKey"
-           [formControlName]="Controls.NodeAffinityPresetKey"
-           type="text"
-           autocomplete="off">
-  </mat-form-field>
-
-  <km-chip-list label="Node Affinity Preset Values"
-                [tags]="nodeAffinityPresetValues"
-                (onChange)="onNodeAffinityPresetValuesChange($event)"
-                [formControlName]="Controls.NodeAffinityPresetValues"
-                [disabled]="form.get(Controls.NodeAffinityPresetValues).disabled"
-                placeholder="Add values..."
-                fxFlex></km-chip-list>
-
-  <ng-template #selectAffinityPreset
-               let-label="label"
-               let-controlName="controlName"
-               let-resetCallback="resetCallback">
-    <mat-form-field fxFlex
-                    class="km-dropdown-with-suffix">
-      <mat-label>{{label}}</mat-label>
-      <mat-select [formControlName]="controlName"
-                  class="km-select-ellipsis"
-                  disableOptionCentering>
-        <mat-option *ngFor="let preset of affinityPresetOptions"
-                    [value]="preset">
-          {{preset}}
-        </mat-option>
-        <mat-select-trigger fxLayout="row">
-          <div fxLayoutAlign="start">{{form.get(controlName).value}}</div>
-
-          <div fxLayoutAlign="end"
-               class="km-select-trigger-button-wrapper">
-            <button matSuffix
-                    mat-icon-button
-                    aria-label="Clear"
-                    (click)="resetCallback(); $event.stopPropagation()">
-              <i class="km-icon-mask km-icon-remove"></i>
-            </button>
-          </div>
-        </mat-select-trigger>
-      </mat-select>
+    <mat-form-field fxFlex>
+      <mat-label>Node Affinity Preset Key</mat-label>
+      <input matInput
+             [id]="Controls.NodeAffinityPresetKey"
+             [formControlName]="Controls.NodeAffinityPresetKey"
+             type="text"
+             autocomplete="off">
     </mat-form-field>
-  </ng-template>
+
+    <km-chip-list label="Node Affinity Preset Values"
+                  [tags]="nodeAffinityPresetValues"
+                  (onChange)="onNodeAffinityPresetValuesChange($event)"
+                  [formControlName]="Controls.NodeAffinityPresetValues"
+                  [disabled]="form.get(Controls.NodeAffinityPresetValues).disabled"
+                  placeholder="Add values..."
+                  fxFlex></km-chip-list>
+
+    <ng-template #selectAffinityPreset
+                 let-label="label"
+                 let-controlName="controlName"
+                 let-resetCallback="resetCallback"
+                 let-hint="hint">
+      <mat-form-field fxFlex
+                      class="km-long-subscript km-dropdown-with-suffix">
+        <mat-label>{{label}}</mat-label>
+        <mat-select [formControlName]="controlName"
+                    class="km-select-ellipsis"
+                    disableOptionCentering>
+          <mat-option *ngFor="let preset of affinityPresetOptions"
+                      [value]="preset">
+            {{preset}}
+          </mat-option>
+          <mat-select-trigger fxLayout="row">
+            <div fxLayoutAlign="start">{{form.get(controlName).value}}</div>
+
+            <div fxLayoutAlign="end"
+                 class="km-select-trigger-button-wrapper">
+              <button matSuffix
+                      mat-icon-button
+                      aria-label="Clear"
+                      (click)="resetCallback(); $event.stopPropagation()">
+                <i class="km-icon-mask km-icon-remove"></i>
+              </button>
+            </div>
+          </mat-select-trigger>
+        </mat-select>
+        <mat-hint>{{hint}}</mat-hint>
+      </mat-form-field>
+    </ng-template>
+  </km-expansion-panel>
 </form>

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -1068,15 +1068,15 @@ limitations under the License.
           </ng-container>
         </ng-container>
 
-        <!-- KubeVirt -->
-        <ng-container *ngIf="cluster.spec.cloud?.kubevirt">
-          <km-property *ngFor="let volume of cluster.spec.cloud?.kubevirt.preAllocatedDataVolumes; let i = index;">
-            <div key>Pre-Allocated Data Volume {{i + 1}}</div>
-            <div value>
-              {{volume.name}}, {{volume.size}}, {{volume.storageClass}}, {{volume.url}}
-            </div>
-          </km-property>
-        </ng-container>
+      </ng-container>
+
+      <!-- KubeVirt -->
+      <ng-container *ngIf="cluster.spec.cloud?.kubevirt?.preAllocatedDataVolumes as dataVolumes">
+        <div fxLayout="row">
+          <div fxFlex="90%">
+            <km-kubevirt-pre-allocated-data-volumes [dataVolumes]="dataVolumes"></km-kubevirt-pre-allocated-data-volumes>
+          </div>
+        </div>
       </ng-container>
     </div>
   </div>

--- a/src/app/shared/components/kubevirt-pre-allocated-data-volumes/component.ts
+++ b/src/app/shared/components/kubevirt-pre-allocated-data-volumes/component.ts
@@ -1,0 +1,51 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, Input, OnChanges, OnInit, SimpleChanges} from '@angular/core';
+import {MatTableDataSource} from '@angular/material/table';
+import {KubeVirtPreAllocatedDataVolume} from '@shared/entity/cluster';
+
+enum Column {
+  Name = 'name',
+  Size = 'size',
+  StorageClass = 'storageClass',
+  URL = 'url',
+}
+
+@Component({
+  selector: 'km-kubevirt-pre-allocated-data-volumes',
+  templateUrl: './template.html',
+})
+export class KubeVirtPreAllocatedDataVolumesComponent implements OnInit, OnChanges {
+  readonly Column = Column;
+  readonly displayedColumns: string[] = [Column.Name, Column.Size, Column.StorageClass, Column.URL];
+
+  @Input() dataVolumes: KubeVirtPreAllocatedDataVolume[] = [];
+
+  dataSource = new MatTableDataSource<KubeVirtPreAllocatedDataVolume>();
+
+  ngOnInit(): void {
+    this.dataSource.data = this.dataVolumes;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.dataVolumes) {
+      this.dataSource.data = this.dataVolumes;
+    }
+  }
+
+  getSizeNumber(size: string): string {
+    return size.match(/\d+/)[0];
+  }
+}

--- a/src/app/shared/components/kubevirt-pre-allocated-data-volumes/template.html
+++ b/src/app/shared/components/kubevirt-pre-allocated-data-volumes/template.html
@@ -1,0 +1,75 @@
+<!--
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<mat-card-header class="km-no-padding"
+                 fxLayoutAlign=" center">
+  <mat-card-title>Custom Local Disks</mat-card-title>
+</mat-card-header>
+
+<table class="km-table"
+       mat-table
+       [dataSource]="dataSource">
+
+  <ng-container [matColumnDef]="Column.Name">
+    <th mat-header-cell
+        *matHeaderCellDef
+        class="km-header-cell p-15">Name
+    </th>
+    <td mat-cell
+        *matCellDef="let element">
+      {{element.name}}
+    </td>
+  </ng-container>
+
+  <ng-container [matColumnDef]="Column.Size">
+    <th mat-header-cell
+        *matHeaderCellDef
+        class="km-header-cell p-10">Size (GB)
+    </th>
+    <td mat-cell
+        *matCellDef="let element">
+      {{getSizeNumber(element.size)}}
+    </td>
+  </ng-container>
+
+  <ng-container [matColumnDef]="Column.StorageClass">
+    <th mat-header-cell
+        *matHeaderCellDef
+        class="km-header-cell p-15">Storage Class
+    </th>
+    <td mat-cell
+        *matCellDef="let element">
+      {{element.storageClass}}
+    </td>
+  </ng-container>
+
+  <ng-container [matColumnDef]="Column.URL">
+    <th mat-header-cell
+        *matHeaderCellDef
+        class="km-header-cell p-20">Operating System URL
+    </th>
+    <td mat-cell
+        *matCellDef="let element">
+      {{element.url}}
+    </td>
+  </ng-container>
+
+  <tr mat-header-row
+      class="km-header-row"
+      *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row
+      *matRowDef="let row; columns: displayedColumns"
+      class="km-mat-row"></tr>
+</table>

--- a/src/app/shared/module.ts
+++ b/src/app/shared/module.ts
@@ -68,6 +68,7 @@ import {CustomCredentialsComponent} from '@shared/components/external-cluster-cr
 import {EKSCredentialsComponent} from '@shared/components/external-cluster-credentials/provider/eks/component';
 import {GKECredentialsComponent} from '@shared/components/external-cluster-credentials/provider/gke/component';
 import {ExternalClusterProviderStepComponent} from '@shared/components/add-external-cluster-dialog/steps/external-provider/component';
+import {KubeVirtPreAllocatedDataVolumesComponent} from '@shared/components/kubevirt-pre-allocated-data-volumes/component';
 import {SelectExternalClusterProviderComponent} from '@shared/components/select-external-cluster-provider/component';
 import {AutocompleteComponent} from '@shared/components/autocomplete/component';
 import {CIDRFormComponent} from '@shared/components/cidr-form/component';
@@ -245,6 +246,7 @@ const components = [
   AddApplicationDialogComponent,
   EditApplicationDialogComponent,
   ApplicationMethodIconComponent,
+  KubeVirtPreAllocatedDataVolumesComponent,
 ];
 
 const directives = [AutofocusDirective, ThrottleClickDirective, OptionDirective];

--- a/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
@@ -16,96 +16,101 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column"
       fxLayoutGap="8px">
-  <mat-card-header class="km-no-padding"
-                   fxLayoutAlign=" center">
-    <mat-card-title>Pre-Allocated Data Volumes</mat-card-title>
-    <div fxFlex></div>
-    <button fxLayoutAlign="center center"
-            mat-flat-button
-            type="button"
-            color="quaternary"
-            matTooltip="Add pre-allocated data volume"
-            (click)="addPreAllocatedDataVolume()">
-      <i class="km-icon-mask km-icon-add"></i>
-      <span>Add Data Volume</span>
-    </button>
+  <km-expansion-panel expandLabel="ADVANCED DISK CONFIGURATION"
+                      collapseLabel="ADVANCED DISK CONFIGURATION">
+    <mat-card-header class="km-no-padding"
+                     fxLayoutAlign=" center">
+      <mat-card-title>Custom Local Disks</mat-card-title>
+      <div fxFlex></div>
+      <button fxLayoutAlign="center center"
+              mat-flat-button
+              type="button"
+              color="quaternary"
+              (click)="addPreAllocatedDataVolume()">
+        <i class="km-icon-mask km-icon-add"></i>
+        <span>Add Local Disk</span>
+      </button>
 
-  </mat-card-header>
+    </mat-card-header>
 
-  <div [formArrayName]="Controls.PreAllocatedDataVolumes"
-       fxLayout="column">
-    <div *ngFor="let control of preAllocatedDataVolumesFormArray.controls; let i = index"
-         [formGroupName]="i"
-         class="data-volume-container">
-      <mat-divider *ngIf="i > 0"></mat-divider>
-      <div fxLayout="column">
-        <div fxFlex
-             fxLayout=" center"
-             class="data-volume-header">
-          <div fxLayoutAlign=" center">Volume {{i + 1}}</div>
-          <div fxFlex></div>
-          <button mat-icon-button
-                  type="button"
-                  matTooltip="Remove pre-allocated data volume"
-                  (click)="preAllocatedDataVolumesFormArray.removeAt(i)">
-            <i class="km-icon-mask km-icon-remove"></i>
-          </button>
-        </div>
-        <div fxLayout="row wrap"
-             fxLayoutAlign="space-between">
-          <div fxFlex="48%">
-            <mat-form-field>
-              <mat-label>Name</mat-label>
-              <input matInput
-                     [formControlName]="Controls.PreAllocatedDataVolumeName"
-                     [name]="Controls.PreAllocatedDataVolumeName"
-                     type="text"
-                     autocomplete="off">
-              <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeName).hasError( 'required')">
-                Name is <strong>required</strong>.
-              </mat-error>
-            </mat-form-field>
+    <div [formArrayName]="Controls.PreAllocatedDataVolumes"
+         fxLayout="column">
+      <div *ngFor="let control of preAllocatedDataVolumesFormArray.controls; let i = index"
+           [formGroupName]="i"
+           class="data-volume-container">
+        <mat-divider *ngIf="i > 0"></mat-divider>
+        <div fxLayout="column">
+          <div fxFlex
+               fxLayout=" center"
+               class="data-volume-header">
+            <div fxLayoutAlign=" center">Disk {{i + 1}}</div>
+            <div fxFlex></div>
+            <button mat-icon-button
+                    type="button"
+                    matTooltip="Remove local disk"
+                    (click)="preAllocatedDataVolumesFormArray.removeAt(i)">
+              <i class="km-icon-mask km-icon-remove"></i>
+            </button>
           </div>
-          <div fxFlex="48%">
-            <km-number-stepper [formControlName]="Controls.PreAllocatedDataVolumeSize"
-                               mode="errors"
-                               label="Size (GB)"
-                               min="1"
-                               required>
-            </km-number-stepper>
-          </div>
-          <div fxFlex="48%">
-            <km-combobox [options]="storageClasses"
-                         [formControlName]="Controls.PreAllocatedDataVolumeStorageClass"
-                         [label]="storageClassLabel"
-                         inputLabel="Select storage class..."
-                         filterBy="name"
-                         required
-                         fxFlex>
-              <div *option="let storageClass">{{storageClass.name}}</div>
-            </km-combobox>
-          </div>
-          <div fxFlex="48%">
-            <mat-form-field fxFlex>
-              <mat-label>URL</mat-label>
-              <input matInput
-                     [formControlName]="Controls.PreAllocatedDataVolumeUrl"
-                     [name]="Controls.PreAllocatedDataVolumeUrl"
-                     type="text"
-                     autocomplete="off">
-              <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeUrl).hasError( 'required')">
-                URL is <strong>required</strong>.
-              </mat-error>
-            </mat-form-field>
+          <div fxLayout="row wrap"
+               fxLayoutAlign="space-between">
+            <div fxFlex="48%">
+              <mat-form-field>
+                <mat-label>Name</mat-label>
+                <input matInput
+                       [formControlName]="Controls.PreAllocatedDataVolumeName"
+                       [name]="Controls.PreAllocatedDataVolumeName + i"
+                       type="text"
+                       autocomplete="off">
+                <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeName).hasError( 'required')">
+                  Name is <strong>required</strong>.
+                </mat-error>
+              </mat-form-field>
+            </div>
+            <div fxFlex="48%">
+              <km-number-stepper [formControlName]="Controls.PreAllocatedDataVolumeSize"
+                                 mode="errors"
+                                 label="Size (GB)"
+                                 min="1"
+                                 required>
+              </km-number-stepper>
+            </div>
+            <div fxFlex="48%">
+              <km-combobox [options]="storageClasses"
+                           [formControlName]="Controls.PreAllocatedDataVolumeStorageClass"
+                           [label]="storageClassLabel"
+                           inputLabel="Select storage class..."
+                           filterBy="name"
+                           required
+                           fxFlex>
+                <div *option="let storageClass">{{storageClass.name}}</div>
+              </km-combobox>
+            </div>
+            <div fxFlex="48%">
+              <mat-form-field fxFlex>
+                <mat-label>Operating System URL</mat-label>
+                <input matInput
+                       [formControlName]="Controls.PreAllocatedDataVolumeUrl"
+                       [name]="Controls.PreAllocatedDataVolumeUrl + i"
+                       type="text"
+                       autocomplete="off">
+                <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeUrl).hasError( 'required')">
+                  Operating System URL is <strong>required</strong>.
+                </mat-error>
+              </mat-form-field>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <div *ngIf="!preAllocatedDataVolumesFormArray.length"
-       class="no-pre-allocated-data-volumes-msg km-text-muted">
-    No pre-allocated data volumes configured. Use the add button above to configure.
-  </div>
+    <div *ngIf="!preAllocatedDataVolumesFormArray.length"
+         class="km-text-muted">
+      Custom local disks are optional disks used for the provisioning of nodes with custom images.
+      <a href="https://docs.kubermatic.com/kubermatic/master/architecture/support_policy/provider_support_matrix/kubevirt/kubevirt/"
+         target="_blank"
+         rel="noreferrer noopener">Learn more ></a>
+    </div>
+  </km-expansion-panel>
 
 </form>


### PR DESCRIPTION
**What this PR does / why we need it**:
- Rename and move pre-allocated data volumes into expansion panel

![screenshot-localhost_8000-2022 08 11-21_47_00](https://user-images.githubusercontent.com/13975988/184194198-9064352e-5719-4d85-afa0-ba30f42b6cd9.png)

- Rename and move affinity settings into expansion panel

![screenshot-localhost_8000-2022 08 11-21_47_32](https://user-images.githubusercontent.com/13975988/184194290-c06e4016-74d1-4789-b273-28326415112f.png)

- Display custom local disks on Cluster Summary page

![screenshot-localhost_8000-2022 08 11-21_44_30](https://user-images.githubusercontent.com/13975988/184194328-4fee1899-5ef1-4129-8e14-154644de960f.png)

-  Display custom local disks in Edit Cluster dialog

![screenshot-localhost_8000-2022 08 11-21_42_30](https://user-images.githubusercontent.com/13975988/184194389-ad30adc7-5f1d-4908-8998-551e1be66421.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4793 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind design

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
