### PR TITLE
prepare for kubevirt kubeconfig fixes

### DIFF
--- a/hack/e2e/setup-kubermatic-in-kind.sh
+++ b/hack/e2e/setup-kubermatic-in-kind.sh
@@ -241,6 +241,23 @@ spec:
 EOF
 retry 2 kubectl apply -f preset-digitalocean.yaml
 
+# safebase64 ensures the given value is base64-encoded.
+# If the given value is already encoded, it will be echoed
+# unchanged.
+safebase64() {
+  local value="$1"
+
+  set +e
+  decoded="$(echo "$value" | base64 -d 2>/dev/null)"
+  if [ $? -eq 0 ]; then
+    echo "$value"
+    return 0
+  fi
+
+  echo "$value" | base64 -w0
+  echo
+}
+
 echodate "Creating UI GCP preset..."
 cat <<EOF > preset-gcp.yaml
 apiVersion: kubermatic.k8c.io/v1
@@ -250,7 +267,7 @@ metadata:
   namespace: kubermatic
 spec:
   gcp:
-    serviceAccount: ${GOOGLE_SERVICE_ACCOUNT}
+    serviceAccount: '$(safebase64 "${GOOGLE_SERVICE_ACCOUNT}")'
 EOF
 retry 2 kubectl apply -f preset-gcp.yaml
 
@@ -263,7 +280,7 @@ metadata:
   namespace: kubermatic
 spec:
   kubevirt:
-    kubeconfig: '${KUBEVIRT_E2E_TESTS_KUBECONFIG}'
+    kubeconfig: '$(safebase64 "${KUBEVIRT_E2E_TESTS_KUBECONFIG}")'
 
 EOF
 retry 2 kubectl apply -f preset-kubevirt.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that the dashboard can deal with an unenoded, cleartext kubeconfig, which is what we want to keep in Vault in the future. The same applies for the GCP ServiceAccount.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
