### PR TITLE
Hide add MD button in custom external cluster details page

### DIFF
--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -36,6 +36,7 @@ import {ExternalClusterService} from '@core/services/external-cluster';
 import {ExternalClusterDeleteConfirmationComponent} from '@app/cluster/details/external-cluster/external-cluster-delete-confirmation/component';
 import {ExternalMachineDeploymentService} from '@app/core/services/external-machine-deployment';
 import {NotificationService} from '@app/core/services/notification';
+import _ from 'lodash';
 
 @Component({
   selector: 'km-external-cluster-details',
@@ -82,6 +83,10 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
 
   get securityGroupIds(): string[] {
     return this.cluster?.spec?.eksclusterSpec?.vpcConfigRequest?.securityGroupIds;
+  }
+
+  get showAddMachineDeploymentButton (): boolean {
+    return !_.isEmpty(this.cluster.cloud)
   }
 
   ngOnInit(): void {

--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -85,8 +85,8 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
     return this.cluster?.spec?.eksclusterSpec?.vpcConfigRequest?.securityGroupIds;
   }
 
-  get showAddMachineDeploymentButton (): boolean {
-    return !_.isEmpty(this.cluster.cloud)
+  get showAddMachineDeploymentButton(): boolean {
+    return !_.isEmpty(this.cluster.cloud);
   }
 
   ngOnInit(): void {

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -56,7 +56,8 @@ limitations under the License.
         <i class="km-icon-mask km-icon-download"></i>
         <span>Get Kubeconfig</span>
       </button>
-      <button mat-flat-button
+      <button *ngIf="showAddMachineDeploymentButton"
+              mat-flat-button
               fxLayoutAlign="center center"
               type="button"
               [disabled]="!isRunning()"

--- a/src/app/cluster/list/external-cluster/template.html
+++ b/src/app/cluster/list/external-cluster/template.html
@@ -100,7 +100,7 @@ limitations under the License.
       <ng-container matColumnDef="created">
         <th mat-header-cell
             *matHeaderCellDef
-            class="km-header-cell p-20">Created
+            class="km-header-cell p-20">Imported
         </th>
         <td mat-cell
             *matCellDef="let element">


### PR DESCRIPTION
**What this PR does / why we need it**:
since in the custom external cluster we  don't provide the feature for adding MD in this pr we hide the add MD button for custom external cluster  
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4745

**What type of PR is this?**
/kind cleanup

```release-note
NONE
```