### PR TITLE
Issues with resource quotas

### DIFF
--- a/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -34,7 +34,7 @@ import {ResourceType} from '@shared/entity/common';
 import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
 import {AdminSettings} from '@shared/entity/settings';
 import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plugin';
-import {AsyncValidators} from '@shared/validators/async-label-form.validator';
+import {AsyncValidators} from '@shared/validators/async.validators';
 import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
 import {startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators';

--- a/src/app/core/services/project.ts
+++ b/src/app/core/services/project.ts
@@ -23,6 +23,7 @@ import {Project, ProjectModel, ProjectStatus} from '@shared/entity/project';
 import {View} from '@shared/entity/common';
 import {EMPTY, merge, Observable, of, Subject, timer} from 'rxjs';
 import {catchError, map, shareReplay, switchMap, take} from 'rxjs/operators';
+import _ from 'lodash';
 
 @Injectable()
 export class ProjectService {
@@ -136,7 +137,10 @@ export class ProjectService {
 
   private _getProjects(displayAll: boolean): Observable<Project[]> {
     const url = `${this._restRoot}/projects?displayAll=${displayAll}`;
-    return this._http.get<Project[]>(url).pipe(catchError(() => of<Project[]>()));
+    return this._http.get<Project[]>(url).pipe(
+      map(projects => _.sortBy(projects, project => project.name.toLowerCase())),
+      catchError(() => of<Project[]>())
+    );
   }
 
   private _getProject(projectID: string): Observable<Project> {

--- a/src/app/dynamic/enterprise/quotas/project-quota-dialog/component.spec.ts
+++ b/src/app/dynamic/enterprise/quotas/project-quota-dialog/component.spec.ts
@@ -31,6 +31,7 @@ import {ProjectMockService} from '@test/services/project-mock';
 import {QuotaMockService} from '@test/services/quota-mock';
 import {UserMockService} from '@test/services/user-mock';
 import {ProjectQuotaDialogComponent} from './component';
+import {GlobalModule} from '@core/services/global/module';
 
 describe('AddProjectQuotaDialogComponent', () => {
   let fixture: ComponentFixture<ProjectQuotaDialogComponent>;
@@ -39,7 +40,7 @@ describe('AddProjectQuotaDialogComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ProjectQuotaDialogComponent],
-      imports: [BrowserModule, NoopAnimationsModule, SharedModule, MatDialogModule],
+      imports: [BrowserModule, NoopAnimationsModule, SharedModule, MatDialogModule, GlobalModule],
       providers: [
         {provide: QuotaService, useClass: QuotaMockService},
         {provide: UserService, useClass: UserMockService},

--- a/src/app/dynamic/enterprise/quotas/project-quota-dialog/style.scss
+++ b/src/app/dynamic/enterprise/quotas/project-quota-dialog/style.scss
@@ -18,6 +18,8 @@
 //
 // END OF TERMS AND CONDITIONS
 
+@use 'variables';
+
 .quota-form {
   margin-bottom: 20px;
 }
@@ -34,4 +36,15 @@
 
 .km-project-name {
   margin-top: 9px;
+}
+
+.mat-card-subtitle {
+  line-height: 16px;
+  margin: 0;
+  padding: 5px 0 0;
+
+  strong {
+    font-family: variables.$font-primary-mono;
+    margin-right: 5px;
+  }
 }

--- a/src/app/dynamic/enterprise/quotas/project-quota-dialog/template.html
+++ b/src/app/dynamic/enterprise/quotas/project-quota-dialog/template.html
@@ -25,6 +25,11 @@ END OF TERMS AND CONDITIONS
   <form [formGroup]="form"
         fxLayout="column"
         fxLayoutAlign="space-between stretch">
+    <p *ngIf="editQuota"
+       class="km-dialog-context-description">
+      Edit quotas of <b>{{editQuota.subjectHumanReadableName}}</b> project
+    </p>
+
     <form [formGroup]="quotaGroup"
           class="quota-form"
           fxLayout="column"
@@ -34,7 +39,6 @@ END OF TERMS AND CONDITIONS
            fxLayout="row"
            fxLayoutGap="5px"
            fxLayoutAlign="space-between center">
-
         <km-number-stepper id="km-cpu-input"
                            label="CPU"
                            min="0"
@@ -65,33 +69,30 @@ END OF TERMS AND CONDITIONS
       </mat-error>
     </form>
 
-    <div fxLayout="column"
+    <div *ngIf="!editQuota"
+         fxLayout="column"
          fxLayoutAlign=" stretch">
-      <mat-form-field class="km-dropdown-with-suffix"
-                      *ngIf="!editQuota; else editMode">
-        <mat-label>Project</mat-label>
-        <mat-select disableOptionCentering
-                    class="km-select-ellipsis"
-                    [formControl]="form.controls.subjectName"
-                    required>
-          <mat-option *ngFor="let project of projects"
-                      [value]="project.id"> {{project.name}} </mat-option>
-          <mat-select-trigger fxLayout="row">
-            <div fxLayoutAlign="start">{{selectedProject?.name || editQuota?.name}}</div>
+      <km-combobox label="Project"
+                   inputLabel="Project"
+                   filterBy="name"
+                   selectBy="id"
+                   [required]="true"
+                   [isDisabled]="!projects.length"
+                   [options]="projects"
+                   [formControl]="projectControl"
+                   [valueFormatter]="projectDisplayFn.bind(this)">
+        <div *option="let project"
+             fxLayout="row"
+             fxLayoutGap="10px"
+             fxLayoutAlign=" center">
+          <span>{{project.name}}</span>
 
-            <div fxLayoutAlign="end"
-                 class="km-select-trigger-button-wrapper">
-              <button matSuffix
-                      mat-icon-button
-                      [disabled]="!!editQuota"
-                      (click)="resetSubjectNameControl()">
-                <i class="km-icon-mask km-icon-remove"></i>
-              </button>
-            </div>
-          </mat-select-trigger>
-        </mat-select>
-        <mat-error> Project is <strong>required</strong> </mat-error>
-      </mat-form-field>
+          <mat-card-subtitle class="km-no-margin km-no-padding"
+                             *ngIf="projectNameCountMap[project.name] > 1">
+            <strong>ID</strong> {{project.id}}
+          </mat-card-subtitle>
+        </div>
+      </km-combobox>
     </div>
   </form>
 </mat-dialog-content>
@@ -99,16 +100,7 @@ END OF TERMS AND CONDITIONS
   <km-button id="km-add-quota-dialog-save-btn"
              [icon]="selectedQuota ? 'km-icon-edit' : 'km-icon-add'"
              label="{{ selectedQuota ? 'Save Changes' : 'Add Project Quota' }}"
-             [disabled]="form.invalid"
+             [disabled]="!isQuotaUpdated || form.invalid"
              [observable]="getObservable()">
   </km-button>
 </mat-dialog-actions>
-
-<ng-template #editMode>
-  <km-property>
-    <div key>Project</div>
-    <div value
-         class="km-project-name">{{ editQuota?.subjectHumanReadableName ?? editQuota?.subjectName }}</div>
-  </km-property>
-
-</ng-template>

--- a/src/app/dynamic/enterprise/quotas/quota-widget/template.html
+++ b/src/app/dynamic/enterprise/quotas/quota-widget/template.html
@@ -60,23 +60,43 @@ END OF TERMS AND CONDITIONS
       <mat-card-content fxLayout="column">
         <div class="km-detail-row">Project Quota</div>
 
-        <div class="km-detail-row"
-             *ngIf="quotaDetails.quota.cpu">
-          <span>CPU</span>
-          <span>{{quotaDetails.status.globalUsage.cpu ?? 0}}/{{quotaDetails.quota.cpu}}</span>
-        </div>
+        <ng-container *ngTemplateOutlet="detailRow; context: {
+         label: 'CPU',
+         usage: quotaDetails.status.globalUsage.cpu,
+         quota: quotaDetails.quota.cpu
+         }"></ng-container>
 
-        <div class="km-detail-row"
-             *ngIf="quotaDetails.quota.memory">
-          <span>Memory</span>
-          <span>{{quotaDetails.status.globalUsage.memory ?? 0}}/{{quotaDetails.quota.memory}}</span>
-        </div>
+        <ng-container *ngTemplateOutlet="detailRow; context: {
+         label: 'Memory',
+         usage: quotaDetails.status.globalUsage.memory,
+         quota: quotaDetails.quota.memory,
+         unit: 'GB'
+         }"></ng-container>
 
-        <div class="km-detail-row"
-             *ngIf="quotaDetails.quota.storage">
-          <span>Disk</span>
-          <span>{{quotaDetails.status.globalUsage.storage ?? 0}}/{{quotaDetails.quota.storage}}</span>
-        </div>
+        <ng-container *ngTemplateOutlet="detailRow; context: {
+         label: 'Disk',
+         usage: quotaDetails.status.globalUsage.storage,
+         quota: quotaDetails.quota.storage,
+         unit: 'GB'
+         }"></ng-container>
+
+        <ng-template #detailRow
+                     let-label="label"
+                     let-usage="usage"
+                     let-quota="quota"
+                     let-unit="unit">
+          <div class="km-detail-row"
+               *ngIf="quota"
+               fxLayout="row"
+               fxLayoutAlign="space-between center">
+            <span fxFlex>{{ label }}</span>
+
+            <span fxFlex="20"
+                  dir="rtl">{{ usage ?? 0 }}/{{ quota }}</span>
+            <span fxFlex="10"
+                  dir="rtl">{{ unit }}</span>
+          </div>
+        </ng-template>
       </mat-card-content>
     </mat-card>
 

--- a/src/app/project/edit-project/component.ts
+++ b/src/app/project/edit-project/component.ts
@@ -18,10 +18,10 @@ import {MatDialogRef} from '@angular/material/dialog';
 import {NotificationService} from '@core/services/notification';
 import {ResourceType} from '@shared/entity/common';
 import {Project, ProjectModel} from '@shared/entity/project';
-import {AsyncValidators} from '@shared/validators/async-label-form.validator';
 import _ from 'lodash';
 import {ProjectService} from '@core/services/project';
 import {Observable} from 'rxjs';
+import {AsyncValidators} from '@shared/validators/async.validators';
 
 @Component({
   selector: 'km-edit-project',

--- a/src/app/shared/components/add-project-dialog/component.ts
+++ b/src/app/shared/components/add-project-dialog/component.ts
@@ -17,11 +17,11 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {MatDialogRef} from '@angular/material/dialog';
 import {NotificationService} from '@core/services/notification';
 import {ResourceType} from '@shared/entity/common';
-import {AsyncValidators} from '@shared/validators/async-label-form.validator';
 import {ProjectService} from '@core/services/project';
 import {Observable} from 'rxjs';
 import {Project} from '@shared/entity/project';
 import {take} from 'rxjs/operators';
+import {AsyncValidators} from '../../validators/async.validators';
 
 @Component({
   selector: 'km-add-project-dialog',

--- a/src/app/shared/components/number-stepper/component.ts
+++ b/src/app/shared/components/number-stepper/component.ts
@@ -34,6 +34,7 @@ import {
   Validator,
 } from '@angular/forms';
 import {noop, Subject} from 'rxjs';
+import _ from 'lodash';
 
 enum Error {
   Required = 'required',
@@ -116,14 +117,16 @@ export class NumberStepperComponent implements AfterViewInit, OnDestroy, Control
   }
 
   set value(val: number | string) {
-    const parsed = this.type === 'decimal' ? this._decimalPipe.transform(val, '1.0-4') : val?.toString();
-    if (!Number.isNaN(parsed) && parsed !== null && parsed !== undefined) {
+    const parsed =
+      this.type === 'decimal' ? this._decimalPipe.transform(val, '1.0-4')?.replace(/,/g, '') : val?.toString();
+
+    if (_.isNil(parsed) || _.isNaN(parsed)) {
+      this._value = null;
+    } else {
       this._value = this.type === 'decimal' ? Number.parseFloat(parsed) : Number.parseInt(parsed);
-      this._onChange(val);
-    } else if (!parsed) {
-      this._value = parsed;
-      this._onChange(val);
     }
+
+    this._onChange(this._value);
     this._cdr.detectChanges();
   }
 

--- a/src/app/shared/components/number-stepper/template.html
+++ b/src/app/shared/components/number-stepper/template.html
@@ -21,6 +21,7 @@ limitations under the License.
          matInput
          type="number"
          autocomplete="off"
+         onkeydown="return event.keyCode !== 69"
          [pattern]="pattern"
          [disabled]="disabled"
          [required]="required"

--- a/src/app/shared/validators/async-label-form.validator.ts
+++ b/src/app/shared/validators/async-label-form.validator.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AbstractControl, AsyncValidator, AsyncValidatorFn, ValidationErrors} from '@angular/forms';
+import {AbstractControl, AsyncValidator, ValidationErrors} from '@angular/forms';
 import {GlobalModule} from '@core/services/global/module';
 import {LabelService} from '@core/services/label';
 import {ResourceLabelMap, ResourceType} from '@shared/entity/common';
@@ -40,12 +40,5 @@ export class RestrictedLabelKeyNameValidator implements AsyncValidator {
       }),
       catchError(() => of(null))
     );
-  }
-}
-
-export class AsyncValidators {
-  static RestrictedLabelKeyName(resourceType: ResourceType): AsyncValidatorFn {
-    const validator = new RestrictedLabelKeyNameValidator(resourceType);
-    return validator.validate.bind(validator);
   }
 }

--- a/src/app/shared/validators/async.validators.ts
+++ b/src/app/shared/validators/async.validators.ts
@@ -1,0 +1,24 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ResourceType} from '../entity/common';
+import {AsyncValidatorFn} from '@angular/forms';
+import {RestrictedLabelKeyNameValidator} from './async-label-form.validator';
+
+export class AsyncValidators {
+  static RestrictedLabelKeyName(resourceType: ResourceType): AsyncValidatorFn {
+    const validator = new RestrictedLabelKeyNameValidator(resourceType);
+    return validator.validate.bind(validator);
+  }
+}

--- a/src/app/wizard/step/cluster/component.ts
+++ b/src/app/wizard/step/cluster/component.ts
@@ -48,7 +48,6 @@ import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
 import {AdminSettings} from '@shared/entity/settings';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plugin';
-import {AsyncValidators} from '@shared/validators/async-label-form.validator';
 import {IPV4_CIDR_PATTERN_VALIDATOR} from '@shared/validators/others';
 import {KmValidators} from '@shared/validators/validators';
 import {combineLatest, merge} from 'rxjs';
@@ -56,6 +55,7 @@ import {filter, startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators
 import * as semver from 'semver';
 import {coerce, compare} from 'semver';
 import {StepBase} from '../base';
+import {AsyncValidators} from '@shared/validators/async.validators';
 
 enum Controls {
   Name = 'name',

--- a/src/assets/css/global/_main.scss
+++ b/src/assets/css/global/_main.scss
@@ -201,6 +201,10 @@ hr {
   padding: 0 !important;
 }
 
+.km-no-margin {
+  margin: 0 !important;
+}
+
 .km-code-block {
   border-radius: variables.$border-radius;
   font-family: variables.$font-primary-mono;

--- a/src/assets/css/global/_theme.scss
+++ b/src/assets/css/global/_theme.scss
@@ -295,8 +295,14 @@
   }
 
   .km-quota-widget {
-    .mat-progress-bar.mat-accent .mat-progress-bar-fill::after {
-      background-color: map.get($colors, indicator-orange);
+    .mat-progress-bar.mat-accent {
+      .mat-progress-bar-buffer {
+        background: map.get($colors, divider);
+      }
+
+      .mat-progress-bar-fill::after {
+        background-color: map.get($colors, indicator-orange);
+      }
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

### Point 1 (b) & 3

While in `edit mode`:
- Project name is moved to the top
- submit button will stay disabled when quotas are unchanged
<img width="664" alt="image" src="https://user-images.githubusercontent.com/56511988/184654158-b5c1a217-af80-419f-83c6-ad6e6d3cb413.png">

### Point 2

Select component is replaced with a typeahead 

<img width="664" alt="image" src="https://user-images.githubusercontent.com/56511988/184654681-4be49f8e-4492-4875-9620-7e60f520a47c.png">

### Point 4

Issues with number inputs are fixed

### Point 6

Units added to quota widget on hover

<img width="260" alt="image" src="https://user-images.githubusercontent.com/56511988/184656050-b0d0e0ba-c237-461c-a42e-780b353e10d2.png">

### Point 8

Fixed background colour of yellow progress bar

<img width="260" alt="image" src="https://user-images.githubusercontent.com/56511988/184656600-cd5e7cf5-0620-46ef-9067-ff34052fa5f7.png">
<img width="260" alt="image" src="https://user-images.githubusercontent.com/56511988/184656647-9f0f0418-7fac-4c75-8c07-53432595643f.png">

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4740

**What type of PR is this?**
/kind bug
/kind design
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

