### PR TITLE
Rename rockylinux in the correct format

### DIFF
--- a/src/app/cluster/details/cluster/machine-deployment-details/template.html
+++ b/src/app/cluster/details/cluster/machine-deployment-details/template.html
@@ -188,8 +188,8 @@ limitations under the License.
           <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rhel"
                                [value]="machineDeployment.spec.template.operatingSystem.rhel.distUpgradeOnBoot"
                                label="Upgrade system on the first boot"></km-property-boolean>
-          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockyLinux"
-                               [value]="machineDeployment.spec.template.operatingSystem.rockyLinux.distUpgradeOnBoot"
+          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockylinux"
+                               [value]="machineDeployment.spec.template.operatingSystem.rockylinux.distUpgradeOnBoot"
                                label="Upgrade system on the first boot"></km-property-boolean>
           <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.flatcar"
                                [value]="machineDeployment.spec.template.operatingSystem.flatcar.disableAutoUpdate"

--- a/src/app/cluster/details/cluster/node-list/template.html
+++ b/src/app/cluster/details/cluster/node-list/template.html
@@ -468,9 +468,9 @@ limitations under the License.
                                  label="Upgrade system on first boot"
                                  [value]="element.spec.operatingSystem.rhel.distUpgradeOnBoot">
             </km-property-boolean>
-            <km-property-boolean *ngIf="!!element.spec.operatingSystem.rockyLinux"
+            <km-property-boolean *ngIf="!!element.spec.operatingSystem.rockylinux"
                                  label="Upgrade system on first boot"
-                                 [value]="element.spec.operatingSystem.rockyLinux.distUpgradeOnBoot">
+                                 [value]="element.spec.operatingSystem.rockylinux.distUpgradeOnBoot">
             </km-property-boolean>
             <km-property-boolean *ngIf="element.spec.cloud.digitalocean"
                                  label="Backups"

--- a/src/app/core/services/node.ts
+++ b/src/app/core/services/node.ts
@@ -61,7 +61,7 @@ export class NodeService {
     patch.spec.template.operatingSystem.ubuntu = patch.spec.template.operatingSystem.ubuntu || null;
     patch.spec.template.operatingSystem.centos = patch.spec.template.operatingSystem.centos || null;
     patch.spec.template.operatingSystem.flatcar = patch.spec.template.operatingSystem.flatcar || null;
-    patch.spec.template.operatingSystem.rockyLinux = patch.spec.template.operatingSystem.rockyLinux || null;
+    patch.spec.template.operatingSystem.rockylinux = patch.spec.template.operatingSystem.rockylinux || null;
     patch.spec.template.operatingSystem.sles = patch.spec.template.operatingSystem.sles || null;
     patch.spec.template.operatingSystem.amzn2 = patch.spec.template.operatingSystem.amzn2 || null;
 

--- a/src/app/node-data/basic/provider/nutanix/component.ts
+++ b/src/app/node-data/basic/provider/nutanix/component.ts
@@ -222,7 +222,7 @@ export class NutanixBasicNodeDataComponent extends BaseFormValidator implements 
       case OperatingSystem.Flatcar:
         return this._images?.flatcar;
       case OperatingSystem.RockyLinux:
-        return this._images?.rockyLinux;
+        return this._images?.rockylinux;
       default:
         return this._images?.ubuntu;
     }

--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -302,7 +302,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
       case OperatingSystem.Flatcar:
         return this._images.flatcar;
       case OperatingSystem.RockyLinux:
-        return this._images.rockyLinux;
+        return this._images.rockylinux;
       default:
         return this._images.ubuntu;
     }

--- a/src/app/node-data/basic/provider/vsphere/component.ts
+++ b/src/app/node-data/basic/provider/vsphere/component.ts
@@ -139,7 +139,7 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
         this._defaultTemplate = this._templates.rhel;
         break;
       case OperatingSystem.RockyLinux:
-        this._defaultTemplate = this._templates.rockyLinux;
+        this._defaultTemplate = this._templates.rockylinux;
         break;
       default:
         this._defaultTemplate = '';
@@ -157,7 +157,7 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
       return OperatingSystem.SLES;
     } else if (this._templates.flatcar) {
       return OperatingSystem.Flatcar;
-    } else if (this._templates.rockyLinux) {
+    } else if (this._templates.rockylinux) {
       return OperatingSystem.RockyLinux;
     }
     return undefined;

--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -451,9 +451,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     if (this.selectedOperatingSystemProfile) {
       ospValue = this.selectedOperatingSystemProfile;
     } else if (this.form.get(Controls.OperatingSystem).value !== '') {
-      // We have to explicitly convert this to a lowercase string to handle the inconsistency between the
-      // node provider name 'rockyLinux' and the operating system name in machine-controller i.e. `rockylinux`.
-      const ospName = 'osp-' + this.form.get(Controls.OperatingSystem).value.toLowerCase();
+      const ospName = 'osp-' + this.form.get(Controls.OperatingSystem).value;
       if (this.supportedOperatingSystemProfiles.indexOf(ospName) > -1) {
         ospValue = ospName;
       }

--- a/src/app/node-data/template.html
+++ b/src/app/node-data/template.html
@@ -104,7 +104,7 @@ limitations under the License.
         </mat-button-toggle>
         <mat-button-toggle [value]="OperatingSystem.RockyLinux"
                            *ngIf="isOperatingSystemSupported(OperatingSystem.RockyLinux)">
-          <i class="km-os-image-rocky-linux"></i>
+          <i class="km-os-image-rockylinux"></i>
           Rocky Linux
         </mat-button-toggle>
       </mat-button-toggle-group>

--- a/src/app/shared/components/cluster-summary/template.html
+++ b/src/app/shared/components/cluster-summary/template.html
@@ -298,9 +298,9 @@ limitations under the License.
                                label="Upgrade system on the first boot"
                                [value]="machineDeployment.spec.template.operatingSystem.rhel.distUpgradeOnBoot">
           </km-property-boolean>
-          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockyLinux?.distUpgradeOnBoot"
+          <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.rockylinux?.distUpgradeOnBoot"
                                label="Upgrade system on the first boot"
-                               [value]="machineDeployment.spec.template.operatingSystem.rockyLinux.distUpgradeOnBoot">
+                               [value]="machineDeployment.spec.template.operatingSystem.rockylinux.distUpgradeOnBoot">
           </km-property-boolean>
           <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.flatcar?.disableAutoUpdate"
                                label="Disable system auto-update"

--- a/src/app/shared/entity/datacenter.ts
+++ b/src/app/shared/entity/datacenter.ts
@@ -55,7 +55,7 @@ export class DatacenterOperatingSystemOptions {
   centos: string;
   flatcar?: string;
   rhel?: string;
-  rockyLinux?: string;
+  rockylinux?: string;
   sles?: string;
   ubuntu: string;
 }

--- a/src/app/shared/entity/node.ts
+++ b/src/app/shared/entity/node.ts
@@ -69,7 +69,7 @@ export class OperatingSystemSpec {
   centos?: CentosSpec;
   flatcar?: FlatcarSpec;
   rhel?: RHELSpec;
-  rockyLinux?: RockyLinuxSpec;
+  rockylinux?: RockyLinuxSpec;
   sles?: SLESSpec;
   ubuntu?: UbuntuSpec;
 
@@ -428,7 +428,7 @@ export function getOperatingSystem(spec: NodeSpec): string {
     return 'RHEL';
   } else if (spec.operatingSystem.flatcar) {
     return 'Flatcar';
-  } else if (spec.operatingSystem.rockyLinux) {
+  } else if (spec.operatingSystem.rockylinux) {
     return 'Rocky Linux';
   } else if (spec.operatingSystem.amzn2) {
     return 'Amazon Linux 2';
@@ -447,8 +447,8 @@ export function getOperatingSystemLogoClass(spec: NodeSpec): string {
     return 'rhel';
   } else if (spec.operatingSystem.flatcar) {
     return 'flatcar';
-  } else if (spec.operatingSystem.rockyLinux) {
-    return 'rocky-linux';
+  } else if (spec.operatingSystem.rockylinux) {
+    return 'rockylinux';
   } else if (spec.operatingSystem.amzn2) {
     return 'amazon-linux-2';
   }

--- a/src/app/shared/model/NodeProviderConstants.ts
+++ b/src/app/shared/model/NodeProviderConstants.ts
@@ -48,7 +48,7 @@ export enum OperatingSystem {
   CentOS = 'centos',
   Flatcar = 'flatcar',
   RHEL = 'rhel',
-  RockyLinux = 'rockyLinux',
+  RockyLinux = 'rockylinux',
   SLES = 'sles',
   Ubuntu = 'ubuntu',
 }
@@ -91,7 +91,7 @@ export namespace NodeProviderConstants {
       return OperatingSystem.RHEL;
     } else if (spec.operatingSystem.flatcar) {
       return OperatingSystem.Flatcar;
-    } else if (spec.operatingSystem.rockyLinux) {
+    } else if (spec.operatingSystem.rockylinux) {
       return OperatingSystem.RockyLinux;
     } else if (spec.operatingSystem.amzn2) {
       return OperatingSystem.AmazonLinux2;

--- a/src/assets/css/_images.scss
+++ b/src/assets/css/_images.scss
@@ -488,7 +488,7 @@
   @include mixins.background-image('/assets/images/os/flatcar.svg', 24px);
 }
 
-.km-os-image-rocky-linux {
+.km-os-image-rockylinux {
   @include mixins.background-image('/assets/images/os/rocky-linux.svg', 24px);
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems that rockylinux was renamed into rockyLinux which has messed up couple of properties in the api and in the OSSpec. For example matching the name with operating system name doesn't work, which leads to failures when trying to pick a template for rockylinux in vsphere for example. Same thing will happen to KubeVirt, Openstack and Bare metal provisioning in the future. This PR reverts back rockylinux to it's original name. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
