### PR TITLE
Make KubeVirt affinity settings mutually exclusive

### DIFF
--- a/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -155,6 +155,32 @@ export class KubeVirtBasicNodeDataComponent
         }
       });
 
+    this.form
+      .get(Controls.PodAffinityPreset)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(value => {
+        const antiAffinityControl = this.form.get(Controls.PodAntiAffinityPreset);
+        if (value && antiAffinityControl.enabled) {
+          antiAffinityControl.reset();
+          antiAffinityControl.disable();
+        } else if (!value && antiAffinityControl.disabled) {
+          antiAffinityControl.enable();
+        }
+      });
+
+    this.form
+      .get(Controls.PodAntiAffinityPreset)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(value => {
+        const affinityControl = this.form.get(Controls.PodAffinityPreset);
+        if (value && affinityControl.enabled) {
+          affinityControl.reset();
+          affinityControl.disable();
+        } else if (!value && affinityControl.disabled) {
+          affinityControl.enable();
+        }
+      });
+
     this._init();
     this._nodeDataService.nodeData = this._getNodeData();
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make KubeVirt pod affinity/anti-affinity preset settings mutually exclusive so if only one of them can be configured.

![screenshot-localhost_8000-2022 08 16-22_21_54](https://user-images.githubusercontent.com/13975988/184940840-73644245-0e41-4ab8-bdde-ec872c7b59d0.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4793 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
