### PR TITLE
Add legacy report prefix to not show raw data csv files

### DIFF
--- a/src/app/dynamic/enterprise/metering/service/metering.ts
+++ b/src/app/dynamic/enterprise/metering/service/metering.ts
@@ -34,6 +34,7 @@ export class MeteringService {
   private _scheduleConfigurations: Observable<MeteringReportConfiguration[]>;
   private _reports$ = new Map<string, Observable<Report[]>>();
   private _legacyReports$: Observable<Report[]>;
+  private readonly _legacyReportPrefix = 'report-';
 
   readonly onConfigurationChange$ = new Subject<void>();
   readonly onCredentialsChange$ = new Subject<void>();
@@ -91,7 +92,7 @@ export class MeteringService {
 
   legacyReports(): Observable<Report[]> {
     if (!this._legacyReports$) {
-      this._legacyReports$ = this._getReports();
+      this._legacyReports$ = this._getReports(this._legacyReportPrefix);
     }
     return this._legacyReports$;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug where raw data was mistakenly shown as reports.

The scheduleName effectively acts as a prefix filter, therefore we can use it and set the prefix for legacy reports.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4807

/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
NONE
```

```documentation
NONE
```
