### PR TITLE
Use flex layout to display project quota details

### DIFF
--- a/src/app/dynamic/enterprise/quotas/quota-widget/template.html
+++ b/src/app/dynamic/enterprise/quotas/quota-widget/template.html
@@ -91,10 +91,18 @@ END OF TERMS AND CONDITIONS
                fxLayoutAlign="space-between center">
             <span fxFlex>{{ label }}</span>
 
-            <span fxFlex="20"
-                  dir="rtl">{{ usage ?? 0 }}/{{ quota }}</span>
-            <span fxFlex="10"
-                  dir="rtl">{{ unit }}</span>
+            <div fxFlex="70%"
+                 fxLayout="row wrap"
+                 fxLayoutGap="5px"
+                 fxLayoutAlign="flex-end center">
+              <span fxLayoutAlign="flex-end">
+                {{ usage ?? 0 }}/{{ quota }}
+              </span>
+              <span fxFlex="15%"
+                    fxLayoutAlign="flex-end">
+                {{ unit }}
+              </span>
+            </div>
           </div>
         </ng-template>
       </mat-card-content>


### PR DESCRIPTION
**What this PR does / why we need it**:
Use flex layout to display project quota details.

**Before**

![screenshot-localhost_8000-2022 08 19-23_59_09](https://user-images.githubusercontent.com/13975988/185694656-acb56e36-e52a-40a2-9594-b24bb7cc55bf.png)


 **After**

![screenshot-localhost_8000-2022 08 20-00_34_17](https://user-images.githubusercontent.com/13975988/185694683-a31f581c-c47e-4284-ad1d-8222fce21967.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
