### PR TITLE
Fix issue to display empty placeholder in case no nodes exists

### DIFF
--- a/src/app/cluster/details/external-cluster/external-node-list/component.ts
+++ b/src/app/cluster/details/external-cluster/external-node-list/component.ts
@@ -17,7 +17,7 @@ import {MatPaginator} from '@angular/material/paginator';
 import {MatSort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
 import {UserService} from '@core/services/user';
-import {ExternalCluster} from '@shared/entity/external-cluster';
+import {ExternalCluster, ExternalClusterState} from '@shared/entity/external-cluster';
 import {NodeMetrics} from '@shared/entity/metrics';
 import {Node, NodeIPAddress} from '@shared/entity/node';
 import {NodeUtils} from '@shared/utils/node';
@@ -36,7 +36,6 @@ export class ExternalNodeListComponent implements OnInit, OnChanges, OnDestroy {
   @Input() nodes: Node[] = [];
   @Input() nodesMetrics: Map<string, NodeMetrics> = new Map<string, NodeMetrics>();
   @Input() projectID: string;
-  @Input() isClusterRunning = false;
   @Input() isInitialized = false;
   @ViewChild(MatSort, {static: true}) sort: MatSort;
   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
@@ -72,11 +71,15 @@ export class ExternalNodeListComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   isLoadingData(): boolean {
-    return (_.isEmpty(this.nodes) && !this.isClusterRunning) || !this.isInitialized;
+    return (_.isEmpty(this.nodes) && !this.isRunning()) || !this.isInitialized;
   }
 
   hasNoData(): boolean {
-    return _.isEmpty(this.nodes) && this.isClusterRunning && this.isInitialized;
+    return _.isEmpty(this.nodes) && this.isRunning() && this.isInitialized;
+  }
+
+  isRunning(): boolean {
+    return this.cluster?.status?.state === ExternalClusterState.Running;
   }
 
   getNodeHealthStatus(n: Node): HealthStatus {

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -280,7 +280,6 @@ limitations under the License.
                          [nodes]="nodes"
                          [nodesMetrics]="nodesMetrics"
                          [projectID]="projectID"
-                         [isClusterRunning]="isRunning()"
                          [isInitialized]="areNodesInitialized"></km-external-node-list>
 
   <km-event-card [events]="events"></km-event-card>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes to display "no nodes available" when nodes list is empty but it was showing `loading` icon.

**Before:**
(Cluster was running && Nodes were empty)

![before](https://user-images.githubusercontent.com/17727069/185710581-1b8f39d8-b03e-419f-861b-2d40f0ad9678.jpeg)

**After:**

**Case-1:**
(Cluster was running && Nodes were empty)

<img width="1431" alt="after" src="https://user-images.githubusercontent.com/17727069/185710953-e47d5404-2c49-418e-a03f-ea9e52ca4ba3.png">


**Case-2:**
(Cluster was running && Nodes list):

https://user-images.githubusercontent.com/17727069/185710814-21bf6813-b9e5-4c28-87e4-ab2668d84cf6.mp4


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4744 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

Issue was `isClusterRunning` was not passed in case of **MD details** page. Although cluster was in running state. Instead of passing cluster **state** from parent in details page NOW state is checked inside nodes list as we are already passing external cluster in both usages. which fixes the issue in following pages.

- Details page
- MD Details page

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Shows placeholder when no nodes exists inside external machine deployment details page
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
