### PR TITLE
Disabled buttons in project view when user only has view-only permission

### DIFF
--- a/src/app/cluster-template/component.ts
+++ b/src/app/cluster-template/component.ts
@@ -49,6 +49,9 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
   currentUser: Member;
   displayedColumns: string[] = ['name', 'scope', 'provider', 'region', 'actions'];
   dataSource = new MatTableDataSource<any>();
+  isGroupConfigLoading: boolean;
+  projectViewOnlyToolTip =
+    'You do not have permission to perform this action. Contact the project owner to change your membership role';
 
   @ViewChild(MatSort, {static: true}) sort: MatSort;
   @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
@@ -110,10 +113,14 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private _loadUserGroup(): void {
+    this.isGroupConfigLoading = true;
     this._onChange
       .pipe(switchMap(_ => this._userService.getCurrentUserGroup(this._selectedProject.id).pipe(take(1))))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(userGroup => (this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup)));
+      .subscribe(userGroup => {
+        this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup);
+        this.isGroupConfigLoading = false;
+      });
   }
 
   private _loadTemplates(): void {

--- a/src/app/cluster-template/template.html
+++ b/src/app/cluster-template/template.html
@@ -22,8 +22,10 @@ limitations under the License.
     <button fxLayoutAlign="center center"
             mat-flat-button
             type="button"
+            [matTooltip]="projectViewOnlyToolTip"
+            [matTooltipDisabled]="canCreate()"
             (click)="create()"
-            [disabled]="!canCreate()">
+            [disabled]="!canCreate() || isGroupConfigLoading">
       <i class="km-icon-mask km-icon-add"></i>
       <span>Create Cluster Template</span>
     </button>

--- a/src/app/project-overview/create-resource-panel/component.ts
+++ b/src/app/project-overview/create-resource-panel/component.ts
@@ -47,6 +47,9 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
   @Output() refreshClusterTemplates = new EventEmitter<void>();
   @Output() refreshBackups = new EventEmitter<void>();
 
+  projectViewOnlyToolTip =
+    'You do not have permission to perform this action. Contact the project owner to change your membership role';
+
   private _user: Member;
   private _currentGroupConfig: GroupConfig;
   private _isOpen = false;

--- a/src/app/project-overview/create-resource-panel/template.html
+++ b/src/app/project-overview/create-resource-panel/template.html
@@ -27,7 +27,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="openClusterWizard()">
+         [matTooltip]="projectViewOnlyToolTip"
+         [matTooltipDisabled]="canCreateCluster"
+         [matRippleDisabled]="!canCreateCluster"
+         (click)="canCreateCluster ? openClusterWizard() : null">
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Create Cluster</span>
@@ -37,7 +40,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="importExternalCluster()">
+         [matTooltip]="projectViewOnlyToolTip"
+         [matTooltipDisabled]="canCreateCluster"
+         [matRippleDisabled]="!canCreateCluster"
+         (click)="canCreateCluster ? importExternalCluster(): null">
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Import External Cluster</span>
@@ -47,7 +53,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="openExternalClusterWizard()">
+         [matTooltip]="projectViewOnlyToolTip"
+         [matTooltipDisabled]="canCreateCluster"
+         [matRippleDisabled]="!canCreateCluster"
+         (click)="canCreateCluster ? openExternalClusterWizard(): null">
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Create External Cluster</span>
@@ -57,7 +66,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="createClusterFromTemplate()">
+         [matTooltip]="projectViewOnlyToolTip"
+         [matTooltipDisabled]="canCreateCluster"
+         [matRippleDisabled]="!canCreateCluster"
+         (click)="canCreateCluster ? createClusterFromTemplate(): null">
       <i class="km-icon-mask km-icon-cluster"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Cluster from Template</span>
@@ -67,7 +79,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="createClusterTemplate()">
+         [matTooltip]="projectViewOnlyToolTip"
+         [matTooltipDisabled]="canCreateCluster"
+         [matRippleDisabled]="!canCreateCluster"
+         (click)="canCreateCluster ? createClusterTemplate() : null">
       <i class="km-icon-mask km-icon-cluster-template"
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Cluster Template</span>
@@ -77,7 +92,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="createAutomaticBackup()">
+         [matTooltip]="projectViewOnlyToolTip"
+         [matTooltipDisabled]="canCreateBackups"
+         [matRippleDisabled]="!canCreateBackups"
+         (click)="canCreateBackups ? createAutomaticBackup(): null">
       <i class="km-icon-mask km-icon-backup"
          [ngClass]="{'km-muted-bg': !canCreateBackups}"></i>
       <span>Automatic Backup</span>
@@ -87,7 +105,10 @@ limitations under the License.
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
          matRipple
-         (click)="createSnapshot()">
+         [matTooltip]="projectViewOnlyToolTip"
+         [matTooltipDisabled]="canCreateBackups"
+         [matRippleDisabled]="!canCreateBackups"
+         (click)="canCreateBackups ? createSnapshot(): null">
       <i class="km-icon-mask km-icon-backup"
          [ngClass]="{'km-muted-bg': !canCreateBackups}"></i>
       <span>Snapshot</span>


### PR DESCRIPTION
**What this PR does / why we need it**:

When user only has view-only permission of a project, we need to disable options of `Create Resource` button and disable the `Create Cluster Template` button.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4882

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
