### PR TITLE
Add resource name validations where applicable

### DIFF
--- a/src/app/dynamic/enterprise/metering/config/config-dialog/component.ts
+++ b/src/app/dynamic/enterprise/metering/config/config-dialog/component.ts
@@ -27,6 +27,7 @@ import {pushToSide} from '@shared/animations/push';
 import {MeteringConfiguration} from '@shared/entity/datacenter';
 import {Observable, Subject} from 'rxjs';
 import {take} from 'rxjs/operators';
+import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
 
 export interface MeteringConfigurationDialogConfig {
   configuration: MeteringConfiguration;
@@ -62,7 +63,10 @@ export class MeteringConfigurationDialog implements OnInit, OnDestroy {
     this.form = this._builder.group({
       [Controls.Enabled]: this._builder.control(this.data.configuration.enabled, Validators.required),
       [Controls.StorageSize]: this._builder.control(this.data.configuration.storageSize, Validators.required),
-      [Controls.StorageClassName]: this._builder.control(this.data.configuration.storageClassName, Validators.required),
+      [Controls.StorageClassName]: this._builder.control(this.data.configuration.storageClassName, [
+        Validators.required,
+        KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
+      ]),
     });
   }
 

--- a/src/app/dynamic/enterprise/metering/config/config-dialog/template.html
+++ b/src/app/dynamic/enterprise/metering/config/config-dialog/template.html
@@ -43,6 +43,9 @@ END OF TERMS AND CONDITIONS
       <mat-error *ngIf="form.get(controls.StorageClassName).hasError('required')">
         Storage Class Name is <strong>required</strong>.
       </mat-error>
+      <mat-error *ngIf="form.get(controls.StorageClassName).hasError('pattern')">
+        Storage Class Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start or end with dash.
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex>

--- a/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/component.ts
+++ b/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/component.ts
@@ -26,6 +26,7 @@ import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering
 import {MeteringReportConfiguration} from '@app/shared/entity/datacenter';
 import {KmValidators} from '@app/shared/validators/validators';
 import {Observable, Subject, take, takeUntil} from 'rxjs';
+import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
 
 export interface MeteringScheduleAddDialogConfig {
   title: string;
@@ -127,7 +128,7 @@ export class MeteringScheduleAddDialog implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Name]: this._builder.control('', Validators.required),
+      [Controls.Name]: this._builder.control('', [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]),
       [Controls.Group]: this._builder.control(DefaultScheduleOption.Daily, Validators.required),
       [Controls.Schedule]: this._builder.control(DefaultSchedule.Daily),
       [Controls.Interval]: this._builder.control('1', Validators.min(1)),

--- a/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/template.html
+++ b/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/template.html
@@ -40,6 +40,9 @@ END OF TERMS AND CONDITIONS
         <mat-error *ngIf="form.get(controls.Name).hasError('required')">
           Schedule name is <strong>required</strong>.
         </mat-error>
+        <mat-error *ngIf="form.get(controls.Name).hasError('pattern')">
+          Schedule name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start or end with dash.
+        </mat-error>
       </mat-form-field>
 
       <mat-radio-group [formControlName]="controls.Group"

--- a/src/app/settings/admin/presets/dialog/steps/preset/component.ts
+++ b/src/app/settings/admin/presets/dialog/steps/preset/component.ts
@@ -18,6 +18,7 @@ import {PresetDialogService} from '@app/settings/admin/presets/dialog/steps/serv
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import {merge} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
 
 enum Controls {
   Name = 'name',
@@ -54,7 +55,7 @@ export class PresetStepComponent extends BaseFormValidator implements OnInit {
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Name]: this._builder.control('', [Validators.required]),
+      [Controls.Name]: this._builder.control('', [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]),
       [Controls.Domains]: this._builder.control(''),
       [Controls.Disable]: this._builder.control(''),
     });


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:

Instead of relying on the API requests to fail, we should explicitly validate resource names at the front-end side as well for early failure.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
