### PR TITLE
Display OIDC groups in user settings

### DIFF
--- a/src/app/settings/user/style.scss
+++ b/src/app/settings/user/style.scss
@@ -32,6 +32,10 @@
     font-size: variables.$font-size-subhead;
   }
 
+  .user-groups-key {
+    margin-bottom: 8px;
+  }
+
   .account-settings {
     font-size: variables.$font-size-subhead;
     min-width: 390px;

--- a/src/app/settings/user/template.html
+++ b/src/app/settings/user/template.html
@@ -38,6 +38,21 @@ limitations under the License.
            fxLayoutGap="10px">
         <div class="user-name">{{user.name}}</div>
         <div class="user-email">{{user.email}}</div>
+        <km-property *ngIf="user.groups; else noGroups">
+          <div key
+               class="user-groups-key">OIDC Groups</div>
+          <div value>
+            <km-labels [labels]="user.groups"></km-labels>
+          </div>
+        </km-property>
+        <ng-template #noGroups>
+          <div>
+            No OIDC groups assigned.
+            <a href="https://docs.kubermatic.com/kubermatic/master/architecture/role-based-access-control/groups-support/"
+               target="_blank"
+               rel="noreferrer noopener">Learn more ></a>
+          </div>
+        </ng-template>
       </div>
     </div>
 

--- a/src/app/shared/entity/member.ts
+++ b/src/app/shared/entity/member.ts
@@ -18,6 +18,7 @@ export class Member {
   creationTimestamp: Date;
   deletionTimestamp?: Date;
   email: string;
+  groups?: string[];
   isAdmin?: boolean;
   id: string;
   name: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
As for today the only way to check OIDC groups assigned to user is to decode JWT token. This PR adds simple list of decoded OIDC groups to user settings view.
<img width="2541" alt="Screenshot 2022-08-30 at 09 06 46" src="https://user-images.githubusercontent.com/9121459/187372294-639c193f-4019-4e79-98e3-19fdcdb82227.png">


**Which issue(s) this PR fixes**:
Fixes #4711 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:

```documentation
https://github.com/kubermatic/docs/blob/master/content/kubermatic/master/architecture/role-based-access-control/groups-support/_index.en.md
```
