### PR TITLE
Allow to change region for EKS external cluster on Import dialog and Create wizard

### DIFF
--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -275,6 +275,15 @@ export class ExternalClusterService {
     return this._http.get<string[]>(url, {headers}).pipe(catchError(() => of([])));
   }
 
+  getEKSRegionsByPreset(presetName: string): Observable<string[]> {
+    const url = `${this._newRestRoot}/providers/eks/regions`;
+    const credentials = {
+      Credential: presetName,
+    };
+    const headers = new HttpHeaders(credentials);
+    return this._http.get<string[]>(url, {headers}).pipe(catchError(() => of([])));
+  }
+
   createExternalCluster(projectID: string, externalClusterModel: ExternalClusterModel): Observable<ExternalCluster> {
     const url = `${this._newRestRoot}/projects/${projectID}/kubernetes/clusters`;
 
@@ -354,7 +363,10 @@ export class ExternalClusterService {
   private _getEKSHeaders(vpcId?: string): HttpHeaders {
     let headers = {};
     if (this._preset) {
-      headers = {Credential: this._preset};
+      headers = {
+        Credential: this._preset,
+        Region: this._externalCluster.cloud.eks.region,
+      };
       if (vpcId) {
         headers = {...headers, VpcId: vpcId};
       }

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -273,12 +273,12 @@ export class ExternalClusterService {
     if (preset) {
       credentials = {
         Credential: preset,
-      }
+      };
     } else {
       credentials = {
         AccessKeyID: accessKeyID,
         SecretAccessKey: secretAccessKey,
-      }
+      };
     }
     const headers = new HttpHeaders(credentials);
     return this._http.get<string[]>(url, {headers}).pipe(catchError(() => of([])));

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -38,12 +38,13 @@ import {MasterVersion} from '@app/shared/entity/cluster';
 export class ExternalClusterService {
   providerChanges = new BehaviorSubject<ExternalClusterProvider>(undefined);
   presetChanges = new BehaviorSubject<string>(undefined);
+  regionChanges = new BehaviorSubject<string>(undefined);
   presetStatusChanges = new BehaviorSubject<boolean>(false);
-  private _providerCredentialChanges$ = new BehaviorSubject<boolean>(false);
 
   private _provider: ExternalClusterProvider;
   private _externalCluster: ExternalClusterModel = ExternalClusterModel.new();
   private _preset: string;
+  private _region: string;
   private _error: string;
   private _isValidating = false;
   private _credentialsStepValidity = false;
@@ -82,6 +83,15 @@ export class ExternalClusterService {
   set preset(preset: string) {
     this._preset = preset;
     this.presetChanges.next(preset);
+  }
+
+  set region(regionName: string) {
+    this._region = regionName;
+    this.regionChanges.next(regionName);
+  }
+
+  get region(): string {
+    return this._region;
   }
 
   get error(): string {
@@ -126,14 +136,6 @@ export class ExternalClusterService {
 
   get isClusterStepValid(): boolean {
     return this._clusterStepValidity;
-  }
-
-  set isCredentialsValidated(validated: boolean) {
-    this._providerCredentialChanges$.next(validated);
-  }
-
-  getProviderCredentialChangesObservable(): Observable<boolean> {
-    return this._providerCredentialChanges$.asObservable();
   }
 
   import(projectID: string, model: ExternalClusterModel): Observable<ExternalCluster> {
@@ -265,21 +267,19 @@ export class ExternalClusterService {
     return this._http.get<MasterVersion[]>(url).pipe(catchError(() => of<[]>()));
   }
 
-  getEKSRegions(accessKeyID: string, secretAccessKey: string): Observable<string[]> {
+  getEKSRegions(preset?: string, accessKeyID?: string, secretAccessKey?: string): Observable<string[]> {
     const url = `${this._newRestRoot}/providers/eks/regions`;
-    const credentials = {
-      AccessKeyID: accessKeyID,
-      SecretAccessKey: secretAccessKey,
-    };
-    const headers = new HttpHeaders(credentials);
-    return this._http.get<string[]>(url, {headers}).pipe(catchError(() => of([])));
-  }
-
-  getEKSRegionsByPreset(presetName: string): Observable<string[]> {
-    const url = `${this._newRestRoot}/providers/eks/regions`;
-    const credentials = {
-      Credential: presetName,
-    };
+    let credentials = {};
+    if (preset) {
+      credentials = {
+        Credential: preset,
+      }
+    } else {
+      credentials = {
+        AccessKeyID: accessKeyID,
+        SecretAccessKey: secretAccessKey,
+      }
+    }
     const headers = new HttpHeaders(credentials);
     return this._http.get<string[]>(url, {headers}).pipe(catchError(() => of([])));
   }

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
@@ -224,22 +224,12 @@ export class EKSClusterSettingsComponent
         });
     }
 
-    this._externalClusterService.presetChanges.pipe(takeUntil(this._unsubscribe)).subscribe(preset => {
-      if (!preset) {
+    this._externalClusterService.regionChanges.pipe(takeUntil(this._unsubscribe)).subscribe(region => {
+      if (!region) {
         return;
       }
       this._getEKSVpcs();
     });
-
-    this._externalClusterService
-      .getProviderCredentialChangesObservable()
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(isValid => {
-        if (!isValid) {
-          return;
-        }
-        this._getEKSVpcs();
-      });
   }
 
   private _getEKSVpcs(): void {

--- a/src/app/external-cluster-wizard/template.html
+++ b/src/app/external-cluster-wizard/template.html
@@ -51,7 +51,6 @@ limitations under the License.
                                                 title="Settings"
                                                 [hideLogo]="true"></km-external-cluster-credentials-step>
         </ng-container>
-
         <ng-container *ngSwitchCase="stepRegistry.ExternalClusterDetails">
           <ng-container *ngIf="isPresetSelected || isCredentialStepValid">
             <km-external-cluster-step [formControl]="form.get(stepRegistry.ExternalClusterDetails)"></km-external-cluster-step>

--- a/src/app/shared/components/external-cluster-credentials/provider/aks/component.ts
+++ b/src/app/shared/components/external-cluster-credentials/provider/aks/component.ts
@@ -16,7 +16,7 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import {AbstractControl, FormBuilder, FormGroup, ValidationErrors, Validators} from '@angular/forms';
 import {ExternalClusterService} from '@core/services/external-cluster';
 import {Observable, of, Subject} from 'rxjs';
-import {catchError, take, takeUntil, tap} from 'rxjs/operators';
+import {catchError, take, takeUntil} from 'rxjs/operators';
 
 export enum Controls {
   TenantID = 'tenantID',
@@ -85,7 +85,6 @@ export class AKSCredentialsComponent implements OnInit, OnDestroy {
     return this._externalClusterService
       .validateAKSCredentials(tenantID, subscriptionID, clientID, clientSecret)
       .pipe(take(1))
-      .pipe(tap(response => (this._externalClusterService.isCredentialsValidated = !!response)))
       .pipe(catchError(() => of({invalidCredentials: true})));
   }
 

--- a/src/app/shared/components/external-cluster-credentials/provider/eks/template.html
+++ b/src/app/shared/components/external-cluster-credentials/provider/eks/template.html
@@ -49,8 +49,8 @@ limitations under the License.
     </mat-error>
   </mat-form-field>
 
-  <km-select label="Region"
-             hint="Select region from the dropdown list"
+  <km-select hint="Select region from the dropdown list"
+             [label]="regionLabel"
              [required]="true"
              [options]="regions"
              [formControlName]="Controls.Region">

--- a/src/app/shared/components/external-cluster-credentials/provider/gke/component.ts
+++ b/src/app/shared/components/external-cluster-credentials/provider/gke/component.ts
@@ -15,9 +15,9 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {AbstractControl, FormBuilder, FormGroup, ValidationErrors, Validators} from '@angular/forms';
 import {ExternalClusterService} from '@core/services/external-cluster';
-import {encode, isValid} from 'js-base64';
 import {Observable, of, Subject} from 'rxjs';
-import {catchError, take, takeUntil, tap} from 'rxjs/operators';
+import {catchError, take, takeUntil} from 'rxjs/operators';
+import {encode, isValid} from 'js-base64';
 
 export enum Controls {
   ServiceAccount = 'serviceAccount',
@@ -73,7 +73,6 @@ export class GKECredentialsComponent implements OnInit, OnDestroy {
     return this._externalClusterService
       .validateGKECredentials(serviceAccount)
       .pipe(take(1))
-      .pipe(tap(response => (this._externalClusterService.isCredentialsValidated = !!response)))
       .pipe(catchError(() => of({invalidCredentials: true})));
   }
 


### PR DESCRIPTION
Signed-off-by: khizerrehan <khizerrehan92@gmail.com>**What this PR does / why we need it**:

This PR allows to change `Region` irrespective of Preset or Credentials are added.

**Create Wizard:**

Allows functionality to change region and fetch VPCs based on region selected.

https://user-images.githubusercontent.com/17727069/187850914-82368991-3afb-420e-a760-a5d565a51549.mp4


**Import Wizard:**

Allows functionality to change region in order to list cluster based on that region. 

https://user-images.githubusercontent.com/17727069/187850677-790be252-fb5f-4119-a73e-05634dcec087.mp4

Fixes: #4915 

[Backend PR](https://github.com/kubermatic/kubermatic/pull/10888)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #
/kind cleanup
/kind design

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
