### PR TITLE
Fix layout on edit/create cluster when Event Rate plugin is selected

### DIFF
--- a/src/app/shared/components/event-rate-limit/template.html
+++ b/src/app/shared/components/event-rate-limit/template.html
@@ -23,39 +23,50 @@ limitations under the License.
   </mat-card-header>
   <form fxLayout="row"
         fxLayoutGap="8px"
+        fxLayout.sm="column"
+        fxLayout.xs="column"
         [formGroup]="form">
-    <mat-form-field class="km-dropdown-with-suffix">
-      <mat-label>Limit Type</mat-label>
-      <mat-select [formControlName]="Controls.LimitType"
-                  title="Namespace is the only supported limit type"
-                  class="km-select-ellipsis"
-                  disableOptionCentering>
-        <mat-option value="Namespace">Namespace</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <km-number-stepper [formControlName]="Controls.QPS"
-                       id="km-event-rate-limit-qps-input"
-                       mode="errors"
-                       label="QPS"
-                       min="1"
-                       step="10"
-                       required>
-    </km-number-stepper>
-    <km-number-stepper [formControlName]="Controls.Burst"
-                       id="km-event-rate-limit-burst-input"
-                       mode="errors"
-                       label="Burst"
-                       min="1"
-                       step="10"
-                       required>
-    </km-number-stepper>
-    <km-number-stepper [formControlName]="Controls.CacheSize"
-                       id="km-event-rate-limit-cache-size-input"
-                       mode="errors"
-                       label="Cache Size"
-                       step="10"
-                       min="1"
-                       required>
-    </km-number-stepper>
+
+    <div fxFlex
+         fxLayout="column">
+      <mat-form-field class="km-dropdown-with-suffix">
+        <mat-label>Limit Type</mat-label>
+        <mat-select [formControlName]="Controls.LimitType"
+                    title="Namespace is the only supported limit type"
+                    class="km-select-ellipsis"
+                    disableOptionCentering>
+          <mat-option value="Namespace">Namespace</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <km-number-stepper [formControlName]="Controls.QPS"
+                         id="km-event-rate-limit-qps-input"
+                         mode="errors"
+                         label="QPS"
+                         min="1"
+                         step="10"
+                         required>
+      </km-number-stepper>
+    </div>
+
+    <div fxFlex
+         fxLayout="column">
+      <km-number-stepper [formControlName]="Controls.Burst"
+                         id="km-event-rate-limit-burst-input"
+                         mode="errors"
+                         label="Burst"
+                         min="1"
+                         step="10"
+                         required>
+      </km-number-stepper>
+      <km-number-stepper [formControlName]="Controls.CacheSize"
+                         id="km-event-rate-limit-cache-size-input"
+                         mode="errors"
+                         label="Cache Size"
+                         step="10"
+                         min="1"
+                         required>
+      </km-number-stepper>
+    </div>
+
   </form>
 </div>


### PR DESCRIPTION
Signed-off-by: khizerrehan <khizerrehan92@gmail.com>

**What this PR does / why we need it**:

This fix layout of wizard and dialog when "Event Rate" plugin
 
**Cluster creation wizard:**

https://user-images.githubusercontent.com/17727069/188080335-54af8f56-a4e7-4437-8c36-6d9a18a2f617.mp4

**Edit Cluster Dialog**

![edit-cluster-dialog](https://user-images.githubusercontent.com/17727069/188080380-b9e2b3ee-9972-43df-80dc-bf3ae8983bce.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4896 

**What type of PR is this?**
/kind design
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

2 column layout was approve by @cschieder. As per video at some breakpoint layout expands to full width that is something not related to specifically this PR change. It is more sort of how page elements are Semantically structured without proper classes IMO, therefore we can look it how to fix semantics of page in sep PR.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
