### PR TITLE
Move location to aks cloud spec instead of cluster spec

### DIFF
--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -239,13 +239,11 @@ export class AKSClusterSettingsComponent
 
       this.vmSizeLabel = VMSizeState.Loading;
       this.control(Controls.VmSize).disable();
-      this._getAKSVmSizesForMachineDeployment(this.cluster.spec.aksclusterSpec.location).subscribe(
-        (vmSizes: AKSVMSize[]) => {
-          this.vmSizes = vmSizes;
-          this.vmSizeLabel = this.vmSizes?.length ? VMSizeState.Ready : VMSizeState.Empty;
-          this.control(Controls.VmSize).enable();
-        }
-      );
+      this._getAKSVmSizesForMachineDeployment(this.cluster.cloud.aks.location).subscribe((vmSizes: AKSVMSize[]) => {
+        this.vmSizes = vmSizes;
+        this.vmSizeLabel = this.vmSizes?.length ? VMSizeState.Ready : VMSizeState.Empty;
+        this.control(Controls.VmSize).enable();
+      });
       this._getAKSAvailableNodePoolVersionsForCreateMachineDeployment().subscribe(
         (nodePoolVersions: AKSNodePoolVersionForMachineDeployments[]) => {
           this.nodePoolVersionsForMD = nodePoolVersions.map(nodePoolVersion => nodePoolVersion.version);
@@ -344,12 +342,12 @@ export class AKSClusterSettingsComponent
           ...this._externalClusterService.externalCluster?.cloud?.aks,
           name: this.controlValue(Controls.Name),
           resourceGroup: this.controlValue(Controls.NodeResourceGroup),
+          location: this.controlValue(Controls.Location),
         } as AKSCloudSpec,
       } as ExternalCloudSpec,
       spec: {
         aksclusterSpec: {
           kubernetesVersion: version,
-          location: this.controlValue(Controls.Location),
           machineDeploymentSpec: {
             name: this.controlValue(Controls.NodePoolName),
             basicSettings: {

--- a/src/app/shared/entity/provider/aks.ts
+++ b/src/app/shared/entity/provider/aks.ts
@@ -35,10 +35,10 @@ export class AKSCloudSpec {
   clientID?: string;
   clientSecret?: string;
   resourceGroup?: string;
+  location?: string;
 }
 
 export class AKSClusterSpec {
-  location: string;
   kubernetesVersion: string;
   nodeResourceGroup?: string;
   enableRBAC?: boolean;


### PR DESCRIPTION
Signed-off-by: khizerrehan <khizerrehan92@gmail.com>**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
This PR updates payload for aks cluster spec and cloud spec while creating external cluster of AKS type.

<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4933 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

This PR doesn't introduces any special change but now `location` is part of `cloud` instead of `cluster` spec

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
