### PR TITLE
Add Resource Group list dropdown for AKS 

### DIFF
--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -125,7 +125,7 @@ limitations under the License.
         <ng-container *ngIf="provider === Provider.AKS">
           <km-property>
             <div key>Location</div>
-            <div value>{{cluster?.spec?.aksclusterSpec?.location}}</div>
+            <div value>{{cluster?.cloud?.aks?.location}}</div>
           </km-property>
           <km-property>
             <div key>Resource Group</div>

--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -17,7 +17,7 @@ import {Injectable} from '@angular/core';
 import {Router} from '@angular/router';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {environment} from '@environments/environment';
-import {AKSCluster, AKSLocation, AKSVMSize} from '@shared/entity/provider/aks';
+import {AKSCluster, AKSLocation, AKSVMSize, AzureResourceGroup} from '@shared/entity/provider/aks';
 import {EKSCluster, EKSSecurityGroup, EKSSubnet, EKSVpc} from '@shared/entity/provider/eks';
 import {GKECluster, GKEZone} from '@shared/entity/provider/gke';
 import {
@@ -213,6 +213,11 @@ export class ExternalClusterService {
     this.credentialsStepValidity = false;
     this.clusterStepValidity = false;
     this.isClusterDetailsStepValid = false;
+  }
+
+  getAKSResourceGroups(): Observable<AzureResourceGroup[]> {
+    const url = `${this._newRestRoot}/providers/aks/resourcegroups`;
+    return this._http.get<AzureResourceGroup[]>(url, {headers: this._getAKSHeaders()}).pipe(catchError(() => of([])));
   }
 
   getAKSVmSizes(location?: string): Observable<AKSVMSize[]> {

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
@@ -34,7 +34,7 @@ limitations under the License.
         <input matInput
                type="text"
                autocomplete="off"
-               [formControlName]="Controls.Name" />
+               [formControlName]="Controls.Name"/>
         <button mat-icon-button
                 type="button"
                 matSuffix
@@ -52,8 +52,7 @@ limitations under the License.
         </mat-error>
       </mat-form-field>
 
-      <km-autocomplete *ngIf="!isDialogView()"
-                       label="Kubernetes Version"
+      <km-autocomplete label="Kubernetes Version"
                        required="true"
                        [options]="kubernetesVersions"
                        [formControlName]="Controls.KubernetesVersion">
@@ -69,32 +68,26 @@ limitations under the License.
                  [formControlName]="Controls.Location">
       </km-select>
 
-      <mat-form-field>
-        <mat-label>Resource Group</mat-label>
-        <input matInput
-               required
-               type="text"
-               autocomplete="off"
-               [formControlName]="Controls.NodeResourceGroup" />
+      <km-combobox filterBy="name"
+                   inputLabel="Select Resource Group..."
+                   [required]="true"
+                   [label]="resourceGroupLabel"
+                   [options]="resourceGroups"
+                   [formControlName]="Controls.NodeResourceGroup">
+        <div *option="let resourceGroup">
+          {{resourceGroup?.name}}
+        </div>
 
-        <mat-hint *ngIf="!isDialogView();">
-          Enter the name of the resource group. The resource group should have sufficient permissions to manage AKS
-          cluster and to pull the Admin kubeconfig.
-          <a href="https://docs.microsoft.com/en-us/azure/aks/concepts-identity#azure-rbac-to-authorize-access-to-the-aks-resource"
-             target="_blank"
-             rel="noreferrer noopener">
-            AKS RBAC guide >
-          </a>
-          To get or create a resource group check <a href="https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal"
-             target="_blank"
-             rel="noreferrer noopener">
-            AKS user guide >
-          </a>
-        </mat-hint>
-        <mat-error *ngIf="form.get(Controls.NodeResourceGroup).hasError(ErrorType.Required)">
-          Resource Group is <strong>required</strong>.
-        </mat-error>
-      </mat-form-field>
+        <ng-container hint>
+          Select the resource group name. To get or create a resource group check <a
+          href="https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal"
+          target="_blank"
+          rel="noreferrer noopener">
+          AKS user guide >
+        </a>
+        </ng-container>
+      </km-combobox>
+
     </div>
   </ng-container>
 
@@ -110,7 +103,7 @@ limitations under the License.
       <input matInput
              type="text"
              autocomplete="off"
-             [formControlName]="Controls.NodePoolName" />
+             [formControlName]="Controls.NodePoolName"/>
       <mat-hint>Enter node pool name. It must contain only lowercase letters and numbers.</mat-hint>
       <mat-error *ngIf="form.get(Controls.NodePoolName).hasError(ErrorType.Required)">
         Node Pool Name is <strong>required</strong>.

--- a/src/app/shared/components/combobox/template.html
+++ b/src/app/shared/components/combobox/template.html
@@ -77,5 +77,10 @@ limitations under the License.
       {{label}} is <strong>required</strong>.
     </mat-error>
     <mat-hint *ngIf="hint">{{hint}}</mat-hint>
+
+    <mat-hint *ngIf="!hint">
+      <ng-content select="[hint]"></ng-content>
+    </mat-hint>
+
   </mat-form-field>
 </form>

--- a/src/app/shared/entity/provider/aks.ts
+++ b/src/app/shared/entity/provider/aks.ts
@@ -109,3 +109,7 @@ export class AKSLocation {
   name: string;
   regionCategory: string;
 }
+
+export class AzureResourceGroup {
+  name?: string;
+}


### PR DESCRIPTION
Signed-off-by: khizerrehan <khizerrehan92@gmail.com>**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
This PR integrates new endpoint to fetch resource groups list and show them in dropdown. Instead of user typing Resource group now it can be selected from dropdown.

**Minor fixes:**
- Display of location on details page from cloud instead of cluster spec
- Add support for hint as content projection inside shared component.

<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4950

**What type of PR is this?**
/kind design
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
