### PR TITLE
Count value in AKS cannot be incremented if Auto Scaling is disabled

### DIFF
--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -118,6 +118,8 @@ export class AKSClusterSettingsComponent
   readonly ErrorType = ErrorType;
   readonly AUTOSCALING_MIN_VALUE = 1;
   readonly AUTOSCALING_MAX_VALUE = 1000;
+  readonly MIN_COUNT_DEFAULT_VALUE = 1;
+  readonly MAX_COUNT_DEFAULT_VALUE = 5;
   readonly DEFAULT_LOCATION = 'eastus';
   @Input() projectID: string;
   @Input() cluster: ExternalCluster;
@@ -171,8 +173,8 @@ export class AKSClusterSettingsComponent
   onEnableAutoScalingChange(evt: MatCheckboxChange) {
     if (!evt.checked) {
       this.form.patchValue({
-        [Controls.MaxCount]: null,
-        [Controls.MinCount]: null,
+        [Controls.MaxCount]: this.MAX_COUNT_DEFAULT_VALUE,
+        [Controls.MinCount]: this.MIN_COUNT_DEFAULT_VALUE,
       });
 
       this.control(Controls.MaxCount).clearValidators();
@@ -207,8 +209,6 @@ export class AKSClusterSettingsComponent
   }
 
   private _initForm(): void {
-    const MIN_COUNT_DEFAULT_VALUE = 1;
-    const MAX_COUNT_DEFAULT_VALUE = 5;
     const DEFAULT_MODE = 'System';
     const DEFAULT_NO_OF_NODES = 1;
     this.form = this._builder.group({
@@ -221,11 +221,11 @@ export class AKSClusterSettingsComponent
       [Controls.VmSize]: this._builder.control('', Validators.required),
       [Controls.Mode]: this._builder.control(DEFAULT_MODE),
       [Controls.EnableAutoScaling]: this._builder.control(true),
-      [Controls.MaxCount]: this._builder.control(MAX_COUNT_DEFAULT_VALUE, [
+      [Controls.MaxCount]: this._builder.control(this.MAX_COUNT_DEFAULT_VALUE, [
         Validators.required,
         Validators.max(this.AUTOSCALING_MAX_VALUE),
       ]),
-      [Controls.MinCount]: this._builder.control(MIN_COUNT_DEFAULT_VALUE, [
+      [Controls.MinCount]: this._builder.control(this.MIN_COUNT_DEFAULT_VALUE, [
         Validators.required,
         Validators.min(this.AUTOSCALING_MIN_VALUE),
       ]),

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
@@ -144,8 +144,8 @@ limitations under the License.
                        [hint]="form.get(Controls.EnableAutoScaling).value ?
                         'Number of Nodes must be in the range of min and max auto scaling config' :
                         'Number of Nodes' "
-                       [min]="form.get(Controls.MinCount).value"
-                       [max]="form.get(Controls.MaxCount).value">
+                       [min]="form.get(Controls.EnableAutoScaling).value ? form.get(Controls.MinCount).value : AUTOSCALING_MIN_VALUE"
+                       [max]="form.get(Controls.EnableAutoScaling).value ? form.get(Controls.MaxCount).value : AUTOSCALING_MAX_VALUE">
     </km-number-stepper>
 
     <label class="km-radio-group-label">Select Mode</label>
@@ -183,7 +183,7 @@ limitations under the License.
                          hint="The maximum number of nodes for auto-scaling. Maximum value can be 1000."
                          [required]="true"
                          [min]="form.get(Controls.MinCount).value"
-                         [max]="1000"
+                         [max]="AUTOSCALING_MAX_VALUE"
                          [formControlName]="Controls.MaxCount">
       </km-number-stepper>
 
@@ -191,7 +191,7 @@ limitations under the License.
                          mode="all"
                          hint="The minimum number of nodes for auto-scaling. Minimum value can be 1"
                          [required]="true"
-                         [min]="1"
+                         [min]="AUTOSCALING_MIN_VALUE"
                          [max]="form.get(Controls.MaxCount).value"
                          [formControlName]="Controls.MinCount">
       </km-number-stepper>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed logic AKS form,
The user can now increment and decrement the `Count` control when `Enable Autoscaling` is not selected.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4955

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
