### PR TITLE
Fix for listing Operating System Profiles for Equinix Metal

### DIFF
--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -441,7 +441,12 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   private getSupportedOperatingSystemProfiles(): string[] {
     return this.operatingSystemProfiles
       .filter(osp => osp.operatingSystem === this.form.get(Controls.OperatingSystem).value.toLowerCase())
-      .filter(osp => osp.supportedCloudProviders.indexOf(this.provider) > -1)
+      .filter(
+        // Packet was renamed to EquinixMetal for the machines.
+        osp =>
+          osp.supportedCloudProviders.indexOf(this.provider === NodeProvider.EQUINIX ? 'equinixmetal' : this.provider) >
+          -1
+      )
       .map(osp => osp.name);
   }
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:

Packet was re-branded to Equnix Metal in machine-controller. Although those changes were not propagated in our API or Dashboard. OSPs use `equinixmetal` instead of `packet` and it leads to a conflict when listing OSPs on the front-end.

This PR adds a special case for listing OSPs for Equinix Metal.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix for listing Operating System Profiles for Equinix Metal
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
