### PR TITLE
Default values are not shown in external cluster wizard when preset/credentials are cleared and selected again

### DIFF
--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -157,7 +157,7 @@ export class AKSClusterSettingsComponent
   }
 
   ngOnDestroy(): void {
-    this.reset();
+    this.onValueChange?.(null);
     this._unsubscribe.next();
     this._unsubscribe.complete();
   }

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
@@ -142,7 +142,7 @@ export class EKSClusterSettingsComponent
   }
 
   ngOnDestroy(): void {
-    this.reset();
+    this.onValueChange?.(null);
     this._unsubscribe.next();
     this._unsubscribe.complete();
   }

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
@@ -181,7 +181,7 @@ export class GKEClusterSettingsComponent
 
   ngOnDestroy(): void {
     this.control(Controls.InitialNodePoolName).enable();
-    this.reset();
+    this.onValueChange?.(null);
     this._unsubscribe.next();
     this._unsubscribe.complete();
   }

--- a/src/app/shared/validators/base-form.validator.ts
+++ b/src/app/shared/validators/base-form.validator.ts
@@ -19,6 +19,7 @@ import {takeUntil} from 'rxjs/operators';
 export abstract class BaseFormValidator implements ControlValueAccessor, Validator {
   form: FormGroup;
   protected _unsubscribe = new Subject<void>();
+  protected onValueChange: (value: unknown) => unknown;
 
   protected constructor(private _formName = 'Form') {}
 
@@ -52,6 +53,7 @@ export abstract class BaseFormValidator implements ControlValueAccessor, Validat
 
   // ControlValueAccessor interface implementation
   registerOnChange(fn: any): void {
+    this.onValueChange = fn;
     this.form.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(fn);
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It fixes the external cluster wizard when a user goes back and re-selects preset.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4940

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The cluster details step form will be filled with default values when the user re-selects preset/credentials
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
