### PR TITLE
Fix check to disable action buttons in external cluster wizard

### DIFF
--- a/src/app/external-cluster-wizard/template.html
+++ b/src/app/external-cluster-wizard/template.html
@@ -91,7 +91,7 @@ limitations under the License.
                   fxLayoutAlign="center center"
                   mat-flat-button
                   (click)="onNext()"
-                  [disabled]="isInvalid">
+                  [disabled]="isInvalidStep()">
             <i class="km-icon-mask km-icon-next"></i>
             <span>Next</span>
           </button>
@@ -100,7 +100,7 @@ limitations under the License.
           <km-button buttonId="km-external-cluster-wizard-create-btn"
                      icon="km-icon-add"
                      label="Create External Cluster"
-                     [disabled]="isInvalid"
+                     [disabled]="isInvalidStep()"
                      [observable]="getObservable()"
                      (next)="onCreateSuccess($event)">
           </km-button>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix check to disable `Next` and `Create External Cluster` buttons in external cluster wizard.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
