### PR TITLE
update to Go 1.19

### DIFF
--- a/.prow/build-image.yaml
+++ b/.prow/build-image.yaml
@@ -22,7 +22,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
           imagePullPolicy: Always
           command:
             - /bin/bash
@@ -50,7 +50,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
           imagePullPolicy: Always
           command:
             - /bin/bash

--- a/.prow/tests-e2e.yaml
+++ b/.prow/tests-e2e.yaml
@@ -44,7 +44,7 @@ presubmits:
       preset-scratch-tmpfs: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.4.0
+        - image: quay.io/kubermatic/chrome-headless:v1.5.0
           imagePullPolicy: Always
           command:
             - make
@@ -100,7 +100,7 @@ presubmits:
       preset-scratch-tmpfs: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.4.0
+        - image: quay.io/kubermatic/chrome-headless:v1.5.0
           imagePullPolicy: Always
           command:
             - make
@@ -136,7 +136,7 @@ presubmits:
       preset-minio: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.4.0
+        - image: quay.io/kubermatic/chrome-headless:v1.5.0
           imagePullPolicy: Always
           command:
             - make
@@ -165,7 +165,7 @@ presubmits:
       preset-minio: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.4.0
+        - image: quay.io/kubermatic/chrome-headless:v1.5.0
           imagePullPolicy: Always
           command:
             - make

--- a/.prow/tests-unit.yaml
+++ b/.prow/tests-unit.yaml
@@ -19,7 +19,7 @@ presubmits:
     clone_uri: 'ssh://git@github.com/kubermatic/dashboard.git'
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.4.0
+        - image: quay.io/kubermatic/chrome-headless:v1.5.0
           command:
             - make
             - test-headless

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -37,7 +37,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
           command:
             - make
             - verify-go
@@ -51,7 +51,7 @@ presubmits:
     clone_uri: 'ssh://git@github.com/kubermatic/dashboard.git'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
           command:
             - make
             - check

--- a/containers/chrome-headless/Dockerfile
+++ b/containers/chrome-headless/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+FROM quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
 
 LABEL maintainer="support@kubermatic.com"
 

--- a/containers/chrome-headless/release.sh
+++ b/containers/chrome-headless/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v1.4.0
+TAG=v1.5.0
 
 set -euo pipefail
 

--- a/containers/custom-dashboard/Dockerfile
+++ b/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.18-node-18-kind-0.14-0
+FROM quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP has [moved to Go 1.19](https://github.com/kubermatic/kubermatic/pull/10665), so let's follow suite.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
