### PR TITLE
PodNodeSelector admission plugin: enforce node labels with clusterDefaultNodeSelector

### DIFF
--- a/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -92,8 +92,11 @@ limitations under the License.
                        keyName="Namespace"
                        valueName="Label Selector"
                        noValidators="true"
-                       [(labels)]="podNodeSelectorAdmissionPluginConfig"
-                       formControlName="podNodeSelectorAdmissionPluginConfig"
+                       [labels]="podNodeSelectorAdmissionPluginConfig"
+                       [formControlName]="Controls.PodNodeSelectorAdmissionPluginConfig"
+                       [labelHint]="CLUSTER_DEFAULT_NODE_SELECTOR_HINT"
+                       [labelHintKey]="CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE"
+                       (labelsChange)="onPodNodeSelectorAdmissionPluginConfigChange($event)"
                        fxFlex="100"></km-label-form>
         <div *ngIf="isPluginEnabled(admissionPlugin.EventRateLimit)">
           <km-wizard-cluster-event-rate-limit [formControl]="form.get(Controls.EventRateLimitConfig)"
@@ -169,7 +172,10 @@ limitations under the License.
       </mat-checkbox>
 
       <km-label-form title="Labels"
-                     [(labels)]="labels"
+                     (labelsChange)="onLabelsChange($event)"
+                     [labels]="labels"
+                     [disabledLabel]="clusterDefaultNodeSelectorNamespace"
+                     [disabledLabelTooltip]="CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP"
                      [inheritedLabels]="cluster.inheritedLabels"
                      [asyncKeyValidators]=asyncLabelValidators
                      [formControlName]="Controls.Labels"></km-label-form>

--- a/src/app/shared/components/label-form/component.spec.ts
+++ b/src/app/shared/components/label-form/component.spec.ts
@@ -54,6 +54,7 @@ describe('LabelFormComponent', () => {
       env: 'test',
     };
     component.ngOnInit();
+    component.ngOnChanges(null);
     component.deleteLabel(0);
 
     expect(component.labels).toEqual({env: null});
@@ -66,6 +67,7 @@ describe('LabelFormComponent', () => {
       env: 'test',
     };
     component.ngOnInit();
+    component.ngOnChanges(null);
     component.initialLabels = {};
     component.deleteLabel(0);
 

--- a/src/app/shared/components/label-form/template.html
+++ b/src/app/shared/components/label-form/template.html
@@ -19,56 +19,73 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column">
   <div formArrayName="labels">
+    <ng-container *ngIf="disabledLabelFormGroup?.value.key && disabledLabelFormGroup?.value.value">
+      <div [matTooltip]="disabledLabelTooltip"
+           matTooltipPosition="above"
+           fxLayout="row"
+           fxLayoutGap="10px">
+        <mat-form-field fxFlex="45">
+          <mat-label>Key</mat-label>
+          <input matInput
+                 [formControl]="disabledLabelFormGroup.controls.key" />
+        </mat-form-field>
+        <mat-form-field fxFlex="45">
+          <mat-label>Value</mat-label>
+          <input matInput
+                 [formControl]="disabledLabelFormGroup.controls.value" />
+        </mat-form-field>
+        <button mat-icon-button
+                type="button"
+                class="delete-button"
+                [disabled]="true">
+          <i class="km-icon-mask km-icon-delete"
+             aria-hidden="true"></i>
+        </button>
+      </div>
+    </ng-container>
+
     <div *ngFor="let label of labelArray.controls; let i = index;"
-         [formGroupName]="i"
-         fxLayout="row"
-         fxLayoutGap="10px">
-      <mat-form-field fxFlex="45">
-        <mat-label>{{keyName}}</mat-label>
-        <input matInput
-               (keyup)="check(i)"
-               name="key"
-               formControlName="key">
-        <mat-error *ngIf="label.get('key').errors?.validLabelKeyUniqueness">
-          {{keyName}} is not unique.
-        </mat-error>
-        <mat-error *ngIf="label.get('key').errors?.validLabelKeyPrefixPattern">
-          Prefix not allowed.
-        </mat-error>
-        <mat-error *ngIf="label.get('key').errors?.validLabelKeyNamePattern">
-          Name not allowed.
-        </mat-error>
-        <mat-error *ngIf="label.get('key').errors?.validLabelKeyPrefixLength">
-          Prefix is too long.
-        </mat-error>
-        <mat-error *ngIf="label.get('key').errors?.validLabelKeyNameLength">
-          Name is too long.
-        </mat-error>
-        <mat-error *ngIf="label.get('key').errors?.labelKeyNameRestricted">
-          Restricted label name.
-        </mat-error>
-      </mat-form-field>
-      <mat-form-field fxFlex="45">
-        <mat-label>{{valueName}}</mat-label>
-        <input matInput
-               (keyup)="check(i)"
-               name="value"
-               formControlName="value">
-        <mat-error *ngIf="label.get('value').errors?.validLabelValuePattern">
-          {{valueName}} not allowed.
-        </mat-error>
-        <mat-error *ngIf="label.get('value').errors?.validLabelValueLength">
-          {{valueName}} is too long.
-        </mat-error>
-      </mat-form-field>
-      <button mat-icon-button
-              type="button"
-              class="delete-button"
-              [disabled]="!isRemovable(i)"
-              (click)="deleteLabel(i)">
-        <i class="km-icon-mask km-icon-delete"
-           aria-hidden="true"></i>
-      </button>
+         fxLayout="column">
+      <div [formGroupName]="i"
+           fxLayout="row"
+           fxLayoutGap="10px">
+        <mat-form-field fxFlex="45">
+          <mat-label>{{keyName}}</mat-label>
+          <input matInput
+                 (keyup)="check(i)"
+                 name="key"
+                 formControlName="key" />
+          <mat-error *ngIf="label.get('key').errors?.validLabelKeyUniqueness"> {{keyName}} is not unique. </mat-error>
+          <mat-error *ngIf="label.get('key').errors?.validLabelKeyPrefixPattern"> Prefix not allowed. </mat-error>
+          <mat-error *ngIf="label.get('key').errors?.validLabelKeyNamePattern"> Name not allowed. </mat-error>
+          <mat-error *ngIf="label.get('key').errors?.validLabelKeyPrefixLength"> Prefix is too long. </mat-error>
+          <mat-error *ngIf="label.get('key').errors?.validLabelKeyNameLength"> Name is too long. </mat-error>
+          <mat-error *ngIf="label.get('key').errors?.labelKeyNameRestricted"> Restricted label name. </mat-error>
+        </mat-form-field>
+        <mat-form-field fxFlex="45">
+          <mat-label>{{valueName}}</mat-label>
+          <input matInput
+                 (keyup)="check(i)"
+                 name="value"
+                 formControlName="value" />
+          <mat-error *ngIf="label.get('value').errors?.validLabelValuePattern"> {{valueName}} not allowed. </mat-error>
+          <mat-error *ngIf="label.get('value').errors?.validLabelValueLength"> {{valueName}} is too long. </mat-error>
+        </mat-form-field>
+        <button mat-icon-button
+                type="button"
+                class="delete-button"
+                [disabled]="!isRemovable(i)"
+                (click)="deleteLabel(i)">
+          <i class="km-icon-mask km-icon-delete"
+             aria-hidden="true"></i>
+        </button>
+      </div>
+
+      <ng-container *ngIf="label.get('key') as control">
+        <mat-hint *ngIf="labelHintKey && control.valid && control.value === labelHintKey"
+                  class="label-hint"
+                  [innerHTML]="labelHint"></mat-hint>
+      </ng-container>
     </div>
   </div>
 </form>

--- a/src/app/shared/types/common.ts
+++ b/src/app/shared/types/common.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@use 'variables';
-
-.mat-icon-button {
-  &.delete-button {
-    margin: 4px 0 0;
-  }
-}
-
-.label-hint {
-  font-size: variables.$font-size-hint;
-  margin-left: 13px;
-  margin-top: -18px;
-  padding-bottom: 21px;
-}
+export type KeyValueEntry = [key: string, value: string];

--- a/src/app/shared/utils/cluster.ts
+++ b/src/app/shared/utils/cluster.ts
@@ -1,0 +1,38 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {KeyValueEntry} from '../types/common';
+
+export const CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE = 'clusterDefaultNodeSelector';
+export const CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP =
+  'Namespace clusterDefaultNodeSelector requires nodes with the labels defined in the Label Selector to start the cluster. The labels are enforced. Edit the label in the Label Selector.';
+export const CLUSTER_DEFAULT_NODE_SELECTOR_HINT =
+  'Namespace <b>clusterDefaultNodeSelector</b> requires nodes with the labels defined in the Label Selector to start the cluster. The labels are enforced.';
+
+export function handleClusterDefaultNodeSelector(
+  labels: Record<string, string>,
+  nodeConfig: Record<string, string>,
+  previousClusterDefaultNodeSelectorNamespace: KeyValueEntry,
+  onComplete: (entry: KeyValueEntry, labels: Record<string, string>) => void
+): void {
+  const [prevKey] = previousClusterDefaultNodeSelectorNamespace ?? [];
+
+  if (Object.hasOwnProperty.call(labels, prevKey)) {
+    delete labels[prevKey];
+  }
+
+  const [currKey, currValue] = nodeConfig[CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE]?.split('=') ?? [];
+
+  onComplete(currKey && currValue ? [currKey, currValue] : null, labels);
+}

--- a/src/app/wizard/step/cluster/template.html
+++ b/src/app/wizard/step/cluster/template.html
@@ -318,6 +318,8 @@ limitations under the License.
                            noValidators="true"
                            [labels]="podNodeSelectorAdmissionPluginConfig"
                            [formControlName]="Controls.PodNodeSelectorAdmissionPluginConfig"
+                           [labelHint]="CLUSTER_DEFAULT_NODE_SELECTOR_HINT"
+                           [labelHintKey]="CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE"
                            (labelsChange)="onPodNodeSelectorAdmissionPluginConfigChange($event)"
                            fxFlex="100"></km-label-form>
             <div *ngIf="isPluginEnabled(admissionPlugin.EventRateLimit)">
@@ -401,8 +403,11 @@ limitations under the License.
                            [labels]="labels"
                            [asyncKeyValidators]="asyncLabelValidators"
                            [formControlName]="Controls.Labels"
+                           [disabledLabel]="clusterDefaultNodeSelectorNamespace"
+                           [disabledLabelTooltip]="CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP"
                            (labelsChange)="onLabelsChange($event)"
-                           fxFlex="100"></km-label-form>
+                           fxFlex="100">
+            </km-label-form>
           </div>
         </div>
       </div>

--- a/src/assets/css/_variables.scss
+++ b/src/assets/css/_variables.scss
@@ -36,6 +36,7 @@ $font-size-subhead: 16px !default;
 $font-size-body: 14px !default;
 $font-size-caption: 12px !default;
 $font-size-small: 10px !default;
+$font-size-hint: 12px !default;
 $font-weight-medium: 500 !default;
 $font-primary: 'Roboto', helvetica, arial, sans-serif;
 $font-primary-mono: 'Roboto Mono', monospace;


### PR DESCRIPTION
**What this PR does / why we need it**:

Enforces the labels of `clusterDefaultNodeSelector` namespace

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4985

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
PodNodeSelector admission plugin: node labels with clusterDefaultNodeSelector namespace are enforced
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
