### PR TITLE
Add  location to import aks external cluster

### DIFF
--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/aks/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/aks/component.ts
@@ -31,7 +31,7 @@ export class AKSClusterSelectComponent implements OnInit, OnDestroy {
   isInitialized = false;
   clusters: AKSCluster[] = [];
   dataSource = new MatTableDataSource<AKSCluster>();
-  columns: string[] = ['name', 'resourceGroup', 'import'];
+  columns: string[] = ['name', 'location', 'resourceGroup', 'import'];
   @ViewChild(MatPaginator, {static: true}) private readonly _paginator: MatPaginator;
   private _selected: AKSCluster;
   private _unsubscribe = new Subject<void>();
@@ -83,5 +83,6 @@ export class AKSClusterSelectComponent implements OnInit, OnDestroy {
     this._externalClusterService.externalCluster.name = this._selected.name;
     this._externalClusterService.externalCluster.cloud.aks.name = this._selected.name;
     this._externalClusterService.externalCluster.cloud.aks.resourceGroup = this._selected.resourceGroup;
+    this._externalClusterService.externalCluster.cloud.aks.location = this._selected.location;
   }
 }

--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/aks/template.html
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/aks/template.html
@@ -31,6 +31,18 @@ limitations under the License.
     </td>
   </ng-container>
 
+  <ng-container matColumnDef="location">
+    <th mat-header-cell
+        *matHeaderCellDef
+        class="km-header-cell">
+      Location
+    </th>
+    <td mat-cell
+        *matCellDef="let element">
+      {{element.location}}
+    </td>
+  </ng-container>
+
   <ng-container matColumnDef="resourceGroup">
     <th mat-header-cell
         *matHeaderCellDef

--- a/src/app/shared/entity/provider/aks.ts
+++ b/src/app/shared/entity/provider/aks.ts
@@ -16,6 +16,7 @@ export class AKSCluster {
   name: string;
   resourceGroup: string;
   imported: boolean;
+  location: string;
 }
 
 export class AKSVMSize {


### PR DESCRIPTION
**What this PR does / why we need it**:
add column `Location` to AKS import dialog to show the cluster location and send it in the payload for the import endpoint  
**Which issue(s) this PR fixes**:
Fixes #5039

**What type of PR is this?**
/kind feature

-->
```release-note
NONE
```
```documentation
NONE
```
