### PR TITLE
Hide delete button for already deleted external clusters

### DIFF
--- a/src/app/cluster/details/external-cluster/component.ts
+++ b/src/app/cluster/details/external-cluster/component.ts
@@ -156,6 +156,10 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
     return this.cluster?.status?.state === ExternalClusterState.Running;
   }
 
+  isClusterDeleted(cluster: ExternalCluster): boolean {
+    return ExternalCluster.isDeleted(cluster);
+  }
+
   downloadKubeconfig(): void {
     window.open(this._clusterService.getExternalKubeconfigURL(this.projectID, this.cluster.id), '_blank');
   }

--- a/src/app/cluster/details/external-cluster/template.html
+++ b/src/app/cluster/details/external-cluster/template.html
@@ -30,26 +30,20 @@ limitations under the License.
               color="tertiary"
               fxLayoutAlign="center center"
               (click)="disconnectCluster()"
-              [disabled]="!canDisconnect() || !!cluster?.deletionTimestamp">
-        <div fxLayoutAlign=" center"
-             [matTooltip]="!!cluster?.deletionTimestamp ? 'Cluster is being deleted.' : ''">
-          <i class="km-icon-mask km-icon-disconnect"></i>
-          <span>Disconnect</span>
-        </div>
+              [disabled]="!canDisconnect()">
+        <i class="km-icon-mask km-icon-disconnect"></i>
+        <span>Disconnect</span>
       </button>
 
-      <button *ngIf="!cluster?.labels || !isImportedCluster"
+      <button *ngIf="(!cluster?.labels || !isImportedCluster) && !isClusterDeleted(cluster)"
               id="km-delete-external-cluster-btn"
               mat-flat-button
               color="tertiary"
               fxLayoutAlign="center center"
-              [disabled]="!canDisconnect() || !!cluster?.deletionTimestamp"
+              [disabled]="!canDisconnect()"
               (click)="deleteClusterDialog()">
-        <div fxLayoutAlign=" center"
-             [matTooltip]="!!cluster?.deletionTimestamp ? 'Cluster is being deleted.' : ''">
-          <i class="km-icon-mask km-icon-delete"></i>
-          <span>Delete</span>
-        </div>
+        <i class="km-icon-mask km-icon-delete"></i>
+        <span>Delete</span>
       </button>
       <div fxFlex></div>
       <button color="alternative"

--- a/src/app/cluster/list/external-cluster/component.ts
+++ b/src/app/cluster/list/external-cluster/component.ts
@@ -186,6 +186,10 @@ export class ExternalClusterListComponent implements OnInit, OnChanges, OnDestro
     return ExternalCluster.getStatusIcon(cluster);
   }
 
+  isClusterDeleted(cluster: ExternalCluster): boolean {
+    return ExternalCluster.isDeleted(cluster);
+  }
+
   disconnectClusterDialog(cluster: ExternalCluster, event: Event): void {
     event.stopPropagation();
     this._externalClusterService.showDisconnectClusterDialog(cluster, this._selectedProject.id);

--- a/src/app/cluster/list/external-cluster/template.html
+++ b/src/app/cluster/list/external-cluster/template.html
@@ -127,7 +127,7 @@ limitations under the License.
                         [disabled]="!can(Permission.Delete)">
                   <i class="km-icon-mask km-icon-disconnect"></i>
                 </button>
-                <button *ngIf="!element?.labels || element?.labels['is-imported'] !== 'true'"
+                <button *ngIf="(!element?.labels || element?.labels['is-imported'] !== 'true') && !isClusterDeleted(element)"
                         mat-icon-button
                         [attr.id]="'km-delete-cluster-' + element.name"
                         matTooltip="Delete Cluster"

--- a/src/app/shared/entity/external-cluster.ts
+++ b/src/app/shared/entity/external-cluster.ts
@@ -64,6 +64,18 @@ export class ExternalCluster {
     return getExternalProviderDisplayName(ExternalCluster.getProvider(cloud));
   }
 
+  static isDeleted(cluster: ExternalCluster): boolean {
+    if (!cluster) {
+      return false;
+    }
+    return (
+      !!cluster.deletionTimestamp ||
+      cluster.status?.state === ExternalClusterState.Deleting ||
+      (cluster.status?.state === ExternalClusterState.Error &&
+        (cluster.status?.statusMessage?.includes('NotFound') || cluster.status?.statusMessage?.includes('Not Found')))
+    );
+  }
+
   static getStatusMessage(cluster: ExternalCluster): string {
     const state = _.capitalize(cluster?.status?.state);
     return cluster?.status?.statusMessage ? `${state}: ${cluster?.status.statusMessage}` : state;


### PR DESCRIPTION
**What this PR does / why we need it**:
Hide delete button for external clusters which are deleted (e.g. from provider side) or do not exist.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4959 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Delete button is not shown for external clusters which are already deleted.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
