### PR TITLE
External cluster wizard: fixed EKS region changes subscription

### DIFF
--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -39,7 +39,7 @@ import {GCPDiskType, GCPMachineSize} from '@app/shared/entity/provider/gcp';
 export class ExternalClusterService {
   providerChanges = new BehaviorSubject<ExternalClusterProvider>(undefined);
   presetChanges = new Subject<string>();
-  regionChanges = new Subject<string>();
+  private _regionChanges = new BehaviorSubject<string>(null);
   presetStatusChanges = new Subject<boolean>();
 
   private _provider: ExternalClusterProvider;
@@ -86,9 +86,13 @@ export class ExternalClusterService {
     this.presetChanges.next(preset);
   }
 
+  get regionChanges(): Observable<string> {
+    return this._regionChanges.asObservable().pipe(filter(region => region !== null));
+  }
+
   set region(regionName: string) {
     this._region = regionName;
-    this.regionChanges.next(regionName);
+    this._regionChanges.next(regionName);
   }
 
   get region(): string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed issue in external cluster EKS credential step where not selecting `provider preset`, entering `Access Key ID` and `Secret Access Key` and then changing regions was causing no `vpcs` API request.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
<!-- Fixes # -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
