### PR TITLE
External cluster wizard: fixed AKS preset change bug

### DIFF
--- a/src/app/core/services/external-cluster.ts
+++ b/src/app/core/services/external-cluster.ts
@@ -38,7 +38,7 @@ import {GCPDiskType, GCPMachineSize} from '@app/shared/entity/provider/gcp';
 @Injectable({providedIn: 'root'})
 export class ExternalClusterService {
   providerChanges = new BehaviorSubject<ExternalClusterProvider>(undefined);
-  presetChanges = new Subject<string>();
+  private _presetChanges = new BehaviorSubject<string>(null);
   private _regionChanges = new BehaviorSubject<string>(null);
   presetStatusChanges = new Subject<boolean>();
 
@@ -59,6 +59,10 @@ export class ExternalClusterService {
     private readonly _notificationService: NotificationService,
     private readonly _router: Router
   ) {}
+
+  get presetChanges(): Observable<string> {
+    return this._presetChanges.asObservable().pipe(filter(preset => preset !== null));
+  }
 
   get provider(): ExternalClusterProvider {
     return this._provider;
@@ -83,7 +87,7 @@ export class ExternalClusterService {
 
   set preset(preset: string) {
     this._preset = preset;
-    this.presetChanges.next(preset);
+    this._presetChanges.next(preset);
   }
 
   get regionChanges(): Observable<string> {

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -26,7 +26,7 @@ import {ExternalClusterService} from '@core/services/external-cluster';
 import {NameGeneratorService} from '@core/services/name-generator';
 import {ErrorType} from '@shared/types/error-type';
 import {Observable, of} from 'rxjs';
-import {debounceTime, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {debounceTime, switchMap, takeUntil, tap, filter} from 'rxjs/operators';
 import {
   ExternalCloudSpec,
   ExternalCluster,
@@ -306,9 +306,16 @@ export class AKSClusterSettingsComponent
           this.vmSizeLabel = this.vmSizes?.length ? VMSizeState.Ready : VMSizeState.Empty;
         });
 
-      this._getAKSKubernetesVersions();
-      this._getAKSLocations();
-      this._getAKSResourceGroups();
+      this._externalClusterService.presetChanges
+        .pipe(
+          filter(preset => !!preset),
+          takeUntil(this._unsubscribe)
+        )
+        .subscribe(_ => {
+          this._getAKSKubernetesVersions();
+          this._getAKSLocations();
+          this._getAKSResourceGroups();
+        });
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed bug in external cluster AKS wizard, where changing the credentials preset was not updating `Kubernetes version`, `locations` and `resource groups` API calls.


- No Ticket exists

<!-- 
**Which issue(s) this PR fixes**:
Fixes #
-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

<!-- **Special notes for your reviewer**: -->

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
