### PR TITLE
add Back button to the Import external cluster dialog

### DIFF
--- a/src/app/shared/components/add-external-cluster-dialog/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/component.ts
@@ -59,6 +59,12 @@ export class AddExternalClusterDialogComponent implements OnInit, OnDestroy {
 
         this._stepper.next();
       });
+
+    this._stepper.selectionChange.pipe(takeUntil(this._unsubscribe)).subscribe(selection => {
+      if (selection.previouslySelectedIndex > selection.selectedIndex) {
+        selection.previouslySelectedStep.reset();
+      }
+    });
   }
 
   ngOnDestroy() {
@@ -81,10 +87,14 @@ export class AddExternalClusterDialogComponent implements OnInit, OnDestroy {
     return this._stepper.selectedIndex === this.steps.length - 1;
   }
 
+  get first(): boolean {
+    return this._stepper.selectedIndex === 0;
+  }
+
   get invalid(): boolean {
     switch (this.active) {
       case Step.Provider:
-        return false;
+        return !this.externalClusterService.provider;
       case Step.Credentials:
         return !this.externalClusterService.isCredentialsStepValid;
       case Step.Cluster:
@@ -112,5 +122,9 @@ export class AddExternalClusterDialogComponent implements OnInit, OnDestroy {
 
   next(): void {
     this._stepper.next();
+  }
+
+  previous(): void {
+    this._stepper.previous();
   }
 }

--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/aks/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/aks/component.ts
@@ -61,6 +61,7 @@ export class AKSClusterSelectComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
+    this._externalClusterService.clusterStepValidity = false;
   }
 
   get isEmpty(): boolean {

--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/eks/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/eks/component.ts
@@ -61,6 +61,7 @@ export class EKSClusterSelectComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
+    this._externalClusterService.clusterStepValidity = false;
   }
 
   get isEmpty(): boolean {

--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/gke/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/provider/gke/component.ts
@@ -61,6 +61,7 @@ export class GKEClusterSelectComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
+    this._externalClusterService.clusterStepValidity = false;
   }
 
   get isEmpty(): boolean {

--- a/src/app/shared/components/add-external-cluster-dialog/style.scss
+++ b/src/app/shared/components/add-external-cluster-dialog/style.scss
@@ -28,3 +28,7 @@ mat-dialog-actions {
     margin: unset;
   }
 }
+
+.external-cluster-add-btn {
+  margin-left: 10px;
+}

--- a/src/app/shared/components/add-external-cluster-dialog/template.html
+++ b/src/app/shared/components/add-external-cluster-dialog/template.html
@@ -43,7 +43,8 @@ limitations under the License.
             fxFlex="100%">
     <ng-template matStepLabel>{{step.Cluster}}</ng-template>
     <ng-template matStepContent>
-      <km-external-cluster-cluster-step [projectID]="projectId"></km-external-cluster-cluster-step>
+      <km-external-cluster-cluster-step *ngIf="active === step.Cluster"
+                                        [projectID]="projectId"></km-external-cluster-cluster-step>
     </ng-template>
   </mat-step>
 </mat-horizontal-stepper>
@@ -56,16 +57,26 @@ limitations under the License.
                [diameter]="25"
                color="accent"
                *ngIf="externalClusterService.isValidating"></mat-spinner>
+  <button fxLayoutAlign="center center"
+          mat-flat-button
+          type="button"
+          color="tertiary"
+          (click)="previous(stepper)"
+          *ngIf="!first">
+    <i class="km-icon-mask km-icon-back"></i>
+    <span>Back</span>
+  </button>
   <button mat-flat-button
           type="button"
           (click)="next()"
           [disabled]="invalid"
-          *ngIf="active === step.Credentials && !last">
+          *ngIf="!last">
     <i class="km-icon-mask km-icon-next"></i>
     <span>Next</span>
   </button>
   <km-button *ngIf="last"
              id="external-cluster-add-btn"
+             class="external-cluster-add-btn"
              icon="km-icon-add"
              [label]="label"
              [disabled]="invalid"


### PR DESCRIPTION
**What this PR does / why we need it**:
add a `Back` button in the import external cluster dialog so the user can navigate through the dialog steps
**Which issue(s) this PR fixes**:
Fixes #4910

**What type of PR is this?**
/kind design

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Add a Back button in the import external cluster dialog.
```
```documentation
NONE
```
