### PR TITLE
[release/v2.20] Bump version to 2.20.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ ifeq (${HUMAN_VERSION},)
 	TARGET_BRANCH=$(or ${PULL_BASE_REF},${CURRENT_BRANCH})
 
 	ifeq (${TARGET_BRANCH},master)
-	HUMAN_VERSION=v2.20.7-dev-g$(shell git rev-parse --short HEAD)
+	HUMAN_VERSION=v2.20.8-dev-g$(shell git rev-parse --short HEAD)
 	else
-	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.20.7-dev-g$(shell git rev-parse --short HEAD))
+	HUMAN_VERSION=$(or $(shell git describe --tags --match "v[0-9]*"),v2.20.8-dev-g$(shell git rev-parse --short HEAD))
 	endif
 endif
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "v2.20.7",
+  "version": "v2.20.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "v2.20.7",
+      "version": "v2.20.8",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kubermatic-dashboard",
   "private": true,
   "type": "module",
-  "version": "v2.20.7",
+  "version": "v2.20.8",
   "description": "Kubermatic Dashboard",
   "repository": "https://github.com/kubermatic/dashboard",
   "license": "proprietary",


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the version to v2.20.8 so we can release an out-of-band set of patches for KKP.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
