### PR TITLE
Use default OperatingSystemProfile values from datacenter

### DIFF
--- a/src/app/node-data/component.ts
+++ b/src/app/node-data/component.ts
@@ -452,11 +452,17 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
 
   private setDefaultOperatingSystemProfiles(): void {
     let ospValue = '';
+    const selectedOperatingSystem = this.form.get(Controls.OperatingSystem).value;
+    const dcOSP = this._datacenterSpec?.spec.operatingSystemProfiles?.[selectedOperatingSystem];
 
     if (this.selectedOperatingSystemProfile) {
       ospValue = this.selectedOperatingSystemProfile;
-    } else if (this.form.get(Controls.OperatingSystem).value !== '') {
-      const ospName = 'osp-' + this.form.get(Controls.OperatingSystem).value;
+    } else if (dcOSP) {
+      if (this.supportedOperatingSystemProfiles.indexOf(dcOSP) > -1) {
+        ospValue = dcOSP;
+      }
+    } else if (selectedOperatingSystem !== '') {
+      const ospName = 'osp-' + selectedOperatingSystem;
       if (this.supportedOperatingSystemProfiles.indexOf(ospName) > -1) {
         ospValue = ospName;
       }

--- a/src/app/shared/entity/datacenter.ts
+++ b/src/app/shared/entity/datacenter.ts
@@ -48,6 +48,7 @@ export class DatacenterSpec {
   alibaba?: AlibabaDatacenterSpec;
   anexia?: AnexiaDatacenterSpec;
   vmwareclouddirector?: VMwareCloudDirectorDatacenterSpec;
+  operatingSystemProfiles?: DatacenterOperatingSystemOptions;
 }
 
 export class DatacenterOperatingSystemOptions {


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Support for consuming default OperatingSystemProfiles from the seed specification, if specified.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5053

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
