### PR TITLE
adopt to kubermatic repo main branch renaming

### DIFF
--- a/.prow/tests-e2e.yaml
+++ b/.prow/tests-e2e.yaml
@@ -22,7 +22,7 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: master
+        base_ref: main
         clone_uri: 'ssh://git@github.com/kubermatic/kubermatic.git'
     labels:
       preset-alibaba: 'true'
@@ -78,7 +78,7 @@ presubmits:
       # Kubermatic repo is required as we need to have access to the helm files used to deploy it.
       - org: kubermatic
         repo: kubermatic
-        base_ref: master
+        base_ref: main
         clone_uri: 'ssh://git@github.com/kubermatic/kubermatic.git'
     labels:
       preset-alibaba: 'true'

--- a/src/app/cluster/details/cluster/share-kubeconfig/template.html
+++ b/src/app/cluster/details/cluster/share-kubeconfig/template.html
@@ -19,7 +19,7 @@ limitations under the License.
     Share <b>{{cluster.name}}</b> cluster with other users by giving them the following link that can be used to authenticate with an OIDC provider and then generate a kubeconfig file.
   </p>
   <p>
-    Please <a href="https://docs.kubermatic.com/kubermatic/master/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
+    Please <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
        target="_blank"
        rel="noopener">visit our documentation</a>
     for more details.

--- a/src/app/project/template.html
+++ b/src/app/project/template.html
@@ -346,7 +346,7 @@ limitations under the License.
            fxLayoutAlign="center center"
            class="placeholder-text">
         <p>Dive right into your first project.</p>
-        <a href="https://docs.kubermatic.com/kubermatic/master/tutorials-howtos/project-and-cluster-management/"
+        <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/project-and-cluster-management/"
            target="_blank"
            rel="noreferrer noopener">
           Learn more in our documentation >

--- a/src/app/settings/admin/interface/template.html
+++ b/src/app/settings/admin/interface/template.html
@@ -99,7 +99,7 @@ limitations under the License.
                       (change)="onSettingsChange()"
                       id="km-enable-oidc-setting">
           <mat-hint *ngIf="!isOIDCKubeCfgEndpointEnabled">This feature is disabled. Visit the
-            <a href="https://docs.kubermatic.com/kubermatic/master/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
+            <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
                target="_blank"
                rel="noopener noreferrer">
               documentation

--- a/src/app/settings/user/template.html
+++ b/src/app/settings/user/template.html
@@ -48,7 +48,7 @@ limitations under the License.
         <ng-template #noGroups>
           <div>
             No OIDC groups assigned.
-            <a href="https://docs.kubermatic.com/kubermatic/master/architecture/role-based-access-control/groups-support/"
+            <a href="https://docs.kubermatic.com/kubermatic/main/architecture/role-based-access-control/groups-support/"
                target="_blank"
                rel="noreferrer noopener">Learn more ></a>
           </div>

--- a/src/app/shared/components/addon-list/install-addon-dialog/template.html
+++ b/src/app/shared/components/addon-list/install-addon-dialog/template.html
@@ -30,7 +30,7 @@ limitations under the License.
         <p>
           Addons are extensions provided by Kubermatic to expand cluster capabilities.
           <br />
-          <a href="https://docs.kubermatic.com/kubermatic/master/architecture/concept/kkp-concepts/addons/"
+          <a href="https://docs.kubermatic.com/kubermatic/main/architecture/concept/kkp-concepts/addons/"
              target="_blank"
              rel="noreferrer noopener">
             Learn more about Addons >

--- a/src/app/shared/components/addon-list/template.html
+++ b/src/app/shared/components/addon-list/template.html
@@ -19,7 +19,7 @@ limitations under the License.
   <div fxFlex>
     <p *ngIf="!addons?.length">
       Addons are extensions provided by Kubermatic to expand cluster capabilities,
-      <a href="https://docs.kubermatic.com/kubermatic/master/architecture/concept/kkp-concepts/addons/"
+      <a href="https://docs.kubermatic.com/kubermatic/main/architecture/concept/kkp-concepts/addons/"
          target="_blank"
          rel="noreferrer noopener">
         learn more about Addons >

--- a/src/app/shared/components/application-list/add-application-dialog/template.html
+++ b/src/app/shared/components/application-list/add-application-dialog/template.html
@@ -29,7 +29,7 @@ limitations under the License.
       <div fxLayout="column">
         <p class="application-settings-desc">
           Install third party Applications into a cluster,
-          <a href="https://docs.kubermatic.com/kubermatic/master/tutorials-howtos/applications/"
+          <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/applications/"
              target="_blank"
              rel="noreferrer noopener">
             learn more about Applications >

--- a/src/app/shared/components/application-list/template.html
+++ b/src/app/shared/components/application-list/template.html
@@ -287,7 +287,7 @@ limitations under the License.
 </div>
 
 <ng-template #applicationDocsLink>
-  <a href="https://docs.kubermatic.com/kubermatic/master/tutorials-howtos/applications/"
+  <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/applications/"
      target="_blank"
      rel="noreferrer noopener">
     learn more about Applications >

--- a/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
@@ -107,7 +107,7 @@ limitations under the License.
     <div *ngIf="!preAllocatedDataVolumesFormArray.length"
          class="km-text-muted">
       Custom local disks are optional disks used for the provisioning of nodes with custom images.
-      <a href="https://docs.kubermatic.com/kubermatic/master/architecture/supported-providers/kubevirt/kubevirt/"
+      <a href="https://docs.kubermatic.com/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt/"
          target="_blank"
          rel="noreferrer noopener">Learn more ></a>
     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
This is required because KKP followed with renaming the default branch to `main` via https://github.com/kubermatic/kubermatic/pull/11206.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
