### PR TITLE
fix docker repo name, fix default command in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ COPY ./_build/ /usr/local/bin/
 COPY ./cmd/kubermatic-api/swagger.json /opt/swagger.json
 COPY ./dist /dist
 
-# We need to duplicate this binary in the root untill we update
-# the KKP operator to use the binary from /usr/local/bin.
-COPY ./_build/dashboard /
-
 USER nobody
+
+# this default CMD is for the legacy KKP Operator, which did not
+# specify an explicit command in the dashboard Deployment
+CMD ["dashboard"]

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ export CGO_ENABLED ?= 0
 export GOFLAGS ?= -mod=readonly -trimpath
 export GO111MODULE = on
 DOCKER_REPO ?= quay.io/kubermatic
-REPO = $(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
+REPO = $(DOCKER_REPO)/dashboard$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
 CMD ?= $(notdir $(wildcard ./cmd/*))
 GOBUILDFLAGS ?= -v
 GIT_VERSION = $(shell git describe --tags --always)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the Dockerimage to have a proper default command (for now, in the future we should not rely on this) and also pushes the Docker image to the correct repository.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
