### PR TITLE
Web terminal: expiration implementation + security improvements + cleanup job for temporary resources

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -35,10 +35,11 @@ import (
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	wsh "k8c.io/dashboard/v2/pkg/handler/websocket"
 	"k8c.io/dashboard/v2/pkg/provider"
+	"k8c.io/dashboard/v2/pkg/watcher"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
-	"k8c.io/dashboard/v2/pkg/watcher"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,7 +81,7 @@ var upgrader = websocket.Upgrader{
 
 type WebsocketSettingsWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn)
 type WebsocketUserWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, userEmail string)
-type WebsocketTerminalWriter func(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string)
+type WebsocketTerminalWriter func(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster)
 
 const (
 	maxNumberOfTerminalActiveConnectionsPerUser = 5
@@ -298,7 +299,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 			return
 		}
 
-		writer(ctx, ws, client, k8sClient, cfg, userEmailID)
+		writer(ctx, ws, client, k8sClient, cfg, userEmailID, cluster)
 	}
 }
 

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -200,7 +200,7 @@ func expirationCheckRoutine(ctx context.Context, clusterClient ctrlruntimeclient
 			Name:      userAppName(userEmailID),
 		}, webTerminalConfigMap); err != nil {
 			log.Logger.Debug(err)
-			continue
+			break
 		}
 
 		if webTerminalConfigMap.Data == nil {
@@ -222,6 +222,12 @@ func expirationCheckRoutine(ctx context.Context, clusterClient ctrlruntimeclient
 
 		expirationTime := time.Unix(expirationTimestamp, 0)
 		remainingExpirationTime := time.Until(expirationTime)
+
+		if remainingExpirationTime < 0 {
+			// web terminal is already expired, so break the check loop
+			break
+		}
+
 		if remainingExpirationTime < remainingExpirationTimeForWarning {
 			_ = websocketConn.WriteJSON(TerminalMessage{
 				Op:   "expiration",

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -21,6 +21,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,19 +43,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	END_OF_TRANSMISSION    = "\u0004"
-	timeout                = 2 * time.Minute
-	appName                = "webterminal"
-	webTerminalStorage     = "web-terminal-storage"
-	podLifetime            = 30 * time.Minute
-	expirationTimestampKey = "ExpirationTimestamp"
+	END_OF_TRANSMISSION               = "\u0004"
+	timeout                           = 2 * time.Minute
+	appName                           = "webterminal"
+	webTerminalStorage                = "web-terminal-storage"
+	podLifetime                       = 30 * time.Minute
+	remainingExpirationTimeForWarning = 5 * time.Minute // should be lesser than "podLifetime"
+	expirationCheckInterval           = 1 * time.Minute // should be lesser than "remainingExpirationTimeForWarning"
+	expirationTimestampKey            = "ExpirationTimestamp"
 )
 
 type TerminalConnStatus string
@@ -78,19 +80,25 @@ type TerminalSession struct {
 	websocketConn *websocket.Conn
 	sizeChan      chan remotecommand.TerminalSize
 	doneChan      chan struct{}
+
+	userEmailID   string
+	clusterClient ctrlruntimeclient.Client
 }
 
 // TerminalMessage is the messaging protocol between ShellController and TerminalSession.
 //
-// OP      DIRECTION  FIELD(S) USED  DESCRIPTION
+// OP          DIRECTION  FIELD(S) USED  DESCRIPTION
 // ---------------------------------------------------------------------
-// stdin   fe->be     Data           Keystrokes/paste buffer
-// resize fe->be      Rows, Cols     New terminal size
-// stdout  be->fe     Data           Output from the process
-// toast   be->fe     Data           OOB message to be shown to the user.
+// stdin       fe->be     Data           Keystrokes/paste buffer.
+// resize      fe->be     Rows, Cols     New terminal size.
+// refresh     fe->be                    Signal to extend expiration time.
+// stdout      be->fe     Data           Output from the process.
+// toast       be->fe     Data           OOB message to be shown to the user.
+// msg         be->fe     Data           Any necessary message from the backend to the frontend.
+// expiration  be->fe     Data           Expiration timestamp in seconds.
 type TerminalMessage struct {
-	Op, Data, SessionID string
-	Rows, Cols          uint16
+	Op, Data   string
+	Rows, Cols uint16
 }
 
 // TerminalSize handles pty->process resize events.
@@ -104,7 +112,7 @@ func (t TerminalSession) Next() *remotecommand.TerminalSize {
 	}
 }
 
-// Read handles pty->process messages (stdin, resize).
+// Read handles pty->process messages (stdin, resize, refresh).
 // Called in a loop from remotecommand as long as the process is running.
 func (t TerminalSession) Read(p []byte) (int, error) {
 	_, m, err := t.websocketConn.ReadMessage()
@@ -124,6 +132,8 @@ func (t TerminalSession) Read(p []byte) (int, error) {
 	case "resize":
 		t.sizeChan <- remotecommand.TerminalSize{Width: msg.Cols, Height: msg.Rows}
 		return 0, nil
+	case "refresh":
+		return 0, t.extendExpirationTime(context.Background())
 	default:
 		return copy(p, END_OF_TRANSMISSION), fmt.Errorf("unknown message type '%s'", msg.Op)
 	}
@@ -164,8 +174,56 @@ func (t TerminalSession) Toast(p string) error {
 	return nil
 }
 
+func (t TerminalSession) extendExpirationTime(ctx context.Context) error {
+	return t.clusterClient.Update(ctx,
+		genWebTerminalConfigMap(
+			userAppName(t.userEmailID),
+		)) // regenerate the configmap to extend the expiration period
+}
+
 func userAppName(userEmailID string) string {
 	return fmt.Sprintf("%s-%s", appName, userEmailID)
+}
+
+func expirationCheckRoutine(ctx context.Context, clusterClient ctrlruntimeclient.Client, userEmailID string, websocketConn *websocket.Conn) {
+	for {
+		time.Sleep(expirationCheckInterval)
+
+		webTerminalConfigMap := &corev1.ConfigMap{}
+		if err := clusterClient.Get(ctx, ctrlruntimeclient.ObjectKey{
+			Namespace: metav1.NamespaceSystem,
+			Name:      userAppName(userEmailID),
+		}, webTerminalConfigMap); err != nil {
+			log.Logger.Debug(err)
+			continue
+		}
+
+		if webTerminalConfigMap.Data == nil {
+			log.Logger.Debug(errors.New("no data set for webterminal configmap"))
+			break
+		}
+
+		expirationTimestampStr, isExpirationSet := webTerminalConfigMap.Data[expirationTimestampKey]
+		if !isExpirationSet {
+			log.Logger.Debug(errors.New("no expiration set in the webterminal configmap"))
+			break
+		}
+
+		expirationTimestamp, err := strconv.ParseInt(expirationTimestampStr, 10, 64)
+		if err != nil {
+			log.Logger.Debug(errors.New("invalid expiration timestamp in the webterminal configmap"))
+			break
+		}
+
+		expirationTime := time.Unix(expirationTimestamp, 0)
+		remainingExpirationTime := time.Until(expirationTime)
+		if remainingExpirationTime < remainingExpirationTimeForWarning {
+			_ = websocketConn.WriteJSON(TerminalMessage{
+				Op:   "expiration",
+				Data: expirationTimestampStr,
+			})
+		}
+	}
 }
 
 // startProcess is called by terminal session creation.
@@ -236,6 +294,8 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 	}) {
 		return fmt.Errorf("the WEB terminal Pod is not ready")
 	}
+
+	go expirationCheckRoutine(ctx, client, userEmailID, websocketConn)
 
 	req := k8sClient.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -456,7 +516,7 @@ func getVolumeMounts() []corev1.VolumeMount {
 }
 
 // Terminal is called for any new websocket connection.
-func Terminal(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *restclient.Config, userEmailID string, cluster *kubermaticv1.Cluster) {
+func Terminal(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster) {
 	if err := startProcess(
 		ctx,
 		client,
@@ -467,6 +527,8 @@ func Terminal(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.
 		[]string{"bash", "-c", "cd /data/terminal && /bin/bash"},
 		TerminalSession{
 			websocketConn: ws,
+			userEmailID:   userEmailID,
+			clusterClient: client,
 		},
 		ws); err != nil {
 		log.Logger.Debug(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- Adds network policy to allow only egress to k8s api server from the web terminal pod.
- Extends the web terminal endpoint to implement pod expiration message/refresh.
- Adds cleanup job for user web terminal temporary k8s resources.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
