### PR TITLE
Quota Information Presence for External Clusters

### DIFF
--- a/src/app/cluster/list/external-cluster/template.html
+++ b/src/app/cluster/list/external-cluster/template.html
@@ -19,6 +19,10 @@ limitations under the License.
   <km-search-field (queryChange)="onSearch($event)"></km-search-field>
   <div fxFlex></div>
 
+  <div fxLayoutAlign="center center">
+    <router-outlet name="quota-widget"
+                   (activate)="onActivate($event)"></router-outlet>
+  </div>
   <button id="km-add-external-cluster-btn"
           mat-flat-button
           [disabled]="!can(Permission.Create)"
@@ -175,3 +179,8 @@ limitations under the License.
 
   </mat-card-content>
 </mat-card>
+
+<ng-template #quotaWidget>
+  <router-outlet name="quota-widget"
+                 (activate)="onActivateQuotaWidgetWithoutCard($event)"></router-outlet>
+</ng-template>

--- a/src/app/dynamic/enterprise/quotas/quota-widget/component.ts
+++ b/src/app/dynamic/enterprise/quotas/quota-widget/component.ts
@@ -55,11 +55,14 @@ export class QuotaWidgetComponent implements OnInit, OnChanges, OnDestroy {
   @Input() showIcon = true;
   @Input() showDetailsOnHover = true;
   @Input() showEmptyPlaceholder = false;
+  @Input() isExternalCluster = false;
+  @Input() isImportedCluster = false;
 
   quotaPercentage: QuotaVariables;
   quotaDetails: QuotaDetails;
   isLoading: boolean;
   showWarning: boolean;
+  isWidgetApplicableForExternalOrImportedCluster: boolean;
   showDetails$ = this._showDetails$.asObservable().pipe(debounceTime(this._debounce));
 
   readonly quotaLimit = 100;
@@ -85,12 +88,17 @@ export class QuotaWidgetComponent implements OnInit, OnChanges, OnDestroy {
   ngOnInit(): void {
     this.isLoading = true;
     this._initSubscriptions();
+    this._setShowNotApplicableText();
   }
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.projectId) {
       this._unsubscribe.next();
       this._subscribeToQuotaDetails();
+    }
+
+    if (changes.isExternalCluster || changes.isImportedCluster) {
+      this._setShowNotApplicableText();
     }
   }
 
@@ -147,5 +155,9 @@ export class QuotaWidgetComponent implements OnInit, OnChanges, OnDestroy {
 
   private _setShowWarningIcon(): void {
     this.showWarning = Object.values(this.quotaPercentage).some((quota: number) => quota > this.quotaLimit);
+  }
+
+  private _setShowNotApplicableText(): void {
+    this.isWidgetApplicableForExternalOrImportedCluster = this.isExternalCluster || this.isImportedCluster;
   }
 }

--- a/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
+++ b/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
@@ -37,6 +37,11 @@
     padding: 0 10px;
   }
 
+  .km-quota-widget {
+    height: 46px;
+    white-space: nowrap;
+  }
+
   km-property {
     padding-top: 9px;
 

--- a/src/app/dynamic/enterprise/quotas/quota-widget/template.html
+++ b/src/app/dynamic/enterprise/quotas/quota-widget/template.html
@@ -36,29 +36,37 @@ END OF TERMS AND CONDITIONS
          [class.km-no-quota-top-margin]="!quotaDetails"
          fxLayout="row"
          fxLayoutAlign=" center">
-      <i *ngIf="showWarning"
+      <i *ngIf="showWarning && !isWidgetApplicableForExternalOrImportedCluster"
          class="km-icon-warning"
          matTooltip="The project quota is overdrawn"></i>
 
       <i *ngIf="showIcon"
          class="km-icon-mask km-icon-quota"></i>
 
-      <ng-container *ngIf="quotaDetails else emptyPlaceholder">
-        <ng-container *ngIf="quotaDetails.quota.cpu"
-                      [ngTemplateOutlet]="progressBar"
-                      [ngTemplateOutletContext]="{label: 'CPU', percentage: quotaPercentage.cpu}">
-        </ng-container>
+      <ng-container [ngTemplateOutlet]="!isWidgetApplicableForExternalOrImportedCluster ? quotaBars : notApplicableText"></ng-container>
 
-        <ng-container *ngIf="quotaDetails.quota.memory"
-                      [ngTemplateOutlet]="progressBar"
-                      [ngTemplateOutletContext]="{label: 'Memory', percentage: quotaPercentage.memory}">
-        </ng-container>
+      <ng-template #quotaBars>
+        <ng-container *ngIf="quotaDetails else emptyPlaceholder">
+          <ng-container *ngIf="quotaDetails.quota.cpu"
+                        [ngTemplateOutlet]="progressBar"
+                        [ngTemplateOutletContext]="{label: 'CPU', percentage: quotaPercentage.cpu}">
+          </ng-container>
 
-        <ng-container *ngIf="quotaDetails.quota.storage"
-                      [ngTemplateOutlet]="progressBar"
-                      [ngTemplateOutletContext]=" {label: 'Disk', percentage: quotaPercentage.storage}">
+          <ng-container *ngIf="quotaDetails.quota.memory"
+                        [ngTemplateOutlet]="progressBar"
+                        [ngTemplateOutletContext]="{label: 'Memory', percentage: quotaPercentage.memory}">
+          </ng-container>
+
+          <ng-container *ngIf="quotaDetails.quota.storage"
+                        [ngTemplateOutlet]="progressBar"
+                        [ngTemplateOutletContext]=" {label: 'Disk', percentage: quotaPercentage.storage}">
+          </ng-container>
         </ng-container>
-      </ng-container>
+      </ng-template>
+
+      <ng-template #notApplicableText>
+        Does not apply to {{ isImportedCluster ? 'imported' : 'external' }} cluster
+      </ng-template>
 
       <ng-template #emptyPlaceholder>
         No quotas configured

--- a/src/app/external-cluster-wizard/routing.ts
+++ b/src/app/external-cluster-wizard/routing.ts
@@ -16,12 +16,19 @@ import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {AuthGuard} from '@core/services/auth/guard';
 import {ExternalClusterWizardComponent} from './component';
+import {DynamicModule} from '@dynamic/module-registry';
 
 const routes: Routes = [
   {
     path: '',
     component: ExternalClusterWizardComponent,
     canActivate: [AuthGuard],
+    children: [
+      {
+        path: '',
+        loadChildren: () => DynamicModule.Quotas,
+      },
+    ],
   },
 ];
 

--- a/src/app/external-cluster-wizard/steps/external-cluster/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/component.ts
@@ -18,6 +18,7 @@ import {ExternalClusterService} from '@core/services/external-cluster';
 import {ExternalClusterProvider} from '@shared/entity/external-cluster';
 import {filter, takeUntil} from 'rxjs/operators';
 import {StepBase} from '../base';
+import {QuotaWidgetComponent} from '@dynamic/enterprise/quotas/quota-widget/component';
 
 enum Controls {
   AKSExternalCluster = 'AKSExternalCluster',
@@ -66,6 +67,13 @@ export class ExternalClusterStepComponent
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
+  }
+
+  onActivate(component: QuotaWidgetComponent): void {
+    component.projectId = this.projectID;
+    component.isExternalCluster = true;
+    component.showAsCard = false;
+    component.showDetailsOnHover = false;
   }
 
   private _initForm() {

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -11,7 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import {ChangeDetectorRef, Component, forwardRef, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  forwardRef,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  TemplateRef,
+} from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -54,6 +63,7 @@ import {
 import {MasterVersion} from '@app/shared/entity/cluster';
 import {EKSSecurityGroup} from '@shared/entity/provider/eks';
 import {ComboboxControls, FilteredComboboxComponent} from '@shared/components/combobox/component';
+import {QuotaWidgetComponent} from '@dynamic/enterprise/quotas/quota-widget/component';
 
 enum Controls {
   Name = 'name',
@@ -130,6 +140,7 @@ export class AKSClusterSettingsComponent
   readonly DEFAULT_VMSIZE = 'Standard_DS2_v2';
   @Input() projectID: string;
   @Input() cluster: ExternalCluster;
+  @Input() quotaWidget: TemplateRef<QuotaWidgetComponent>;
   vmSizeLabel = VMSizeState.Ready;
   vmSizes: AKSVMSize[] = [];
   locationLabel = LocationState.Ready;

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/template.html
@@ -117,6 +117,10 @@ limitations under the License.
       </mat-error>
     </mat-form-field>
 
+    <div>
+      <ng-container *ngTemplateOutlet="quotaWidget"></ng-container>
+    </div>
+
     <km-combobox #vmSizeCombobox
                  filterBy="name"
                  inputLabel="Select VM Sizes..."

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/component.ts
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ChangeDetectorRef, Component, forwardRef, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  forwardRef,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  TemplateRef,
+} from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -54,6 +63,7 @@ import {
 import {MasterVersion} from '@app/shared/entity/cluster';
 import {ComboboxControls, FilteredComboboxComponent} from '@shared/components/combobox/component';
 import {EKSArchitecture} from '@app/shared/entity/provider/eks';
+import {QuotaWidgetComponent} from '@dynamic/enterprise/quotas/quota-widget/component';
 
 enum Controls {
   Vpc = 'vpc',
@@ -151,6 +161,7 @@ export class EKSClusterSettingsComponent
 
   @Input() projectID: string;
   @Input() cluster: ExternalCluster;
+  @Input() quotaWidget: TemplateRef<QuotaWidgetComponent>;
   private readonly _debounceTime = 500;
 
   @ViewChild('vpcCombobox')

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
@@ -224,6 +224,10 @@ limitations under the License.
       </div>
     </km-combobox>
 
+    <div>
+      <ng-container *ngTemplateOutlet="quotaWidget"></ng-container>
+    </div>
+
     <ng-container *ngIf="isDialogView()">
       <mat-card-header class="km-no-padding">
         <mat-card-title>AutoScaling</mat-card-title>

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ChangeDetectorRef, Component, forwardRef, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  forwardRef,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  TemplateRef,
+} from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -46,6 +55,7 @@ import {GCPDiskType, GCPMachineSize} from '@app/shared/entity/provider/gcp';
 import {NameGeneratorService} from '@app/core/services/name-generator';
 import {MasterVersion} from '@app/shared/entity/cluster';
 import {ComboboxControls, FilteredComboboxComponent} from '@app/shared/components/combobox/component';
+import {QuotaWidgetComponent} from '@dynamic/enterprise/quotas/quota-widget/component';
 
 enum Controls {
   Name = 'name',
@@ -155,6 +165,7 @@ export class GKEClusterSettingsComponent
 
   @Input() projectID: string;
   @Input() cluster: ExternalCluster;
+  @Input() quotaWidget: TemplateRef<QuotaWidgetComponent>;
 
   @ViewChild('diskTypesCombobox')
   private readonly _diskTypesCombobox: FilteredComboboxComponent;

--- a/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -132,6 +132,10 @@ limitations under the License.
       </mat-form-field>
     </ng-container>
 
+    <div>
+      <ng-container *ngTemplateOutlet="quotaWidget"></ng-container>
+    </div>
+
     <km-combobox #machineTypesCombobox
                  filterBy="name"
                  inputLabel="Select Machine Type..."

--- a/src/app/external-cluster-wizard/steps/external-cluster/template.html
+++ b/src/app/external-cluster-wizard/steps/external-cluster/template.html
@@ -16,9 +16,17 @@ limitations under the License.
 <div [ngSwitch]="selectedProvider"
      fxLayout="column">
   <km-aks-cluster-settings *ngSwitchCase="Provider.AKS"
+                           [quotaWidget]="quotaWidget"
                            [formControl]="form.get(Controls.AKSExternalCluster)"></km-aks-cluster-settings>
   <km-eks-cluster-settings *ngSwitchCase="Provider.EKS"
+                           [quotaWidget]="quotaWidget"
                            [formControl]="form.get(Controls.EKSExternalCluster)"></km-eks-cluster-settings>
   <km-gke-cluster-settings *ngSwitchCase="Provider.GKE"
+                           [quotaWidget]="quotaWidget"
                            [formControl]="form.get(Controls.GKEExternalCluster)"></km-gke-cluster-settings>
 </div>
+
+<ng-template #quotaWidget>
+  <router-outlet name="quota-widget"
+                 (activate)="onActivate($event)"></router-outlet>
+</ng-template>

--- a/src/app/external-cluster-wizard/template.html
+++ b/src/app/external-cluster-wizard/template.html
@@ -53,7 +53,8 @@ limitations under the License.
         </ng-container>
         <ng-container *ngSwitchCase="stepRegistry.ExternalClusterDetails">
           <ng-container *ngIf="isPresetSelected || isCredentialStepValid">
-            <km-external-cluster-step [formControl]="form.get(stepRegistry.ExternalClusterDetails)"></km-external-cluster-step>
+            <km-external-cluster-step [formControl]="form.get(stepRegistry.ExternalClusterDetails)"
+                                      [projectID]="project.id"></km-external-cluster-step>
           </ng-container>
         </ng-container>
 

--- a/src/app/shared/components/add-external-cluster-dialog/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, Input, OnDestroy, OnInit, ViewChild, TemplateRef} from '@angular/core';
 import {MatDialogRef} from '@angular/material/dialog';
 import {ExternalClusterService} from '@core/services/external-cluster';
 import {MatStepper} from '@angular/material/stepper';
@@ -21,6 +21,7 @@ import {NotificationService} from '@core/services/notification';
 import {Router} from '@angular/router';
 import {ExternalCluster, ExternalClusterProvider} from '@shared/entity/external-cluster';
 import {Observable, Subject} from 'rxjs';
+import {QuotaWidgetComponent} from '@dynamic/enterprise/quotas/quota-widget/component';
 
 export enum Step {
   Provider = 'Pick Provider',
@@ -34,6 +35,7 @@ export enum Step {
 })
 export class AddExternalClusterDialogComponent implements OnInit, OnDestroy {
   @Input() projectId: string;
+  @Input() quotaWidget: TemplateRef<QuotaWidgetComponent>;
   steps: Step[] = [Step.Provider, Step.Credentials];
   readonly step = Step;
   readonly provider = ExternalClusterProvider;

--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/component.ts
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/component.ts
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, Input, OnDestroy, OnInit, TemplateRef} from '@angular/core';
 import {ExternalClusterProvider} from '@shared/entity/external-cluster';
 import {takeUntil} from 'rxjs/operators';
 import {ExternalClusterService} from '@core/services/external-cluster';
 import {Subject} from 'rxjs';
+import {QuotaWidgetComponent} from '@dynamic/enterprise/quotas/quota-widget/component';
 
 @Component({
   selector: 'km-external-cluster-cluster-step',
@@ -25,6 +26,7 @@ import {Subject} from 'rxjs';
 })
 export class ClusterStepComponent implements OnInit, OnDestroy {
   @Input() projectID: string;
+  @Input() quotaWidget: TemplateRef<QuotaWidgetComponent>;
   provider: ExternalClusterProvider;
   readonly Provider = ExternalClusterProvider;
   private _unsubscribe = new Subject<void>();

--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/style.scss
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/style.scss
@@ -19,3 +19,7 @@
   background-position: left;
   margin: 15px 0 20px;
 }
+
+.quota-widget {
+  width: auto;
+}

--- a/src/app/shared/components/add-external-cluster-dialog/steps/cluster/template.html
+++ b/src/app/shared/components/add-external-cluster-dialog/steps/cluster/template.html
@@ -14,7 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div class="km-provider-logo km-provider-logo-{{provider}}"></div>
+<div fxLayout="row"
+     fxLayoutAlign="space-between center">
+  <div class="km-provider-logo km-provider-logo-{{provider}}"></div>
+  <div class="quota-widget">
+    <ng-container *ngTemplateOutlet="quotaWidget"></ng-container>
+  </div>
+</div>
 
 <div [ngSwitch]="provider"
      fxLayout="column">

--- a/src/app/shared/components/add-external-cluster-dialog/template.html
+++ b/src/app/shared/components/add-external-cluster-dialog/template.html
@@ -44,7 +44,8 @@ limitations under the License.
     <ng-template matStepLabel>{{step.Cluster}}</ng-template>
     <ng-template matStepContent>
       <km-external-cluster-cluster-step *ngIf="active === step.Cluster"
-                                        [projectID]="projectId"></km-external-cluster-cluster-step>
+                                        [projectID]="projectId"
+                                        [quotaWidget]="quotaWidget"></km-external-cluster-cluster-step>
     </ng-template>
   </mat-step>
 </mat-horizontal-stepper>


### PR DESCRIPTION
**What this PR does / why we need it**:

Added quota widget to external cluster pages (list, wizard and import cluster)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5078

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

As external clusters are currently not affected by quotas, so instead of the actual quota widget `Does not apply to external cluster` is shown 

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The quota widget is shown on the external cluster list, wizard, and import dialog
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
