### PR TITLE
Set sig-api and sig-ui OWNERS accordingly

### DIFF
--- a/certs/OWNERS
+++ b/certs/OWNERS
@@ -1,9 +1,13 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - sig-ui
   - sig-api
 
 reviewers:
-  - sig-ui
   - sig-api
+
+labels:
+  - sig/api
+
+options:
+  no_parent_owners: true

--- a/cmd/dashboard/OWNERS
+++ b/cmd/dashboard/OWNERS
@@ -2,8 +2,12 @@
 
 approvers:
   - sig-ui
-  - sig-api
 
 reviewers:
   - sig-ui
-  - sig-api
+
+labels:
+  - sig-ui
+
+options:
+  no_parent_owners: true

--- a/containers/OWNERS
+++ b/containers/OWNERS
@@ -2,8 +2,12 @@
 
 approvers:
   - sig-ui
-  - sig-api
 
 reviewers:
   - sig-ui
-  - sig-api
+
+labels:
+  - sig-ui
+
+options:
+  no_parent_owners: true

--- a/cypress/OWNERS
+++ b/cypress/OWNERS
@@ -2,8 +2,12 @@
 
 approvers:
   - sig-ui
-  - sig-api
 
 reviewers:
   - sig-ui
-  - sig-api
+
+labels:
+  - sig-ui
+
+options:
+  no_parent_owners: true

--- a/fixtures/OWNERS
+++ b/fixtures/OWNERS
@@ -2,8 +2,12 @@
 
 approvers:
   - sig-ui
-  - sig-api
 
 reviewers:
   - sig-ui
-  - sig-api
+
+labels:
+  - sig-ui
+
+options:
+  no_parent_owners: true

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,9 +1,13 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - sig-ui
   - sig-api
 
 reviewers:
-  - sig-ui
   - sig-api
+
+labels:
+  - sig/api
+
+options:
+  no_parent_owners: true

--- a/src/OWNERS
+++ b/src/OWNERS
@@ -2,8 +2,12 @@
 
 approvers:
   - sig-ui
-  - sig-api
 
 reviewers:
   - sig-ui
-  - sig-api
+
+labels:
+  - sig-ui
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets up the OWNERS file for sig-api and sig-ui to differentiate areas of responsibility

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
