### PR TITLE
Use the operator's native support for a custom dashboard/api image

### DIFF
--- a/.prow/tests-e2e.yaml
+++ b/.prow/tests-e2e.yaml
@@ -41,7 +41,6 @@ presubmits:
       preset-kind-volume-mounts: 'true'
       preset-kubeconfig-ci: 'true'
       preset-minio: 'true'
-      preset-scratch-tmpfs: 'true'
     spec:
       containers:
         - image: quay.io/kubermatic/chrome-headless:v1.6.0
@@ -97,7 +96,6 @@ presubmits:
       preset-kind-volume-mounts: 'true'
       preset-kubeconfig-ci: 'true'
       preset-minio: 'true'
-      preset-scratch-tmpfs: 'true'
     spec:
       containers:
         - image: quay.io/kubermatic/chrome-headless:v1.6.0

--- a/hack/ci/testdata/kubermatic.yaml
+++ b/hack/ci/testdata/kubermatic.yaml
@@ -36,6 +36,9 @@ spec:
     OperatingSystemManager: __KUBERMATIC_OSM_ENABLED__
   ui:
     replicas: 0
+    # this is how we override KKP's default API/UI docker tag and inject
+    # the locally built Docker image tag
+    dockerTag: '__DASHBOARD_VERSION__'
   # Dex integration
   auth:
     tokenIssuer: "http://dex.oauth:5556/dex"

--- a/hack/e2e/setup-kind-cluster.sh
+++ b/hack/e2e/setup-kind-cluster.sh
@@ -50,34 +50,8 @@ nodes:
       - containerPort: 32001
         hostPort: 8080
         protocol: TCP
-    # make sure PVCs can be mounted to this tmpfs instead
-    # of to an SSD-backed emptyDir
-    extraMounts:
-      - hostPath: /scratch
-        containerPath: /scratch
 EOF
 pushElapsed kind_cluster_create_duration_milliseconds $beforeKindCreate "node_version=\"$KIND_NODE_VERSION\""
-
-# reconfigure the local-path-provisioner to use the tmpfs
-cat << EOF | kubectl apply --filename -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-path-config
-  namespace: local-path-storage
-data:
-  config.json: |-
-    {
-      "nodePathMap":[
-        {
-          "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
-          "paths":["/scratch"]
-        }
-      ]
-    }
-EOF
-
-kubectl --namespace local-path-storage rollout restart deployment/local-path-provisioner
 
 # Start cluster exposer, which will expose services from within kind as
 # a NodePort service on the host


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that https://github.com/kubermatic/kubermatic/pull/11229 is merged we can get rid of the hack to inject our Docker image for the API and just rely on the operator for us. :tada: 

I ran one test version first where I purposefully did not push the dashboard image into kind, in order to verify that the operator is indeed picking up our injected version. As expected, the prowjob failed: https://public-prow.loodse.com/view/gs/prow-dev-public-data/pr-logs/pull/kubermatic_dashboard/5167/pre-dashboard-api-e2e/1586437233034924032

I also removed the /scratch hack, which I introduced a long time ago but seemingly more modern kind versions are configured slightly differently. Since we do not use this tmpfs in kubermatic anymore, I figure it's not needed in today's CI cluster and simply removed it. Otherwise the local-path-provisioner crashloops with

> time="2022-10-29T19:32:16Z" level=fatal msg="Error starting daemon: invalid empty flag helper-pod-file and it also does not exist at ConfigMap local-path-storage/local-path-config with err: helperPod.yaml is not exist in local-path-config ConfigMap"

And this then prevents Minio from coming up, as the PVC stays Pending. The full e2e tests still fail, but this is now related to the way they depend on the KKP repo's scripting. Maybe a future PR could refactor them to setup KKP in the same way as the dashboard-api-e2e tests do it (i.e. use the installler from the docker image).

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
