### PR TITLE
Block Web Terminal access if the feature is not enabled

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -212,6 +212,12 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
+
+		if err := checkWebTerminalEnabled(ctx, providers.SettingsProvider); err != nil {
+			log.Logger.Debug(err)
+			return
+		}
+
 		authenticatedUser, err := verifyAuthorizationToken(req, routing.tokenVerifiers, routing.tokenExtractors)
 		if err != nil {
 			log.Logger.Debug(err)
@@ -355,4 +361,18 @@ func requestLoggingReader(websocket *websocket.Conn) {
 
 		log.Logger.Debug(message)
 	}
+}
+
+func checkWebTerminalEnabled(ctx context.Context, settingsProvider provider.SettingsProvider) error {
+	settings, err := settingsProvider.GetGlobalSettings(ctx)
+
+	if err != nil {
+		return utilerrors.New(http.StatusInternalServerError, "could not read global settings")
+	}
+
+	if !settings.Spec.EnableWebTerminal {
+		return utilerrors.New(http.StatusForbidden, "Web Terminal is disabled by the global settings")
+	}
+
+	return nil
 }

--- a/pkg/test/e2e/api/settings_test.go
+++ b/pkg/test/e2e/api/settings_test.go
@@ -54,6 +54,7 @@ func TestGetDefaultGlobalSettings(t *testing.T) {
 				DisplayAPIDocs:              false,
 				DisplayTermsOfService:       false,
 				EnableDashboard:             true,
+				EnableWebTerminal:           false,
 				EnableOIDCKubeconfig:        false,
 				UserProjectsLimit:           0,
 				RestrictProjectCreation:     false,

--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -1036,6 +1036,7 @@ func convertGlobalSettings(gSettings *models.GlobalSettings) *apiv1.GlobalSettin
 		DisplayTermsOfService: gSettings.DisplayTermsOfService,
 		EnableOIDCKubeconfig:  gSettings.EnableOIDCKubeconfig,
 		EnableDashboard:       gSettings.EnableDashboard,
+		EnableWebTerminal:     gSettings.EnableWebTerminal,
 		OpaOptions: kubermaticv1.OpaOptions{
 			Enabled:  gSettings.OpaOptions.Enabled,
 			Enforced: gSettings.OpaOptions.Enforced,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR disables the Web Terminal feature (backend side) if it's not enabled by configuration.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
