### PR TITLE
Mark E2E tests as optional in release v2.20

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -203,6 +203,7 @@ presubmits:
 
   - name: pre-dashboard-test-e2e
     skip_if_only_changed: "^(containers|docs)/|\\.(md)$"
+    optional: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     labels:
@@ -231,6 +232,7 @@ presubmits:
 
   - name: pre-dashboard-test-e2e-ce
     skip_if_only_changed: "^(containers|docs)/|\\.(md)$"
+    optional: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
E2E tests in `release/v2.20` branch have become too flaky so until those tests are fixed (#5104), marking them as `optional` should make patch release process a bit smoother.
Also, those E2E tests are ignored and are being rewritten since `2.21`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
