### PR TITLE
KubeVirt UI/UX improvements

### DIFF
--- a/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -40,6 +40,7 @@ import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import _ from 'lodash';
 import {Observable} from 'rxjs';
 import {map, takeUntil} from 'rxjs/operators';
+import {KUBERNETES_RESOURCE_NAME_PATTERN} from '@shared/validators/others';
 
 enum Controls {
   VMFlavor = 'vmFlavor',
@@ -110,6 +111,9 @@ export class KubeVirtBasicNodeDataComponent
   nodeAffinityPresetValues: string[] = [];
   selectedFlavorCpus: string;
   selectedFlavorMemory: string;
+  nodeAffinityPresetValuesPattern = KUBERNETES_RESOURCE_NAME_PATTERN;
+  nodeAffinityPresetValuesPatternError =
+    'Field can only contain <b>alphanumeric characters</b> and <b>dashes</b> (a-z, 0-9 and -). <b>Must not start or end with dash</b>.';
 
   constructor(
     private readonly _builder: FormBuilder,

--- a/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/src/app/node-data/basic/provider/kubevirt/template.html
@@ -213,6 +213,8 @@ limitations under the License.
                   [formControlName]="Controls.NodeAffinityPresetValues"
                   [disabled]="form.get(Controls.NodeAffinityPresetValues).disabled"
                   placeholder="Add values..."
+                  [kmPattern]="nodeAffinityPresetValuesPattern"
+                  [kmPatternError]="nodeAffinityPresetValuesPatternError"
                   fxFlex></km-chip-list>
 
     <ng-template #selectAffinityPreset

--- a/src/app/shared/components/chip-list/template.html
+++ b/src/app/shared/components/chip-list/template.html
@@ -42,7 +42,7 @@ limitations under the License.
       Value already exists.
     </mat-error>
     <mat-error *ngIf="form.get(controls.Tags).hasError('pattern')">
-      {{patternError}}
+      <span [innerHTML]="patternError"></span>
     </mat-error>
   </mat-form-field>
 </form>

--- a/src/app/shared/validators/others.ts
+++ b/src/app/shared/validators/others.ts
@@ -18,8 +18,11 @@ export const IPV4_CIDR_PATTERN_VALIDATOR = Validators.pattern(/^((\d{1,3}\.){3}\
 export const IPV6_CIDR_PATTERN_VALIDATOR = Validators.pattern(
   /^s*((([\dA-Fa-f]{1,4}:){7}([\dA-Fa-f]{1,4}|:))|(([\dA-Fa-f]{1,4}:){6}(:[\dA-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([\dA-Fa-f]{1,4}:){5}(((:[\dA-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([\dA-Fa-f]{1,4}:){4}(((:[\dA-Fa-f]{1,4}){1,3})|((:[\dA-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([\dA-Fa-f]{1,4}:){3}(((:[\dA-Fa-f]{1,4}){1,4})|((:[\dA-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([\dA-Fa-f]{1,4}:){2}(((:[\dA-Fa-f]{1,4}){1,5})|((:[\dA-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([\dA-Fa-f]{1,4}:)(((:[\dA-Fa-f]{1,4}){1,6})|((:[\dA-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[\dA-Fa-f]{1,4}){1,7})|((:[\dA-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/(\d|[1-9]\d|1[0-1]\d|12[0-8]))?$/
 );
-export const KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR = Validators.pattern(
-  '^(?=.{1,63}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
-);
+export const KUBERNETES_RESOURCE_NAME_PATTERN =
+  '^(?=.{1,63}$)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*';
+export const KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR = Validators.pattern(KUBERNETES_RESOURCE_NAME_PATTERN);
 export const AKS_POOL_NAME_VALIDATOR = Validators.pattern('[a-z0-9]{0,12}$');
 export const GKE_POOL_NAME_VALIDATOR = Validators.pattern('(?:[a-z](?:[-a-z0-9]{0,38}[a-z0-9])?)');
+export const URL_PATTERN_VALIDATOR = Validators.pattern(
+  /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+$/
+);

--- a/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
+++ b/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
@@ -24,6 +24,7 @@ import {BaseFormValidator} from '@shared/validators/base-form.validator';
 import _ from 'lodash';
 import {merge, Observable, of, onErrorResumeNext} from 'rxjs';
 import {catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
+import {URL_PATTERN_VALIDATOR, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
 
 enum Controls {
   PreAllocatedDataVolumes = 'preAllocatedDataVolumes',
@@ -127,13 +128,16 @@ export class KubeVirtProviderExtendedComponent extends BaseFormValidator impleme
   addPreAllocatedDataVolume(): void {
     this.preAllocatedDataVolumesFormArray.push(
       this._builder.group({
-        [Controls.PreAllocatedDataVolumeName]: this._builder.control('', Validators.required),
+        [Controls.PreAllocatedDataVolumeName]: this._builder.control('', [
+          Validators.required,
+          KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
+        ]),
         [Controls.PreAllocatedDataVolumeSize]: this._builder.control(
           this._defaultPreAllocatedDataVolumeSize,
           Validators.required
         ),
         [Controls.PreAllocatedDataVolumeStorageClass]: this._builder.control('', Validators.required),
-        [Controls.PreAllocatedDataVolumeUrl]: this._builder.control('', Validators.required),
+        [Controls.PreAllocatedDataVolumeUrl]: this._builder.control('', [Validators.required, URL_PATTERN_VALIDATOR]),
       })
     );
   }

--- a/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
+++ b/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
@@ -17,7 +17,8 @@ limitations under the License.
       fxLayout="column"
       fxLayoutGap="8px">
   <km-expansion-panel expandLabel="ADVANCED DISK CONFIGURATION"
-                      collapseLabel="ADVANCED DISK CONFIGURATION">
+                      collapseLabel="ADVANCED DISK CONFIGURATION"
+                      [expanded]="true">
     <mat-card-header class="km-no-padding"
                      fxLayoutAlign=" center">
       <mat-card-title>Custom Local Disks</mat-card-title>
@@ -32,6 +33,13 @@ limitations under the License.
       </button>
 
     </mat-card-header>
+
+    <div class="km-text-muted">
+      Custom local disks are optional disks used for the provisioning of nodes with custom images.
+      <a href="https://docs.kubermatic.com/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt/"
+         target="_blank"
+         rel="noreferrer noopener">Learn more ></a>
+    </div>
 
     <div [formArrayName]="Controls.PreAllocatedDataVolumes"
          fxLayout="column">
@@ -55,15 +63,19 @@ limitations under the License.
           <div fxLayout="row wrap"
                fxLayoutAlign="space-between">
             <div fxFlex="48%">
-              <mat-form-field>
+              <mat-form-field [ngClass]="{'km-long-subscript': control.get(Controls.PreAllocatedDataVolumeName).hasError('pattern')}">
                 <mat-label>Name</mat-label>
                 <input matInput
                        [formControlName]="Controls.PreAllocatedDataVolumeName"
                        [name]="Controls.PreAllocatedDataVolumeName + i"
                        type="text"
                        autocomplete="off">
-                <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeName).hasError( 'required')">
+                <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeName).hasError('required')">
                   <strong>Required</strong>
+                </mat-error>
+                <mat-error
+                           *ngIf="control.get(Controls.PreAllocatedDataVolumeName).hasError('pattern')">
+                  Field can only contain <b>alphanumeric characters</b> and <b>dashes</b> (a-z, 0-9 and -). <b>Must not start or end with dash</b>.
                 </mat-error>
               </mat-form-field>
             </div>
@@ -92,24 +104,19 @@ limitations under the License.
                 <input matInput
                        [formControlName]="Controls.PreAllocatedDataVolumeUrl"
                        [name]="Controls.PreAllocatedDataVolumeUrl + i"
-                       type="text"
+                       type="url"
                        autocomplete="off">
-                <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeUrl).hasError( 'required')">
+                <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeUrl).hasError('required')">
                   <strong>Required</strong>
+                </mat-error>
+                <mat-error *ngIf="control.get(Controls.PreAllocatedDataVolumeUrl).hasError('pattern')">
+                  Please enter a valid <strong>URL</strong>
                 </mat-error>
               </mat-form-field>
             </div>
           </div>
         </div>
       </div>
-    </div>
-
-    <div *ngIf="!preAllocatedDataVolumesFormArray.length"
-         class="km-text-muted">
-      Custom local disks are optional disks used for the provisioning of nodes with custom images.
-      <a href="https://docs.kubermatic.com/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt/"
-         target="_blank"
-         rel="noreferrer noopener">Learn more ></a>
     </div>
   </km-expansion-panel>
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- In the third step while creating a cluster while using the KubeVirt provider, `ADVANCED DISK CONFIGURATION` will be expanded by default.
- Info text under `ADVANCED DISK CONFIGURATION` will stay visible after the user clicks the `Add local Disk` button
- Validation is added to **Custom local disks** `name` and **ADVANCED SCHEDULING SETTINGS** `Node affinity preset values` inputs

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4715

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- While creating a cluster while using the KubeVirt provider, "ADVANCED DISK CONFIGURATION" will be expanded by default.
- Info text under "ADVANCED DISK CONFIGURATION" will stay visible after the user clicks the "Add local Disk" button.
- Validation is added to Custom local disks' "name" and ADVANCED SCHEDULING SETTINGS "node affinity preset values" inputs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
