### PR TITLE
Update web-terminal Docker image to 0.3

### DIFF
--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -62,7 +62,7 @@ const (
 	expirationTimestampKey            = "ExpirationTimestamp"
 	expirationRefreshesKey            = "ExpirationRefreshes"
 
-	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.2.0"
+	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.3.0"
 	webTerminalContainerKubeconfigPath = "/etc/kubernetes/kubeconfig/kubeconfig"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubermatic/kubermatic/pull/11286 built a new image with a more recent kubectl binary on board. This PR makes sure the dashboard is making use of that the image.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
