### PR TITLE
Add Support for ExposeStrategy in network defaults

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -31373,6 +31373,9 @@
       "type": "object",
       "title": "NetworkDefaults contains cluster network default settings.",
       "properties": {
+        "clusterExposeStrategy": {
+          "$ref": "#/definitions/ExposeStrategy"
+        },
         "ipv4": {
           "$ref": "#/definitions/NetworkDefaultsIPFamily"
         },

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -1672,6 +1672,8 @@ type NetworkDefaults struct {
 	ProxyMode string `json:"proxyMode,omitempty"`
 	// NodeLocalDNSCacheEnabled controls whether the NodeLocal DNS Cache feature is enabled.
 	NodeLocalDNSCacheEnabled bool `json:"nodeLocalDNSCacheEnabled,omitempty"`
+	// ClusterExposeStrategy is the strategy used to expose a cluster control plane.
+	ClusterExposeStrategy kubermaticv1.ExposeStrategy `json:"clusterExposeStrategy,omitempty"`
 }
 
 // NetworkDefaultsIPFamily contains cluster network default settings for an IP family.

--- a/pkg/handler/v2/networkdefaults/networkdefaults_test.go
+++ b/pkg/handler/v2/networkdefaults/networkdefaults_test.go
@@ -68,6 +68,7 @@ func TestGetEndpoint(t *testing.T) {
 				},
 				ProxyMode:                resources.IPVSProxyMode,
 				NodeLocalDNSCacheEnabled: true,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 		{
@@ -94,6 +95,7 @@ func TestGetEndpoint(t *testing.T) {
 				},
 				ProxyMode:                resources.IPVSProxyMode,
 				NodeLocalDNSCacheEnabled: true,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 		{
@@ -120,6 +122,7 @@ func TestGetEndpoint(t *testing.T) {
 				},
 				ProxyMode:                resources.IPTablesProxyMode,
 				NodeLocalDNSCacheEnabled: true,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 	}

--- a/pkg/handler/v2/networkdefaults/networkdefaults_unit_test.go
+++ b/pkg/handler/v2/networkdefaults/networkdefaults_unit_test.go
@@ -53,6 +53,7 @@ func TestOverrideNetworkDefaultsByDefaultingTemplate(t *testing.T) {
 				},
 				ProxyMode:                "ipvs",
 				NodeLocalDNSCacheEnabled: true,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 		{
@@ -74,6 +75,7 @@ func TestOverrideNetworkDefaultsByDefaultingTemplate(t *testing.T) {
 				},
 				ProxyMode:                "ipvs",
 				NodeLocalDNSCacheEnabled: true,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 		{
@@ -95,6 +97,7 @@ func TestOverrideNetworkDefaultsByDefaultingTemplate(t *testing.T) {
 				},
 				ProxyMode:                "iptables",
 				NodeLocalDNSCacheEnabled: true,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 		{
@@ -131,6 +134,7 @@ func TestOverrideNetworkDefaultsByDefaultingTemplate(t *testing.T) {
 				},
 				ProxyMode:                "ipvs",
 				NodeLocalDNSCacheEnabled: false,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 		{
@@ -168,6 +172,7 @@ func TestOverrideNetworkDefaultsByDefaultingTemplate(t *testing.T) {
 				},
 				ProxyMode:                "proxy-test",
 				NodeLocalDNSCacheEnabled: false,
+				ClusterExposeStrategy:    "NodePort",
 			},
 		},
 	}

--- a/pkg/handler/v2/routes_v2.go
+++ b/pkg/handler/v2/routes_v2.go
@@ -8002,7 +8002,7 @@ func (r Routing) getNetworkDefaults() http.Handler {
 			middleware.TokenVerifier(r.tokenVerifiers, r.userProvider),
 			middleware.UserSaver(r.userProvider),
 			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
-		)(networkdefaults.GetNetworkDefaultsEndpoint(r.seedsGetter, r.userInfoGetter)),
+		)(networkdefaults.GetNetworkDefaultsEndpoint(r.seedsGetter, r.userInfoGetter, r.kubermaticConfigGetter)),
 		networkdefaults.DecodeGetNetworkDefaultsReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,

--- a/pkg/test/e2e/utils/apiclient/models/network_defaults.go
+++ b/pkg/test/e2e/utils/apiclient/models/network_defaults.go
@@ -24,6 +24,9 @@ type NetworkDefaults struct {
 	// ProxyMode defines the default kube-proxy mode ("ipvs" / "iptables" / "ebpf").
 	ProxyMode string `json:"proxyMode,omitempty"`
 
+	// cluster expose strategy
+	ClusterExposeStrategy ExposeStrategy `json:"clusterExposeStrategy,omitempty"`
+
 	// ipv4
 	IPV4 *NetworkDefaultsIPFamily `json:"ipv4,omitempty"`
 
@@ -34,6 +37,10 @@ type NetworkDefaults struct {
 // Validate validates this network defaults
 func (m *NetworkDefaults) Validate(formats strfmt.Registry) error {
 	var res []error
+
+	if err := m.validateClusterExposeStrategy(formats); err != nil {
+		res = append(res, err)
+	}
 
 	if err := m.validateIPV4(formats); err != nil {
 		res = append(res, err)
@@ -46,6 +53,23 @@ func (m *NetworkDefaults) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *NetworkDefaults) validateClusterExposeStrategy(formats strfmt.Registry) error {
+	if swag.IsZero(m.ClusterExposeStrategy) { // not required
+		return nil
+	}
+
+	if err := m.ClusterExposeStrategy.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("clusterExposeStrategy")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("clusterExposeStrategy")
+		}
+		return err
+	}
+
 	return nil
 }
 
@@ -91,6 +115,10 @@ func (m *NetworkDefaults) validateIPV6(formats strfmt.Registry) error {
 func (m *NetworkDefaults) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateClusterExposeStrategy(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateIPV4(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -102,6 +130,20 @@ func (m *NetworkDefaults) ContextValidate(ctx context.Context, formats strfmt.Re
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *NetworkDefaults) contextValidateClusterExposeStrategy(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.ClusterExposeStrategy.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("clusterExposeStrategy")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("clusterExposeStrategy")
+		}
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -115,6 +115,11 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("exposeStrategy"), "cannot create cluster with Tunneling expose strategy because the TunnelingExposeStrategy feature gate is not enabled"))
 	}
 
+	// Validate APIServerAllowedIPRanges for LoadBalancer expose strategy
+	if spec.ExposeStrategy != kubermaticv1.ExposeStrategyLoadBalancer && spec.APIServerAllowedIPRanges != nil {
+		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("APIServerAllowedIPRanges"), "Access control for API server is supported only for LoadBalancer expose strategy"))
+	}
+
 	// External CCM is not supported for all providers and all Kubernetes versions.
 	if spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 		if !resources.ExternalCloudControllerFeatureSupported(dc, &spec.Cloud, spec.Version, versionManager.GetIncompatibilities()...) {


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
This PR implements web hook validation  and default value for ExposeStrategy. This is required for feature [#11119](https://github.com/kubermatic/kubermatic/issues/11119)
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This PR changes are part of Allowed API server source IP ranges feature. This has only validation and defaulting changes, other feature logic is part of Kubermatic repo.
**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
