### PR TITLE
Remove vSphere overwrite cloud spec from machine deployment

### DIFF
--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -31,7 +31,6 @@ import (
 	"k8c.io/dashboard/v2/pkg/validation"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/resources/cloudconfig"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 	osmresources "k8c.io/operating-system-manager/pkg/controllers/osc/resources"
 
@@ -159,11 +158,6 @@ func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *ku
 		err      error
 	)
 
-	credentials, err := resources.GetCredentials(data)
-	if err != nil {
-		return nil, err
-	}
-
 	switch {
 	case nd.Spec.Template.Cloud.AWS != nil && dc.Spec.AWS != nil:
 		config.CloudProvider = providerconfig.CloudProviderAWS
@@ -179,15 +173,6 @@ func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *ku
 		}
 	case nd.Spec.Template.Cloud.VSphere != nil && dc.Spec.VSphere != nil:
 		config.CloudProvider = providerconfig.CloudProviderVsphere
-
-		// We use OverwriteCloudConfig for VSphere to ensure we always use the credentials
-		// passed in via frontend for the cloud-provider functionality.
-		overwriteCloudConfig, err := cloudconfig.CloudConfig(c, dc, credentials)
-		if err != nil {
-			return nil, err
-		}
-		config.OverwriteCloudConfig = &overwriteCloudConfig
-
 		cloudExt, err = getVSphereProviderSpec(c, nd.Spec.Template, dc)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Machine deployment for vSphere, contains the credentials for vcenter, written explicitly. This pr removes that overwriteCloudSpec field and rely only on the OSM configs 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/4974

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove the overwriteCloudSpec field from vSphere Machine Deployment 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
