### PR TITLE
Ignore broken seeds during API requests

### DIFF
--- a/cmd/kubermatic-api/main.go
+++ b/cmd/kubermatic-api/main.go
@@ -577,7 +577,7 @@ func createAPIHandler(options serverRunOptions, prov providers, oidcIssuerVerifi
 				dummyWriter := newResponseLogger(w)
 				next.ServeHTTP(dummyWriter, r)
 
-				log.Debugw("response", "body", dummyWriter.buf.String(), "status", dummyWriter.statusCode)
+				log.Debugw("response", "body", dummyWriter.buf.String(), "status", dummyWriter.statusCode, "uri", r.RequestURI)
 			})
 		})
 	}

--- a/pkg/handler/middleware/middleware.go
+++ b/pkg/handler/middleware/middleware.go
@@ -33,6 +33,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	"k8c.io/kubermatic/v2/pkg/log"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -427,7 +428,9 @@ func getClusterProviderByClusterID(ctx context.Context, seeds map[string]*kuberm
 	for _, seed := range seeds {
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
-			return nil, ctx, utilerrors.NewNotFound("cluster-provider", clusterID)
+			// if one or more Seeds are bad, continue with the request, log that a Seed is in error
+			log.Logger.Warnw("error getting cluster provider", "cluster", clusterID, "seed", seed.Name, "error", err)
+			continue
 		}
 		if clusterProvider.IsCluster(ctx, clusterID) {
 			return clusterProvider, ctx, nil
@@ -623,7 +626,9 @@ func getRuleGroupProvider(ctx context.Context, clusterProviderGetter provider.Cl
 		for _, seed := range seeds {
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
-				return nil, common.KubernetesErrorToHTTPError(err)
+				// if one or more Seeds are bad, continue with the request, log that a Seed is in error
+				log.Logger.Warnw("error getting cluster provider", "cluster", clusterID, "seed", seed.Name, "error", err)
+				continue
 			}
 			if clusterProvider.IsCluster(ctx, clusterID) {
 				seedName = seed.Name

--- a/pkg/handler/middleware/middleware.go
+++ b/pkg/handler/middleware/middleware.go
@@ -31,9 +31,9 @@ import (
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/log"
 	kubermaticcontext "k8c.io/kubermatic/v2/pkg/util/context"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
-	"k8c.io/kubermatic/v2/pkg/log"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/provider/kubernetes/etcdbackupconfig.go
+++ b/pkg/provider/kubernetes/etcdbackupconfig.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/log"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,7 +183,9 @@ func EtcdBackupConfigProjectProviderFactory(mapper meta.RESTMapper, seedKubeconf
 		for seedName, seed := range seeds {
 			cfg, err := seedKubeconfigGetter(seed)
 			if err != nil {
-				return nil, err
+				// if one or more Seeds are bad, continue with the request, log that a Seed is in error
+				log.Logger.Warnw("error getting seed kubeconfig", "seed", seedName, "error", err)
+				continue
 			}
 			createSeedImpersonationClients[seedName] = NewImpersonationClient(cfg, mapper).CreateImpersonatedClient
 			clientPrivileged, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{Mapper: mapper})

--- a/pkg/provider/kubernetes/etcdrestore.go
+++ b/pkg/provider/kubernetes/etcdrestore.go
@@ -22,6 +22,7 @@ import (
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
+	"k8c.io/kubermatic/v2/pkg/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -167,7 +168,9 @@ func EtcdRestoreProjectProviderFactory(mapper meta.RESTMapper, seedKubeconfigGet
 		for seedName, seed := range seeds {
 			cfg, err := seedKubeconfigGetter(seed)
 			if err != nil {
-				return nil, err
+				// if one or more Seeds are bad, continue with the request, log that a Seed is in error
+				log.Logger.Warnw("error getting seed kubeconfig", "seed", seedName, "error", err)
+				continue
 			}
 			createSeedImpersonationClients[seedName] = NewImpersonationClient(cfg, mapper).CreateImpersonatedClient
 			clientPrivileged, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{Mapper: mapper})

--- a/pkg/provider/kubernetes/etcdrestore.go
+++ b/pkg/provider/kubernetes/etcdrestore.go
@@ -21,8 +21,8 @@ import (
 
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-
 	"k8c.io/kubermatic/v2/pkg/log"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
**What this PR does / why we need it**:

The problem this PR tries to fix is that when a particular Seed is misconfigured or not responding, the requests which need to go through the whole list of seeds and get its kubeconfigs and/or create some providers based on them fail because that Seed is broken. 

The new approach would be to ignore those Seeds, and just list (for example Clusters) from working Seeds. This enables the API/UI to still work, at least for the working Seeds. BUT on the other hand the issue is hidden now, and just appears in logs.

To make it clear to API/UI that some Seeds are broken and the results they are getting may not be complete, we will add a new Seed health endpoint, which will return information about Seed health. #5225

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5108 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The KKP API/UI will now return partial results from requests to resources which are listed across seeds, as the broken/unaccesible seeds will now be skipped. The behaviour before was that the whole request fails.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
