### PR TITLE
Fix for server group defaulting

### DIFF
--- a/src/app/node-data/basic/provider/openstack/component.ts
+++ b/src/app/node-data/basic/provider/openstack/component.ts
@@ -256,6 +256,8 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
         const serverGroup = this.serverGroups.find(
           key => key.id === this._nodeDataService.nodeData.spec.cloud.openstack.serverGroup
         )?.name;
+
+        this.selectedServerGroupID = this._nodeDataService.nodeData.spec.cloud.openstack.serverGroup;
         this.form.get(Controls.ServerGroup).setValue(serverGroup);
       }
 
@@ -395,7 +397,7 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
             diskSize: this.form.get(Controls.DiskSize).value,
             instanceReadyCheckPeriod: `${this.form.get(Controls.InstanceReadyCheckPeriod).value}s`,
             instanceReadyCheckTimeout: `${this.form.get(Controls.InstanceReadyCheckTimeout).value}s`,
-            serverGroup: this.form.get(Controls.ServerGroup).value,
+            serverGroup: this.selectedServerGroupID,
           } as OpenstackNodeSpec,
         } as NodeCloudSpec,
       } as NodeSpec,


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Fixes a small bug where `serverGroup` field in initial machine deployment step(wizard) was being incorrectly initialized.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
