### PR TITLE
Add OpenIDAuthPlugin feature gate to API

### DIFF
--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -1044,6 +1044,7 @@ type FeatureGates struct {
 	KonnectivityService    *bool `json:"konnectivityService,omitempty"`
 	OIDCKubeCfgEndpoint    *bool `json:"oidcKubeCfgEndpoint,omitempty"`
 	OperatingSystemManager *bool `json:"operatingSystemManager,omitempty"`
+	OpenIDAuthPlugin       *bool `json:"openIDAuthPlugin,omitempty"`
 }
 
 // ExternalClusterMachineDeploymentCloudSpec represents an object holding machine deployment cloud details.

--- a/pkg/provider/kubernetes/featuregates.go
+++ b/pkg/provider/kubernetes/featuregates.go
@@ -39,7 +39,7 @@ func (fg featureGatesProvider) GetFeatureGates() (apiv2.FeatureGates, error) {
 	if v, ok := fg[features.OIDCKubeCfgEndpoint]; ok {
 		f.OIDCKubeCfgEndpoint = &v
 	}
-	if v,ok := fg[features.OpenIDAuthPlugin]; ok {
+	if v, ok := fg[features.OpenIDAuthPlugin]; ok {
 		f.OpenIDAuthPlugin = &v
 	}
 

--- a/pkg/provider/kubernetes/featuregates.go
+++ b/pkg/provider/kubernetes/featuregates.go
@@ -39,6 +39,9 @@ func (fg featureGatesProvider) GetFeatureGates() (apiv2.FeatureGates, error) {
 	if v, ok := fg[features.OIDCKubeCfgEndpoint]; ok {
 		f.OIDCKubeCfgEndpoint = &v
 	}
+	if v,ok := fg[features.OpenIDAuthPlugin]; ok {
+		f.OpenIDAuthPlugin = &v
+	}
 
 	return f, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to return `OpenIDAuthPlugin` feature gate in order to conditionally let the administrator enable or disable the kubernetes dashboard functionality.

**Which issue(s) this PR fixes**:
Relates to #5220 

**What type of PR is this?**
/kind regression

**Special notes for your reviewer**:
Swagger gen is broken at the moment, hence I did not attach it.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
