### PR TITLE
Added logic disable "Enable Kubernetes Dashboard" checkbox

### DIFF
--- a/modules/web/src/app/core/services/feature-gate.ts
+++ b/modules/web/src/app/core/services/feature-gate.ts
@@ -22,6 +22,7 @@ import {catchError, shareReplay, switchMap} from 'rxjs/operators';
 export interface FeatureGates {
   konnectivityService?: boolean;
   oidcKubeCfgEndpoint?: boolean;
+  openIDAuthPlugin?: boolean;
 }
 
 @Injectable({

--- a/modules/web/src/app/settings/admin/interface/template.html
+++ b/modules/web/src/app/settings/admin/interface/template.html
@@ -82,7 +82,19 @@ limitations under the License.
         </div>
         <mat-checkbox [(ngModel)]="settings.enableDashboard"
                       (change)="onSettingsChange()"
-                      id="km-enable-kubernetes-dashboard-setting"></mat-checkbox>
+                      [disabled]="!isKubernetesDashboardFeatureGatesEnabled()"
+                      id="km-enable-kubernetes-dashboard-setting">
+          <ng-container *ngIf="!isKubernetesDashboardFeatureGatesEnabled()">
+            <mat-hint>This feature is disabled. Visit the
+              <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
+                 target="_blank"
+                 rel="noopener noreferrer">
+                documentation
+              </a>
+              to learn more.
+            </mat-hint>
+          </ng-container>
+        </mat-checkbox>
         <km-spinner-with-confirmation [isSaved]="isEqual(settings.enableDashboard, apiSettings.enableDashboard)"></km-spinner-with-confirmation>
       </div>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Logic to disable the `Enable Kubernetes Dashboard` checkbox in the `admin setting > interface` page based on `OIDCKubeCfgEndpoint` and `OpenIDAuthPlugin` feature gates 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5220

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
In the interface section of admin settings, Enable Kubernetes Dashboard checkbox will be disabled when either OIDCKubeCfgEndpoint or OpenIDAuthPlugin feature flags are disabled
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
