### PR TITLE
Option to enforce custom disk for OpenStack machines

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/openstack/template.html
+++ b/modules/web/src/app/node-data/basic/provider/openstack/template.html
@@ -36,7 +36,7 @@ limitations under the License.
       </div>
     </km-combobox>
 
-    <mat-checkbox [formControlName]="Controls.CustomDiskSize"
+    <mat-checkbox [formControlName]="Controls.UseCustomDisk"
                   class="custom-disk-size">
       Custom Disk
       <i class="km-pointer km-custom-disk-size-info-icon"
@@ -44,8 +44,8 @@ limitations under the License.
     </mat-checkbox>
   </div>
 
-  <km-number-stepper *ngIf="!!form.get(Controls.CustomDiskSize).value"
-                     [formControlName]="Controls.DiskSize"
+  <km-number-stepper *ngIf="form.get(Controls.UseCustomDisk).value"
+                     [formControlName]="Controls.CustomDiskSize"
                      mode="errors"
                      label="Disk Size in GB"
                      hint="An additional network storage volume will be created and used as the disk for the VM."

--- a/modules/web/src/app/settings/admin/defaults/template.html
+++ b/modules/web/src/app/settings/admin/defaults/template.html
@@ -278,3 +278,44 @@ limitations under the License.
     </div>
   </mat-card-content>
 </mat-card>
+
+<mat-card>
+  <mat-card-header>
+    <mat-card-title fxFlex
+                    fxLayout="row"
+                    fxLayoutAlign=" center">
+      <div fxFlex>Provider Defaults</div>
+    </mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <div fxLayout="column"
+         fxLayoutGap="32px"
+         class="admin-settings">
+      <div fxFlex
+           fxLayout="column"
+           fxLayoutGap="16px">
+
+        <div fxLayout="row"
+             fxLayoutAlign=" center">
+          <div fxFlex="16%"
+               fxLayoutAlign=" center"
+               class="entry-label">
+            <span>OpenStack - Custom Disk</span>
+            <div class="km-icon-info km-pointer"
+                 matTooltip="Used to enforce custom disks for OpenStack machines."></div>
+          </div>
+          <div fxFlexAlign=" center"
+               fxLayout="row">
+            <mat-checkbox [(ngModel)]="settings.providerConfiguration.openStack.enforceCustomDisk"
+                          (change)="onSettingsChange()"
+                          id="km-openstack-enforce-custom-disk"
+                          fxFlexAlign=" center">Enforce Default
+            </mat-checkbox>
+            <km-spinner-with-confirmation [isSaved]="isEqual(settings.providerConfiguration.openStack.enforceCustomDisk, settings.providerConfiguration.openStack.enforceCustomDisk)"></km-spinner-with-confirmation>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/modules/web/src/app/shared/entity/settings.ts
+++ b/modules/web/src/app/shared/entity/settings.ts
@@ -44,6 +44,7 @@ export interface AdminSettings {
   mlaAlertmanagerPrefix: string;
   mlaGrafanaPrefix: string;
   notifications?: NotificationOptions;
+  providerConfiguration?: ProviderConfiguration;
 }
 
 export interface MachineDeploymentVMResourceQuota {
@@ -74,6 +75,14 @@ export interface MLAOptions {
 export interface NotificationOptions {
   hideErrors: boolean;
   hideErrorEvents: boolean;
+}
+
+export interface ProviderConfiguration {
+  openStack: OpenStack;
+}
+
+export interface OpenStack {
+  enforceCustomDisk: boolean;
 }
 
 export class CustomLink {


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
This PR adds an option to enforce custom disks on OpenStack. This setting can be toggled from the admin settings.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5243

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduced an option in admin settings to enforce custom disks for OpenStack Machines.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
