### PR TITLE
Add support for Nutanix categories

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/machine-deployment-details/template.html
+++ b/modules/web/src/app/cluster/details/cluster/machine-deployment-details/template.html
@@ -137,6 +137,12 @@ limitations under the License.
             <div key>Disk Size</div>
             <div value>{{machineDeployment.spec.template.cloud.nutanix.diskSize}} GB</div>
           </km-property>
+          <km-property *ngIf="machineDeployment.spec.template.cloud.nutanix.categories as categories">
+            <div key>Categories</div>
+            <div value>
+              <km-labels [labels]="categories"></km-labels>
+            </div>
+          </km-property>
         </ng-container>
 
         <ng-container *ngIf="machineDeployment.spec.template.cloud.vmwareclouddirector as vmwareclouddirector">

--- a/modules/web/src/app/core/services/node-data/provider/nutanix.ts
+++ b/modules/web/src/app/core/services/node-data/provider/nutanix.ts
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 import {NodeDataMode} from '@app/node-data/config';
-import {ProjectService} from '@core/services/project';
-import {PresetsService} from '@core/services/wizard/presets';
-import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {ClusterSpecService} from '@core/services/cluster-spec';
-import {merge, Observable, of, onErrorResumeNext} from 'rxjs';
-import {catchError, debounceTime, filter, map, switchMap, take, tap} from 'rxjs/operators';
-import {NodeDataService} from '../service';
+import {ProjectService} from '@core/services/project';
 import {NutanixService} from '@core/services/provider/nutanix';
-import {NutanixSubnet} from '@shared/entity/provider/nutanix';
+import {PresetsService} from '@core/services/wizard/presets';
+import {NutanixCategory, NutanixCategoryValue, NutanixSubnet} from '@shared/entity/provider/nutanix';
+import {NodeProvider} from '@shared/model/NodeProviderConstants';
+import {merge, Observable, of, onErrorResumeNext} from 'rxjs';
+import {catchError, debounceTime, filter, map, startWith, switchMap, take, tap} from 'rxjs/operators';
+import {NodeDataService} from '../service';
 
 export class NodeDataNutanixProvider {
   private readonly _debounce = 500;
@@ -70,6 +70,113 @@ export class NodeDataNutanixProvider {
           .pipe(tap(project => (selectedProject = project.id)))
           .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
           .pipe(switchMap(_ => this._nutanixService.getSubnets(selectedProject, this._clusterSpecService.cluster.id)))
+          .pipe(
+            catchError(_ => {
+              if (onError) {
+                onError();
+              }
+
+              return onErrorResumeNext(of([]));
+            })
+          )
+          .pipe(take(1));
+      }
+    }
+  }
+
+  categories(onError: () => void = undefined, onLoadingCb: () => void = null): Observable<NutanixCategory[]> {
+    switch (this._nodeDataService.mode) {
+      case NodeDataMode.Wizard:
+        return merge(this._clusterSpecService.clusterChanges, this._clusterSpecService.providerSpecChanges)
+          .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.NUTANIX))
+          .pipe(debounceTime(this._debounce))
+          .pipe(switchMap(() => this._projectService.selectedProject.pipe(take(1))))
+          .pipe(
+            switchMap(project => {
+              const cluster = this._clusterSpecService.cluster;
+              return this._presetService
+                .provider(NodeProvider.NUTANIX)
+                .username(cluster.spec.cloud.nutanix.username)
+                .password(cluster.spec.cloud.nutanix.password)
+                .proxyURL(cluster.spec.cloud.nutanix.proxyURL)
+                .credential(this._presetService.preset)
+                .categories(cluster.spec.cloud.dc, project.id, onLoadingCb)
+                .pipe(
+                  catchError(_ => {
+                    if (onError) {
+                      onError();
+                    }
+                    return onErrorResumeNext(of([]));
+                  })
+                );
+            })
+          );
+      case NodeDataMode.Dialog: {
+        let selectedProject: string;
+        return this._projectService.selectedProject
+          .pipe(debounceTime(this._debounce))
+          .pipe(tap(project => (selectedProject = project.id)))
+          .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
+          .pipe(
+            switchMap(_ => this._nutanixService.getCategories(selectedProject, this._clusterSpecService.cluster.id))
+          )
+          .pipe(
+            catchError(_ => {
+              if (onError) {
+                onError();
+              }
+
+              return onErrorResumeNext(of([]));
+            })
+          )
+          .pipe(take(1));
+      }
+    }
+  }
+
+  categoryValues(
+    categoryName: string,
+    onError: () => void = undefined,
+    onLoadingCb: () => void = null
+  ): Observable<NutanixCategoryValue[]> {
+    switch (this._nodeDataService.mode) {
+      case NodeDataMode.Wizard:
+        return merge(this._clusterSpecService.clusterChanges, this._clusterSpecService.providerSpecChanges)
+          .pipe(startWith(true))
+          .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.NUTANIX))
+          .pipe(debounceTime(this._debounce))
+          .pipe(switchMap(() => this._projectService.selectedProject.pipe(take(1))))
+          .pipe(
+            switchMap(project => {
+              const cluster = this._clusterSpecService.cluster;
+              return this._presetService
+                .provider(NodeProvider.NUTANIX)
+                .username(cluster.spec.cloud.nutanix.username)
+                .password(cluster.spec.cloud.nutanix.password)
+                .proxyURL(cluster.spec.cloud.nutanix.proxyURL)
+                .credential(this._presetService.preset)
+                .categoryValues(cluster.spec.cloud.dc, project.id, categoryName, onLoadingCb)
+                .pipe(
+                  catchError(_ => {
+                    if (onError) {
+                      onError();
+                    }
+                    return onErrorResumeNext(of([]));
+                  })
+                );
+            })
+          );
+      case NodeDataMode.Dialog: {
+        let selectedProject: string;
+        return this._projectService.selectedProject
+          .pipe(debounceTime(this._debounce))
+          .pipe(tap(project => (selectedProject = project.id)))
+          .pipe(tap(_ => (onLoadingCb ? onLoadingCb() : null)))
+          .pipe(
+            switchMap(_ =>
+              this._nutanixService.getCategoryValues(selectedProject, this._clusterSpecService.cluster.id, categoryName)
+            )
+          )
           .pipe(
             catchError(_ => {
               if (onError) {

--- a/modules/web/src/app/core/services/provider/nutanix.ts
+++ b/modules/web/src/app/core/services/provider/nutanix.ts
@@ -15,8 +15,8 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {environment} from '@environments/environment';
-import {Observable} from 'rxjs';
-import {NutanixSubnet} from '@shared/entity/provider/nutanix';
+import {catchError, Observable, of} from 'rxjs';
+import {NutanixCategory, NutanixCategoryValue, NutanixSubnet} from '@shared/entity/provider/nutanix';
 
 @Injectable()
 export class NutanixService {
@@ -27,5 +27,15 @@ export class NutanixService {
   getSubnets(projectID: string, clusterID: string): Observable<NutanixSubnet[]> {
     const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/providers/nutanix/subnets`;
     return this._httpClient.get<NutanixSubnet[]>(url);
+  }
+
+  getCategories(projectID: string, clusterID: string): Observable<NutanixCategory[]> {
+    const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/providers/nutanix/categories`;
+    return this._httpClient.get<NutanixCategory[]>(url).pipe(catchError(() => of([])));
+  }
+
+  getCategoryValues(projectID: string, clusterID: string, categoryName: string): Observable<NutanixCategoryValue[]> {
+    const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/providers/nutanix/categories/${categoryName}/values`;
+    return this._httpClient.get<NutanixCategoryValue[]>(url).pipe(catchError(() => of([])));
   }
 }

--- a/modules/web/src/app/core/services/wizard/provider/nutanix.ts
+++ b/modules/web/src/app/core/services/wizard/provider/nutanix.ts
@@ -16,7 +16,13 @@ import {HttpClient} from '@angular/common/http';
 import {EMPTY, Observable} from 'rxjs';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {Provider} from './provider';
-import {NutanixCluster, NutanixProject, NutanixSubnet} from '@shared/entity/provider/nutanix';
+import {
+  NutanixCategory,
+  NutanixCategoryValue,
+  NutanixCluster,
+  NutanixProject,
+  NutanixSubnet,
+} from '@shared/entity/provider/nutanix';
 
 export class Nutanix extends Provider {
   constructor(http: HttpClient, provider: NodeProvider) {
@@ -107,6 +113,39 @@ export class Nutanix extends Provider {
 
     const url = `${this._newRestRoot}/providers/${this._provider}/${seed}/subnets`;
     return this._http.get<NutanixSubnet[]>(url, {headers: this._headers});
+  }
+
+  categories(seed: string, projectID: string, onLoadingCb: () => void = null): Observable<NutanixCategory[]> {
+    this._setRequiredHeaders(Nutanix.Header.NutanixUsername, Nutanix.Header.NutanixPassword);
+    if (!this._hasRequiredHeaders() || !seed) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._newRestRoot}/projects/${projectID}/providers/${this._provider}/${seed}/categories`;
+    return this._http.get<NutanixCategory[]>(url, {headers: this._headers});
+  }
+
+  categoryValues(
+    seed: string,
+    projectID: string,
+    categoryName: string,
+    onLoadingCb: () => void = null
+  ): Observable<NutanixCategoryValue[]> {
+    this._setRequiredHeaders(Nutanix.Header.NutanixUsername, Nutanix.Header.NutanixPassword);
+    if (!this._hasRequiredHeaders() || !seed) {
+      return EMPTY;
+    }
+
+    if (onLoadingCb) {
+      onLoadingCb();
+    }
+
+    const url = `${this._newRestRoot}/projects/${projectID}/providers/${this._provider}/${seed}/categories/${categoryName}/values`;
+    return this._http.get<NutanixCategoryValue[]>(url, {headers: this._headers});
   }
 }
 

--- a/modules/web/src/app/node-data/basic/provider/nutanix/style.scss
+++ b/modules/web/src/app/node-data/basic/provider/nutanix/style.scss
@@ -1,4 +1,4 @@
-// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export class NutanixSubnet {
-  name: string;
-  type: string;
-  vlanID?: number;
+.mat-icon-button {
+  &.delete-button {
+    margin-top: 4px;
+  }
 }
 
-export class NutanixCluster {
-  name: string;
-}
-
-export class NutanixProject {
-  name: string;
-}
-
-export class NutanixCategory {
-  name: string;
-  description: string;
-  systemDefined: boolean;
-}
-
-export class NutanixCategoryValue {
-  value: string;
+.categories-msg {
+  padding-bottom: 15px;
 }

--- a/modules/web/src/app/node-data/basic/provider/nutanix/template.html
+++ b/modules/web/src/app/node-data/basic/provider/nutanix/template.html
@@ -69,4 +69,59 @@ limitations under the License.
                      min="1"
                      required>
   </km-number-stepper>
+
+  <mat-card-header class="km-no-padding"
+                   fxLayoutAlign=" center">
+    <mat-card-title>Categories</mat-card-title>
+    <div fxFlex></div>
+    <button fxLayoutAlign="center center"
+            mat-flat-button
+            type="button"
+            color="quaternary"
+            (click)="addCategory()">
+      <i class="km-icon-mask km-icon-add"></i>
+      <span>Add Category</span>
+    </button>
+  </mat-card-header>
+
+  <div [formArrayName]="Controls.Categories">
+    <div *ngFor="let control of categoriesFormArray.controls; let i = index"
+         [formGroupName]="i">
+      <div fxFlex
+           fxLayoutGap="10px">
+        <km-combobox [options]="filteredCategories[getSelectedCategory(control) || '']"
+                     [formControlName]="Controls.Category"
+                     [label]="getCategoryLabel(control)"
+                     [required]="true"
+                     inputLabel="Select category..."
+                     filterBy="name"
+                     fxFlex>
+          <div *option="let category">{{category.name}}</div>
+        </km-combobox>
+        <km-combobox [options]="categoryValues[getSelectedCategory(control)]"
+                     [formControlName]="Controls.CategoryValue"
+                     [label]="categoryValuesLabel[getSelectedCategory(control)] || CategoryValueState.Empty"
+                     [isDisabled]="control.get(Controls.Category).invalid"
+                     [required]="true"
+                     inputLabel="Select category value..."
+                     filterBy="value"
+                     fxFlex>
+          <div *option="let categoryValue">{{categoryValue.value}}</div>
+        </km-combobox>
+        <button mat-icon-button
+                type="button"
+                matTooltip="Delete category"
+                class="delete-button"
+                (click)="removeCategory(i)">
+          <i class="km-icon-mask km-icon-delete"></i>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div *ngIf="categoriesFormArray.length === 0"
+       class="categories-msg km-text-muted">
+    Select categories for Nutanix.
+  </div>
+
 </form>

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -841,6 +841,12 @@ limitations under the License.
                   <div key>Disk Size</div>
                   <div value>{{machineDeployment.spec.template.cloud.nutanix.diskSize}} GB</div>
                 </km-property>
+                <km-property *ngIf="displayTags(machineDeployment.spec.template.cloud.nutanix.categories)">
+                  <div key>Categories</div>
+                  <div value>
+                    <km-labels [labels]="machineDeployment.spec.template.cloud.nutanix.categories"></km-labels>
+                  </div>
+                </km-property>
               </ng-container>
               <km-property-boolean *ngIf="machineDeployment.spec.template.cloud.nutanix?.cpuPassthrough"
                                    label="CPU Passthrough"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for configuring categories in Nutanix provider.

**Cluster Wizard:**

![screenshot-localhost_8000-2022 11 14-23_28_00](https://user-images.githubusercontent.com/13975988/201738432-fd9d94cf-4212-42e1-83a8-f43e16402927.png)

**Cluster Wizard Summary:**

![screenshot-localhost_8000-2022 11 14-23_28_34](https://user-images.githubusercontent.com/13975988/201738492-7e911171-ff40-4bac-a8fa-d9323ba1153f.png)


**Edit Machine Deployment:**

![screenshot-localhost_8000-2022 11 14-23_26_08](https://user-images.githubusercontent.com/13975988/201738542-24d874d3-9d9f-4e27-a70d-b4dfee857551.png)


**Machine Deployment Details:**

![screenshot-localhost_8000-2022 11 14-23_26_40](https://user-images.githubusercontent.com/13975988/201738606-c06a26d6-5893-4dee-9a27-f63abf3cb4bd.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4160 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
