### PR TITLE
Use the same version for the KKP installer as is pinned in go.mod

### DIFF
--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -36,7 +36,7 @@ if [[ "${PULL_BASE_REF:-main}" =~ release/v[0-9]+.* ]]; then
   KUBERMATIC_VERSION="${PULL_BASE_REF#release/}"
   KUBERMATIC_VERSION="${KUBERMATIC_VERSION//\//-}-latest"
 else
-  KUBERMATIC_VERSION=latest
+  KUBERMATIC_VERSION="$(kubermatic_git_hash)"
 fi
 
 export DASHBOARD_VERSION="${DASHBOARD_VERSION:-$(git rev-parse HEAD)}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to make the dashboard API tests more reliable. Instead of following KKP and breaking everytime a change is made over there, we now deduce the KKP version based on what we have in our go.mod. With a bit of Github hackery we can translate Go's pseudo version into the full Git commit hash.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
