### PR TITLE
Remove Nutanix system categories from api response

### DIFF
--- a/modules/api/pkg/machine/convert.go
+++ b/modules/api/pkg/machine/convert.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/userdata/sles"
 	"github.com/kubermatic/machine-controller/pkg/userdata/ubuntu"
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
+	nutanixprovider "k8c.io/dashboard/v2/pkg/provider/cloud/nutanix"
 
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/pointer"
@@ -390,10 +391,16 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			if err := json.Unmarshal(decodedProviderSpec.CloudProviderSpec.Raw, &config); err != nil {
 				return nil, fmt.Errorf("failed to parse nutanix config: %w", err)
 			}
+
+			// remove system categories
+			categories := config.Categories
+			delete(categories, nutanixprovider.ClusterCategoryName)
+			delete(categories, nutanixprovider.ProjectCategoryName)
+
 			cloudSpec.Nutanix = &apiv1.NutanixNodeSpec{
 				SubnetName:     config.SubnetName.Value,
 				ImageName:      config.ImageName.Value,
-				Categories:     config.Categories,
+				Categories:     categories,
 				CPUs:           config.CPUs,
 				CPUCores:       config.CPUCores,
 				CPUPassthrough: config.CPUPassthrough,


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't want system categories we use to categorize KKP resources in Nutanix to be visible to end users. This hides the categories in our API response.

This is a follow-up to #5275.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KKP specific Nutanix categories (`KKPProject` and `KKPCluster`) are hidden in API responses
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
