### PR TITLE
Display instance type and preference category instead of kind

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/node-list/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/node-list/component.ts
@@ -26,6 +26,7 @@ import {Cluster} from '@shared/entity/cluster';
 import {Member} from '@shared/entity/member';
 import {NodeMetrics} from '@shared/entity/metrics';
 import {getOperatingSystem, getOperatingSystemLogoClass, Node, NodeIPAddress, VSphereTag} from '@shared/entity/node';
+import {KubeVirtNodeInstanceType, KubeVirtNodePreference} from '@shared/entity/provider/kubevirt';
 import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member';
 import {NodeUtils} from '@shared/utils/node';
@@ -230,5 +231,13 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
 
   getMetrics(nodeName: string): NodeMetrics | undefined {
     return this.nodesMetrics.get(nodeName);
+  }
+
+  getKubeVirtInstanceTypeCategory(instanceType: KubeVirtNodeInstanceType): string {
+    return KubeVirtNodeInstanceType.getCategory(instanceType);
+  }
+
+  getKubeVirtPreferenceCategory(preference: KubeVirtNodePreference): string {
+    return KubeVirtNodePreference.getCategory(preference);
   }
 }

--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -288,7 +288,7 @@ limitations under the License.
                 <div key>Instance Type</div>
                 <div value>
                   <mat-chip>
-                    <div>{{instanceType.kind}}</div>
+                    <div>{{getKubeVirtInstanceTypeCategory(instanceType)}}</div>
                     <div class="km-chip-accent">{{instanceType.name}}</div>
                   </mat-chip>
                 </div>
@@ -297,7 +297,7 @@ limitations under the License.
                 <div key>Preference</div>
                 <div value>
                   <mat-chip>
-                    <div>{{preference.kind}}</div>
+                    <div>{{getKubeVirtPreferenceCategory(preference)}}</div>
                     <div class="km-chip-accent">{{preference.name}}</div>
                   </mat-chip>
                 </div>

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -575,28 +575,12 @@ export class KubeVirtBasicNodeDataComponent
   }
 
   private _getSelectedInstanceTypeId(instanceType: KubeVirtNodeInstanceType): string {
-    let category;
-    switch (instanceType.kind) {
-      case KubeVirtInstanceTypeKind.VirtualMachineInstancetype:
-        category = KubeVirtInstanceTypeCategory.Kubermatic;
-        break;
-      case KubeVirtInstanceTypeKind.VirtualMachineClusterInstancetype:
-        category = KubeVirtInstanceTypeCategory.Custom;
-        break;
-    }
+    const category = KubeVirtNodeInstanceType.getCategory(instanceType);
     return `${category}${this._instanceTypeIDSeparator}${instanceType.name}`;
   }
 
   private _getSelectedPreferenceId(preference: KubeVirtNodePreference): string {
-    let category;
-    switch (preference.kind) {
-      case KubeVirtPreferenceKind.VirtualMachinePreference:
-        category = KubeVirtInstanceTypeCategory.Kubermatic;
-        break;
-      case KubeVirtPreferenceKind.VirtualMachineClusterPreference:
-        category = KubeVirtInstanceTypeCategory.Custom;
-        break;
-    }
+    const category = KubeVirtNodePreference.getCategory(preference);
     return `${category}${this._instanceTypeIDSeparator}${preference.name}`;
   }
 

--- a/modules/web/src/app/shared/components/cluster-summary/component.ts
+++ b/modules/web/src/app/shared/components/cluster-summary/component.ts
@@ -20,6 +20,7 @@ import {Cluster} from '@shared/entity/cluster';
 import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
 import {MachineDeployment, OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@shared/entity/machine-deployment';
 import {getOperatingSystem, getOperatingSystemLogoClass, VSphereTag} from '@shared/entity/node';
+import {KubeVirtNodeInstanceType, KubeVirtNodePreference} from '@shared/entity/provider/kubevirt';
 import {SSHKey} from '@shared/entity/ssh-key';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plugin';
@@ -148,6 +149,14 @@ export class ClusterSummaryComponent {
   // conversion array into object form to pass onto `km-labels` component as Input
   convertVSphereTagsIntoObject(tags: Array<VSphereTag>): VSphereTag | {} {
     return convertArrayToObject(tags, 'name', 'description');
+  }
+
+  getKubeVirtInstanceTypeCategory(instanceType: KubeVirtNodeInstanceType): string {
+    return KubeVirtNodeInstanceType.getCategory(instanceType);
+  }
+
+  getKubeVirtPreferenceCategory(preference: KubeVirtNodePreference): string {
+    return KubeVirtNodePreference.getCategory(preference);
   }
 
   private _hasProviderOptions(provider: NodeProvider): boolean {

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -778,7 +778,7 @@ limitations under the License.
                   <div key>Instance Type</div>
                   <div value>
                     <mat-chip>
-                      <div>{{instanceType.kind}}</div>
+                      <div>{{getKubeVirtInstanceTypeCategory(instanceType)}}</div>
                       <div class="km-chip-accent">{{instanceType.name}}</div>
                     </mat-chip>
                   </div>
@@ -787,7 +787,7 @@ limitations under the License.
                   <div key>Preference</div>
                   <div value>
                     <mat-chip>
-                      <div>{{preference.kind}}</div>
+                      <div>{{getKubeVirtPreferenceCategory(preference)}}</div>
                       <div class="km-chip-accent">{{preference.name}}</div>
                     </mat-chip>
                   </div>

--- a/modules/web/src/app/shared/entity/provider/kubevirt.ts
+++ b/modules/web/src/app/shared/entity/provider/kubevirt.ts
@@ -36,12 +36,34 @@ export class KubeVirtNodeInstanceType {
   name: string;
   kind: KubeVirtInstanceTypeKind;
   revisionName?: string;
+
+  static getCategory(instanceType: KubeVirtNodeInstanceType): KubeVirtInstanceTypeCategory {
+    switch (instanceType.kind) {
+      case KubeVirtInstanceTypeKind.VirtualMachineInstancetype:
+        return KubeVirtInstanceTypeCategory.Kubermatic;
+      case KubeVirtInstanceTypeKind.VirtualMachineClusterInstancetype:
+        return KubeVirtInstanceTypeCategory.Custom;
+      default:
+        return instanceType.kind;
+    }
+  }
 }
 
 export class KubeVirtNodePreference {
   name: string;
   kind: KubeVirtPreferenceKind;
   revisionName?: string;
+
+  static getCategory(preference: KubeVirtNodePreference): KubeVirtInstanceTypeCategory {
+    switch (preference.kind) {
+      case KubeVirtPreferenceKind.VirtualMachinePreference:
+        return KubeVirtInstanceTypeCategory.Kubermatic;
+      case KubeVirtPreferenceKind.VirtualMachineClusterPreference:
+        return KubeVirtInstanceTypeCategory.Custom;
+      default:
+        return preference.kind;
+    }
+  }
 }
 
 export class KubeVirtStorageClass {


### PR DESCRIPTION
**What this PR does / why we need it**:
Display instance type and preference category instead of `kind` on cluster summary and node list details page.

**Cluster Summary:**

![screenshot-localhost_8000-2022 11 18-19_42_02](https://user-images.githubusercontent.com/13975988/202732469-3900ea19-3809-486b-8738-923d3d7c7e5c.png)

**Node Details:**

![screenshot-localhost_8000-2022 11 18-19_44_49](https://user-images.githubusercontent.com/13975988/202732531-a065ff66-cf2e-4d7d-a6a6-7dd97fd88627.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Display instance type and preference category instead of `kind` on cluster summary and node list details page.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
