### PR TITLE
Add support to configure topology spread constraints in KubeVirt

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -318,14 +318,6 @@ limitations under the License.
                 <div key>Secondary Disk {{i + 1}}</div>
                 <div value>{{disk.storageClassName}}, {{disk.size}}</div>
               </km-property>
-              <km-property *ngIf="element.spec.cloud.kubevirt?.podAffinityPreset">
-                <div key>Pod Affinity Preset</div>
-                <div value>{{element.spec.cloud.kubevirt.podAffinityPreset}}</div>
-              </km-property>
-              <km-property *ngIf="element.spec.cloud.kubevirt.podAntiAffinityPreset">
-                <div key>Pod Anti-Affinity Preset</div>
-                <div value>{{element.spec.cloud.kubevirt.podAntiAffinityPreset}}</div>
-              </km-property>
               <ng-container *ngIf="element.spec.cloud.kubevirt.nodeAffinityPreset as nodeAffinityPreset">
                 <km-property>
                   <div key>Node Affinity Preset</div>

--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -340,6 +340,18 @@ limitations under the License.
                   <div value>{{nodeAffinityPreset.Values.join(', ')}}</div>
                 </km-property>
               </ng-container>
+              <km-property *ngIf="element.spec.cloud.kubevirt.topologySpreadConstraints?.length > 0">
+                <div key>Topology Spread Constraints</div>
+                <div value>
+                  <mat-chip-list selectable="false">
+                    <mat-chip *ngFor="let constraint of element.spec.cloud.kubevirt.topologySpreadConstraints">
+                      <div>{{constraint.topologyKey}}</div>
+                      <div class="km-chip-accent">{{constraint.maxSkew}}</div>
+                      <div>{{constraint.whenUnsatisfiable}}</div>
+                    </mat-chip>
+                  </mat-chip-list>
+                </div>
+              </km-property>
             </ng-container>
 
             <km-property *ngIf="element.spec.cloud.vsphere">

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -66,8 +66,6 @@ enum Controls {
   SecondaryDisks = 'secondaryDisks',
   SecondaryDiskStorageClass = 'secondaryDiskStorageClass',
   SecondaryDiskSize = 'secondaryDiskSize',
-  PodAffinityPreset = 'podAffinityPreset',
-  PodAntiAffinityPreset = 'podAntiAffinityPreset',
   NodeAffinityPreset = 'nodeAffinityPreset',
   NodeAffinityPresetKey = 'nodeAffinityPresetKey',
   NodeAffinityPresetValues = 'nodeAffinityPresetValues',
@@ -161,8 +159,6 @@ export class KubeVirtBasicNodeDataComponent
       [Controls.PrimaryDiskStorageClassName]: this._builder.control('', Validators.required),
       [Controls.PrimaryDiskSize]: this._builder.control('10', Validators.required),
       [Controls.SecondaryDisks]: this._builder.array([]),
-      [Controls.PodAffinityPreset]: this._builder.control(''),
-      [Controls.PodAntiAffinityPreset]: this._builder.control(''),
       [Controls.NodeAffinityPreset]: this._builder.control(''),
       [Controls.NodeAffinityPresetKey]: this._builder.control(''),
       [Controls.NodeAffinityPresetValues]: this._builder.control(''),
@@ -200,32 +196,6 @@ export class KubeVirtBasicNodeDataComponent
           this.form.get(Controls.NodeAffinityPresetValues).reset();
           this.form.get(Controls.NodeAffinityPresetValues).disable();
           this.nodeAffinityPresetValues = [];
-        }
-      });
-
-    this.form
-      .get(Controls.PodAffinityPreset)
-      .valueChanges.pipe(takeUntil(this._unsubscribe))
-      .subscribe(value => {
-        const antiAffinityControl = this.form.get(Controls.PodAntiAffinityPreset);
-        if (value && antiAffinityControl.enabled) {
-          antiAffinityControl.reset();
-          antiAffinityControl.disable();
-        } else if (!value && antiAffinityControl.disabled) {
-          antiAffinityControl.enable();
-        }
-      });
-
-    this.form
-      .get(Controls.PodAntiAffinityPreset)
-      .valueChanges.pipe(takeUntil(this._unsubscribe))
-      .subscribe(value => {
-        const affinityControl = this.form.get(Controls.PodAffinityPreset);
-        if (value && affinityControl.enabled) {
-          affinityControl.reset();
-          affinityControl.disable();
-        } else if (!value && affinityControl.disabled) {
-          affinityControl.enable();
         }
       });
 
@@ -406,14 +376,6 @@ export class KubeVirtBasicNodeDataComponent
     });
   }
 
-  resetPodAffinityPresetControl(): void {
-    this.form.get(Controls.PodAffinityPreset).reset();
-  }
-
-  resetPodAntiAffinityPresetControl(): void {
-    this.form.get(Controls.PodAntiAffinityPreset).reset();
-  }
-
   resetNodeAffinityPresetControl(): void {
     this.form.get(Controls.NodeAffinityPreset).reset();
   }
@@ -564,8 +526,6 @@ export class KubeVirtBasicNodeDataComponent
       this.form.get(Controls.CPUs).setValue(parseInt(this._initialData.cpus) || this._defaultCPUs);
       this.form.get(Controls.PrimaryDiskSize).setValue(this._initialData.primaryDiskSize);
       this.form.get(Controls.PrimaryDiskOSImage).setValue(this._initialData.primaryDiskOSImage);
-      this.form.get(Controls.PodAffinityPreset).setValue(this._initialData.podAffinityPreset);
-      this.form.get(Controls.PodAntiAffinityPreset).setValue(this._initialData.podAntiAffinityPreset);
       this.form.get(Controls.NodeAffinityPreset).setValue(this._initialData.nodeAffinityPreset?.Type);
       this.form.get(Controls.NodeAffinityPresetKey).setValue(this._initialData.nodeAffinityPreset?.Key);
       this.nodeAffinityPresetValues = this._initialData.nodeAffinityPreset?.Values || [];
@@ -620,8 +580,6 @@ export class KubeVirtBasicNodeDataComponent
               ComboboxControls.Select
             ],
             primaryDiskSize: `${this.form.get(Controls.PrimaryDiskSize).value}Gi`,
-            podAffinityPreset: this.form.get(Controls.PodAffinityPreset).value,
-            podAntiAffinityPreset: this.form.get(Controls.PodAntiAffinityPreset).value,
             nodeAffinityPreset: nodeAffinityPresetData,
           } as KubeVirtNodeSpec,
         } as NodeCloudSpec,

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -46,6 +46,7 @@ import {
   KubeVirtPreferenceKind,
   KubeVirtPreferenceList,
   KubeVirtStorageClass,
+  KubeVirtTopologySpreadConstraint,
 } from '@shared/entity/provider/kubevirt';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
@@ -70,6 +71,7 @@ enum Controls {
   NodeAffinityPreset = 'nodeAffinityPreset',
   NodeAffinityPresetKey = 'nodeAffinityPresetKey',
   NodeAffinityPresetValues = 'nodeAffinityPresetValues',
+  TopologySpreadConstraints = 'topologySpreadConstraints',
 }
 
 enum InstanceTypeState {
@@ -164,6 +166,7 @@ export class KubeVirtBasicNodeDataComponent
       [Controls.NodeAffinityPreset]: this._builder.control(''),
       [Controls.NodeAffinityPresetKey]: this._builder.control(''),
       [Controls.NodeAffinityPresetValues]: this._builder.control(''),
+      [Controls.TopologySpreadConstraints]: this._builder.control(''),
     });
 
     this.form.get(Controls.Preference).disable();
@@ -273,6 +276,10 @@ export class KubeVirtBasicNodeDataComponent
 
   get secondaryDisksFormArray(): FormArray {
     return this.form.get(Controls.SecondaryDisks) as FormArray;
+  }
+
+  get topologySpreadConstraints(): KubeVirtTopologySpreadConstraint[] {
+    return this._nodeDataService.nodeData.spec.cloud.kubevirt?.topologySpreadConstraints || [];
   }
 
   getInstanceTypeOptions(group: string): KubeVirtInstanceType[] {
@@ -414,6 +421,11 @@ export class KubeVirtBasicNodeDataComponent
   onNodeAffinityPresetValuesChange(values: string[]): void {
     this.nodeAffinityPresetValues = values;
     this._nodeDataService.nodeData.spec.cloud.kubevirt.nodeAffinityPreset.Values = values;
+  }
+
+  onTopologySpreadConstraintsChange(constraints: KubeVirtTopologySpreadConstraint[]): void {
+    this._nodeDataService.nodeData.spec.cloud.kubevirt.topologySpreadConstraints = constraints;
+    this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
   }
 
   private get _instanceTypesObservable(): Observable<KubeVirtInstanceTypeList> {

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
@@ -272,5 +272,9 @@ limitations under the License.
         <mat-hint>{{hint}}</mat-hint>
       </mat-form-field>
     </ng-template>
+
+    <km-topology-spread-constraint-form [formControlName]="Controls.TopologySpreadConstraints"
+                                        [constraints]="topologySpreadConstraints"
+                                        (constraintsChange)="onTopologySpreadConstraintsChange($event)"></km-topology-spread-constraint-form>
   </km-expansion-panel>
 </form>

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
@@ -201,20 +201,6 @@ limitations under the License.
   <km-expansion-panel expandLabel="ADVANCED SCHEDULING SETTINGS"
                       collapseLabel="ADVANCED SCHEDULING SETTINGS">
     <ng-container *ngTemplateOutlet="selectAffinityPreset;
-                                      context: {label: 'Pod Affinity Preset',
-                                      controlName: Controls.PodAffinityPreset,
-                                      resetCallback: resetPodAffinityPresetControl.bind(this),
-                                      hint: 'Ensures two tenant nodes to be co-located in a single infrastructure node. Hard and soft values represent required and preferred scheduling.'}">
-    </ng-container>
-
-    <ng-container *ngTemplateOutlet="selectAffinityPreset;
-                                      context: {label: 'Pod Anti-Affinity Preset',
-                                      controlName: Controls.PodAntiAffinityPreset,
-                                      resetCallback: resetPodAntiAffinityPresetControl.bind(this),
-                                      hint: 'Allows you to prevent tenant nodes to be co-located in a single infrastructure node. Hard and soft values represent required and preferred scheduling.'}">
-    </ng-container>
-
-    <ng-container *ngTemplateOutlet="selectAffinityPreset;
                                       context: {label: 'Node Affinity Preset Type',
                                       controlName: Controls.NodeAffinityPreset,
                                       resetCallback: resetNodeAffinityPresetControl.bind(this),

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/component.ts
@@ -1,0 +1,181 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, EventEmitter, forwardRef, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {
+  AbstractControl,
+  FormArray,
+  FormBuilder,
+  FormGroup,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  Validators,
+} from '@angular/forms';
+import {KubeVirtTopologySpreadConstraint, KubeVirtTopologyWhenUnsatisfiable} from '@shared/entity/provider/kubevirt';
+import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import _ from 'lodash';
+import {takeUntil} from 'rxjs/operators';
+
+enum Controls {
+  Constraints = 'constraints',
+  MaxSkew = 'maxSkew',
+  TopologyKey = 'topologyKey',
+  WhenUnsatisfiable = 'whenUnsatisfiable',
+}
+
+@Component({
+  selector: 'km-topology-spread-constraint-form',
+  templateUrl: './template.html',
+  styleUrls: ['./style.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TopologySpreadConstraintFormComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => TopologySpreadConstraintFormComponent),
+      multi: true,
+    },
+  ],
+})
+export class TopologySpreadConstraintFormComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  readonly Controls = Controls;
+  readonly minimumMaxSkew = 1;
+
+  @Input() constraints: KubeVirtTopologySpreadConstraint[];
+  @Output() constraintsChange = new EventEmitter<KubeVirtTopologySpreadConstraint[]>();
+
+  form: FormGroup;
+  whenUnsatisfiableOptions = Object.keys(KubeVirtTopologyWhenUnsatisfiable);
+
+  constructor(private readonly _formBuilder: FormBuilder) {
+    super();
+  }
+
+  get constraintArray(): FormArray {
+    return this.form.get(Controls.Constraints) as FormArray;
+  }
+
+  static filterNullifiedConstraints(
+    constraints: KubeVirtTopologySpreadConstraint[]
+  ): KubeVirtTopologySpreadConstraint[] {
+    const filteredConstraints = [];
+    if (constraints && Array.isArray(constraints)) {
+      constraints.forEach(constraint => {
+        if (constraint.maxSkew && constraint.topologyKey && constraint.whenUnsatisfiable) {
+          filteredConstraints.push(constraint);
+        }
+      });
+    }
+    return filteredConstraints;
+  }
+
+  ngOnInit(): void {
+    this.form = this._formBuilder.group({[Controls.Constraints]: this._formBuilder.array([])});
+
+    if (!this.constraints) {
+      this.constraints = [];
+    }
+
+    // Setup constraints form with constraint data.
+    this.constraints.forEach(constraint => {
+      this._addConstraint(constraint);
+    });
+
+    // Add initial constraint for the user.
+    this._addConstraint();
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  onControlValueChange(constraintControl: AbstractControl): void {
+    this._addConstraintIfNeeded();
+    this._validateKey(constraintControl);
+    this._updateConstraints();
+  }
+
+  isRemovable(index: number): boolean {
+    return index < this.constraintArray.length - 1;
+  }
+
+  deleteConstraint(index: number): void {
+    this.constraintArray.removeAt(index);
+    this._updateConstraints();
+  }
+
+  private static _isFilled(constraint: AbstractControl): boolean {
+    return (
+      _.isInteger(constraint.get(Controls.MaxSkew).value) &&
+      constraint.get(Controls.TopologyKey).value &&
+      constraint.get(Controls.WhenUnsatisfiable).value
+    );
+  }
+
+  private _addConstraintIfNeeded(): void {
+    const lastLabel = this.constraintArray.at(this.constraintArray.length - 1);
+    if (TopologySpreadConstraintFormComponent._isFilled(lastLabel)) {
+      this._addConstraint();
+    }
+  }
+
+  private _addConstraint(constraint: KubeVirtTopologySpreadConstraint = null): void {
+    this.constraintArray.controls.forEach(control =>
+      control.get(Controls.TopologyKey).setValidators(Validators.required)
+    );
+    this.form.updateValueAndValidity({emitEvent: false});
+
+    const maxSkewControl = this._formBuilder.control(
+      constraint?.maxSkew || this.minimumMaxSkew,
+      Validators.min(this.minimumMaxSkew)
+    );
+    const constraintControl = this._formBuilder.group({
+      [Controls.MaxSkew]: maxSkewControl,
+      [Controls.TopologyKey]: this._formBuilder.control(constraint?.topologyKey || ''),
+      [Controls.WhenUnsatisfiable]: this._formBuilder.control(constraint?.whenUnsatisfiable || ''),
+    });
+    this.constraintArray.push(constraintControl);
+    maxSkewControl.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => this.onControlValueChange(constraintControl));
+  }
+
+  private _validateKey(constraintControl: AbstractControl): void {
+    const keyControl = constraintControl.get(Controls.TopologyKey);
+
+    if (this._isKeyDuplicated(keyControl.value)) {
+      keyControl.setErrors({validLabelKeyUniqueness: true});
+    }
+
+    this.form.updateValueAndValidity();
+  }
+
+  private _isKeyDuplicated(key: string): boolean {
+    if (!key) {
+      return false;
+    }
+    return this.constraintArray.controls.filter(control => control.get(Controls.TopologyKey).value === key).length > 1;
+  }
+
+  private _updateConstraints(): void {
+    this.constraints = TopologySpreadConstraintFormComponent.filterNullifiedConstraints(
+      this.constraintArray.getRawValue()
+    );
+    this.constraintsChange.emit(this.constraints);
+  }
+}

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/style.scss
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/style.scss
@@ -1,0 +1,23 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@use 'variables';
+
+.topology-spread-constraints-title {
+  margin-top: 10px;
+}
+
+.delete-button {
+  margin-top: 4px;
+}

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/template.html
@@ -1,0 +1,64 @@
+<!--
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<mat-card-header class="km-no-padding topology-spread-constraints-title">
+  <mat-card-title>Topology Spread Constraints</mat-card-title>
+</mat-card-header>
+<form [formGroup]="form"
+      fxLayout="column">
+  <div [formArrayName]="Controls.Constraints">
+    <div *ngFor="let constraint of constraintArray.controls; let i = index; let isLast = last"
+         [formGroupName]="i"
+         fxLayout="row"
+         fxLayoutGap="10px">
+      <div fxFlex="29">
+        <km-number-stepper [formControlName]="Controls.MaxSkew"
+                           [min]="minimumMaxSkew"
+                           [forceFormFieldMinWidth]="false"
+                           [required]="!isLast"
+                           mode="raw"
+                           label="Max Skew">
+        </km-number-stepper>
+      </div>
+      <mat-form-field fxFlex="29">
+        <mat-label>Topology Key</mat-label>
+        <input matInput
+               [name]="Controls.TopologyKey"
+               [formControlName]="Controls.TopologyKey"
+               (keyup)="onControlValueChange(constraint)">
+        <mat-error *ngIf="constraint.get(Controls.TopologyKey).errors?.validLabelKeyUniqueness">
+          Key is not unique.
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field fxFlex="29">
+        <mat-label>When Unsatisfiable</mat-label>
+        <mat-select [formControlName]="Controls.WhenUnsatisfiable"
+                    disableOptionCentering
+                    (selectionChange)="onControlValueChange(constraint)">
+          <mat-option *ngFor="let option of whenUnsatisfiableOptions"
+                      [value]="option">
+            {{option}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <button mat-icon-button
+              class="delete-button"
+              *ngIf="isRemovable(i)"
+              (click)="deleteConstraint(i)">
+        <i class="km-icon-mask km-icon-delete"></i>
+      </button>
+    </div>
+  </div>
+</form>

--- a/modules/web/src/app/node-data/module.ts
+++ b/modules/web/src/app/node-data/module.ts
@@ -34,6 +34,7 @@ import {DigitalOceanBasicNodeDataComponent} from './basic/provider/digitalocean/
 import {GCPBasicNodeDataComponent} from './basic/provider/gcp/component';
 import {HetznerBasicNodeDataComponent} from './basic/provider/hetzner/component';
 import {KubeVirtBasicNodeDataComponent} from './basic/provider/kubevirt/component';
+import {TopologySpreadConstraintFormComponent} from './basic/provider/kubevirt/topology-spread-contraint-form/component';
 import {OpenstackBasicNodeDataComponent} from './basic/provider/openstack/component';
 import {EquinixBasicNodeDataComponent} from './basic/provider/equinix/component';
 import {VSphereBasicNodeDataComponent} from './basic/provider/vsphere/component';
@@ -82,6 +83,7 @@ const components = [
   NutanixBasicNodeDataComponent,
   InstanceDetailsDialogComponent,
   VMwareCloudDirectorBasicNodeDataComponent,
+  TopologySpreadConstraintFormComponent,
 ];
 
 // component NodeDataComponent is added to routing module so we can use our dynamic component here

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -830,6 +830,18 @@ limitations under the License.
                     <div value>{{nodeAffinityPreset.Values.join(', ')}}</div>
                   </km-property>
                 </ng-container>
+                <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.topologySpreadConstraints?.length > 0">
+                  <div key>Topology Spread Constraints</div>
+                  <div value>
+                    <mat-chip-list selectable="false">
+                      <mat-chip *ngFor="let constraint of machineDeployment.spec.template.cloud?.kubevirt.topologySpreadConstraints">
+                        <div>{{constraint.topologyKey}}</div>
+                        <div class="km-chip-accent">{{constraint.maxSkew}}</div>
+                        <div>{{constraint.whenUnsatisfiable}}</div>
+                      </mat-chip>
+                    </mat-chip-list>
+                  </div>
+                </km-property>
               </ng-container>
 
               <!-- Nutanix Nodes -->

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -808,14 +808,6 @@ limitations under the License.
                   <div key>Secondary Disk {{i + 1}}</div>
                   <div value>{{disk.storageClassName}}, {{disk.size}}</div>
                 </km-property>
-                <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.podAffinityPreset">
-                  <div key>Pod Affinity Preset</div>
-                  <div value>{{machineDeployment.spec.template.cloud?.kubevirt.podAffinityPreset}}</div>
-                </km-property>
-                <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.podAntiAffinityPreset">
-                  <div key>Pod Anti-Affinity Preset</div>
-                  <div value>{{machineDeployment.spec.template.cloud?.kubevirt.podAntiAffinityPreset}}</div>
-                </km-property>
                 <ng-container *ngIf="machineDeployment.spec.template.cloud?.kubevirt.nodeAffinityPreset as nodeAffinityPreset">
                   <km-property>
                     <div key>Node Affinity Preset</div>

--- a/modules/web/src/app/shared/components/number-stepper/component.ts
+++ b/modules/web/src/app/shared/components/number-stepper/component.ts
@@ -76,6 +76,7 @@ export class NumberStepperComponent implements AfterViewInit, OnDestroy, Control
   @Input() disabled = false;
   @Input() step = 1;
   @Input() type: 'integer' | 'decimal' = 'integer';
+  @Input() forceFormFieldMinWidth = true;
 
   @HostBinding('attr.id')
   protected _hostID = '';

--- a/modules/web/src/app/shared/components/number-stepper/style.scss
+++ b/modules/web/src/app/shared/components/number-stepper/style.scss
@@ -43,6 +43,6 @@ input[type='number'] {
   }
 }
 
-.mat-form-field {
+.mat-form-field.force-min-width {
   min-width: 150px;
 }

--- a/modules/web/src/app/shared/components/number-stepper/template.html
+++ b/modules/web/src/app/shared/components/number-stepper/template.html
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <mat-form-field class="km-number-stepper-input"
-                [ngClass]="mode === 'hint' || mode === 'errors' || mode === 'all' ? 'message' : ''">
+                [ngClass]="{'message': mode === 'hint' || mode === 'errors' || mode === 'all', 'force-min-width': forceFormFieldMinWidth}">
   <mat-label *ngIf="!!label">{{label}}</mat-label>
   <input #input="ngModel"
          matInput

--- a/modules/web/src/app/shared/entity/node.ts
+++ b/modules/web/src/app/shared/entity/node.ts
@@ -16,6 +16,7 @@ import {
   KubeVirtAffinityPreset,
   KubeVirtNodeInstanceType,
   KubeVirtNodePreference,
+  KubeVirtTopologySpreadConstraint,
 } from '@shared/entity/provider/kubevirt';
 import {VMwareCloudDirectorIPAllocationMode} from '@shared/entity/provider/vmware-cloud-director';
 import {NodeProvider, OperatingSystem} from '../model/NodeProviderConstants';
@@ -231,6 +232,7 @@ export class KubeVirtNodeSpec {
   podAffinityPreset?: KubeVirtAffinityPreset;
   podAntiAffinityPreset?: KubeVirtAffinityPreset;
   nodeAffinityPreset?: KubeVirtNodeAffinityPreset;
+  topologySpreadConstraints?: KubeVirtTopologySpreadConstraint[];
 }
 
 export class KubeVirtSecondaryDisk {

--- a/modules/web/src/app/shared/entity/node.ts
+++ b/modules/web/src/app/shared/entity/node.ts
@@ -229,8 +229,6 @@ export class KubeVirtNodeSpec {
   primaryDiskStorageClassName: string;
   primaryDiskSize: string;
   secondaryDisks?: KubeVirtSecondaryDisk[];
-  podAffinityPreset?: KubeVirtAffinityPreset;
-  podAntiAffinityPreset?: KubeVirtAffinityPreset;
   nodeAffinityPreset?: KubeVirtNodeAffinityPreset;
   topologySpreadConstraints?: KubeVirtTopologySpreadConstraint[];
 }

--- a/modules/web/src/app/shared/entity/provider/kubevirt.ts
+++ b/modules/web/src/app/shared/entity/provider/kubevirt.ts
@@ -70,6 +70,12 @@ export class KubeVirtStorageClass {
   name: string;
 }
 
+export class KubeVirtTopologySpreadConstraint {
+  maxSkew: number;
+  topologyKey: string;
+  whenUnsatisfiable: KubeVirtTopologyWhenUnsatisfiable;
+}
+
 export enum KubeVirtAffinityPreset {
   Hard = 'hard',
   Soft = 'soft',
@@ -88,4 +94,9 @@ export enum KubeVirtInstanceTypeKind {
 export enum KubeVirtPreferenceKind {
   VirtualMachinePreference = 'VirtualMachinePreference',
   VirtualMachineClusterPreference = 'VirtualMachineClusterPreference',
+}
+
+export enum KubeVirtTopologyWhenUnsatisfiable {
+  ScheduleAnyway = 'ScheduleAnyway',
+  DoNotSchedule = 'DoNotSchedule',
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove Pod Affinity/Anti-affinity settings and add support to configure topology spread constraints in KubeVirt provider.

**Cluster Wizard:**

![screenshot-localhost_8000-2022 11 21-17_38_13](https://user-images.githubusercontent.com/13975988/203057308-481c205c-2c7a-4618-98ca-c4a69595ebe8.png)


**Cluster Summary:**

![screenshot-localhost_8000-2022 11 21-14_01_45](https://user-images.githubusercontent.com/13975988/203028682-2a6edbc6-9652-4c24-9ba1-3d8998c57de9.png)


**Node List Details:**

![screenshot-localhost_8000-2022 11 21-14_05_17](https://user-images.githubusercontent.com/13975988/203028722-55fe9104-75c7-49fd-b14e-2ac799005b31.png)



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5067 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove Pod Affinity/Anti-affinity settings and add support to configure topology spread constraints in KubeVirt provider.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
