### PR TITLE
Resource quota calculation

### DIFF
--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1746,6 +1746,16 @@ type Quota struct {
 	Storage *float64 `json:"storage,omitempty"`
 }
 
+// swagger:model ResourceQuotaUpdateCalculation
+type ResourceQuotaUpdateCalculation struct {
+	// ResourceQuota represents the requested resource quota.
+	ResourceQuota ResourceQuota `json:"resourceQuota"`
+	// CalculatedQuota represents the calculation of the resource quota global usage + the updated node usage.
+	CalculatedQuota Quota `json:"calculatedQuota"`
+	// Message is filled if a resource in the calculated quota exceeds the resource quota limits.
+	Message string `json:"message"`
+}
+
 // swagger:model GroupProjectBinding
 type GroupProjectBinding struct {
 	Name      string `json:"name"`

--- a/modules/api/pkg/ee/resource-quota/handler.go
+++ b/modules/api/pkg/ee/resource-quota/handler.go
@@ -287,7 +287,8 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 
 	var err error
 
-	if req.Body.AlibabaInstanceType != nil {
+	switch {
+	case req.Body.AlibabaInstanceType != nil:
 		nc.WithCPUCount(req.Body.AlibabaInstanceType.CPUCoreCount)
 
 		if err = nc.WithMemory(int(req.Body.AlibabaInstanceType.MemorySize), "G"); err != nil {
@@ -296,7 +297,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(req.Body.DiskSizeGB, "G"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.AnexiaNodeSpec != nil {
+	case req.Body.AnexiaNodeSpec != nil:
 		nc.WithCPUCount(req.Body.AnexiaNodeSpec.CPUs)
 
 		if err = nc.WithMemory(int(req.Body.AnexiaNodeSpec.Memory), "M"); err != nil {
@@ -310,7 +311,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(int(diskSize), "G"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.AWSSize != nil {
+	case req.Body.AWSSize != nil:
 		nc.WithCPUCount(req.Body.AWSSize.VCPUs)
 
 		if err = nc.WithMemory(int(req.Body.AWSSize.Memory), "G"); err != nil {
@@ -319,7 +320,8 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(req.Body.DiskSizeGB, "G"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.AzureSize != nil {
+
+	case req.Body.AzureSize != nil:
 		nc.WithCPUCount(int(req.Body.AzureSize.NumberOfCores))
 
 		if err = nc.WithMemory(int(req.Body.AzureSize.MemoryInMB), "M"); err != nil {
@@ -329,7 +331,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(int(req.Body.AzureSize.ResourceDiskSizeInMB+req.Body.AzureSize.OsDiskSizeInMB), "M"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.DOSize != nil {
+	case req.Body.DOSize != nil:
 		nc.WithCPUCount(req.Body.DOSize.VCPUs)
 
 		if err = nc.WithMemory(req.Body.DOSize.Memory, "M"); err != nil {
@@ -338,7 +340,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(req.Body.DOSize.Disk, "G"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.EquinixSize != nil {
+	case req.Body.EquinixSize != nil:
 		var cpuCount int
 		for _, c := range req.Body.EquinixSize.CPUs {
 			cpuCount += c.Count
@@ -372,7 +374,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 			allDrivesStorage.Add(totalStorage)
 		}
 		nc.Storage = &allDrivesStorage
-	} else if req.Body.GCPSize != nil {
+	case req.Body.GCPSize != nil:
 		nc.WithCPUCount(int(req.Body.GCPSize.VCPUs))
 
 		if err = nc.WithMemory(int(req.Body.GCPSize.Memory), "M"); err != nil {
@@ -381,7 +383,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(req.Body.DiskSizeGB, "G"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.HetznerSize != nil {
+	case req.Body.HetznerSize != nil:
 		nc.WithCPUCount(req.Body.HetznerSize.Cores)
 
 		if err = nc.WithMemory(int(req.Body.HetznerSize.Memory), "G"); err != nil {
@@ -390,7 +392,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(req.Body.HetznerSize.Disk, "G"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.NutanixNodeSpec != nil {
+	case req.Body.NutanixNodeSpec != nil:
 		nc.WithCPUCount(int(req.Body.NutanixNodeSpec.CPUs))
 
 		if err = nc.WithMemory(int(req.Body.NutanixNodeSpec.MemoryMB), "M"); err != nil {
@@ -404,8 +406,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		} else {
 			nc.Storage = &resource.Quantity{}
 		}
-
-	} else if req.Body.OpenstackSize != nil {
+	case req.Body.OpenstackSize != nil:
 		nc.WithCPUCount(req.Body.OpenstackSize.VCPUs)
 
 		if err = nc.WithMemory(req.Body.OpenstackSize.Memory, "G"); err != nil {
@@ -414,7 +415,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		if err = nc.WithStorage(req.Body.OpenstackSize.Disk, "G"); err != nil {
 			return nil, err
 		}
-	} else if req.Body.VSphereNodeSpec != nil {
+	case req.Body.VSphereNodeSpec != nil:
 		nc.WithCPUCount(req.Body.VSphereNodeSpec.CPUs)
 
 		if err = nc.WithMemory(req.Body.VSphereNodeSpec.Memory, "G"); err != nil {
@@ -428,8 +429,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		} else {
 			nc.Storage = &resource.Quantity{}
 		}
-
-	} else if req.Body.VMDirectorNodeSpec != nil {
+	case req.Body.VMDirectorNodeSpec != nil:
 		nc.WithCPUCount(req.Body.VMDirectorNodeSpec.CPUCores * req.Body.VMDirectorNodeSpec.CPUs)
 
 		if err = nc.WithMemory(req.Body.VMDirectorNodeSpec.MemoryMB, "M"); err != nil {
@@ -443,7 +443,7 @@ func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*ku
 		} else {
 			nc.Storage = &resource.Quantity{}
 		}
-	} else {
+	default:
 		return nil, fmt.Errorf("provider set in request not supported: %v", req.Body)
 	}
 

--- a/modules/api/pkg/ee/resource-quota/handler.go
+++ b/modules/api/pkg/ee/resource-quota/handler.go
@@ -56,7 +56,7 @@ type getResourceQuota struct {
 
 // swagger:parameters calculateProjectResourceQuotaUpdate
 type calculateProjectResourceQuotaUpdate struct {
-	common.ProjectReq
+	common.GetProjectRq
 	Body struct {
 		Replicas int `json:"replicas"`
 		// DiskSizeGB will be processed only for those providers which don't have the disk size in their API objects, like AWS, Alibabla and GCP.
@@ -234,7 +234,7 @@ func CalculateResourceQuotaUpdateForProject(ctx context.Context, request interfa
 		return nil, utilerrors.NewBadRequest("invalid request")
 	}
 
-	projectResourceQuota, projectName, err := getProjectResourceQuota(ctx, request, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
+	projectResourceQuota, projectName, err := getProjectResourceQuota(ctx, req.GetProjectRq, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/api/pkg/ee/resource-quota/handler.go
+++ b/modules/api/pkg/ee/resource-quota/handler.go
@@ -30,16 +30,18 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
 
+	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermaticprovider "k8c.io/kubermatic/v2/pkg/provider"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -50,6 +52,29 @@ type getResourceQuota struct {
 	// in: path
 	// required: true
 	Name string `json:"quota_name"`
+}
+
+// swagger:parameters calculateProjectResourceQuotaUpdate
+type calculateProjectResourceQuotaUpdate struct {
+	common.ProjectReq
+	Body struct {
+		Replicas int `json:"replicas"`
+		// DiskSizeGB will be processed only for those providers which don't have the disk size in their API objects, like AWS, Alibabla and GCP.
+		DiskSizeGB          int                        `json:"diskSizeGB,omitempty"`
+		AlibabaInstanceType *apiv1.AlibabaInstanceType `json:"alibabaInstanceType,omitempty"`
+		AnexiaNodeSpec      *apiv1.AnexiaNodeSpec      `json:"anexiaNodeSpec,omitempty"`
+		AWSSize             *apiv1.AWSSize             `json:"awsSize,omitempty"`
+		AzureSize           *apiv1.AzureSize           `json:"azureSize,omitempty"`
+		DOSize              *apiv1.DigitaloceanSize    `json:"doSize,omitempty"`
+		EquinixSize         *apiv1.PacketSize          `json:"equinixSize,omitempty"`
+		GCPSize             *apiv1.GCPMachineSize      `json:"gcpSize,omitempty"`
+		HetznerSize         *apiv1.HetznerSize         `json:"hetznerSize,omitempty"`
+		// TODO Kubevirt
+		NutanixNodeSpec    *apiv1.NutanixNodeSpec             `json:"nutanixNodeSpec,omitempty"`
+		OpenstackSize      *apiv1.OpenstackSize               `json:"openstackSize,omitempty"`
+		VMDirectorNodeSpec *apiv1.VMwareCloudDirectorNodeSpec `json:"vmDirectorNodeSpec,omitempty"`
+		VSphereNodeSpec    *apiv1.VSphereNodeSpec             `json:"vSphereNodeSpec,omitempty"`
+	}
 }
 
 // swagger:parameters listResourceQuotas
@@ -143,6 +168,22 @@ func DecodePutResourceQuotaReq(r *http.Request) (interface{}, error) {
 	return req, nil
 }
 
+func DecodeCalculateProjectResourceQuotaUpdateReq(c context.Context, r *http.Request) (interface{}, error) {
+	var req calculateProjectResourceQuotaUpdate
+
+	pReq, err := common.DecodeProjectRequest(c, r)
+	if err != nil {
+		return nil, err
+	}
+	req.ProjectReq = pReq.(common.ProjectReq)
+
+	if err := json.NewDecoder(r.Body).Decode(&req.Body); err != nil {
+		return nil, utilerrors.NewBadRequest(err.Error())
+	}
+
+	return req, nil
+}
+
 func GetResourceQuota(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider, projectProvider provider.PrivilegedProjectProvider) (*apiv2.ResourceQuota, error) {
 	req, ok := request.(getResourceQuota)
 	if !ok {
@@ -172,27 +213,9 @@ func GetResourceQuota(ctx context.Context, request interface{}, provider provide
 func GetResourceQuotaForProject(ctx context.Context, request interface{}, projectProvider provider.ProjectProvider,
 	privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter,
 	quotaProvider provider.ResourceQuotaProvider) (*apiv2.ResourceQuota, error) {
-	req, ok := request.(common.GetProjectRq)
-	if !ok {
-		return nil, utilerrors.NewBadRequest("invalid request")
-	}
-	if len(req.ProjectID) == 0 {
-		return nil, utilerrors.NewBadRequest("the id of the project cannot be empty")
-	}
-
-	kubermaticProject, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
-	if err != nil {
-		return nil, common.KubernetesErrorToHTTPError(err)
-	}
-
-	userInfo, err := userInfoGetter(ctx, kubermaticProject.Name)
+	projectResourceQuota, projectName, err := getProjectResourceQuota(ctx, request, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
 	if err != nil {
 		return nil, err
-	}
-
-	projectResourceQuota, err := quotaProvider.Get(ctx, userInfo, kubermaticProject.Name, strings.ToLower(kubermaticv1.ProjectKindName))
-	if err != nil {
-		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
 	if projectResourceQuota == nil {
@@ -200,7 +223,280 @@ func GetResourceQuotaForProject(ctx context.Context, request interface{}, projec
 		return nil, nil
 	}
 
-	return convertToAPIStruct(projectResourceQuota, kubermaticProject.Spec.Name), nil
+	return convertToAPIStruct(projectResourceQuota, projectName), nil
+}
+
+func CalculateResourceQuotaUpdateForProject(ctx context.Context, request interface{}, projectProvider provider.ProjectProvider,
+	privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter,
+	quotaProvider provider.ResourceQuotaProvider) (*apiv2.ResourceQuotaUpdateCalculation, error) {
+	req, ok := request.(calculateProjectResourceQuotaUpdate)
+	if !ok {
+		return nil, utilerrors.NewBadRequest("invalid request")
+	}
+
+	projectResourceQuota, projectName, err := getProjectResourceQuota(ctx, request, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	if projectResourceQuota == nil {
+		// ResourceQuota not found. Return an empty response.
+		return nil, nil
+	}
+
+	calculatedResources, err := getResourceDetailsFromRequest(req)
+	if err != nil {
+		return nil, utilerrors.NewBadRequest("invalid request, failed getting resources from request body: %v", err)
+	}
+
+	// Add the current global usage
+	if projectResourceQuota.Status.GlobalUsage.CPU != nil && calculatedResources.CPU != nil {
+		calculatedResources.CPU.Add(*projectResourceQuota.Status.GlobalUsage.CPU)
+	}
+	if projectResourceQuota.Status.GlobalUsage.Memory != nil && calculatedResources.Memory != nil {
+		calculatedResources.Memory.Add(*projectResourceQuota.Status.GlobalUsage.Memory)
+	}
+	if projectResourceQuota.Status.GlobalUsage.Storage != nil && calculatedResources.Storage != nil {
+		calculatedResources.Storage.Add(*projectResourceQuota.Status.GlobalUsage.Storage)
+	}
+
+	// check if quota is exceeded
+	var msg string
+	if projectResourceQuota.Spec.Quota.CPU != nil && calculatedResources.CPU != nil &&
+		calculatedResources.CPU.Cmp(*projectResourceQuota.Spec.Quota.CPU) > 0 {
+		msg += fmt.Sprintf("Calculated cpu (%s) exceeds resource quota (%s)", calculatedResources.CPU, projectResourceQuota.Spec.Quota.CPU)
+	}
+	if projectResourceQuota.Spec.Quota.Memory != nil && calculatedResources.Memory != nil &&
+		calculatedResources.Memory.Cmp(*projectResourceQuota.Spec.Quota.Memory) > 0 {
+		msg += fmt.Sprintf("Calculated memory (%s) exceeds resource quota (%s)", calculatedResources.Memory, projectResourceQuota.Spec.Quota.Memory)
+	}
+	if projectResourceQuota.Spec.Quota.Storage != nil && calculatedResources.Storage != nil &&
+		calculatedResources.Storage.Cmp(*projectResourceQuota.Spec.Quota.Storage) > 0 {
+		msg += fmt.Sprintf("Calculated disk size (%s) exceeds resource quota (%s)", calculatedResources.Storage, projectResourceQuota.Spec.Quota.Storage)
+	}
+
+	return &apiv2.ResourceQuotaUpdateCalculation{
+		ResourceQuota:   *convertToAPIStruct(projectResourceQuota, projectName),
+		CalculatedQuota: convertToAPIQuota(*calculatedResources),
+		Message:         msg,
+	}, nil
+}
+
+func getResourceDetailsFromRequest(req calculateProjectResourceQuotaUpdate) (*kubermaticv1.ResourceDetails, error) {
+	nc := kubermaticprovider.NodeCapacity{}
+
+	var err error
+
+	if req.Body.AlibabaInstanceType != nil {
+		nc.WithCPUCount(req.Body.AlibabaInstanceType.CPUCoreCount)
+
+		if err = nc.WithMemory(int(req.Body.AlibabaInstanceType.MemorySize), "G"); err != nil {
+			return nil, err
+		}
+		if err = nc.WithStorage(req.Body.DiskSizeGB, "G"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.AnexiaNodeSpec != nil {
+		nc.WithCPUCount(req.Body.AnexiaNodeSpec.CPUs)
+
+		if err = nc.WithMemory(int(req.Body.AnexiaNodeSpec.Memory), "M"); err != nil {
+			return nil, err
+		}
+
+		var diskSize int64
+		for _, disk := range req.Body.AnexiaNodeSpec.Disks {
+			diskSize += disk.Size
+		}
+		if err = nc.WithStorage(int(diskSize), "G"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.AWSSize != nil {
+		nc.WithCPUCount(req.Body.AWSSize.VCPUs)
+
+		if err = nc.WithMemory(int(req.Body.AWSSize.Memory), "G"); err != nil {
+			return nil, err
+		}
+		if err = nc.WithStorage(req.Body.DiskSizeGB, "G"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.AzureSize != nil {
+		nc.WithCPUCount(int(req.Body.AzureSize.NumberOfCores))
+
+		if err = nc.WithMemory(int(req.Body.AzureSize.MemoryInMB), "M"); err != nil {
+			return nil, err
+		}
+
+		if err = nc.WithStorage(int(req.Body.AzureSize.ResourceDiskSizeInMB+req.Body.AzureSize.OsDiskSizeInMB), "M"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.DOSize != nil {
+		nc.WithCPUCount(req.Body.DOSize.VCPUs)
+
+		if err = nc.WithMemory(req.Body.DOSize.Memory, "M"); err != nil {
+			return nil, err
+		}
+		if err = nc.WithStorage(req.Body.DOSize.Disk, "G"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.EquinixSize != nil {
+		var cpuCount int
+		for _, c := range req.Body.EquinixSize.CPUs {
+			cpuCount += c.Count
+		}
+		nc.WithCPUCount(cpuCount)
+
+		// trimming "B" as quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'.
+		memory, err := resource.ParseQuantity(strings.TrimSuffix(req.Body.EquinixSize.Memory, "B"))
+		if err != nil {
+			return nil, err
+		}
+		nc.Memory = &memory
+
+		var allDrivesStorage resource.Quantity
+		for _, drive := range req.Body.EquinixSize.Drives {
+			if drive.Size == "" || drive.Count == 0 {
+				continue
+			}
+
+			storage, err := resource.ParseQuantity(strings.TrimSuffix(drive.Size, "B"))
+			if err != nil {
+				return nil, err
+			}
+
+			// total storage for each types = drive count *drive Size.
+			strDrive := strconv.FormatInt(storage.Value()*int64(drive.Count), 10)
+			totalStorage, err := resource.ParseQuantity(strDrive)
+			if err != nil {
+				return nil, err
+			}
+			allDrivesStorage.Add(totalStorage)
+		}
+		nc.Storage = &allDrivesStorage
+	} else if req.Body.GCPSize != nil {
+		nc.WithCPUCount(int(req.Body.GCPSize.VCPUs))
+
+		if err = nc.WithMemory(int(req.Body.GCPSize.Memory), "M"); err != nil {
+			return nil, err
+		}
+		if err = nc.WithStorage(req.Body.DiskSizeGB, "G"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.HetznerSize != nil {
+		nc.WithCPUCount(req.Body.HetznerSize.Cores)
+
+		if err = nc.WithMemory(int(req.Body.HetznerSize.Memory), "G"); err != nil {
+			return nil, err
+		}
+		if err = nc.WithStorage(req.Body.HetznerSize.Disk, "G"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.NutanixNodeSpec != nil {
+		nc.WithCPUCount(int(req.Body.NutanixNodeSpec.CPUs))
+
+		if err = nc.WithMemory(int(req.Body.NutanixNodeSpec.MemoryMB), "M"); err != nil {
+			return nil, err
+		}
+
+		if req.Body.NutanixNodeSpec.DiskSize != nil {
+			if err = nc.WithStorage(int(*req.Body.NutanixNodeSpec.DiskSize), "G"); err != nil {
+				return nil, err
+			}
+		} else {
+			nc.Storage = &resource.Quantity{}
+		}
+
+	} else if req.Body.OpenstackSize != nil {
+		nc.WithCPUCount(req.Body.OpenstackSize.VCPUs)
+
+		if err = nc.WithMemory(req.Body.OpenstackSize.Memory, "G"); err != nil {
+			return nil, err
+		}
+		if err = nc.WithStorage(req.Body.OpenstackSize.Disk, "G"); err != nil {
+			return nil, err
+		}
+	} else if req.Body.VSphereNodeSpec != nil {
+		nc.WithCPUCount(req.Body.VSphereNodeSpec.CPUs)
+
+		if err = nc.WithMemory(req.Body.VSphereNodeSpec.Memory, "G"); err != nil {
+			return nil, err
+		}
+
+		if req.Body.VSphereNodeSpec.DiskSizeGB != nil {
+			if err = nc.WithStorage(int(*req.Body.VSphereNodeSpec.DiskSizeGB), "G"); err != nil {
+				return nil, err
+			}
+		} else {
+			nc.Storage = &resource.Quantity{}
+		}
+
+	} else if req.Body.VMDirectorNodeSpec != nil {
+		nc.WithCPUCount(req.Body.VMDirectorNodeSpec.CPUCores * req.Body.VMDirectorNodeSpec.CPUs)
+
+		if err = nc.WithMemory(req.Body.VMDirectorNodeSpec.MemoryMB, "M"); err != nil {
+			return nil, err
+		}
+
+		if req.Body.VMDirectorNodeSpec.DiskSizeGB != nil {
+			if err = nc.WithStorage(int(*req.Body.VMDirectorNodeSpec.DiskSizeGB), "G"); err != nil {
+				return nil, err
+			}
+		} else {
+			nc.Storage = &resource.Quantity{}
+		}
+	} else {
+		return nil, fmt.Errorf("provider set in request not supported: %v", req.Body)
+	}
+
+	// These should not happen, unless we have a bug in the setting resource values code above
+	if nc.CPUCores == nil {
+		return nil, fmt.Errorf("cpu not set in the request: %v", req.Body)
+	}
+	if nc.Memory == nil {
+		return nil, fmt.Errorf("memory not set in the request: %v", req.Body)
+	}
+	if nc.Storage == nil {
+		return nil, fmt.Errorf("storage not set in the request: %v", req.Body)
+	}
+
+	// Multiply by replicas count
+	var cpu, mem, sto resource.Quantity
+	for i := 0; i < req.Body.Replicas; i++ {
+		cpu.Add(*nc.CPUCores)
+		mem.Add(*nc.Memory)
+		sto.Add(*nc.Storage)
+	}
+
+	rd := kubermaticv1.NewResourceDetails(cpu, mem, sto)
+
+	return rd, nil
+}
+
+func getProjectResourceQuota(ctx context.Context, request interface{}, projectProvider provider.ProjectProvider,
+	privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter,
+	quotaProvider provider.ResourceQuotaProvider) (*kubermaticv1.ResourceQuota, string, error) {
+	req, ok := request.(common.GetProjectRq)
+	if !ok {
+		return nil, "", utilerrors.NewBadRequest("invalid request")
+	}
+	if len(req.ProjectID) == 0 {
+		return nil, "", utilerrors.NewBadRequest("the id of the project cannot be empty")
+	}
+
+	kubermaticProject, err := common.GetProject(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, nil)
+	if err != nil {
+		return nil, "", common.KubernetesErrorToHTTPError(err)
+	}
+
+	userInfo, err := userInfoGetter(ctx, kubermaticProject.Name)
+	if err != nil {
+		return nil, "", err
+	}
+
+	projectResourceQuota, err := quotaProvider.Get(ctx, userInfo, kubermaticProject.Name, strings.ToLower(kubermaticv1.ProjectKindName))
+	if err != nil {
+		return nil, "", common.KubernetesErrorToHTTPError(err)
+	}
+	return projectResourceQuota, kubermaticProject.Spec.Name, err
 }
 
 func ListResourceQuotas(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider, projectProvider provider.ProjectProvider) ([]*apiv2.ResourceQuota, error) {

--- a/modules/api/pkg/ee/resource-quota/handler.go
+++ b/modules/api/pkg/ee/resource-quota/handler.go
@@ -42,6 +42,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticprovider "k8c.io/kubermatic/v2/pkg/provider"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/modules/api/pkg/ee/resource-quota/handler_test.go
+++ b/modules/api/pkg/ee/resource-quota/handler_test.go
@@ -28,7 +28,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"k8s.io/utils/pointer"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -43,6 +42,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/modules/api/pkg/ee/resource-quota/handler_test.go
+++ b/modules/api/pkg/ee/resource-quota/handler_test.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"k8s.io/utils/pointer"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -481,7 +482,7 @@ func TestCalculateResourceQuotaUpdate(t *testing.T) {
 				build(),
 		},
 		{
-			Name:      "should process do request successfully",
+			Name:      "should process digitalocean request successfully",
 			ProjectID: test.GenDefaultProject().Name,
 			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
 				newRQBuilder().
@@ -492,6 +493,147 @@ func TestCalculateResourceQuotaUpdate(t *testing.T) {
 			RequestBody: newCalcReq().
 				withReplicas(2).
 				withDO(2, 3000, 10).
+				encode(t),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: newRQUpdateCalculationBuilder().
+				withQuota(genAPIQuota(12, 10, 30)).
+				withGlobalUsage(genAPIQuota(2, 3, 5)).
+				withCalculatedQuota(genAPIQuota(6, 9, 25)).
+				build(),
+		},
+		{
+			Name:      "should process equinix request successfully",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				newRQBuilder().
+					withQuota("12", "10G", "30G").
+					withGlobalUsage("2", "3G", "5G").
+					build()),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			RequestBody: newCalcReq().
+				withReplicas(2).
+				withEquinix(2, "3GB", "10GB").
+				encode(t),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: newRQUpdateCalculationBuilder().
+				withQuota(genAPIQuota(12, 10, 30)).
+				withGlobalUsage(genAPIQuota(2, 3, 5)).
+				withCalculatedQuota(genAPIQuota(6, 9, 25)).
+				build(),
+		},
+		{
+			Name:      "should process gcp request successfully",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				newRQBuilder().
+					withQuota("12", "10G", "30G").
+					withGlobalUsage("2", "3G", "5G").
+					build()),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			RequestBody: newCalcReq().
+				withReplicas(2).
+				withDiskSize(10).
+				withGCP(2, 3000).
+				encode(t),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: newRQUpdateCalculationBuilder().
+				withQuota(genAPIQuota(12, 10, 30)).
+				withGlobalUsage(genAPIQuota(2, 3, 5)).
+				withCalculatedQuota(genAPIQuota(6, 9, 25)).
+				build(),
+		},
+		{
+			Name:      "should process hetzner request successfully",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				newRQBuilder().
+					withQuota("12", "10G", "30G").
+					withGlobalUsage("2", "3G", "5G").
+					build()),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			RequestBody: newCalcReq().
+				withReplicas(2).
+				withHetzner(2, 3, 10).
+				encode(t),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: newRQUpdateCalculationBuilder().
+				withQuota(genAPIQuota(12, 10, 30)).
+				withGlobalUsage(genAPIQuota(2, 3, 5)).
+				withCalculatedQuota(genAPIQuota(6, 9, 25)).
+				build(),
+		},
+		{
+			Name:      "should process nutanix request successfully",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				newRQBuilder().
+					withQuota("12", "10G", "30G").
+					withGlobalUsage("2", "3G", "5G").
+					build()),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			RequestBody: newCalcReq().
+				withReplicas(2).
+				withNutanix(2, 3000, 10).
+				encode(t),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: newRQUpdateCalculationBuilder().
+				withQuota(genAPIQuota(12, 10, 30)).
+				withGlobalUsage(genAPIQuota(2, 3, 5)).
+				withCalculatedQuota(genAPIQuota(6, 9, 25)).
+				build(),
+		},
+		{
+			Name:      "should process openstack request successfully",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				newRQBuilder().
+					withQuota("12", "10G", "30G").
+					withGlobalUsage("2", "3G", "5G").
+					build()),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			RequestBody: newCalcReq().
+				withReplicas(2).
+				withOpenstack(2, 3, 10).
+				encode(t),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: newRQUpdateCalculationBuilder().
+				withQuota(genAPIQuota(12, 10, 30)).
+				withGlobalUsage(genAPIQuota(2, 3, 5)).
+				withCalculatedQuota(genAPIQuota(6, 9, 25)).
+				build(),
+		},
+		{
+			Name:      "should process vmclouddirector request successfully",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				newRQBuilder().
+					withQuota("12", "10G", "30G").
+					withGlobalUsage("2", "3G", "5G").
+					build()),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			RequestBody: newCalcReq().
+				withReplicas(2).
+				withVMDirector(2, 3000, 10).
+				encode(t),
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse: newRQUpdateCalculationBuilder().
+				withQuota(genAPIQuota(12, 10, 30)).
+				withGlobalUsage(genAPIQuota(2, 3, 5)).
+				withCalculatedQuota(genAPIQuota(6, 9, 25)).
+				build(),
+		},
+		{
+			Name:      "should process vsphere request successfully",
+			ProjectID: test.GenDefaultProject().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				newRQBuilder().
+					withQuota("12", "10G", "30G").
+					withGlobalUsage("2", "3G", "5G").
+					build()),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			RequestBody: newCalcReq().
+				withReplicas(2).
+				withVsphere(2, 3, 10).
 				encode(t),
 			ExpectedHTTPStatusCode: http.StatusOK,
 			ExpectedResponse: newRQUpdateCalculationBuilder().
@@ -592,6 +734,7 @@ func (c *calcReq) withAnexia(cpu int, memory, diskSize int64) *calcReq {
 		CPUs:       cpu,
 		Memory:     memory,
 		Disks:      []apiv1.AnexiaDiskConfig{{Size: diskSize}},
+		// needed for json encoding
 		VlanID:     "2",
 		TemplateID: "5",
 	}
@@ -612,6 +755,75 @@ func (c *calcReq) withDO(cpu, memory, storage int) *calcReq {
 		VCPUs:  cpu,
 		Memory: memory,
 		Disk:   storage,
+	}
+	return c
+}
+
+func (c *calcReq) withEquinix(cpu int, memory, storage string) *calcReq {
+	c.EquinixSize = &apiv1.PacketSize{
+		CPUs:   []apiv1.PacketCPU{{Count: cpu}},
+		Memory: memory,
+		Drives: []apiv1.PacketDrive{{Size: storage, Count: 1}},
+	}
+	return c
+}
+
+func (c *calcReq) withGCP(cpu, memory int64) *calcReq {
+	c.GCPSize = &apiv1.GCPMachineSize{
+		VCPUs:  cpu,
+		Memory: memory,
+	}
+	return c
+}
+
+func (c *calcReq) withHetzner(cpu, memory, storage int) *calcReq {
+	c.HetznerSize = &apiv1.HetznerSize{
+		Cores:  cpu,
+		Memory: float32(memory),
+		Disk:   storage,
+	}
+	return c
+}
+
+func (c *calcReq) withNutanix(cpu, memory, storage int64) *calcReq {
+	c.NutanixNodeSpec = &apiv1.NutanixNodeSpec{
+		CPUs:     cpu,
+		CPUCores: pointer.Int64(1),
+		MemoryMB: memory,
+		DiskSize: pointer.Int64(storage),
+	}
+	return c
+}
+
+func (c *calcReq) withOpenstack(cpu, memory, storage int) *calcReq {
+	c.OpenstackSize = &apiv1.OpenstackSize{
+		VCPUs:  cpu,
+		Memory: memory,
+		Disk:   storage,
+	}
+	return c
+}
+
+func (c *calcReq) withVMDirector(cpu, memory, storage int) *calcReq {
+	c.VMDirectorNodeSpec = &apiv1.VMwareCloudDirectorNodeSpec{
+		CPUCores:   1,
+		CPUs:       cpu,
+		MemoryMB:   memory,
+		DiskSizeGB: pointer.Int64(int64(storage)),
+		// needed for json encoding
+		Template: "t",
+		Catalog:  "c",
+	}
+	return c
+}
+
+func (c *calcReq) withVsphere(cpu, memory, storage int) *calcReq {
+	c.VSphereNodeSpec = &apiv1.VSphereNodeSpec{
+		CPUs:       cpu,
+		Memory:     memory,
+		DiskSizeGB: pointer.Int64(int64(storage)),
+		// needed for json encoding
+		Template: "t",
 	}
 	return c
 }
@@ -678,19 +890,6 @@ func genDefaultResourceQuota() *kubermaticv1.ResourceQuota {
 		Status: kubermaticv1.ResourceQuotaStatus{
 			GlobalUsage: genQuota(resource.MustParse("3"), resource.MustParse("2000M"), resource.MustParse("10G")),
 		},
-	}
-}
-
-func genAPIResourceQuota(quota, globalUsage apiv2.Quota) apiv2.ResourceQuota {
-	return apiv2.ResourceQuota{
-		Name:        fmt.Sprintf("project-%s", projectName),
-		SubjectName: projectName,
-		SubjectKind: kubermaticv1.ProjectSubjectKind,
-		Quota:       quota,
-		Status: apiv2.ResourceQuotaStatus{
-			GlobalUsage: globalUsage,
-		},
-		SubjectHumanReadableName: "my-first-project",
 	}
 }
 

--- a/modules/api/pkg/ee/resource-quota/handler_test.go
+++ b/modules/api/pkg/ee/resource-quota/handler_test.go
@@ -731,9 +731,9 @@ func (c *calcReq) withAlibaba(cpu, memory int) *calcReq {
 
 func (c *calcReq) withAnexia(cpu int, memory, diskSize int64) *calcReq {
 	c.AnexiaNodeSpec = &apiv1.AnexiaNodeSpec{
-		CPUs:       cpu,
-		Memory:     memory,
-		Disks:      []apiv1.AnexiaDiskConfig{{Size: diskSize}},
+		CPUs:   cpu,
+		Memory: memory,
+		Disks:  []apiv1.AnexiaDiskConfig{{Size: diskSize}},
 		// needed for json encoding
 		VlanID:     "2",
 		TemplateID: "5",

--- a/modules/api/pkg/handler/v2/resource_quota/resourequota.go
+++ b/modules/api/pkg/handler/v2/resource_quota/resourequota.go
@@ -35,6 +35,13 @@ func GetForProjectEndpoint(projectProvider provider.ProjectProvider, privilegedP
 	}
 }
 
+func CalculateProjectQuotaUpdateEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider,
+	userInfoGetter provider.UserInfoGetter, quotaProvider provider.ResourceQuotaProvider) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		return calculateResourceQuotaUpdateForProject(ctx, request, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
+	}
+}
+
 func GetResourceQuotaEndpoint(userInfoGetter provider.UserInfoGetter, provider provider.ResourceQuotaProvider, projectProvider provider.PrivilegedProjectProvider) endpoint.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		userInfo, err := userInfoGetter(ctx, "")

--- a/modules/api/pkg/handler/v2/resource_quota/wrappers_ce.go
+++ b/modules/api/pkg/handler/v2/resource_quota/wrappers_ce.go
@@ -30,6 +30,12 @@ func getResourceQuotaForProject(_ context.Context, _ interface{}, _ provider.Pro
 	_ provider.PrivilegedProjectProvider, _ provider.UserInfoGetter, _ provider.ResourceQuotaProvider) (*apiv2.ResourceQuota, error) {
 	return nil, nil
 }
+
+func calculateResourceQuotaUpdateForProject(_ context.Context, _ interface{}, _ provider.ProjectProvider,
+	_ provider.PrivilegedProjectProvider, _ provider.UserInfoGetter, _ provider.ResourceQuotaProvider) (*apiv2.ResourceQuota, error) {
+	return nil, nil
+}
+
 func getResourceQuota(_ context.Context, _ interface{}, _ provider.ResourceQuotaProvider, _ provider.PrivilegedProjectProvider) (*apiv2.ResourceQuota, error) {
 	return nil, nil
 }
@@ -63,5 +69,9 @@ func DecodeCreateResourceQuotasReq(_ context.Context, _ *http.Request) (interfac
 }
 
 func DecodePutResourceQuotasReq(_ context.Context, _ *http.Request) (interface{}, error) {
+	return nil, nil
+}
+
+func DecodeCalculateProjectResourceQuotaUpdateReq(_ context.Context, _ *http.Request) (interface{}, error) {
 	return nil, nil
 }

--- a/modules/api/pkg/handler/v2/resource_quota/wrappers_ee.go
+++ b/modules/api/pkg/handler/v2/resource_quota/wrappers_ee.go
@@ -33,6 +33,12 @@ func getResourceQuotaForProject(ctx context.Context, request interface{}, projec
 	return resourcequota.GetResourceQuotaForProject(ctx, request, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
 }
 
+func calculateResourceQuotaUpdateForProject(ctx context.Context, request interface{}, projectProvider provider.ProjectProvider,
+	privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter,
+	quotaProvider provider.ResourceQuotaProvider) (*apiv2.ResourceQuotaUpdateCalculation, error) {
+	return resourcequota.CalculateResourceQuotaUpdateForProject(ctx, request, projectProvider, privilegedProjectProvider, userInfoGetter, quotaProvider)
+}
+
 func getResourceQuota(ctx context.Context, request interface{}, provider provider.ResourceQuotaProvider, projectProvider provider.PrivilegedProjectProvider) (*apiv2.ResourceQuota, error) {
 	return resourcequota.GetResourceQuota(ctx, request, provider, projectProvider)
 }
@@ -67,4 +73,8 @@ func DecodeCreateResourceQuotasReq(_ context.Context, r *http.Request) (interfac
 
 func DecodePutResourceQuotasReq(_ context.Context, r *http.Request) (interface{}, error) {
 	return resourcequota.DecodePutResourceQuotaReq(r)
+}
+
+func DecodeCalculateProjectResourceQuotaUpdateReq(c context.Context, r *http.Request) (interface{}, error) {
+	return resourcequota.DecodeCalculateProjectResourceQuotaUpdateReq(c, r)
 }

--- a/modules/api/pkg/handler/v2/routes_v2.go
+++ b/modules/api/pkg/handler/v2/routes_v2.go
@@ -1420,7 +1420,7 @@ func (r Routing) RegisterV2(mux *mux.Router, oidcKubeConfEndpoint bool, oidcCfg 
 		Handler(r.getProjectQuota())
 
 	mux.Methods(http.MethodPost).
-		Path("/projects/{project_id}/calculatequotaupdate").
+		Path("/projects/{project_id}/quotacalculation").
 		Handler(r.calculateProjectQuotaUpdate())
 
 	mux.Methods(http.MethodGet).


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds endpoint for resource quota calculation, based on the current project quota + the chose node from a provider.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5313 

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[EE] Added an resource quota endpoint which given a provider node size and replica count, returns the calculation of what the projects resource quota usage would be and a message if the quota is exceeded.
`POST /api/v2/projects/{project_id}/quotacalculation`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
