### PR TITLE
KubeVirt split csi driver deployment

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -103,7 +103,7 @@ require (
 	github.com/go-openapi/validate v0.22.0
 	github.com/go-swagger/go-swagger v0.30.3
 	github.com/onsi/ginkgo v1.16.5
-	k8c.io/kubermatic/v2 v2.21.1-0.20221111113237-e6c193aeffb0
+	k8c.io/kubermatic/v2 v2.21.1-0.20221122140205-50133d9551f3
 	k8s.io/code-generator v0.25.3
 	sigs.k8s.io/controller-tools v0.10.0
 )

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1455,8 +1455,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.5.2 h1:eA3bh6qMoDAqrG2gXPlJCspjw1So2y+RLUPfODZmx0s=
 k8c.io/kubeone v1.5.2/go.mod h1:xNlAertZO2iKVE8pL0Ruf/zjtM+EBeiZJtueuncyjxI=
-k8c.io/kubermatic/v2 v2.21.1-0.20221111113237-e6c193aeffb0 h1:e73Mng4m5rkrUVhD9r8mOhzG2diIIeB/WWpL/2+naPw=
-k8c.io/kubermatic/v2 v2.21.1-0.20221111113237-e6c193aeffb0/go.mod h1:emSeMfwCv1yKtZXecd6tQhPQSjGqvI+Q+GAm/DQLVC0=
+k8c.io/kubermatic/v2 v2.21.1-0.20221122140205-50133d9551f3 h1:44/5UPcqzhrpEGkt7SUb0HVzFAaLqqQd356s2o1fKxA=
+k8c.io/kubermatic/v2 v2.21.1-0.20221122140205-50133d9551f3/go.mod h1:KD+BchPap6180cJXPMsbc1jCn8deC9X6ZmP9kpPv+1M=
 k8c.io/operating-system-manager v1.1.1 h1:nQ4/3pnGwolxkboxRAfPOl7Uhk2/rayaJ0paCMZnHFM=
 k8c.io/operating-system-manager v1.1.1/go.mod h1:ybfmS133EOoBMm1MHOC1HIdrgCzn5nu29KCDtyaShqs=
 k8s.io/api v0.25.3 h1:Q1v5UFfYe87vi5H7NU0p4RXC26PPMT8KOpr1TLQbCMQ=

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -28,7 +28,6 @@ import (
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	vcd "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vmwareclouddirector/types"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
-	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
 
@@ -2510,7 +2509,10 @@ type ApplicationRef struct {
 	Name string `json:"name" required:"true"`
 
 	// Version of the Application. Must be a valid SemVer version
-	Version appskubermaticv1.Version `json:"version" required:"true"`
+	// NOTE: We are not using Masterminds/semver here, as it keeps data in unexported fields witch causes issues for
+	// DeepEqual used in our reconciliation packages. At the same time, we are not using pkg/semver because
+	// of the reasons stated in https://github.com/kubermatic/kubermatic/pull/10891.
+	Version string `json:"version" required:"true"`
 }
 
 // NodeDeployment represents a set of worker nodes that is part of a cluster

--- a/modules/api/pkg/handler/test/helper.go
+++ b/modules/api/pkg/handler/test/helper.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	semverlib "github.com/Masterminds/semver/v3"
 	constrainttemplatev1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	gatekeeperconfigv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/config/v1alpha1"
 	prometheusapi "github.com/prometheus/client_golang/api"
@@ -2181,10 +2180,8 @@ func GenApplicationInstallation(name, clusterName, targetnamespace string) *apps
 				Create: true,
 			},
 			ApplicationRef: appskubermaticv1.ApplicationRef{
-				Name: "sample-app",
-				Version: appskubermaticv1.Version{
-					Version: *semverlib.MustParse("v1.0.0"),
-				},
+				Name:    "sample-app",
+				Version: "1.0.0",
 			},
 		},
 	}
@@ -2203,10 +2200,8 @@ func GenApiApplicationInstallation(name, clusterName, targetnamespace string) *a
 				Create: true,
 			},
 			ApplicationRef: appskubermaticv1.ApplicationRef{
-				Name: "sample-app",
-				Version: appskubermaticv1.Version{
-					Version: *semverlib.MustParse("v1.0.0"),
-				},
+				Name:    "sample-app",
+				Version: "1.0.0",
 			},
 		},
 		Status: &apiv2.ApplicationInstallationStatus{},

--- a/modules/api/pkg/handler/v1/admin/settings_test.go
+++ b/modules/api/pkg/handler/v1/admin/settings_test.go
@@ -43,7 +43,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		// scenario 1
 		{
 			name:                   "scenario 1: user gets settings first time",
-			expectedResponse:       `{"customLinks":[],"defaultNodeCount":2,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableWebTerminal":false,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
+			expectedResponse:       `{"customLinks":[],"defaultNodeCount":2,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
@@ -51,7 +51,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		// scenario 2
 		{
 			name:             "scenario 2: user gets existing global settings",
-			expectedResponse: `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"defaultNodeCount":5,"displayDemoInfo":true,"displayAPIDocs":true,"displayTermsOfService":true,"enableDashboard":false,"enableWebTerminal":false,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{"enabled":true,"enforced":true},"mlaOptions":{"loggingEnabled":true,"loggingEnforced":true,"monitoringEnabled":true,"monitoringEnforced":true},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}}}`,
+			expectedResponse: `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"defaultNodeCount":5,"displayDemoInfo":true,"displayAPIDocs":true,"displayTermsOfService":true,"enableDashboard":false,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{"enabled":true,"enforced":true},"mlaOptions":{"loggingEnabled":true,"loggingEnforced":true,"monitoringEnabled":true,"monitoringEnforced":true},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}}}`,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true),
 				test.GenDefaultGlobalSettings()},
@@ -107,7 +107,7 @@ func TestUpdateGlobalSettings(t *testing.T) {
 		{
 			name:                   "scenario 2: authorized user updates default settings",
 			body:                   `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"enabled":true,"enforced":true},"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true}`,
-			expectedResponse:       `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":true,"enableWebTerminal":false,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
+			expectedResponse:       `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
@@ -116,7 +116,7 @@ func TestUpdateGlobalSettings(t *testing.T) {
 		{
 			name:             "scenario 3: authorized user updates existing global settings",
 			body:             `{"customLinks":[],"cleanupOptions":{"enabled":true,"enforced":true},"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"userProjectsLimit":10,"restrictProjectCreation":true}`,
-			expectedResponse: `{"customLinks":[],"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":false,"enableWebTerminal":false,"enableOIDCKubeconfig":false,"userProjectsLimit":10,"restrictProjectCreation":true,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{"enabled":true,"enforced":true},"mlaOptions":{"loggingEnabled":true,"loggingEnforced":true,"monitoringEnabled":true,"monitoringEnforced":true},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}}}`,
+			expectedResponse: `{"customLinks":[],"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":false,"enableOIDCKubeconfig":false,"userProjectsLimit":10,"restrictProjectCreation":true,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{"enabled":true,"enforced":true},"mlaOptions":{"loggingEnabled":true,"loggingEnforced":true,"monitoringEnabled":true,"monitoringEnforced":true},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}}}`,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true),
 				test.GenDefaultGlobalSettings()},

--- a/modules/api/pkg/handler/v2/application_installation/application_installation_test.go
+++ b/modules/api/pkg/handler/v2/application_installation/application_installation_test.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	semverlib "github.com/Masterminds/semver/v3"
-
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	"k8c.io/dashboard/v2/pkg/handler/test"
@@ -76,10 +74,8 @@ func TestListApplicationInstallations(t *testing.T) {
 							Create: true,
 						},
 						ApplicationRef: appskubermaticv1.ApplicationRef{
-							Name: "sample-app",
-							Version: appskubermaticv1.Version{
-								Version: *semverlib.MustParse("v1.0.0"),
-							},
+							Name:    "sample-app",
+							Version: "1.0.0",
 						},
 					},
 					Status: &apiv2.ApplicationInstallationListItemStatus{},
@@ -92,10 +88,8 @@ func TestListApplicationInstallations(t *testing.T) {
 							Create: true,
 						},
 						ApplicationRef: appskubermaticv1.ApplicationRef{
-							Name: "sample-app",
-							Version: appskubermaticv1.Version{
-								Version: *semverlib.MustParse("v1.0.0"),
-							},
+							Name:    "sample-app",
+							Version: "1.0.0",
 						},
 					},
 					Status: &apiv2.ApplicationInstallationListItemStatus{},
@@ -169,10 +163,8 @@ func TestCreateApplicationInstallation(t *testing.T) {
 						Create: true,
 					},
 					ApplicationRef: appskubermaticv1.ApplicationRef{
-						Name: "sample-app",
-						Version: appskubermaticv1.Version{
-							Version: *semverlib.MustParse("v1.0.0"),
-						},
+						Name:    "sample-app",
+						Version: "1.0.0",
 					},
 				},
 				Status: &apiv2.ApplicationInstallationStatus{},
@@ -347,10 +339,8 @@ func TestGetApplication(t *testing.T) {
 						Create: true,
 					},
 					ApplicationRef: appskubermaticv1.ApplicationRef{
-						Name: "sample-app",
-						Version: appskubermaticv1.Version{
-							Version: *semverlib.MustParse("v1.0.0"),
-						},
+						Name:    "sample-app",
+						Version: "1.0.0",
 					},
 				},
 				Status: &apiv2.ApplicationInstallationStatus{},
@@ -426,10 +416,8 @@ func TestUpdateApplicationInstallation(t *testing.T) {
 						Create: true,
 					},
 					ApplicationRef: appskubermaticv1.ApplicationRef{
-						Name: "sample-app",
-						Version: appskubermaticv1.Version{
-							Version: *semverlib.MustParse("v1.0.0"),
-						},
+						Name:    "sample-app",
+						Version: "1.0.0",
 					},
 					Values: *test.CreateRawVariables(t, map[string]interface{}{"key": "val"}),
 				},

--- a/modules/api/pkg/provider/cloud/kubevirt/provider.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/provider.go
@@ -182,7 +182,7 @@ func GetCredentialsForCluster(cloud kubermaticv1.CloudSpec, secretKeySelector pr
 		if cloud.Kubevirt.CredentialsReference == nil {
 			return "", errors.New("no credentials provided")
 		}
-		kubeconfig, err = secretKeySelector(cloud.Kubevirt.CredentialsReference, resources.KubevirtKubeConfig)
+		kubeconfig, err = secretKeySelector(cloud.Kubevirt.CredentialsReference, resources.KubeVirtKubeconfig)
 		if err != nil {
 			return "", err
 		}

--- a/modules/api/pkg/provider/kubernetes/credentials.go
+++ b/modules/api/pkg/provider/kubernetes/credentials.go
@@ -37,7 +37,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/alibaba"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/anexia"
-	"k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/nutanix"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/vmwareclouddirector"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/vsphere"
@@ -421,17 +420,9 @@ func createOrUpdateKubevirtSecret(ctx context.Context, seedClient ctrlruntimecli
 		return false, nil
 	}
 
-	// ensure that CSI driver on user cluster will have access to KubeVirt cluster
-	// RBAC reconciliation takes place in the kubevirt cloud provider
-	csiKubeconfig, err := kubevirt.EnsureCSIInfraTokenAccess(ctx, spec.Kubeconfig)
-	if err != nil {
-		return false, err
-	}
-
 	// move credentials into dedicated Secret
 	credentialRef, err := ensureCredentialSecret(ctx, seedClient, cluster, map[string][]byte{
-		resources.KubevirtKubeConfig:    []byte(spec.Kubeconfig),
-		resources.KubevirtCSIKubeConfig: csiKubeconfig,
+		resources.KubeVirtKubeconfig: []byte(spec.Kubeconfig),
 	})
 	if err != nil {
 		return false, err

--- a/modules/api/pkg/validation/cluster.go
+++ b/modules/api/pkg/validation/cluster.go
@@ -936,7 +936,7 @@ func validateFakeCloudSpec(spec *kubermaticv1.FakeCloudSpec) error {
 
 func validateKubevirtCloudSpec(spec *kubermaticv1.KubevirtCloudSpec) error {
 	if spec.Kubeconfig == "" {
-		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.KubevirtKubeConfig); err != nil {
+		if err := kuberneteshelper.ValidateSecretKeySelector(spec.CredentialsReference, resources.KubeVirtKubeconfig); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Following the split of the KubeVirt CSI driver deployment between tenant (user) and infra cluster (https://github.com/kubermatic/kubermatic/pull/11370), this PR contains the dashboard changes needed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5149 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
- https://github.com/kubermatic/kubermatic/pull/11362 -> enableWebTerminal is now optional, adjusting the unit tests
- https://github.com/kubermatic/kubermatic/pull/11359 -> Application Version is now a string.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt: split CSI driver deployment between user and infra cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
