### PR TITLE
limit husky to fe in pre-commit hook

### DIFF
--- a/modules/web/.husky/pre-commit
+++ b/modules/web/.husky/pre-commit
@@ -16,5 +16,12 @@
 . "$(dirname "$0")/_/husky.sh"
 cd modules/web/.husky
 
+# If there are no changes in modules/web, exit the hook early so we don't run on BE-only changes.
+# Since we cd into husky dir, run git diff based on git root directory
+if git diff --quiet main -- "$(git rev-parse --show-toplevel)/modules/web" ; then
+  echo "No changes detected in modules/web, skipping pre-commit hook"
+  exit 0
+fi
+
 npx lint-staged
 npm run check

--- a/modules/web/.husky/pre-commit
+++ b/modules/web/.husky/pre-commit
@@ -18,10 +18,12 @@ cd modules/web/.husky
 
 # If there are no changes in modules/web, exit the hook early so we don't run on BE-only changes.
 # Since we cd into husky dir, run git diff based on git root directory
-if git diff --quiet main -- "$(git rev-parse --show-toplevel)/modules/web" ; then
-  echo "No changes detected in modules/web, skipping pre-commit hook"
+web_dir_path="$(git rev-parse --show-toplevel)/modules/web"
+
+if git diff --quiet -- $web_dir_path || git diff --quiet --cached -- $web_dir_path
+then
+  npx lint-staged
+  npm run check
+else
   exit 0
 fi
-
-npx lint-staged
-npm run check

--- a/modules/web/.husky/pre-push
+++ b/modules/web/.husky/pre-push
@@ -16,4 +16,9 @@
 . "$(dirname "$0")/_/husky.sh"
 cd modules/web/.husky
 
+# If there are no changes in modules/web, exit the hook early so we don't run on BE-only changes.
+if git diff --quiet --cached main -- "$(git rev-parse --show-toplevel)/modules/web"; then
+  exit 0
+fi
+
 npm run test


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that husky pre-commit and pre-push hooks exit early if there are no changes made to `modules/web`

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

There is one caveat to the current solution: Let's assume you have branch that has commits in the `modules/web` folder. If you are now making a new commit which does not change the folder, it will still run the pre-commit hook. The reason for this is because it compares your current ref with main.

There is a really weird reason though why we need to compare with main: Running `git diff --quiet` on a branch that has only new files staged, fails because new files cannot be diffed against event if they just have been added
Here's a full example

```sh
❯ touch modules/web/file
❯ git add modules/web/file
❯ git status
# On branch: limit-husky-to-fe  |  [*] => $e*
#
➤ Changes to be committed
#
#       new file:  [1] modules/web/file
#
❯ git diff --quiet -- "$(git rev-parse --show-toplevel)/modules/web" # will succeed, even though it should fail
❯ git diff --quiet main -- "$(git rev-parse --show-toplevel)/modules/web" # fails as expected
```


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
