### PR TITLE
Use KKP version in links

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/share-kubeconfig/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/share-kubeconfig/component.ts
@@ -18,6 +18,7 @@ import {UserService} from '@core/services/user';
 import {Cluster} from '@shared/entity/cluster';
 import {take} from 'rxjs/operators';
 import {ClusterService} from '@core/services/cluster';
+import {getEditionVersion} from '@shared/utils/common';
 
 @Component({
   selector: 'km-share-kubeconfig',
@@ -30,6 +31,7 @@ export class ShareKubeconfigComponent implements OnInit {
   @Input() projectID: string;
   private userID: string;
   kubeconfigLink: string;
+  editionVersion: string = getEditionVersion();
 
   constructor(
     private readonly _clusterService: ClusterService,

--- a/modules/web/src/app/cluster/details/cluster/share-kubeconfig/template.html
+++ b/modules/web/src/app/cluster/details/cluster/share-kubeconfig/template.html
@@ -19,7 +19,7 @@ limitations under the License.
     Share <b>{{cluster.name}}</b> cluster with other users by giving them the following link that can be used to authenticate with an OIDC provider and then generate a kubeconfig file.
   </p>
   <p>
-    Please <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
+    Please <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
        target="_blank"
        rel="noopener">visit our documentation</a>
     for more details.

--- a/modules/web/src/app/project/component.ts
+++ b/modules/web/src/app/project/component.ts
@@ -40,7 +40,7 @@ import {View} from '@shared/entity/common';
 import {Member} from '@shared/entity/member';
 import {Project, ProjectOwner, ProjectStatus} from '@shared/entity/project';
 import {UserSettings} from '@shared/entity/settings';
-import {objectDiff} from '@shared/utils/common';
+import {getEditionVersion, objectDiff} from '@shared/utils/common';
 import {MemberUtils, Permission} from '@shared/utils/member';
 import _ from 'lodash';
 import {CookieService} from 'ngx-cookie-service';
@@ -73,6 +73,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
   isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   hasQuota: boolean;
   isProjectsLoading: boolean;
+  editionVersion: string = getEditionVersion();
 
   private readonly _maxOwnersLen = 30;
   private _apiSettings: UserSettings;

--- a/modules/web/src/app/project/template.html
+++ b/modules/web/src/app/project/template.html
@@ -346,7 +346,7 @@ limitations under the License.
            fxLayoutAlign="center center"
            class="placeholder-text">
         <p>Dive right into your first project.</p>
-        <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/project-and-cluster-management/"
+        <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/project-and-cluster-management/"
            target="_blank"
            rel="noreferrer noopener">
           Learn more in our documentation >

--- a/modules/web/src/app/settings/admin/interface/component.ts
+++ b/modules/web/src/app/settings/admin/interface/component.ts
@@ -19,7 +19,7 @@ import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
 import {Member} from '@shared/entity/member';
 import {AdminSettings} from '@shared/entity/settings';
-import {objectDiff} from '@shared/utils/common';
+import {getEditionVersion, objectDiff} from '@shared/utils/common';
 import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {debounceTime, switchMap, take, takeUntil} from 'rxjs/operators';
@@ -35,6 +35,7 @@ export class InterfaceComponent implements OnInit, OnDestroy {
   apiSettings: AdminSettings; // Original settings from the API. Cannot be edited by the user.
   isOIDCKubeCfgEndpointEnabled = true;
   isOpenIDAuthPluginEnabled = true;
+  editionVersion: string = getEditionVersion();
 
   private readonly _debounceTime = 500;
   private _settingsChange = new Subject<void>();

--- a/modules/web/src/app/settings/admin/interface/template.html
+++ b/modules/web/src/app/settings/admin/interface/template.html
@@ -86,7 +86,7 @@ limitations under the License.
                       id="km-enable-kubernetes-dashboard-setting">
           <ng-container *ngIf="!isKubernetesDashboardFeatureGatesEnabled()">
             <mat-hint>This feature is disabled. Visit the
-              <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
+              <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
                  target="_blank"
                  rel="noopener noreferrer">
                 documentation
@@ -111,7 +111,7 @@ limitations under the License.
                       (change)="onOIDCKubeconfigSettingsChange()"
                       id="km-enable-oidc-setting">
           <mat-hint *ngIf="!isOIDCKubeCfgEndpointEnabled">This feature is disabled. Visit the
-            <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
+            <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
                target="_blank"
                rel="noopener noreferrer">
               documentation

--- a/modules/web/src/app/settings/user/component.ts
+++ b/modules/web/src/app/settings/user/component.ts
@@ -20,7 +20,7 @@ import {UserService} from '@core/services/user';
 import {Member} from '@shared/entity/member';
 import {Project} from '@shared/entity/project';
 import {UserSettings} from '@shared/entity/settings';
-import {objectDiff} from '@shared/utils/common';
+import {getEditionVersion, objectDiff} from '@shared/utils/common';
 import {View} from '@shared/entity/common';
 import _ from 'lodash';
 import {Subject} from 'rxjs';
@@ -41,6 +41,8 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
   apiSettings: UserSettings; // Original settings from the API. Cannot be edited by the user.
   selectedProjectLandingPage: string;
   view = View;
+  editionVersion: string = getEditionVersion();
+
   private readonly _debounceTime = 1000;
   private _settingsChange = new Subject<void>();
   private _unsubscribe = new Subject<void>();

--- a/modules/web/src/app/settings/user/template.html
+++ b/modules/web/src/app/settings/user/template.html
@@ -48,7 +48,7 @@ limitations under the License.
         <ng-template #noGroups>
           <div>
             No OIDC groups assigned.
-            <a href="https://docs.kubermatic.com/kubermatic/main/architecture/role-based-access-control/groups-support/"
+            <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/architecture/role-based-access-control/groups-support/"
                target="_blank"
                rel="noreferrer noopener">Learn more ></a>
           </div>

--- a/modules/web/src/app/shared/components/addon-list/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/component.ts
@@ -24,6 +24,7 @@ import {ConfirmationDialogComponent} from '../confirmation-dialog/component';
 import {EditAddonDialogComponent} from './edit-addon-dialog/component';
 import {InstallAddonDialogComponent} from './install-addon-dialog/component';
 import {AddonService} from '@core/services/addon';
+import {getEditionVersion} from '@shared/utils/common';
 
 @Component({
   selector: 'km-addon-list',
@@ -46,6 +47,8 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
   accessibleAddons: string[] = [];
   installableAddons: string[] = [];
   addonConfigs = new Map<string, AddonConfig>();
+  editionVersion: string = getEditionVersion();
+
   private _unsubscribe: Subject<void> = new Subject<void>();
 
   constructor(

--- a/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
@@ -27,6 +27,7 @@ import {
 } from '@shared/entity/addon';
 import {FormBuilder, FormControl, FormGroup, ValidatorFn, Validators} from '@angular/forms';
 import {MatStepper} from '@angular/material/stepper';
+import {getEditionVersion} from '@shared/utils/common';
 
 export enum Controls {
   ContinuouslyReconcile = 'continuouslyReconcile',
@@ -55,6 +56,7 @@ export class InstallAddonDialogComponent {
   selectedAddon: string;
   form: FormGroup;
   formBasic: FormGroup;
+  editionVersion: string = getEditionVersion();
 
   constructor(
     public dialogRef: MatDialogRef<Component>,

--- a/modules/web/src/app/shared/components/addon-list/install-addon-dialog/template.html
+++ b/modules/web/src/app/shared/components/addon-list/install-addon-dialog/template.html
@@ -30,7 +30,7 @@ limitations under the License.
         <p>
           Addons are extensions provided by Kubermatic to expand cluster capabilities.
           <br />
-          <a href="https://docs.kubermatic.com/kubermatic/main/architecture/concept/kkp-concepts/addons/"
+          <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/architecture/concept/kkp-concepts/addons/"
              target="_blank"
              rel="noreferrer noopener">
             Learn more about Addons >

--- a/modules/web/src/app/shared/components/addon-list/template.html
+++ b/modules/web/src/app/shared/components/addon-list/template.html
@@ -19,7 +19,7 @@ limitations under the License.
   <div fxFlex>
     <p *ngIf="!addons?.length">
       Addons are extensions provided by Kubermatic to expand cluster capabilities,
-      <a href="https://docs.kubermatic.com/kubermatic/main/architecture/concept/kkp-concepts/addons/"
+      <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/architecture/concept/kkp-concepts/addons/"
          target="_blank"
          rel="noreferrer noopener">
         learn more about Addons >

--- a/modules/web/src/app/shared/components/application-list/add-application-dialog/component.ts
+++ b/modules/web/src/app/shared/components/application-list/add-application-dialog/component.ts
@@ -31,6 +31,7 @@ import * as y from 'js-yaml';
 import _ from 'lodash';
 import {Subject, Subscription} from 'rxjs';
 import {finalize, takeUntil} from 'rxjs/operators';
+import {getEditionVersion} from '@shared/utils/common';
 
 enum Controls {
   Version = 'version',
@@ -68,6 +69,7 @@ export class AddApplicationDialogComponent implements OnInit, OnChanges, OnDestr
   selectedVersionSource: string;
   isValuesConfigValid = true;
   isLoadingDetails: boolean;
+  editionVersion: string = getEditionVersion();
 
   private readonly _unsubscribe = new Subject<void>();
   private _namespaceValueChangesSubscription$: Subscription;

--- a/modules/web/src/app/shared/components/application-list/add-application-dialog/template.html
+++ b/modules/web/src/app/shared/components/application-list/add-application-dialog/template.html
@@ -29,7 +29,7 @@ limitations under the License.
       <div fxLayout="column">
         <p class="application-settings-desc">
           Install third party Applications into a cluster,
-          <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/applications/"
+          <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/applications/"
              target="_blank"
              rel="noreferrer noopener">
             learn more about Applications >

--- a/modules/web/src/app/shared/components/application-list/component.ts
+++ b/modules/web/src/app/shared/components/application-list/component.ts
@@ -26,6 +26,7 @@ import {StatusIcon} from '@shared/utils/health-status';
 import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
+import {getEditionVersion} from '@shared/utils/common';
 
 export enum ApplicationsListView {
   Default,
@@ -97,6 +98,7 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
   applicationsMethodMap: ApplicationMethodMap = {};
   applicationsSourceMap: ApplicationSourceMap = {};
   applicationsStatusMap: ApplicationStatusMap = {};
+  editionVersion: string = getEditionVersion();
 
   private readonly _unsubscribe: Subject<void> = new Subject<void>();
 

--- a/modules/web/src/app/shared/components/application-list/template.html
+++ b/modules/web/src/app/shared/components/application-list/template.html
@@ -287,7 +287,7 @@ limitations under the License.
 </div>
 
 <ng-template #applicationDocsLink>
-  <a href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/applications/"
+  <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/applications/"
      target="_blank"
      rel="noreferrer noopener">
     learn more about Applications >

--- a/modules/web/src/app/shared/utils/common.ts
+++ b/modules/web/src/app/shared/utils/common.ts
@@ -14,6 +14,7 @@
 
 import _ from 'lodash';
 import {load as loadYAML} from 'js-yaml';
+import version from '@assets/config/version.json';
 
 export function objectDiff(object: any, base: any): any {
   return _.transform(object, (result, value, key) => {
@@ -97,4 +98,8 @@ export function verifyJSON(data: string): boolean {
 const maxUsageDefault = 100;
 export function getPercentage(total: number, used: number, maxUsage = maxUsageDefault): number {
   return Math.round(((used / total) * maxUsage + Number.EPSILON) * maxUsage) / maxUsage;
+}
+
+export function getEditionVersion(): string {
+  return `v${version.semver?.major}.${version.semver?.minor}`;
 }

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -68,6 +68,7 @@ import {
   handleClusterDefaultNodeSelector,
 } from '@shared/utils/cluster';
 import {KeyValueEntry} from '@shared/types/common';
+import {getEditionVersion} from '@shared/utils/common';
 
 enum Controls {
   Name = 'name',
@@ -134,6 +135,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   cniPlugin = CNIPlugin;
   cniPluginVersions: string[] = [];
   availableProxyModes = [ProxyMode.ipvs, ProxyMode.iptables];
+  editionVersion: string = getEditionVersion();
   exposeStrategies = [ExposeStrategy.loadbalancer, ExposeStrategy.nodePort, ExposeStrategy.tunneling];
   isKonnectivityEnabled = false;
   isDualStackAllowed = false;

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -125,7 +125,7 @@ limitations under the License.
             </mat-select>
             <mat-hint>Leave empty to use the default value. Check the documentation for more information&nbsp;<a target="_blank"
                  rel="noopener"
-                 href="https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/networking/expose-strategies/#configure-the-expose-strategy">here</a>.
+                 href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/expose-strategies/#configure-the-expose-strategy">here</a>.
             </mat-hint>
           </mat-form-field>
           <km-chip-list *ngIf="isExposeStrategyLoadBalancer()"

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/kubevirt/component.ts
@@ -25,6 +25,7 @@ import _ from 'lodash';
 import {merge, Observable, of, onErrorResumeNext} from 'rxjs';
 import {catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, takeUntil, tap} from 'rxjs/operators';
 import {URL_PATTERN_VALIDATOR, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
+import {getEditionVersion} from '@shared/utils/common';
 
 enum Controls {
   PreAllocatedDataVolumes = 'preAllocatedDataVolumes',
@@ -63,6 +64,7 @@ export class KubeVirtProviderExtendedComponent extends BaseFormValidator impleme
   private readonly _defaultPreAllocatedDataVolumeSize = 10;
   readonly Controls = Controls;
 
+  editionVersion: string = getEditionVersion();
   storageClasses: KubeVirtStorageClass[] = [];
   storageClassLabel = StorageClassState.Empty;
   private _preset: string;

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/kubevirt/template.html
@@ -36,7 +36,7 @@ limitations under the License.
 
     <div class="km-text-muted">
       Custom local disks are optional disks used for the provisioning of nodes with custom images.
-      <a href="https://docs.kubermatic.com/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt/"
+      <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/architecture/supported-providers/kubevirt/kubevirt/"
          target="_blank"
          rel="noreferrer noopener">Learn more ></a>
     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds abiltity to to use KKP Version in links to navigate that matches the KKP version that is currently being used.

**Examples:**

https://user-images.githubusercontent.com/17727069/203507367-91a9882f-4654-441e-afa4-6ce2f4a45535.mp4


https://user-images.githubusercontent.com/17727069/203507799-aac7e1da-adbf-4cd6-978c-ebc72b41422d.mp4



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4912 

/kind chore

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
