### PR TITLE
updated default resource filter minCPU from 1 to 2

### DIFF
--- a/modules/api/pkg/handler/v1/admin/settings_test.go
+++ b/modules/api/pkg/handler/v1/admin/settings_test.go
@@ -43,7 +43,7 @@ func TestGetGlobalSettings(t *testing.T) {
 		// scenario 1
 		{
 			name:                   "scenario 1: user gets settings first time",
-			expectedResponse:       `{"customLinks":[],"defaultNodeCount":2,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
+			expectedResponse:       `{"customLinks":[],"defaultNodeCount":2,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":false,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":2,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),
@@ -107,7 +107,7 @@ func TestUpdateGlobalSettings(t *testing.T) {
 		{
 			name:                   "scenario 2: authorized user updates default settings",
 			body:                   `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"cleanupOptions":{"enabled":true,"enforced":true},"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true}`,
-			expectedResponse:       `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":1,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
+			expectedResponse:       `{"customLinks":[{"label":"label","url":"url:label","icon":"icon","location":"EU"}],"defaultNodeCount":100,"displayDemoInfo":false,"displayAPIDocs":false,"displayTermsOfService":true,"enableDashboard":true,"enableOIDCKubeconfig":false,"userProjectsLimit":0,"restrictProjectCreation":false,"enableExternalClusterImport":true,"cleanupOptions":{"enabled":true,"enforced":true},"opaOptions":{},"mlaOptions":{},"mlaAlertmanagerPrefix":"","mlaGrafanaPrefix":"","notifications":{},"providerConfiguration":{"openStack":{}},"machineDeploymentVMResourceQuota":{"minCPU":2,"maxCPU":32,"minRAM":2,"maxRAM":128,"enableGPU":false}}`,
 			httpStatus:             http.StatusOK,
 			existingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true)},
 			existingAPIUser:        test.GenDefaultAPIUser(),

--- a/modules/api/pkg/provider/kubernetes/settings.go
+++ b/modules/api/pkg/provider/kubernetes/settings.go
@@ -87,7 +87,7 @@ func (s *SettingsProvider) createDefaultGlobalSettings(ctx context.Context) (*ku
 			RestrictProjectCreation:     false,
 			EnableExternalClusterImport: true,
 			MachineDeploymentVMResourceQuota: &kubermaticv1.MachineFlavorFilter{
-				MinCPU:    1,
+				MinCPU:    2,
 				MaxCPU:    32,
 				MinRAM:    2,
 				MaxRAM:    128,


### PR DESCRIPTION
**What this PR does / why we need it**:
updates the default/initial KubermaticSetting to have the resource filter minCPU option set from 1 to 2. This is done because we would like to display nodes with higher resource values by default, as they are more likely to be able to run a valid cluster (for example when integrating a cluster with MLA or OPA, 2 CPUs are minimum, and that is just KKP deployed resources).

This setting affects just the API/UI, the /size endpoints and the UI section where node sizes are chosen, and can be changed by admins in the admin settings.

It wont affect existing installations, as its only applied to the initial KubermaticSetting.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5332 

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The initial KubermaticSetting's ResourceFilter is changed from minCPU=1 to minCPU=2. This only affects new KKP installations and just the API/UI. The initial values can be changed as always in the KKP UI Admin settings, or in the KubermaticSetting `globalsettings` resource manually. The change was done to help avoid the creation of clusters which are too small to function properly.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
