### PR TITLE
KubeVirt cleanup Flavor and instancetype

### DIFF
--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2031,9 +2031,7 @@ type TopologySpreadConstraint struct {
 func (spec *KubevirtNodeSpec) MarshalJSON() ([]byte, error) {
 	missing := make([]string, 0)
 
-	// Deprecated. Flavor is deprecated. Will be removed when migration to instancetype/preference is fully done.
-	// When UI is not using it any more.
-	if spec.FlavorName == "" && spec.Instancetype == nil {
+	if spec.Instancetype == nil {
 		if len(spec.CPUs) == 0 {
 			missing = append(missing, "cpus")
 		}

--- a/modules/api/pkg/api/v1/types_test.go
+++ b/modules/api/pkg/api/v1/types_test.go
@@ -646,14 +646,14 @@ func TestKubevirtNodeSpec_MarshalJSON(t *testing.T) {
 			"{\"flavorName\":\"\",\"flavorProfile\":\"\",\"instancetype\":null,\"preference\":null,\"cpus\":\"1\",\"memory\":\"1\",\"primaryDiskOSImage\":\"test-url\",\"primaryDiskStorageClassName\":\"test-sc\",\"primaryDiskSize\":\"1\",\"secondaryDisks\":null,\"podAffinityPreset\":\"\",\"podAntiAffinityPreset\":\"\",\"nodeAffinityPreset\":{\"Type\":\"\",\"Key\":\"\",\"Values\":null},\"topologySpreadConstraints\":null}",
 		},
 		{
-			"case 8: should marshal when instance type is provided with vm-flavor",
+			"case 8: should fail when cpu/memory is provided with vm-flavor",
 			&apiv1.KubevirtNodeSpec{
 				FlavorName:                  "test-flavor",
 				PrimaryDiskOSImage:          "test-url",
 				PrimaryDiskStorageClassName: "test-sc",
 				PrimaryDiskSize:             "1",
 			},
-			"{\"flavorName\":\"test-flavor\",\"flavorProfile\":\"\",\"instancetype\":null,\"preference\":null,\"cpus\":\"\",\"memory\":\"\",\"primaryDiskOSImage\":\"test-url\",\"primaryDiskStorageClassName\":\"test-sc\",\"primaryDiskSize\":\"1\",\"secondaryDisks\":null,\"podAffinityPreset\":\"\",\"podAntiAffinityPreset\":\"\",\"nodeAffinityPreset\":{\"Type\":\"\",\"Key\":\"\",\"Values\":null},\"topologySpreadConstraints\":null}",
+			"missing or invalid required parameter(s): cpus, memory",
 		},
 		{
 			"case 9: should marshal when flavor is provided with affinity",

--- a/modules/api/pkg/machine/convert.go
+++ b/modules/api/pkg/machine/convert.go
@@ -304,8 +304,6 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 		}
 
 		cloudSpec.Kubevirt = &apiv1.KubevirtNodeSpec{
-			FlavorName:                  config.VirtualMachine.Flavor.Name.Value,
-			FlavorProfile:               config.VirtualMachine.Flavor.Profile.Value,
 			Instancetype:                config.VirtualMachine.Instancetype,
 			Preference:                  config.VirtualMachine.Preference,
 			CPUs:                        config.VirtualMachine.Template.CPUs.Value,
@@ -313,8 +311,6 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			PrimaryDiskOSImage:          config.VirtualMachine.Template.PrimaryDisk.OsImage.Value,
 			PrimaryDiskStorageClassName: config.VirtualMachine.Template.PrimaryDisk.StorageClassName.Value,
 			PrimaryDiskSize:             config.VirtualMachine.Template.PrimaryDisk.Size.Value,
-			PodAffinityPreset:           config.Affinity.PodAffinityPreset.Value,     //nolint:staticcheck
-			PodAntiAffinityPreset:       config.Affinity.PodAntiAffinityPreset.Value, //nolint:staticcheck
 			NodeAffinityPreset: apiv1.NodeAffinityPreset{
 				Type: config.Affinity.NodeAffinityPreset.Type.Value,
 				Key:  config.Affinity.NodeAffinityPreset.Key.Value,

--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -520,10 +520,6 @@ func getGCPProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 func GetKubevirtProviderConfig(cluster *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*kubevirt.RawConfig, error) {
 	config := &kubevirt.RawConfig{
 		VirtualMachine: kubevirt.VirtualMachine{
-			Flavor: kubevirt.Flavor{
-				Name:    providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.FlavorName},
-				Profile: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.FlavorProfile},
-			},
 			Instancetype: nodeSpec.Cloud.Kubevirt.Instancetype,
 			Preference:   nodeSpec.Cloud.Kubevirt.Preference,
 			Template: kubevirt.Template{
@@ -541,8 +537,6 @@ func GetKubevirtProviderConfig(cluster *kubermaticv1.Cluster, nodeSpec apiv1.Nod
 			DNSConfig: dc.Spec.Kubevirt.DNSConfig.DeepCopy(),
 		},
 		Affinity: kubevirt.Affinity{
-			PodAffinityPreset:     providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.PodAffinityPreset},     //nolint:staticcheck
-			PodAntiAffinityPreset: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.PodAntiAffinityPreset}, //nolint:staticcheck
 			NodeAffinityPreset: kubevirt.NodeAffinityPreset{
 				Type: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Type},
 				Key:  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Key},


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Small cleanup after sig/virtualization did agree that all MD will require a **manual** migration (migration doc will be written part of https://github.com/kubermatic/docs/issues/1261).
Any existing MD that contains:
- Flavor
- PodAffinity/AntiAffinity/Preset
**will have to be manually migrated.**

We can then clean the code for KubeVirt GA and remove the handling of those fields.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5311 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Action required: KubeVirt- Manual migration of existing MD (https://github.com/kubermatic/docs/issues/1261)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD (https://github.com/kubermatic/docs/issues/1261)
```
