### PR TITLE
New field ClusterName in kubevirt providerconfig

### DIFF
--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -519,6 +519,7 @@ func getGCPProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 
 func GetKubevirtProviderConfig(cluster *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*kubevirt.RawConfig, error) {
 	config := &kubevirt.RawConfig{
+		ClusterName: providerconfig.ConfigVarString{Value: cluster.Name},
 		VirtualMachine: kubevirt.VirtualMachine{
 			Instancetype: nodeSpec.Cloud.Kubevirt.Instancetype,
 			Preference:   nodeSpec.Cloud.Kubevirt.Preference,


### PR DESCRIPTION
**What this PR does / why we need it**:
This is needed for the machine-controller to set the new cluster labels. (see [#10923](https://github.com/kubermatic/kubermatic/issues/10923))

**Special notes for your reviewer**:
Sister PR of kubermatic/kubermatic#11453

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
We have a draft document including all KubeVirt changes and a migration guide for KKP 2.22. That document will include the documentation for this feature.