### PR TITLE
Allow to edit Allowed IP Ranges for apiserver in existing cluster

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -126,7 +126,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       this.cluster.spec.podNodeSelectorAdmissionPluginConfig
     ) as Record<string, string>;
     this.eventRateLimitConfig = _.cloneDeep(this.cluster.spec.eventRateLimitConfig);
-    this.apiServerAllowedIPRanges = this.cluster.spec.apiServerAllowedIPRanges.cidrBlocks;
+    this.apiServerAllowedIPRanges = this.cluster.spec.apiServerAllowedIPRanges?.cidrBlocks;
 
     this.form = this._builder.group({
       [Controls.Name]: new FormControl(this.cluster.name, [
@@ -157,7 +157,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.PodNodeSelectorAdmissionPluginConfig]: new FormControl(''),
       [Controls.EventRateLimitConfig]: new FormControl(),
       [Controls.Labels]: new FormControl(null),
-      [Controls.APIServerAllowedIPRanges]: new FormControl(this.cluster.spec.apiServerAllowedIPRanges),
+      [Controls.APIServerAllowedIPRanges]: new FormControl(this.cluster.spec.apiServerAllowedIPRanges?.cidrBlocks),
     });
 
     this._settingsService.adminSettings.pipe(take(1)).subscribe(settings => {

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -23,6 +23,7 @@ import {
   AuditPolicyPreset,
   Cluster,
   ClusterPatch,
+  ClusterSpecPatch,
   CNIPlugin,
   ContainerRuntime,
   END_OF_DOCKER_SUPPORT_VERSION,
@@ -125,6 +126,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       this.cluster.spec.podNodeSelectorAdmissionPluginConfig
     ) as Record<string, string>;
     this.eventRateLimitConfig = _.cloneDeep(this.cluster.spec.eventRateLimitConfig);
+    this.apiServerAllowedIPRanges = this.cluster.spec.apiServerAllowedIPRanges.cidrBlocks;
 
     this.form = this._builder.group({
       [Controls.Name]: new FormControl(this.cluster.name, [
@@ -362,8 +364,11 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         admissionPlugins: this.form.get(Controls.AdmissionPlugins).value,
         podNodeSelectorAdmissionPluginConfig: this.podNodeSelectorAdmissionPluginConfig,
         containerRuntime: this.form.get(Controls.ContainerRuntime).value,
-      },
-    };
+        apiServerAllowedIPRanges: {
+          cidrBlocks: this.form.get(Controls.APIServerAllowedIPRanges).value?.tags,
+        } as NetworkRanges,
+      } as ClusterSpecPatch,
+    } as ClusterPatch;
 
     if (this.isPluginEnabled(this.admissionPlugin.EventRateLimit)) {
       patch.spec.eventRateLimitConfig = {

--- a/modules/web/src/test/data/cluster.ts
+++ b/modules/web/src/test/data/cluster.ts
@@ -35,6 +35,9 @@ export function fakeDigitaloceanCluster(): Cluster {
         type: CNIPlugin.Cilium,
         version: 'v1.11',
       },
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://4k6txp5sq.europe-west3-c.dev.kubermatic.io:30002',
@@ -60,6 +63,9 @@ export function fakeEquinixCluster(): Cluster {
         providerName: 'packet',
       },
       version: '1.8.5',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://4k6txp5sq.europe-west3-c.dev.kubermatic.io:30002',
@@ -83,6 +89,9 @@ export function fakeHetznerCluster(): Cluster {
         providerName: 'digitalocean',
       },
       version: '1.8.5',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://4k6txp5sq.europe-west3-c.dev.kubermatic.io:30002',
@@ -113,6 +122,9 @@ export function fakeVSphereCluster(): Cluster {
         providerName: 'vsphere',
       },
       version: '1.8.5',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://4k6txp5sq.europe-west3-c.dev.kubermatic.io:30002',
@@ -144,6 +156,9 @@ export function fakeAWSCluster(): Cluster {
         providerName: 'aws',
       },
       version: '1.9.6',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://vr4m6wpqv6.europe-west3-c.dev.kubermatic.io:30003',
@@ -177,6 +192,9 @@ export function fakeOpenstackCluster(): Cluster {
         providerName: 'openstack',
       },
       version: '1.9.6',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://vr4m6wpqv6.europe-west3-c.dev.kubermatic.io:30003',
@@ -211,6 +229,9 @@ export function fakeAzureCluster(): Cluster {
         providerName: 'azure',
       },
       version: '1.8.5',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://4k6txp5sq.europe-west3-c.dev.kubermatic.io:30002',
@@ -232,6 +253,9 @@ export function fakeBringyourownCluster(): Cluster {
         providerName: 'bringyourown',
       },
       version: '1.8.5',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://4k6txp5sq.europe-west3-c.dev.kubermatic.io:30002',
@@ -256,6 +280,9 @@ export function fakeAlibabaCluster(): Cluster {
         providerName: 'alibaba',
       },
       version: '1.9.6',
+      apiServerAllowedIPRanges: {
+        cidrBlocks: ['10.0.0.0/8'],
+      },
     },
     status: {
       url: 'https://vr4m6wpqv6.europe-west3-c.dev.kubermatic.io:30003',


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR handles both points to display already configured IP ranges in existing cluster and allows to edit and send update payload to configure new/updated IP ranges.


https://user-images.githubusercontent.com/17727069/204507288-aff596d4-b0db-4b87-b18e-33953d306add.mp4



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5338 

/kind chore

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**Special notes for your reviewer**:
Update DCO can be found [here](https://developercertificate.org/) or see "CONTRIBUTING.md" file in repo to find link.

Hold till this [PR](https://github.com/kubermatic/dashboard/pull/5355) is merged: 

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
