### PR TITLE
Add option to set cluster autoscaler annotation on MD through API

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -32839,12 +32839,12 @@
         },
         "maxReplicas": {
           "type": "integer",
-          "format": "int32",
+          "format": "uint32",
           "x-go-name": "MaxReplicas"
         },
         "minReplicas": {
           "type": "integer",
-          "format": "int32",
+          "format": "uint32",
           "x-go-name": "MinReplicas"
         },
         "paused": {

--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -32837,6 +32837,16 @@
           "type": "boolean",
           "x-go-name": "DynamicConfig"
         },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MaxReplicas"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "x-go-name": "MinReplicas"
+        },
         "paused": {
           "type": "boolean",
           "x-go-name": "Paused"

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2558,7 +2558,11 @@ type NodeDeploymentSpec struct {
 	// required: false
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
 	// required: false
-	AutoscalingOptions *AutoscalingOptions `json:"autoscalingOptions,omitempty"`
+	MinReplicas *uint32 `json:"minReplicas,omitempty"`
+	// required: false
+	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
+	// required: false
+	// AutoscalingOptions *AutoscalingOptions `json:"autoscalingOptions,omitempty"`
 	// // required: false
 	// MinReplicas *int32 `json:"minReplicas,omitempty"`
 	// // required: false
@@ -2566,12 +2570,12 @@ type NodeDeploymentSpec struct {
 }
 
 // swagger:model AutoscalingOptions
-type AutoscalingOptions struct {
-	// required: false
-	MinReplicas *uint32 `json:"minReplicas,omitempty"`
-	// required: false
-	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
-}
+// type AutoscalingOptions struct {
+// 	// required: false
+// 	MinReplicas *uint32 `json:"minReplicas,omitempty"`
+// 	// required: false
+// 	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
+// }
 
 // Event is a report of an event somewhere in the cluster.
 // swagger:model Event

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2557,6 +2557,10 @@ type NodeDeploymentSpec struct {
 	// Only supported for nodes with Kubernetes 1.23 or less.
 	// required: false
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
+	// required: false
+	MinReplicas *int32 `json:"minReplicas,omitempty"`
+	// required: false
+	MaxReplicas *int32 `json:"maxReplicas,omitempty"`
 }
 
 // Event is a report of an event somewhere in the cluster.

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2558,9 +2558,19 @@ type NodeDeploymentSpec struct {
 	// required: false
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
 	// required: false
-	MinReplicas *int32 `json:"minReplicas,omitempty"`
+	AutoscalingOptions *AutoscalingOptions `json:"autoscalingOptions,omitempty"`
+	// // required: false
+	// MinReplicas *int32 `json:"minReplicas,omitempty"`
+	// // required: false
+	// MaxReplicas *int32 `json:"maxReplicas,omitempty"`
+}
+
+// swagger:model AutoscalingOptions
+type AutoscalingOptions struct {
 	// required: false
-	MaxReplicas *int32 `json:"maxReplicas,omitempty"`
+	MinReplicas *uint32 `json:"minReplicas,omitempty"`
+	// required: false
+	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
 }
 
 // Event is a report of an event somewhere in the cluster.

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2561,21 +2561,7 @@ type NodeDeploymentSpec struct {
 	MinReplicas *uint32 `json:"minReplicas,omitempty"`
 	// required: false
 	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
-	// required: false
-	// AutoscalingOptions *AutoscalingOptions `json:"autoscalingOptions,omitempty"`
-	// // required: false
-	// MinReplicas *int32 `json:"minReplicas,omitempty"`
-	// // required: false
-	// MaxReplicas *int32 `json:"maxReplicas,omitempty"`
 }
-
-// swagger:model AutoscalingOptions
-// type AutoscalingOptions struct {
-// 	// required: false
-// 	MinReplicas *uint32 `json:"minReplicas,omitempty"`
-// 	// required: false
-// 	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
-// }
 
 // Event is a report of an event somewhere in the cluster.
 // swagger:model Event

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -159,7 +159,7 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 		}
 	}
 
-	min, max, err := getAutoscalingRange(md)
+	min, max, err := getAutoscalingConfiguration(md)
 	if err != nil {
 		return nil, err
 	}
@@ -923,7 +923,7 @@ func selectedOperatingSystems(os apiv1.OperatingSystemSpec) int {
 	return counter
 }
 
-func getAutoscalingRange(md *clusterv1alpha1.MachineDeployment) (*uint32, *uint32, error) {
+func getAutoscalingConfiguration(md *clusterv1alpha1.MachineDeployment) (*uint32, *uint32, error) {
 	var minReplicas *uint32
 	if min, ok := md.Annotations[machineresource.AutoscalerMinSizeAnnotation]; ok && min != "" {
 		minInt, err := strconv.ParseInt(min, 10, 32)

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -472,7 +472,7 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 	}
 	var unmarshalPatched *apiv1.NodeDeployment
 	if err := json.Unmarshal(patch, &unmarshalPatched); err != nil {
-		return nil, fmt.Errorf("cannot decode patched nodedeployment: %w ===", err)
+		return nil, utilerrors.NewBadRequest("cannot decode patched nodedeployment: %s", patch)
 	}
 
 	selectedOperatingSystems := selectedOperatingSystems(unmarshalPatched.Spec.Template.OperatingSystem)

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/utils/pointer"
 	"net/http"
 	"strconv"
 	"strings"
@@ -50,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -160,6 +160,9 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 	}
 
 	minReplicas, maxReplicas, err := getMinAndMaxReplicas(md)
+	if err != nil {
+		return nil, err
+	}
 
 	hasDynamicConfig := md.Spec.Template.Spec.ConfigSource != nil
 
@@ -915,7 +918,7 @@ func getMinAndMaxReplicas(md *clusterv1alpha1.MachineDeployment) (*int32, *int32
 	if min, ok := md.Annotations[machineresource.AutoscalerMinSizeAnnotation]; ok && min != "" {
 		minInt, err := strconv.ParseInt(min, 10, 32)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read autoscaler min size annotation: %v", err)
+			return nil, nil, fmt.Errorf("failed to read autoscaler min size annotation: %w", err)
 		}
 		minReplicas = pointer.Int32(int32(minInt))
 	}
@@ -923,7 +926,7 @@ func getMinAndMaxReplicas(md *clusterv1alpha1.MachineDeployment) (*int32, *int32
 	if max, ok := md.Annotations[machineresource.AutoscalerMaxSizeAnnotation]; ok && max != "" {
 		maxInt, err := strconv.ParseInt(max, 10, 32)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read autoscaler max size annotation: %v", err)
+			return nil, nil, fmt.Errorf("failed to read autoscaler max size annotation: %w", err)
 		}
 		maxReplicas = pointer.Int32(int32(maxInt))
 	}

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -159,7 +159,7 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 		}
 	}
 
-	min, max, err := getAutoscalingConfiguration(md)
+	minReplicaCount, maxReplicaCount, err := getAutoscalingConfiguration(md)
 	if err != nil {
 		return nil, err
 	}
@@ -187,8 +187,8 @@ func outputMachineDeployment(md *clusterv1alpha1.MachineDeployment) (*apiv1.Node
 			},
 			Paused:        &md.Spec.Paused,
 			DynamicConfig: &hasDynamicConfig,
-			MinReplicas:   min,
-			MaxReplicas:   max,
+			MinReplicas:   minReplicaCount,
+			MaxReplicas:   maxReplicaCount,
 		},
 		Status: md.Status,
 	}, nil

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -500,6 +500,14 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 		return nil, fmt.Errorf("cannot decode patched cluster: %w", err)
 	}
 
+	// validate min/max replicas
+	if patchedNodeDeployment.Spec.MaxReplicas != nil && patchedNodeDeployment.Spec.Replicas > *patchedNodeDeployment.Spec.MaxReplicas {
+		return nil, utilerrors.NewBadRequest("replica count (%d) cannot be higher then autoscaler maxreplicas (%d)", patchedNodeDeployment.Spec.Replicas, *patchedNodeDeployment.Spec.MaxReplicas)
+	}
+	if patchedNodeDeployment.Spec.MinReplicas != nil && patchedNodeDeployment.Spec.Replicas > *patchedNodeDeployment.Spec.MinReplicas {
+		return nil, utilerrors.NewBadRequest("replica count (%d) cannot be lower then autoscaler minreplicas (%d)", patchedNodeDeployment.Spec.Replicas, *patchedNodeDeployment.Spec.MinReplicas)
+	}
+
 	kversion, err := semverlib.NewVersion(patchedNodeDeployment.Spec.Template.Versions.Kubelet)
 	if err != nil {
 		return nil, utilerrors.NewBadRequest("failed to parse kubelet version: %v", err)

--- a/modules/api/pkg/handler/v1/node/node.go
+++ b/modules/api/pkg/handler/v1/node/node.go
@@ -64,17 +64,9 @@ func DecodeCreateNodeDeployment(c context.Context, r *http.Request) (interface{}
 }
 
 func (r *createNodeDeploymentReq) ValidateCreateNodeDeploymentReq() error {
-	var msg string
-
-	if r.Body.Spec.MaxReplicas != nil && r.Body.Spec.Replicas > *r.Body.Spec.MaxReplicas {
-		msg += fmt.Sprintf("replica count (%d) cannot be higher then autoscaler maxreplicas (%d).", r.Body.Spec.Replicas, *r.Body.Spec.MaxReplicas)
-	}
-	if r.Body.Spec.MinReplicas != nil && r.Body.Spec.Replicas < *r.Body.Spec.MinReplicas {
-		msg += fmt.Sprintf("replica count (%d) cannot be lower then autoscaler minreplicas (%d).", r.Body.Spec.Replicas, *r.Body.Spec.MinReplicas)
-	}
-
-	if msg != "" {
-		return fmt.Errorf(msg)
+	errMsg := handlercommon.ValidateAutoscalingOptions(&r.Body.Spec)
+	if errMsg != "" {
+		return fmt.Errorf(errMsg)
 	}
 	return nil
 }

--- a/modules/api/pkg/handler/v2/machine/machine.go
+++ b/modules/api/pkg/handler/v2/machine/machine.go
@@ -78,17 +78,9 @@ func DecodeCreateMachineDeployment(c context.Context, r *http.Request) (interfac
 }
 
 func (r *createMachineDeploymentReq) ValidateCreateNodeDeploymentReq() error {
-	var msg string
-
-	if r.Body.Spec.MaxReplicas != nil && r.Body.Spec.Replicas > *r.Body.Spec.MaxReplicas {
-		msg += fmt.Sprintf("replica count (%d) cannot be higher then autoscaler maxreplicas (%d).", r.Body.Spec.Replicas, *r.Body.Spec.MaxReplicas)
-	}
-	if r.Body.Spec.MinReplicas != nil && r.Body.Spec.Replicas < *r.Body.Spec.MinReplicas {
-		msg += fmt.Sprintf("replica count (%d) cannot be lower then autoscaler minreplicas (%d).", r.Body.Spec.Replicas, *r.Body.Spec.MinReplicas)
-	}
-
-	if msg != "" {
-		return fmt.Errorf(msg)
+	errMsg := handlercommon.ValidateAutoscalingOptions(&r.Body.Spec)
+	if errMsg != "" {
+		return fmt.Errorf(errMsg)
 	}
 	return nil
 }

--- a/modules/api/pkg/handler/v2/machine/machine_test.go
+++ b/modules/api/pkg/handler/v2/machine/machine_test.go
@@ -745,10 +745,8 @@ func TestGetMachineDeployment(t *testing.T) {
 					Replicas:      replicas,
 					Paused:        &paused,
 					DynamicConfig: pointer.Bool(false),
-					AutoscalingOptions: &apiv1.AutoscalingOptions{
-						MinReplicas: pointer.Uint32(5),
-						MaxReplicas: pointer.Uint32(7),
-					},
+					MinReplicas:   pointer.Uint32(5),
+					MaxReplicas:   pointer.Uint32(7),
 				},
 				Status: clusterv1alpha1.MachineDeploymentStatus{},
 			},
@@ -799,9 +797,7 @@ func TestGetMachineDeployment(t *testing.T) {
 					Replicas:      replicas,
 					Paused:        &paused,
 					DynamicConfig: pointer.Bool(false),
-					AutoscalingOptions: &apiv1.AutoscalingOptions{
-						MinReplicas: pointer.Uint32(5),
-					},
+					MinReplicas:   pointer.Uint32(5),
 				},
 				Status: clusterv1alpha1.MachineDeploymentStatus{},
 			},
@@ -1661,7 +1657,7 @@ func TestPatchMachineDeployment(t *testing.T) {
 			Name: "Scenario 8: Update replicas count in range",
 			Body: fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
 			ExpectedResponse: fmt.Sprintf(
-				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[2]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%[1]v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"autoscalingOptions":{"minReplicas":%[2]v}},"status":{}}`,
+				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[2]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%[1]v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"minReplicas":%[2]v},"status":{}}`,
 				replicasUpdated,
 				minReplicas,
 			),
@@ -1735,9 +1731,9 @@ func TestPatchMachineDeployment(t *testing.T) {
 		// Scenario 11: Update autoscaling options - increase min
 		{
 			Name: "Scenario 11: Update autoscaling options - increase min",
-			Body: fmt.Sprintf(`{"spec":{"autoscalingOptions":{"minReplicas": %d}}}`, minReplicasUpdated),
+			Body: fmt.Sprintf(`{"spec":{"minReplicas": %d}}`, minReplicasUpdated),
 			ExpectedResponse: fmt.Sprintf(
-				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[1]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":5,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"autoscalingOptions":{"minReplicas":%[1]v}},"status":{}}`,
+				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[1]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":5,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"minReplicas":%[1]v},"status":{}}`,
 				minReplicasUpdated,
 			),
 			cluster:          "keen-snyder",
@@ -1763,7 +1759,7 @@ func TestPatchMachineDeployment(t *testing.T) {
 		// Scenario 12: Unset autoscaling options - unset
 		{
 			Name:             "Scenario 12: Unset autoscaling options",
-			Body:             `{"spec":{"autoscalingOptions":null}}`,
+			Body:             `{"spec":{"minReplicas":null,"maxReplicas":null}}`,
 			ExpectedResponse: `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":5,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false},"status":{}}`,
 			cluster:          "keen-snyder",
 			HTTPStatus:       http.StatusOK,
@@ -1789,9 +1785,9 @@ func TestPatchMachineDeployment(t *testing.T) {
 		// Scenario 13: Create autoscaling options
 		{
 			Name: "Scenario 13: Create autoscaling options",
-			Body: fmt.Sprintf(`{"spec":{"autoscalingOptions":{"minReplicas": %[1]d,"maxReplicas": %[2]d}}}`, minReplicas, maxReplicas),
+			Body: fmt.Sprintf(`{"spec":{"minReplicas": %[1]d,"maxReplicas": %[2]d}}`, minReplicas, maxReplicas),
 			ExpectedResponse: fmt.Sprintf(
-				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-max-size":"%[1]v","cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[2]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"autoscalingOptions":{"minReplicas":%[2]d,"maxReplicas":%[1]d}},"status":{}}`,
+				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-max-size":"%[1]v","cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[2]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"minReplicas":%[2]d,"maxReplicas":%[1]d},"status":{}}`,
 				maxReplicas,
 				minReplicas,
 			),

--- a/modules/api/pkg/handler/v2/machine/machine_test.go
+++ b/modules/api/pkg/handler/v2/machine/machine_test.go
@@ -745,8 +745,63 @@ func TestGetMachineDeployment(t *testing.T) {
 					Replicas:      replicas,
 					Paused:        &paused,
 					DynamicConfig: pointer.Bool(false),
-					MinReplicas:   pointer.Int32(5),
-					MaxReplicas:   pointer.Int32(7),
+					AutoscalingOptions: &apiv1.AutoscalingOptions{
+						MinReplicas: pointer.Uint32(5),
+						MaxReplicas: pointer.Uint32(7),
+					},
+				},
+				Status: clusterv1alpha1.MachineDeploymentStatus{},
+			},
+		},
+		{
+			Name:            "scenario 5: get machine deployment that has cluster-autoscaler min replicas set",
+			HTTPStatus:      http.StatusOK,
+			ClusterIDToSync: test.GenDefaultCluster().Name,
+			ProjectIDToSync: test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				func() *clusterv1alpha1.MachineDeployment {
+					md := genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)
+					md.Annotations = map[string]string{
+						machine.AutoscalerMinSizeAnnotation: "5",
+					}
+					return md
+				}(),
+			},
+			ExpectedResponse: apiv1.NodeDeployment{
+				ObjectMeta: apiv1.ObjectMeta{
+					ID:   "venus",
+					Name: "venus",
+					Annotations: map[string]string{
+						machine.AutoscalerMinSizeAnnotation: "5",
+					},
+				},
+				Spec: apiv1.NodeDeploymentSpec{
+					Template: apiv1.NodeSpec{
+						Cloud: apiv1.NodeCloudSpec{
+							Digitalocean: &apiv1.DigitaloceanNodeSpec{
+								Size: "2GB",
+							},
+						},
+						OperatingSystem: apiv1.OperatingSystemSpec{
+							Ubuntu: &apiv1.UbuntuSpec{
+								DistUpgradeOnBoot: true,
+							},
+						},
+						Versions: apiv1.NodeVersionInfo{
+							Kubelet: "v9.9.9",
+						},
+					},
+					Replicas:      replicas,
+					Paused:        &paused,
+					DynamicConfig: pointer.Bool(false),
+					AutoscalingOptions: &apiv1.AutoscalingOptions{
+						MinReplicas: pointer.Uint32(5),
+					},
 				},
 				Status: clusterv1alpha1.MachineDeploymentStatus{},
 			},
@@ -1468,6 +1523,9 @@ func TestPatchMachineDeployment(t *testing.T) {
 
 	var replicas int32 = 1
 	var replicasUpdated int32 = 3
+	var minReplicas = 1
+	var minReplicasUpdated = 2
+	var maxReplicas = 10
 	var kubeletVerUpdated = "v9.8.0"
 
 	testcases := []struct {
@@ -1484,15 +1542,17 @@ func TestPatchMachineDeployment(t *testing.T) {
 	}{
 		// Scenario 1: Update replicas count.
 		{
-			Name:                       "Scenario 1: Update replicas count",
-			Body:                       fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
-			ExpectedResponse:           fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false},"status":{}}`, replicasUpdated),
-			cluster:                    "keen-snyder",
-			HTTPStatus:                 http.StatusOK,
-			project:                    test.GenDefaultProject().Name,
-			ExistingAPIUser:            test.GenDefaultAPIUser(),
-			NodeDeploymentID:           "venus",
-			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)},
+			Name:             "Scenario 1: Update replicas count",
+			Body:             fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
+			ExpectedResponse: fmt.Sprintf(`{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false},"status":{}}`, replicasUpdated),
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusOK,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			NodeDeploymentID: "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false),
+			},
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),
 				genTestCluster(true),
@@ -1594,6 +1654,158 @@ func TestPatchMachineDeployment(t *testing.T) {
 				test.GenTestSeed(),
 				genTestCluster(true),
 				test.GenAdminUser("John", "john@acme.com", false),
+			),
+		},
+		// Scenario 8: Update replicas count in range
+		{
+			Name: "Scenario 8: Update replicas count in range",
+			Body: fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
+			ExpectedResponse: fmt.Sprintf(
+				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[2]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":%[1]v,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"autoscalingOptions":{"minReplicas":%[2]v}},"status":{}}`,
+				replicasUpdated,
+				minReplicas,
+			),
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusOK,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			NodeDeploymentID: "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				func() *clusterv1alpha1.MachineDeployment {
+					md := genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)
+					md.Annotations = map[string]string{
+						machine.AutoscalerMinSizeAnnotation: "1",
+					}
+					return md
+				}(),
+			},
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
+			),
+		},
+		// Scenario 9: Try to update to replicas count over max
+		{
+			Name:             "Scenario 9: Try to update replicas count over max",
+			Body:             fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
+			ExpectedResponse: `{"error":{"code":400,"message":"replica count (3) cannot be higher then autoscaler maxreplicas (2)"}}`,
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusBadRequest,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			NodeDeploymentID: "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				func() *clusterv1alpha1.MachineDeployment {
+					md := genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)
+					md.Annotations = map[string]string{
+						machine.AutoscalerMaxSizeAnnotation: "2",
+					}
+					return md
+				}(),
+			},
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
+			),
+		},
+		// Scenario 10: Try to update replicas count below min
+		{
+			Name:             "Scenario 10: Try to update replicas count below min",
+			Body:             fmt.Sprintf(`{"spec":{"replicas":%v}}`, replicasUpdated),
+			ExpectedResponse: `{"error":{"code":400,"message":"replica count (3) cannot be lower then autoscaler minreplicas (5)"}}`,
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusBadRequest,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			NodeDeploymentID: "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				func() *clusterv1alpha1.MachineDeployment {
+					md := genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)
+					md.Annotations = map[string]string{
+						machine.AutoscalerMinSizeAnnotation: "5",
+					}
+					return md
+				}(),
+			},
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
+			),
+		},
+		// Scenario 11: Update autoscaling options - increase min
+		{
+			Name: "Scenario 11: Update autoscaling options - increase min",
+			Body: fmt.Sprintf(`{"spec":{"autoscalingOptions":{"minReplicas": %d}}}`, minReplicasUpdated),
+			ExpectedResponse: fmt.Sprintf(
+				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[1]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":5,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"autoscalingOptions":{"minReplicas":%[1]v}},"status":{}}`,
+				minReplicasUpdated,
+			),
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusOK,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			NodeDeploymentID: "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				func() *clusterv1alpha1.MachineDeployment {
+					md := genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)
+					md.Annotations = map[string]string{
+						machine.AutoscalerMinSizeAnnotation: fmt.Sprintf("%d", minReplicas),
+					}
+					md.Spec.Replicas = pointer.Int32(5)
+					return md
+				}(),
+			},
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
+			),
+		},
+		// Scenario 12: Unset autoscaling options - unset
+		{
+			Name:             "Scenario 12: Unset autoscaling options",
+			Body:             `{"spec":{"autoscalingOptions":null}}`,
+			ExpectedResponse: `{"id":"venus","name":"venus","creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":5,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false},"status":{}}`,
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusOK,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			NodeDeploymentID: "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				func() *clusterv1alpha1.MachineDeployment {
+					md := genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false)
+					md.Annotations = map[string]string{
+						machine.AutoscalerMinSizeAnnotation: fmt.Sprintf("%d", minReplicas),
+						machine.AutoscalerMaxSizeAnnotation: fmt.Sprintf("%d", maxReplicas),
+					}
+					md.Spec.Replicas = pointer.Int32(5)
+					return md
+				}(),
+			},
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
+			),
+		},
+		// Scenario 13: Create autoscaling options
+		{
+			Name: "Scenario 13: Create autoscaling options",
+			Body: fmt.Sprintf(`{"spec":{"autoscalingOptions":{"minReplicas": %[1]d,"maxReplicas": %[2]d}}}`, minReplicas, maxReplicas),
+			ExpectedResponse: fmt.Sprintf(
+				`{"id":"venus","name":"venus","annotations":{"cluster.k8s.io/cluster-api-autoscaler-node-group-max-size":"%[1]v","cluster.k8s.io/cluster-api-autoscaler-node-group-min-size":"%[2]v"},"creationTimestamp":"0001-01-01T00:00:00Z","spec":{"replicas":1,"template":{"cloud":{"digitalocean":{"size":"2GB","backups":false,"ipv6":false,"monitoring":false,"tags":["kubernetes","kubernetes-cluster-defClusterID","system-cluster-defClusterID","system-project-my-first-project-ID"]}},"operatingSystem":{"ubuntu":{"distUpgradeOnBoot":true}},"versions":{"kubelet":"v9.9.9"},"labels":{"system/cluster":"defClusterID","system/project":"my-first-project-ID"}},"paused":false,"dynamicConfig":false,"autoscalingOptions":{"minReplicas":%[2]d,"maxReplicas":%[1]d}},"status":{}}`,
+				maxReplicas,
+				minReplicas,
+			),
+			cluster:          "keen-snyder",
+			HTTPStatus:       http.StatusOK,
+			project:          test.GenDefaultProject().Name,
+			ExistingAPIUser:  test.GenDefaultAPIUser(),
+			NodeDeploymentID: "venus",
+			ExistingMachineDeployments: []*clusterv1alpha1.MachineDeployment{
+				genTestMachineDeployment("venus", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"}, "operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":true}}`, nil, false),
+			},
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				genTestCluster(true),
 			),
 		},
 	}

--- a/modules/api/pkg/handler/v2/machine/machine_test.go
+++ b/modules/api/pkg/handler/v2/machine/machine_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8c.io/dashboard/v2/pkg/resources/machine"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
 	"k8c.io/dashboard/v2/pkg/handler/test"
 	"k8c.io/dashboard/v2/pkg/handler/test/hack"
+	"k8c.io/dashboard/v2/pkg/resources/machine"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	corev1 "k8s.io/api/core/v1"

--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -102,25 +102,20 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	md.Spec.Replicas = &replicas
 
 	// Set autoscaler min and max replicas if present
-	if nd.Spec.AutoscalingOptions != nil {
-		if md.Annotations == nil {
-			md.Annotations = map[string]string{}
-		}
-		max := nd.Spec.AutoscalingOptions.MaxReplicas
-		if max != nil {
-			md.Annotations[AutoscalerMaxSizeAnnotation] = strconv.Itoa(int(*max))
-		} else {
-			delete(md.Annotations, AutoscalerMaxSizeAnnotation)
-		}
-
-		min := nd.Spec.AutoscalingOptions.MinReplicas
-		if min != nil {
-			md.Annotations[AutoscalerMinSizeAnnotation] = strconv.Itoa(int(*min))
-		} else {
-			delete(md.Annotations, AutoscalerMinSizeAnnotation)
-		}
-	} else if md.Annotations != nil {
+	if md.Annotations == nil {
+		md.Annotations = map[string]string{}
+	}
+	max := nd.Spec.MaxReplicas
+	if max != nil {
+		md.Annotations[AutoscalerMaxSizeAnnotation] = strconv.Itoa(int(*max))
+	} else {
 		delete(md.Annotations, AutoscalerMaxSizeAnnotation)
+	}
+
+	min := nd.Spec.MinReplicas
+	if min != nil {
+		md.Annotations[AutoscalerMinSizeAnnotation] = strconv.Itoa(int(*min))
+	} else {
 		delete(md.Annotations, AutoscalerMinSizeAnnotation)
 	}
 

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
@@ -22,6 +22,12 @@ type NodeDeploymentSpec struct {
 	// Only supported for nodes with Kubernetes 1.23 or less.
 	DynamicConfig bool `json:"dynamicConfig,omitempty"`
 
+	// max replicas
+	MaxReplicas int32 `json:"maxReplicas,omitempty"`
+
+	// min replicas
+	MinReplicas int32 `json:"minReplicas,omitempty"`
+
 	// paused
 	Paused bool `json:"paused,omitempty"`
 

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
@@ -23,10 +23,10 @@ type NodeDeploymentSpec struct {
 	DynamicConfig bool `json:"dynamicConfig,omitempty"`
 
 	// max replicas
-	MaxReplicas int32 `json:"maxReplicas,omitempty"`
+	MaxReplicas uint32 `json:"maxReplicas,omitempty"`
 
 	// min replicas
-	MinReplicas int32 `json:"minReplicas,omitempty"`
+	MinReplicas uint32 `json:"minReplicas,omitempty"`
 
 	// paused
 	Paused bool `json:"paused,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds option to set cluster autoscaler min/max replicas on the MachineDeployments through the API. 

revival of https://github.com/kubermatic/kubermatic/pull/6596


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5347 

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TBD
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
