### PR TITLE
Revert "Fix nil pointer for version"

### DIFF
--- a/modules/api/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/modules/api/pkg/handler/v2/external_cluster/external_cluster.go
@@ -1112,8 +1112,7 @@ func convertClusterToAPIWithStatus(ctx context.Context, userInfo *provider.UserI
 			State:         apiv2.ErrorExternalClusterState,
 			StatusMessage: "Can't access cluster via kubeconfig. Please check the credentials privileges.",
 		}
-	}
-	if version != nil {
+	} else {
 		apiCluster.Spec.Version = *version
 	}
 	return apiCluster


### PR DESCRIPTION
Reverts kubermatic/dashboard#5373
will revert this pr  https://github.com/kubermatic/dashboard/pull/5367 which caused the issue, so no need for this fix. 
this pr https://github.com/kubermatic/dashboard/pull/5367  needs to be reverted as it doesn't fix the issue of the namespace access in the manager client by using an impersonation client, so the changes seem to be unnecessary.