### PR TITLE
bump KKP to bd4abe02b7de

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -123,10 +123,10 @@ containerize() {
     mkdir -p "$gomodcache"
 
     exec docker run \
-      -v "$PWD":/go/src/k8c.io/kubermatic \
+      -v "$PWD":/go/src/k8c.io/dashboard \
       -v "$gocache":"$gocache" \
       -v "$gomodcache":"$gomodcache" \
-      -w /go/src/k8c.io/kubermatic \
+      -w /go/src/k8c.io/dashboard \
       -e "GOCACHE=$gocache" \
       -e "GOMODCACHE=$gomodcache" \
       -e "CONTAINERIZED=true" \
@@ -138,121 +138,6 @@ containerize() {
 
     exit $?
   fi
-}
-
-ensure_github_host_pubkey() {
-  # check whether we already have a known_hosts entry for Github
-  if ssh-keygen -F github.com > /dev/null 2>&1; then
-    echo " [*] Github's SSH host key already present" > /dev/stderr
-  else
-    local github_rsa_key
-    # https://help.github.com/en/github/authenticating-to-github/githubs-ssh-key-fingerprints
-    github_rsa_key="github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
-
-    echo " [*] Adding Github's SSH host key to known hosts" > /dev/stderr
-    mkdir -p "$HOME/.ssh"
-    chmod 700 "$HOME/.ssh"
-    echo "$github_rsa_key" >> "$HOME/.ssh/known_hosts"
-    chmod 600 "$HOME/.ssh/known_hosts"
-  fi
-}
-
-vault_ci_login() {
-  # already logged in
-  if [ -n "${VAULT_TOKEN:-}" ]; then
-    return 0
-  fi
-
-  # check environment variables
-  if [ -z "${VAULT_ROLE_ID:-}" ] || [ -z "${VAULT_SECRET_ID:-}" ]; then
-    echo "VAULT_ROLE_ID and VAULT_SECRET_ID must be set to programmatically authenticate against Vault."
-    return 1
-  fi
-
-  local token
-  token=$(vault write --format=json auth/approle/login "role_id=$VAULT_ROLE_ID" "secret_id=$VAULT_SECRET_ID" | jq -r '.auth.client_token')
-
-  export VAULT_TOKEN="$token"
-}
-
-get_latest_dashboard_hash() {
-  local FOR_BRANCH="$1"
-
-  ensure_github_host_pubkey
-  git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
-  local DASHBOARD_URL="git@github.com:kubermatic/dashboard.git"
-
-  # `local` always sets the rc to 0, so declare as local _before_ doing the substitution
-  # which may fail
-  local HASH
-  HASH="$(retry 5 git ls-remote "$DASHBOARD_URL" "refs/heads/$FOR_BRANCH" | awk '{print $1}')"
-  echodate "The latest dashboard hash for $FOR_BRANCH is $HASH" > /dev/stderr
-  echo "$HASH"
-}
-
-# This should only be used for release branches, as it only fetches the last 25 commits
-# for checking for tags.
-get_latest_dashboard_tag() {
-  local FOR_BRANCH="$1"
-  local DEPTH="${2:-25}"
-
-  ensure_github_host_pubkey
-  git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
-  local DASHBOARD_URL="git@github.com:kubermatic/dashboard.git"
-
-  local TMPDIR
-  TMPDIR=$(mktemp -d dashboard.XXXXX)
-
-  # git ls-remote cannot list tags in a meaningful way, so we have to clone the repo
-  echodate "Cloning dashboard repository to find tags in $FOR_BRANCH branch..." > /dev/stderr
-  git clone -b "$FOR_BRANCH" --single-branch --depth $DEPTH "$DASHBOARD_URL" "$TMPDIR"
-
-  local TAG
-  TAG="$(git --git-dir $TMPDIR/.git describe --abbrev=0 --tags --first-parent)"
-
-  echodate "The latest dashboard tag in $FOR_BRANCH is $TAG" > /dev/stderr
-  echo "$TAG"
-}
-
-check_dashboard_tag() {
-  local TAG="$1"
-
-  ensure_github_host_pubkey
-  git config --global core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
-  local DASHBOARD_URL="git@github.com:kubermatic/dashboard.git"
-
-  retry 5 git ls-remote "$DASHBOARD_URL" "refs/tags/$TAG"
-}
-
-format_dashboard() {
-  local filename="$1"
-  local tmpfile="$filename.tmp"
-
-  cat "$filename" |
-    jq '(.templating.list[] | select(.type=="query") | .options) = []' |
-    jq '(.templating.list[] | select(.type=="query") | .refresh) = 2' |
-    jq '(.templating.list[] | select(.type=="query") | .current) = {}' |
-    jq '(.templating.list[] | select(.type=="datasource") | .current) = {}' |
-    jq '(.templating.list[] | select(.type=="interval") | .current) = {}' |
-    jq '(.panels[] | select(.scopedVars!=null) | .scopedVars) = {}' |
-    jq '(.annotations.list) = []' |
-    jq '(.links) = []' |
-    jq '(.refresh) = "30s"' |
-    jq '(.time.from) = "now-6h"' |
-    jq '(.editable) = true' |
-    jq '(.panels[] | select(.type!="row") | .editable) = true' |
-    jq '(.panels[] | select(.type!="row") | .transparent) = true' |
-    jq '(.panels[] | select(.type!="row") | .timeRegions) = []' |
-    jq '(.hideControls) = false' |
-    jq '(.time.to) = "now"' |
-    jq '(.timezone) = ""' |
-    jq '(.graphTooltip) = 1' |
-    jq 'del(.panels[] | select(.repeatPanelId!=null))' |
-    jq 'del(.id)' |
-    jq 'del(.iteration)' |
-    jq --sort-keys '.' > "$tmpfile"
-
-  mv "$tmpfile" "$filename"
 }
 
 # appendTrap appends to existing traps, if any. It is needed because Bash replaces existing handlers
@@ -434,24 +319,6 @@ heading() {
   echo
 }
 
-# This is used during releases to set the correct version on all Helm charts.
-set_helm_charts_version() {
-  local version="$1"
-  local dockerTag="${2:-$version}"
-
-  echodate "Setting Helm chart version to $version..."
-
-  while IFS= read -r -d '' chartFile; do
-    chart="$(basename $(dirname "$chartFile"))"
-
-    yq --inplace ".version = \"$version\"" "$chartFile"
-    if [ "$chart" = "kubermatic-operator" ]; then
-      yq --inplace ".appVersion = \"$version\"" "$chartFile"
-      yq --inplace ".kubermaticOperator.image.tag = \"$dockerTag\"" "$(dirname "$chartFile")/values.yaml"
-    fi
-  done < <(find charts -name 'Chart.yaml' -print0 | sort --zero-terminated)
-}
-
 # copy_crds_to_chart is used during GitHub releases and for e2e tests,
 # it ensures that the auto-generated CRDs in pkg/ are copied into the
 # operator chart.
@@ -461,23 +328,6 @@ copy_crds_to_chart() {
 
   mkdir -p $chartCRDs
   cp $sourceCRDs/* $chartCRDs
-}
-
-# set_crds_version_annotation will inject a annotation label into all YAML files
-# of the given directory. This is important for GitOps installations that
-# do not use the KKP installer, so that the CRDs are still properly annotated,
-# as the KKP operator needs to determine the CRD versions.
-set_crds_version_annotation() {
-  local version="${1:-}"
-  local directory="${2:-charts/kubermatic-operator/crd/k8c.io}"
-
-  if [ -z "$version" ]; then
-    version="$(git describe)"
-  fi
-
-  while IFS= read -r -d '' filename; do
-    yq --inplace ".metadata.annotations.\"app.kubernetes.io/version\" = \"$version\"" "$filename"
-  done < <(find "$directory" -name '*.yaml' -print0 | sort --zero-terminated)
 }
 
 # go_test wraps running `go test` commands. The first argument needs to be file name

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/packethost/packngo v0.29.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/spf13/cobra v1.6.1
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.8.1
 	github.com/vmware/go-vcloud-director/v2 v2.17.0
 	github.com/vmware/govmomi v0.29.0
@@ -66,8 +66,9 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.5.3
-	k8c.io/kubermatic/v2 v2.21.1-0.20221201142112-dd5fd6c6fbc5
+	k8c.io/kubermatic/v2 v2.21.1-0.20221202132228-bd4abe02b7de
 	k8c.io/operating-system-manager v1.1.1
+	k8c.io/reconciler v0.3.1
 	k8s.io/api v0.25.4
 	k8s.io/apiextensions-apiserver v0.25.4
 	k8s.io/apimachinery v0.25.4

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -706,7 +706,7 @@ github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
 github.com/onsi/ginkgo/v2 v2.1.6/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7AG4VIk=
-github.com/onsi/ginkgo/v2 v2.2.0 h1:3ZNA3L1c5FYDFTTxbFeVGGD8jYvjYauHD30YgLxVsNI=
+github.com/onsi/ginkgo/v2 v2.4.0 h1:+Ig9nvqgS5OBSACXNk15PLdp0U9XPYROt9CFzVdFGIs=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -824,8 +824,9 @@ github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUq
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace h1:9PNP1jnUjRhfmGMlkXHjYPishpcw4jpSt/V/xYY3FMA=
+github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.12.0 h1:CZ7eSOd3kZoaYDLbXnmzgQI5RlciuXBMA+18HwHRfZQ=
 github.com/spf13/viper v1.12.0/go.mod h1:b6COn30jlNxbm/V2IqWiNWkJ+vZNiMNksliPCiuKtSI=
 github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
@@ -1461,10 +1462,12 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.5.3 h1:A4k9VgKn/DlCbp/oiTdz6NQO18MSdV96+X2TtH1mYIM=
 k8c.io/kubeone v1.5.3/go.mod h1:xNlAertZO2iKVE8pL0Ruf/zjtM+EBeiZJtueuncyjxI=
-k8c.io/kubermatic/v2 v2.21.1-0.20221201142112-dd5fd6c6fbc5 h1:QsneuiT2dlBNA0tFWCZZMYn04lG8EizVhyRG92RZaww=
-k8c.io/kubermatic/v2 v2.21.1-0.20221201142112-dd5fd6c6fbc5/go.mod h1:yv2deJxff9d01c3WxPaFPxNK5a39IH7G4boTnGGKYQE=
+k8c.io/kubermatic/v2 v2.21.1-0.20221202132228-bd4abe02b7de h1:zaGLmLenciv6nqs11FKHtchowLd+6px4i6IIE1fZgUU=
+k8c.io/kubermatic/v2 v2.21.1-0.20221202132228-bd4abe02b7de/go.mod h1:E1FRYH+em+fxSQaDeEA3y+0gGiSavb4HqmfMv6zw5qE=
 k8c.io/operating-system-manager v1.1.1 h1:nQ4/3pnGwolxkboxRAfPOl7Uhk2/rayaJ0paCMZnHFM=
 k8c.io/operating-system-manager v1.1.1/go.mod h1:ybfmS133EOoBMm1MHOC1HIdrgCzn5nu29KCDtyaShqs=
+k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=
+k8c.io/reconciler v0.3.1/go.mod h1:tEnGL+1N4TmlbgvXYgtZerhVU221NnmlUcK3WdOHzLo=
 k8s.io/api v0.25.4 h1:3YO8J4RtmG7elEgaWMb4HgmpS2CfY1QlaOz9nwB+ZSs=
 k8s.io/api v0.25.4/go.mod h1:IG2+RzyPQLllQxnhzD8KQNEu4c4YvyDTpSMztf4A0OQ=
 k8s.io/apiextensions-apiserver v0.25.4 h1:7hu9pF+xikxQuQZ7/30z/qxIPZc2J1lFElPtr7f+B6U=

--- a/modules/api/hack/reconciling.yaml
+++ b/modules/api/hack/reconciling.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This defines the reconciling helpers we generate using
+# https://github.com/kubermatic/reconciler
+
+package: reconciling
+boilerplate: ../../hack/boilerplate/ce/boilerplate.go.txt
+resourceTypes:
+  # instancetype/v1alpha1
+  - { package: kubevirt.io/api/instancetype/v1alpha1, resourceName: VirtualMachineInstancetype }
+  - { package: kubevirt.io/api/instancetype/v1alpha1, resourceName: VirtualMachinePreference }

--- a/modules/api/hack/update-codegen.sh
+++ b/modules/api/hack/update-codegen.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+source ../../hack/lib.sh
+
+echodate "Generating reconciling helpers"
+
+reconcileHelpers=pkg/resources/reconciling/zz_generated_reconcile.go
+go run k8c.io/reconciler/cmd/reconciler-gen --config hack/reconciling.yaml > $reconcileHelpers
+
+currentYear=$(date +%Y)
+sed -i "s/Copyright YEAR/Copyright $currentYear/g" $reconcileHelpers

--- a/modules/api/pkg/ee/metering/handler.go
+++ b/modules/api/pkg/ee/metering/handler.go
@@ -33,8 +33,8 @@ import (
 
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -185,14 +185,14 @@ func CreateOrUpdateCredentials(ctx context.Context, request interface{}, seedsGe
 }
 
 func ensureMeteringToolSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, seed *kubermaticv1.Seed, secretData map[string][]byte) error {
-	creator := func() (name string, create reconciling.SecretCreator) {
+	reconciler := func() (name string, create reconciling.SecretReconciler) {
 		return SecretName, func(existing *corev1.Secret) (*corev1.Secret, error) {
 			existing.Data = secretData
 			return existing, nil
 		}
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, []reconciling.NamedSecretCreatorGetter{creator}, seed.Namespace, seedClient); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, []reconciling.NamedSecretReconcilerFactory{reconciler}, seed.Namespace, seedClient); err != nil {
 		return err
 	}
 

--- a/modules/api/pkg/handler/v2/application_installation/application_installation.go
+++ b/modules/api/pkg/handler/v2/application_installation/application_installation.go
@@ -27,8 +27,8 @@ import (
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	"k8c.io/dashboard/v2/pkg/provider"
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,10 +90,10 @@ func CreateApplicationInstallation(userInfoGetter provider.UserInfoGetter, proje
 		}
 
 		// check if namespace for CR already exists and create it if not
-		creators := []reconciling.NamedNamespaceCreatorGetter{
-			genericNamespaceCreator(req.Body.Namespace),
+		reconcilers := []reconciling.NamedNamespaceReconcilerFactory{
+			genericNamespaceReconciler(req.Body.Namespace),
 		}
-		if err := reconciling.ReconcileNamespaces(ctx, creators, "", client); err != nil {
+		if err := reconciling.ReconcileNamespaces(ctx, reconcilers, "", client); err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
@@ -212,8 +212,8 @@ func UpdateApplicationInstallation(userInfoGetter provider.UserInfoGetter, proje
 	}
 }
 
-func genericNamespaceCreator(name string) reconciling.NamedNamespaceCreatorGetter {
-	return func() (string, reconciling.NamespaceCreator) {
+func genericNamespaceReconciler(name string) reconciling.NamedNamespaceReconcilerFactory {
+	return func() (string, reconciling.NamespaceReconciler) {
 		return name, func(n *corev1.Namespace) (*corev1.Namespace, error) {
 			return n, nil
 		}

--- a/modules/api/pkg/provider/kubernetes/cluster.go
+++ b/modules/api/pkg/provider/kubernetes/cluster.go
@@ -32,9 +32,9 @@ import (
 	k8cuserclusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	utilcluster "k8c.io/kubermatic/v2/pkg/util/cluster"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/modules/api/pkg/provider/kubernetes/credentials.go
+++ b/modules/api/pkg/provider/kubernetes/credentials.go
@@ -41,8 +41,8 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/vmwareclouddirector"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/vsphere"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -108,12 +108,12 @@ func createOrUpdateCredentialSecretForCluster(ctx context.Context, seedClient ct
 }
 
 func ensureCredentialSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, secretData map[string][]byte) (*providerconfig.GlobalSecretKeySelector, error) {
-	creator, err := credentialSecretCreatorGetter(cluster.GetSecretName(), cluster.Labels, secretData)
+	reconciler, err := credentialSecretReconcilerFactory(cluster.GetSecretName(), cluster.Labels, secretData)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, []reconciling.NamedSecretCreatorGetter{creator}, resources.KubermaticNamespace, seedClient); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, []reconciling.NamedSecretReconcilerFactory{reconciler}, resources.KubermaticNamespace, seedClient); err != nil {
 		return nil, err
 	}
 
@@ -627,15 +627,15 @@ func GetKubeOneNamespaceName(externalClusterName string) string {
 }
 
 func ensureCredentialKubeOneSecret(ctx context.Context, masterClient ctrlruntimeclient.Client, externalcluster *kubermaticv1.ExternalCluster, secretName string, secretData map[string][]byte) (*providerconfig.GlobalSecretKeySelector, error) {
-	creator, err := credentialSecretCreatorGetter(secretName, externalcluster.Labels, secretData)
+	reconciler, err := credentialSecretReconcilerFactory(secretName, externalcluster.Labels, secretData)
 	if err != nil {
 		return nil, err
 	}
 
 	kubeOneNamespaceName := GetKubeOneNamespaceName(externalcluster.Name)
-	creators := []reconciling.NamedSecretCreatorGetter{creator}
+	reconcilers := []reconciling.NamedSecretReconcilerFactory{reconciler}
 
-	if err := reconciling.ReconcileSecrets(ctx, creators, kubeOneNamespaceName, masterClient); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, reconcilers, kubeOneNamespaceName, masterClient); err != nil {
 		return nil, err
 	}
 
@@ -984,13 +984,13 @@ func GetKubeOneCredentialsSecretName(cloud apiv2.KubeOneCloudSpec) string {
 	return ""
 }
 
-func credentialSecretCreatorGetter(secretName string, clusterLabels map[string]string, secretData map[string][]byte) (reconciling.NamedSecretCreatorGetter, error) {
+func credentialSecretReconcilerFactory(secretName string, clusterLabels map[string]string, secretData map[string][]byte) (reconciling.NamedSecretReconcilerFactory, error) {
 	projectID := clusterLabels[kubermaticv1.ProjectIDLabelKey]
 	if len(projectID) == 0 {
 		return nil, fmt.Errorf("cluster is missing '%s' label", kubermaticv1.ProjectIDLabelKey)
 	}
 
-	return func() (name string, create reconciling.SecretCreator) {
+	return func() (name string, reconciler reconciling.SecretReconciler) {
 		return secretName, func(existing *corev1.Secret) (*corev1.Secret, error) {
 			if existing.Labels == nil {
 				existing.Labels = map[string]string{}

--- a/modules/api/pkg/provider/kubernetes/external_cluster.go
+++ b/modules/api/pkg/provider/kubernetes/external_cluster.go
@@ -29,9 +29,9 @@ import (
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/util/restmapper"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -349,12 +349,12 @@ func (p *ExternalClusterProvider) IsMetricServerAvailable(ctx context.Context, u
 }
 
 func (p *ExternalClusterProvider) ensureKubeconfigSecret(ctx context.Context, cluster *kubermaticv1.ExternalCluster, secretData map[string][]byte) (*providerconfig.GlobalSecretKeySelector, error) {
-	creator, err := kubeconfigSecretCreatorGetter(cluster, secretData)
+	reconciler, err := kubeconfigSecretReconcilerFactory(cluster, secretData)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := reconciling.ReconcileSecrets(ctx, []reconciling.NamedSecretCreatorGetter{creator}, resources.KubermaticNamespace, p.clientPrivileged); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, []reconciling.NamedSecretReconcilerFactory{reconciler}, resources.KubermaticNamespace, p.clientPrivileged); err != nil {
 		return nil, err
 	}
 
@@ -366,13 +366,13 @@ func (p *ExternalClusterProvider) ensureKubeconfigSecret(ctx context.Context, cl
 	}, nil
 }
 
-func kubeconfigSecretCreatorGetter(cluster *kubermaticv1.ExternalCluster, secretData map[string][]byte) (reconciling.NamedSecretCreatorGetter, error) {
+func kubeconfigSecretReconcilerFactory(cluster *kubermaticv1.ExternalCluster, secretData map[string][]byte) (reconciling.NamedSecretReconcilerFactory, error) {
 	projectID := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
 	if len(projectID) == 0 {
 		return nil, fmt.Errorf("external cluster is missing '%s' label", kubermaticv1.ProjectIDLabelKey)
 	}
 
-	return func() (name string, create reconciling.SecretCreator) {
+	return func() (name string, reconciler reconciling.SecretReconciler) {
 		return cluster.GetKubeconfigSecretName(), func(existing *corev1.Secret) (*corev1.Secret, error) {
 			if existing.Labels == nil {
 				existing.Labels = map[string]string{}

--- a/modules/api/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/modules/api/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciling
+
+import (
+	"context"
+	"fmt"
+
+	"k8c.io/reconciler/pkg/reconciling"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+)
+
+// VirtualMachineInstancetypeReconciler defines an interface to create/update VirtualMachineInstancetypes.
+type VirtualMachineInstancetypeReconciler = func(existing *instancetypev1alpha1.VirtualMachineInstancetype) (*instancetypev1alpha1.VirtualMachineInstancetype, error)
+
+// NamedVirtualMachineInstancetypeReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
+type NamedVirtualMachineInstancetypeReconcilerFactory = func() (name string, reconciler VirtualMachineInstancetypeReconciler)
+
+// VirtualMachineInstancetypeObjectWrapper adds a wrapper so the VirtualMachineInstancetypeReconciler matches ObjectReconciler.
+// This is needed as Go does not support function interface matching.
+func VirtualMachineInstancetypeObjectWrapper(reconciler VirtualMachineInstancetypeReconciler) reconciling.ObjectReconciler {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return reconciler(existing.(*instancetypev1alpha1.VirtualMachineInstancetype))
+		}
+		return reconciler(&instancetypev1alpha1.VirtualMachineInstancetype{})
+	}
+}
+
+// ReconcileVirtualMachineInstancetypes will create and update the VirtualMachineInstancetypes coming from the passed VirtualMachineInstancetypeReconciler slice.
+func ReconcileVirtualMachineInstancetypes(ctx context.Context, namedFactories []NamedVirtualMachineInstancetypeReconcilerFactory, namespace string, client ctrlruntimeclient.Client, objectModifiers ...reconciling.ObjectModifier) error {
+	for _, factory := range namedFactories {
+		name, reconciler := factory()
+		reconcileObject := VirtualMachineInstancetypeObjectWrapper(reconciler)
+		reconcileObject = reconciling.CreateWithNamespace(reconcileObject, namespace)
+		reconcileObject = reconciling.CreateWithName(reconcileObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			reconcileObject = objectModifier(reconcileObject)
+		}
+
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1alpha1.VirtualMachineInstancetype{}, false); err != nil {
+			return fmt.Errorf("failed to ensure VirtualMachineInstancetype %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}
+
+// VirtualMachinePreferenceReconciler defines an interface to create/update VirtualMachinePreferences.
+type VirtualMachinePreferenceReconciler = func(existing *instancetypev1alpha1.VirtualMachinePreference) (*instancetypev1alpha1.VirtualMachinePreference, error)
+
+// NamedVirtualMachinePreferenceReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
+type NamedVirtualMachinePreferenceReconcilerFactory = func() (name string, reconciler VirtualMachinePreferenceReconciler)
+
+// VirtualMachinePreferenceObjectWrapper adds a wrapper so the VirtualMachinePreferenceReconciler matches ObjectReconciler.
+// This is needed as Go does not support function interface matching.
+func VirtualMachinePreferenceObjectWrapper(reconciler VirtualMachinePreferenceReconciler) reconciling.ObjectReconciler {
+	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+		if existing != nil {
+			return reconciler(existing.(*instancetypev1alpha1.VirtualMachinePreference))
+		}
+		return reconciler(&instancetypev1alpha1.VirtualMachinePreference{})
+	}
+}
+
+// ReconcileVirtualMachinePreferences will create and update the VirtualMachinePreferences coming from the passed VirtualMachinePreferenceReconciler slice.
+func ReconcileVirtualMachinePreferences(ctx context.Context, namedFactories []NamedVirtualMachinePreferenceReconcilerFactory, namespace string, client ctrlruntimeclient.Client, objectModifiers ...reconciling.ObjectModifier) error {
+	for _, factory := range namedFactories {
+		name, reconciler := factory()
+		reconcileObject := VirtualMachinePreferenceObjectWrapper(reconciler)
+		reconcileObject = reconciling.CreateWithNamespace(reconcileObject, namespace)
+		reconcileObject = reconciling.CreateWithName(reconcileObject, name)
+
+		for _, objectModifier := range objectModifiers {
+			reconcileObject = objectModifier(reconcileObject)
+		}
+
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1alpha1.VirtualMachinePreference{}, false); err != nil {
+			return fmt.Errorf("failed to ensure VirtualMachinePreference %s/%s: %w", namespace, name, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings in the new reconciler framework. To lessen the dependency on KKP, I made it so that the dashboard just generates its own reconciling functions for kubevirt stuff.

This PR also removes a bunch of unused code from the hack/lib.sh.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
