### PR TITLE
Add autoscaling config in cluster template node data

### DIFF
--- a/modules/web/src/app/core/services/node-data/service.ts
+++ b/modules/web/src/app/core/services/node-data/service.ts
@@ -137,6 +137,8 @@ export class NodeDataService {
       name: md.name,
       spec: md.spec.template,
       dynamicConfig: md.spec.dynamicConfig,
+      minReplicas: md.spec.minReplicas,
+      maxReplicas: md.spec.maxReplicas,
     } as NodeData;
   }
 

--- a/modules/web/src/app/shared/components/save-cluster-template/component.ts
+++ b/modules/web/src/app/shared/components/save-cluster-template/component.ts
@@ -101,6 +101,8 @@ export class SaveClusterTemplateDialogComponent implements OnInit {
           template: this.data.nodeData.spec,
           replicas: this.data.nodeData.count,
           dynamicConfig: this.data.nodeData.dynamicConfig,
+          minReplicas: this.data.nodeData.minReplicas,
+          maxReplicas: this.data.nodeData.maxReplicas,
         },
       },
       userSshKeys: this._getClusterTemplateSSHKeys(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `minReplicas` and `maxReplicas` in cluster template node data, which was missed in https://github.com/kubermatic/dashboard/pull/5369.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
