### PR TITLE
Increase timeout for e2e test API call to fetch Azure sizes

### DIFF
--- a/modules/api/pkg/test/e2e/utils/client.go
+++ b/modules/api/pkg/test/e2e/utils/client.go
@@ -1716,10 +1716,10 @@ func (r *TestClient) ListDOSizes(credential string) (*models.DigitaloceanSizeLis
 
 // ListAzureSizes returns list Azure sizes.
 func (r *TestClient) ListAzureSizes(credential, location string) (models.AzureSizeList, error) {
-	params := &azure.ListAzureSizesParams{
-		Credential: &credential,
-		Location:   &location,
-	}
+	params := azure.NewListAzureSizesParamsWithTimeout(time.Second * 30)
+	params.Credential = &credential
+	params.Location = &location
+
 	SetupRetryParams(r.test, params, Backoff{
 		Duration: 1 * time.Second,
 		Steps:    4,


### PR DESCRIPTION
**What this PR does / why we need it**:
This endpoint timing out again and again is a major pain, so I would like to increase it to 30 seconds (by default, it should be ten as far as I understand). This will also be backported to release branches in `kubermatic/kubermatic` as the api test failing because of this tends to delay release work.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind flake

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
