### PR TITLE
Remove karma testing config from angular configuration

### DIFF
--- a/modules/web/angular.json
+++ b/modules/web/angular.json
@@ -7,6 +7,7 @@
       "root": "",
       "sourceRoot": "src",
       "projectType": "application",
+      "prefix": "km",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
@@ -20,7 +21,11 @@
             "assets": [
               "src/assets",
               "src/favicon.png",
-              { "glob": "**/*", "input": "node_modules/monaco-editor", "output": "assets/monaco-editor" }
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor",
+                "output": "assets/monaco-editor"
+              }
             ],
             "allowedCommonJsDependencies": [
               "country-code-lookup",
@@ -308,26 +313,6 @@
           "options": {
             "browserTarget": "kubermatic:build"
           }
-        },
-        "test": {
-          "builder": "@angular-devkit/build-angular:karma",
-          "options": {
-            "main": "src/test.ts",
-            "karmaConfig": "./karma.conf.js",
-            "codeCoverage": true,
-            "polyfills": "src/polyfills.ts",
-            "tsConfig": "src/tsconfig.spec.json",
-            "scripts": [
-              "node_modules/jquery/dist/jquery.js"
-            ],
-            "styles": [
-              "src/assets/css/root.scss"
-            ],
-            "assets": [
-              "src/assets",
-              "src/favicon.png"
-            ]
-          }
         }
       }
     }
@@ -335,10 +320,10 @@
   "defaultProject": "kubermatic",
   "schematics": {
     "@schematics/angular:component": {
-      "prefix": "kubermatic"
+      "prefix": "km"
     },
     "@schematics/angular:directive": {
-      "prefix": "kubermatic"
+      "prefix": "km"
     },
     "@schematics/angular:guard": {},
     "@schematics/angular:interface": {},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains removal of karma configuration from `angular.json` and setting default prefix for selector in case component/directive is generate via `ng cli`. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

This change was not catered in this PR:

[Use Jest instead of karma #1896](https://github.com/kubermatic/dashboard/pull/1896)

**What type of PR is this?**
/kind cleanup
/kind chore

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
