### PR TITLE
add sync-client

### DIFF
--- a/modules/api/hack/ci/sync-apiclient.sh
+++ b/modules/api/hack/ci/sync-apiclient.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### This script is run as a postsubmit to copy the generated API client
+### into the github.com/kubermatic/go-kubermatic repository.
+
+set -euo pipefail
+
+cd $(dirname $0)/../../../..
+source hack/lib.sh
+
+URL="git@github.com:kubermatic/go-kubermatic.git"
+
+commit_and_push() {
+  local repodir branch source_sha
+  repodir="$1"
+  branch="$2"
+  source_sha="$3"
+
+  (
+    cd "$repodir"
+
+    git config --local user.email "dev@kubermatic.com"
+    git config --local user.name "Prow CI Robot"
+    git config --local core.sshCommand 'ssh -o CheckHostIP=no -i /ssh/id_rsa'
+
+    git add .
+    if ! git status | grep -q 'nothing to commit'; then
+      git commit -m "Syncing client from Kubermatic $source_sha"
+      git push origin "$branch"
+    fi
+  )
+}
+
+if [ -z "${PULL_BASE_REF=}" ]; then
+  echo "\$PULL_BASE_REF undefined, I don't know which branch to sync."
+  exit 1
+fi
+
+if [ -n "$(git rev-parse --show-prefix)" ]; then
+  echo "You must run this script from repo root"
+  exit 1
+fi
+
+# Ensure Github's host key is available and disable IP checking.
+ensure_github_host_pubkey
+
+# clone the target and pick the right branch
+tempdir="$(mktemp -d)"
+trap "rm -rf '$tempdir'" EXIT
+GIT_SSH_COMMAND="ssh -o CheckHostIP=no -i /ssh/id_rsa" git clone "$URL" "$tempdir"
+(
+  cd "$tempdir"
+  git checkout "$PULL_BASE_REF" || git checkout -b "$PULL_BASE_REF"
+)
+
+# rewrite all the import paths
+echo "Rewriting import paths"
+sed_expression="s#k8c.io/dashboard/v2/pkg/test/e2e/utils/apiclient#github.com/kubermatic/go-kubermatic#g"
+time find pkg/test/e2e/utils/apiclient/ -type f -exec sed "$sed_expression" -i {} \;
+
+# sync the files
+echo "Synchronizing the files"
+rsync --archive --verbose --delete "./pkg/test/e2e/utils/apiclient/client/" "$tempdir/client/"
+rsync --archive --verbose --delete "./pkg/test/e2e/utils/apiclient/models/" "$tempdir/models/"
+
+# commit and push
+commit_and_push "$tempdir" "$PULL_BASE_REF" "$(git rev-parse HEAD)"


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
With the move of the API from KKP to dashboard, the go client generation was removed from kkp post-submits job and not added to the dashboard repo (https://github.com/kubermatic/infra/pull/1937)
This PR adds the sync script in dashboard and a infra PR is also raised for the prow job (https://github.com/kubermatic/infra/pull/1999)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes kubermatic/go-kubermatic#

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
