### PR TITLE
Fix bug apiServerAllowedIPRanges is allowed for LB expose strategy

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -364,9 +364,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         admissionPlugins: this.form.get(Controls.AdmissionPlugins).value,
         podNodeSelectorAdmissionPluginConfig: this.podNodeSelectorAdmissionPluginConfig,
         containerRuntime: this.form.get(Controls.ContainerRuntime).value,
-        apiServerAllowedIPRanges: {
-          cidrBlocks: this.form.get(Controls.APIServerAllowedIPRanges).value?.tags,
-        } as NetworkRanges,
       } as ClusterSpecPatch,
     } as ClusterPatch;
 
@@ -376,7 +373,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       };
     }
 
-    if (this.cluster.spec.exposeStrategy === ExposeStrategy.loadbalancer) {
+    if (this.isExposeStrategyLoadBalancer()) {
       patch.spec.apiServerAllowedIPRanges = this.getAPIServerAllowedIPRange();
     }
 
@@ -402,7 +399,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   private getAPIServerAllowedIPRange(): NetworkRanges {
-    if (this.cluster.spec.exposeStrategy !== ExposeStrategy.loadbalancer) {
+    if (!this.isExposeStrategyLoadBalancer()) {
       return null;
     }
     const apiServerAllowedIPRange = this.form.get(Controls.APIServerAllowedIPRanges).value?.tags;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fix edit cluster as in patch request by default "apiServerAllowedIPRanges" was send in payload even thought expose strategy was not LB(Load balance) + Code Clean to use existing method.


This bug was introduced in this [PR](https://github.com/kubermatic/dashboard/pull/5356/files#diff-4cde679d28715ceee620ba265cb68ce799fdda1401908486688da58bff1a6416R367)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

/kind bug
/kind cleanup

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
