### PR TITLE
add ensure_github_host_pubkey for sync-client

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -396,3 +396,20 @@ kubermatic_git_hash() {
   # this uses https://unix.stackexchange.com/a/13472 to extract the hash
   curl --silent "$patchURL" | grep -oP '^From \K\w+'
 }
+
+ensure_github_host_pubkey() {
+  # check whether we already have a known_hosts entry for Github
+  if ssh-keygen -F github.com > /dev/null 2>&1; then
+    echo " [*] Github's SSH host key already present" > /dev/stderr
+  else
+    local github_rsa_key
+    # https://help.github.com/en/github/authenticating-to-github/githubs-ssh-key-fingerprints
+    github_rsa_key="github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+
+    echo " [*] Adding Github's SSH host key to known hosts" > /dev/stderr
+    mkdir -p "$HOME/.ssh"
+    chmod 700 "$HOME/.ssh"
+    echo "$github_rsa_key" >> "$HOME/.ssh/known_hosts"
+    chmod 600 "$HOME/.ssh/known_hosts"
+  fi
+}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Step by step...
fixing this one:
https://public-prow.loodse.com/view/gs/prow-dev-public-data/logs/post-dashboard-sync-client/1603672583847284736

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
