### PR TITLE
Hide KubeVirt's secondary disks wizard and view

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -317,10 +317,6 @@ limitations under the License.
                 <div key>Size</div>
                 <div value>{{element.spec.cloud.kubevirt.primaryDiskSize}}</div>
               </km-property>
-              <km-property *ngFor="let disk of element.spec.cloud.kubevirt?.secondaryDisks; let i = index;">
-                <div key>Secondary Disk {{i + 1}}</div>
-                <div value>{{disk.storageClassName}}, {{disk.size}}</div>
-              </km-property>
               <ng-container *ngIf="element.spec.cloud.kubevirt.nodeAffinityPreset as nodeAffinityPreset">
                 <km-property>
                   <div key>Node Affinity Preset</div>

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
@@ -146,58 +146,6 @@ limitations under the License.
                      required>
   </km-number-stepper>
 
-  <mat-card-header class="km-no-padding"
-                   fxLayoutAlign=" center">
-    <mat-card-title>Secondary Disks</mat-card-title>
-    <div fxFlex></div>
-    <button fxLayoutAlign="center center"
-            mat-flat-button
-            type="button"
-            color="quaternary"
-            matTooltip="Add secondary disk"
-            (click)="addSecondaryDisk()"
-            [disabled]="this.secondaryDisksFormArray.length >= this.maxSecondaryDisks">
-      <i class="km-icon-mask km-icon-add"></i>
-      <span>Add Disk</span>
-    </button>
-  </mat-card-header>
-
-  <div [formArrayName]="Controls.SecondaryDisks">
-    <div *ngFor="let control of secondaryDisksFormArray.controls; let i = index"
-         [formGroupName]="i">
-      <div fxFlex
-           fxLayoutGap="10px">
-        <km-combobox [options]="storageClasses"
-                     [formControlName]="Controls.SecondaryDiskStorageClass"
-                     [label]="storageClassLabel"
-                     inputLabel="Select storage class..."
-                     filterBy="name"
-                     required
-                     fxFlex>
-          <div *option="let storageClass">{{storageClass.name}}</div>
-        </km-combobox>
-        <km-number-stepper [formControlName]="Controls.SecondaryDiskSize"
-                           mode="errors"
-                           label="Size (GB)"
-                           min="10"
-                           step="10"
-                           required>
-        </km-number-stepper>
-        <button mat-icon-button
-                type="button"
-                matTooltip="Delete secondary disk"
-                (click)="secondaryDisksFormArray.removeAt(i)">
-          <i class="km-icon-mask km-icon-delete"></i>
-        </button>
-      </div>
-    </div>
-  </div>
-
-  <div *ngIf="secondaryDisksFormArray.length === 0"
-       class="no-secondary-disks-msg km-text-muted">
-    Optional disks that will be mounted to the nodes. Configure up to three disks.
-  </div>
-
   <km-expansion-panel expandLabel="ADVANCED SCHEDULING SETTINGS"
                       collapseLabel="ADVANCED SCHEDULING SETTINGS">
     <ng-container *ngTemplateOutlet="selectAffinityPreset;

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -826,10 +826,6 @@ limitations under the License.
                   <div key>Size</div>
                   <div value>{{machineDeployment.spec.template.cloud?.kubevirt.primaryDiskSize}}</div>
                 </km-property>
-                <km-property *ngFor="let disk of machineDeployment.spec.template.cloud?.kubevirt?.secondaryDisks; let i = index;">
-                  <div key>Secondary Disk {{i + 1}}</div>
-                  <div value>{{disk.storageClassName}}, {{disk.size}}</div>
-                </km-property>
                 <ng-container *ngIf="machineDeployment.spec.template.cloud?.kubevirt.nodeAffinityPreset as nodeAffinityPreset">
                   <km-property>
                     <div key>Node Affinity Preset</div>

--- a/modules/web/src/app/shared/entity/node.ts
+++ b/modules/web/src/app/shared/entity/node.ts
@@ -228,14 +228,8 @@ export class KubeVirtNodeSpec {
   primaryDiskOSImage: string;
   primaryDiskStorageClassName: string;
   primaryDiskSize: string;
-  secondaryDisks?: KubeVirtSecondaryDisk[];
   nodeAffinityPreset?: KubeVirtNodeAffinityPreset;
   topologySpreadConstraints?: KubeVirtTopologySpreadConstraint[];
-}
-
-export class KubeVirtSecondaryDisk {
-  size: string;
-  storageClassName: string;
 }
 
 export class KubeVirtNodeAffinityPreset {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes secondary disk section from "Initial nodes" wizard step
Hides all usage:
- Cluster summary page
- Edit MD dialog to edit secondary disks
- MD details page under Nodes list expansion panel


Wizard Initial Nodes step:

![removed-secondary-disk](https://user-images.githubusercontent.com/17727069/208075756-bd226a10-7d81-4dd3-84fb-5555da304e56.png)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5396 

**What type of PR is this?**
/kind cleanup
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removes configuring of optional secondary disks to mount nodes
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
