### PR TITLE
Add `io2` and `gp3` to AWS provider disk types list

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/aws/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/aws/component.ts
@@ -84,7 +84,7 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
   subnetLabel = SubnetState.Empty;
   selectedDiskType = '';
   private readonly _defaultDiskSize = 25;
-  private _diskTypes: string[] = ['standard', 'gp2', 'io1', 'sc1', 'st1'];
+  private _diskTypes: string[] = ['standard', 'gp2', 'gp3', 'io1', 'io2', 'sc1', 'st1'];
   diskTypes = this._diskTypes.map(type => ({name: type}));
   private _subnets: AWSSubnet[] = [];
   private _subnetMap: {[type: string]: AWSSubnet[]} = {};


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `io2` and `gp3` to AWS provider disk types list.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5448 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `io2` and `gp3` to AWS provider disk types list.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
