### PR TITLE
Add support to import GCP KubeOne cluster

### DIFF
--- a/modules/web/src/app/kubeone-wizard/module.ts
+++ b/modules/web/src/app/kubeone-wizard/module.ts
@@ -17,6 +17,7 @@ import {KubeOneClusterStepComponent} from '@app/kubeone-wizard/steps/cluster/com
 import {KubeOneCredentialsStepComponent} from '@app/kubeone-wizard/steps/credentials/component';
 import {KubeOneAWSCredentialsBasicComponent} from '@app/kubeone-wizard/steps/credentials/provider/basic/aws/component';
 import {KubeOneCredentialsBasicComponent} from '@app/kubeone-wizard/steps/credentials/provider/basic/component';
+import {KubeOneGCPCredentialsBasicComponent} from '@app/kubeone-wizard/steps/credentials/provider/basic/gcp/component';
 import {KubeOneProviderStepComponent} from '@app/kubeone-wizard/steps/provider/component';
 import {KubeOneSummaryStepComponent} from '@app/kubeone-wizard/steps/summary/component';
 import {KubeOneWizardService} from '@core/services/kubeone-wizard/wizard';
@@ -31,6 +32,7 @@ const components = [
   KubeOneCredentialsStepComponent,
   KubeOneCredentialsBasicComponent,
   KubeOneAWSCredentialsBasicComponent,
+  KubeOneGCPCredentialsBasicComponent,
   KubeOneClusterStepComponent,
   KubeOneSummaryStepComponent,
 ];

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/component.ts
@@ -1,0 +1,92 @@
+// Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
+import {KubeOneCloudSpec, KubeOneClusterSpec, KubeOneGCPCloudSpec} from '@shared/entity/kubeone-cluster';
+import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import {merge} from 'rxjs';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
+
+export enum Controls {
+  ServiceAccount = 'serviceAccount',
+}
+
+@Component({
+  selector: 'km-kubeone-wizard-gcp-credentials-basic',
+  templateUrl: './template.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => KubeOneGCPCredentialsBasicComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => KubeOneGCPCredentialsBasicComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KubeOneGCPCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  readonly Controls = Controls;
+
+  constructor(private readonly _builder: FormBuilder, private readonly _clusterSpecService: KubeOneClusterSpecService) {
+    super('GCP Credentials Basic');
+  }
+
+  ngOnInit(): void {
+    this._initForm();
+    this._initSubscriptions();
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  private _initForm(): void {
+    this.form = this._builder.group({
+      [Controls.ServiceAccount]: this._builder.control('', [Validators.required]),
+    });
+  }
+
+  private _initSubscriptions(): void {
+    merge(this._clusterSpecService.providerChanges)
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => this.form.reset());
+
+    merge(this.form.get(Controls.ServiceAccount).valueChanges)
+      .pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _getClusterEntity(): ExternalCluster {
+    return {
+      cloud: {
+        kubeOne: {
+          cloudSpec: {
+            gcp: {
+              serviceAccount: this.form.get(Controls.ServiceAccount).value,
+            } as KubeOneGCPCloudSpec,
+          } as KubeOneCloudSpec,
+        } as KubeOneClusterSpec,
+      } as ExternalCloudSpec,
+    } as ExternalCluster;
+  }
+}

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/template.html
@@ -1,0 +1,32 @@
+<!--
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<form [formGroup]="form"
+      fxLayout="column"
+      fxLayoutGap="8px">
+  <mat-form-field fxFlex>
+    <mat-label>Service Account</mat-label>
+    <textarea matInput
+              rows="4"
+              required
+              [formControlName]="Controls.ServiceAccount"
+              [name]="Controls.ServiceAccount"
+              autocomplete="off"></textarea>
+    <mat-hint>Enter Service Account used to create the KubeOne cluster.</mat-hint>
+    <mat-error *ngIf="form.get(Controls.ServiceAccount).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+</form>

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
@@ -17,4 +17,6 @@ limitations under the License.
      [ngSwitch]="provider">
   <km-kubeone-wizard-aws-credentials-basic *ngSwitchCase="NodeProvider.AWS"
                                            [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-aws-credentials-basic>
+  <km-kubeone-wizard-gcp-credentials-basic *ngSwitchCase="NodeProvider.GCP"
+                                           [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-gcp-credentials-basic>
 </div>

--- a/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
@@ -43,7 +43,7 @@ enum Controls {
   ],
 })
 export class KubeOneProviderStepComponent extends StepBase implements OnInit {
-  readonly providers: NodeProvider[] = [NodeProvider.AWS];
+  readonly providers: NodeProvider[] = [NodeProvider.AWS, NodeProvider.GCP];
   readonly controls = Controls;
 
   constructor(

--- a/modules/web/src/app/kubeone-wizard/steps/summary/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/summary/template.html
@@ -45,6 +45,13 @@ limitations under the License.
             <div value>{{SECRET_MASK}}</div>
           </km-property>
         </ng-container>
+        <!-- GCP -->
+        <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.gcp">
+          <km-property>
+            <div key>Service Account</div>
+            <div value>{{SECRET_MASK}}</div>
+          </km-property>
+        </ng-container>
       </div>
     </div>
   </div>

--- a/modules/web/src/app/shared/entity/kubeone-cluster.ts
+++ b/modules/web/src/app/shared/entity/kubeone-cluster.ts
@@ -35,9 +35,14 @@ export class KubeOneSSHKeySpec {
 
 export class KubeOneCloudSpec {
   aws?: KubeOneAWSCloudSpec;
+  gcp?: KubeOneGCPCloudSpec;
 }
 
 export class KubeOneAWSCloudSpec {
   accessKeyID: string;
   secretAccessKey: string;
+}
+
+export class KubeOneGCPCloudSpec {
+  serviceAccount: string;
 }

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -21,7 +21,8 @@ limitations under the License.
 </ng-container>
 
 
-<form *ngIf="!loadingClusterDefaults" [formGroup]="form">
+<form *ngIf="!loadingClusterDefaults"
+      [formGroup]="form">
   <div fxLayout="row"
        fxLayout.md="column"
        fxLayout.sm="column"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to import GCP KubeOne cluster.

**Provider Step:**

![screenshot-localhost_8000-2022 12 22-15_19_22](https://user-images.githubusercontent.com/13975988/209116798-a0112f4c-3615-48a5-a12a-9134a671e3ef.png)

**Credentials Step:**

![screenshot-localhost_8000-2022 12 22-15_19_46](https://user-images.githubusercontent.com/13975988/209116843-fce4e3af-fa68-445e-b336-bb91d664a8f8.png)

**Summary Step:**

![screenshot-localhost_8000-2022 12 22-15_19_58](https://user-images.githubusercontent.com/13975988/209116882-b2a560c2-e792-4954-8fea-ae99bc4156bb.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5456 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to import GCP KubeOne cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
