### PR TITLE
Redirect to KubeOne clusters list page after disconnect

### DIFF
--- a/modules/web/src/app/core/services/external-cluster.ts
+++ b/modules/web/src/app/core/services/external-cluster.ts
@@ -14,12 +14,14 @@
 
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Injectable} from '@angular/core';
-import {Router} from '@angular/router';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
+import {Router} from '@angular/router';
+import {MasterVersion} from '@app/shared/entity/cluster';
+import {View} from '@app/shared/entity/common';
+import {GCPDiskType, GCPMachineSize} from '@app/shared/entity/provider/gcp';
+import {NotificationService} from '@core/services/notification';
 import {environment} from '@environments/environment';
-import {AKSCluster, AKSLocation, AKSVMSize, AzureResourceGroup} from '@shared/entity/provider/aks';
-import {EKSCluster, EKSClusterRole, EKSSecurityGroup, EKSSubnet, EKSVpc} from '@shared/entity/provider/eks';
-import {GKECluster, GKEZone} from '@shared/entity/provider/gke';
+import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {
   DeleteExternalClusterAction,
   ExternalCluster,
@@ -27,13 +29,11 @@ import {
   ExternalClusterProvider,
 } from '@shared/entity/external-cluster';
 import {PresetList} from '@shared/entity/preset';
+import {AKSCluster, AKSLocation, AKSVMSize, AzureResourceGroup} from '@shared/entity/provider/aks';
+import {EKSCluster, EKSClusterRole, EKSSecurityGroup, EKSSubnet, EKSVpc} from '@shared/entity/provider/eks';
+import {GKECluster, GKEZone} from '@shared/entity/provider/gke';
 import {BehaviorSubject, Observable, of, Subject} from 'rxjs';
 import {catchError, filter} from 'rxjs/operators';
-import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
-import {NotificationService} from '@core/services/notification';
-import {MasterVersion} from '@app/shared/entity/cluster';
-import {GCPDiskType, GCPMachineSize} from '@app/shared/entity/provider/gcp';
-import {View} from '@app/shared/entity/common';
 
 @Injectable({providedIn: 'root'})
 export class ExternalClusterService {
@@ -359,7 +359,11 @@ export class ExternalClusterService {
       .afterClosed()
       .pipe(filter(isConfirmed => isConfirmed))
       .subscribe(_ => {
-        this._router.navigate([`/projects/${projectID}/${View.ExternalClusters}`]);
+        const view =
+          ExternalCluster.getProvider(cluster.cloud) === ExternalClusterProvider.KubeOne
+            ? View.KubeOneClusters
+            : View.ExternalClusters;
+        this._router.navigate([`/projects/${projectID}/${view}`]);
         this._notificationService.success(`Disconnected the ${cluster.name} cluster`);
       });
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Redirect to KubeOne clusters list page after disconnect.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
