### PR TITLE
Add KubeOneCluster to ExternalCluster API object

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -65,7 +65,7 @@ require (
 	google.golang.org/api v0.103.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8c.io/kubeone v1.5.3
+	k8c.io/kubeone v1.5.4
 	k8c.io/operating-system-manager v1.1.2-0.20221201183812-4f7c5a687353
 	k8c.io/reconciler v0.3.1
 	k8s.io/api v0.25.4
@@ -111,7 +111,10 @@ replace (
 	go.opentelemetry.io/proto/otlp => go.opentelemetry.io/proto/otlp v0.7.0
 )
 
-require k8c.io/kubermatic/v2 v2.21.1-0.20221208091954-b39911917701
+require (
+	github.com/pkg/errors v0.9.1
+	k8c.io/kubermatic/v2 v2.21.1-0.20221212090404-ec5780e39357
+)
 
 require (
 	cloud.google.com/go/compute v1.12.1 // indirect
@@ -221,7 +224,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/peterhellberg/link v1.2.0 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1461,10 +1461,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8c.io/kubeone v1.5.3 h1:A4k9VgKn/DlCbp/oiTdz6NQO18MSdV96+X2TtH1mYIM=
-k8c.io/kubeone v1.5.3/go.mod h1:xNlAertZO2iKVE8pL0Ruf/zjtM+EBeiZJtueuncyjxI=
-k8c.io/kubermatic/v2 v2.21.1-0.20221208091954-b39911917701 h1:23GGGKAK7NJZZeiiTVuTAoiI+lU9Y7VC6H2ftDPZDeI=
-k8c.io/kubermatic/v2 v2.21.1-0.20221208091954-b39911917701/go.mod h1:E1FRYH+em+fxSQaDeEA3y+0gGiSavb4HqmfMv6zw5qE=
+k8c.io/kubeone v1.5.4 h1:+OUuz7zdLlRC6HTNKi1fAIUYimmVFwcCzDOu6TiBx9Q=
+k8c.io/kubeone v1.5.4/go.mod h1:xNlAertZO2iKVE8pL0Ruf/zjtM+EBeiZJtueuncyjxI=
+k8c.io/kubermatic/v2 v2.21.1-0.20221212090404-ec5780e39357 h1:4KuRGu2NBiZthjbgvM6V68CcwwO0Dcgy9lJa+4fkQmA=
+k8c.io/kubermatic/v2 v2.21.1-0.20221212090404-ec5780e39357/go.mod h1:4ofjSobsMXpEf56tHtpw6izxTbx8A96pEBlFsbcPjJg=
 k8c.io/operating-system-manager v1.1.2-0.20221201183812-4f7c5a687353 h1:d9GuR+62IjJkhk8v3aGg3ewRQPN1TxWKhCVlk8ZaYKg=
 k8c.io/operating-system-manager v1.1.2-0.20221201183812-4f7c5a687353/go.mod h1:NGru44utIUfEOCkX2FwlrR+lyEXB+x/DPqh5Eq+fd4A=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -497,9 +497,15 @@ type ExternalClusterSpec struct {
 	// Version desired version of the kubernetes master components
 	Version ksemver.Semver `json:"version,omitempty"`
 
-	GKEClusterSpec *GKEClusterSpec `json:"gkeclusterSpec,omitempty"`
-	EKSClusterSpec *EKSClusterSpec `json:"eksclusterSpec,omitempty"`
-	AKSClusterSpec *AKSClusterSpec `json:"aksclusterSpec,omitempty"`
+	GKEClusterSpec     *GKEClusterSpec     `json:"gkeClusterSpec,omitempty"`
+	EKSClusterSpec     *EKSClusterSpec     `json:"eksClusterSpec,omitempty"`
+	AKSClusterSpec     *AKSClusterSpec     `json:"aksClusterSpec,omitempty"`
+	KubeOneClusterSpec *KubeOneClusterSpec `json:"kubeOneClusterSpec,omitempty"`
+}
+
+type KubeOneClusterSpec struct {
+	Region           string `json:"region,omitempty"`
+	ContainerRuntime string `json:"containerRuntime,omitempty"`
 }
 
 // ExternalClusterCloudSpec represents an object holding cluster cloud details
@@ -515,6 +521,10 @@ type ExternalClusterCloudSpec struct {
 type BringYourOwnSpec struct{}
 
 type KubeOneSpec struct {
+	// ProviderName is the name of the cloud provider used, one of
+	// "aws", "azure", "digitalocean", "gcp",
+	// "hetzner", "nutanix", "openstack", "packet", "vsphere" KubeOne natively-supported providers
+	ProviderName string `json:"providerName"`
 	// Manifest Base64 encoded manifest
 	Manifest         string            `json:"manifest,omitempty"`
 	SSHKey           KubeOneSSHKey     `json:"sshKey,omitempty"`

--- a/modules/api/pkg/provider/kubernetes/credentials.go
+++ b/modules/api/pkg/provider/kubernetes/credentials.go
@@ -659,7 +659,7 @@ func createOrUpdateKubeOneAWSSecret(ctx context.Context, cloud apiv2.KubeOneClou
 	}
 
 	// add secret key selectors to externalCluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -687,7 +687,7 @@ func createOrUpdateKubeOneGCPSecret(ctx context.Context, cloud apiv2.KubeOneClou
 	}
 
 	// add secret key selectors to cluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -728,7 +728,7 @@ func createOrUpdateKubeOneAzureSecret(ctx context.Context, cloud apiv2.KubeOneCl
 	}
 
 	// add secret key selectors to externalCluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -753,7 +753,7 @@ func createOrUpdateKubeOneDigitaloceanSecret(ctx context.Context, cloud apiv2.Ku
 	}
 
 	// add secret key selectors to externalCluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -786,7 +786,7 @@ func createOrUpdateKubeOneOpenstackSecret(ctx context.Context, cloud apiv2.KubeO
 	}
 
 	// add secret key selectors to externalCluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -811,7 +811,7 @@ func createOrUpdateKubeOneVSphereSecret(ctx context.Context, cloud apiv2.KubeOne
 	}
 
 	// add secret key selectors to externalCluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -838,7 +838,7 @@ func createOrUpdateKubeOneEquinixSecret(ctx context.Context, cloud apiv2.KubeOne
 	}
 
 	// add secret key selectors to cluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -863,7 +863,7 @@ func createOrUpdateKubeOneHetznerSecret(ctx context.Context, cloud apiv2.KubeOne
 	}
 
 	// add secret key selectors to cluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -911,7 +911,7 @@ func createOrUpdateKubeOneNutanixSecret(ctx context.Context, cloud apiv2.KubeOne
 	}
 
 	// add secret key selectors to cluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 
 	return nil
 }
@@ -940,7 +940,7 @@ func createOrUpdateKubeOneVMwareCloudDirectorSecret(ctx context.Context, cloud a
 	}
 
 	// add secret key selectors to externalCluster object
-	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.CredentialsReference = credentialRef
 	return nil
 }
 

--- a/modules/api/pkg/provider/kubernetes/external_cluster.go
+++ b/modules/api/pkg/provider/kubernetes/external_cluster.go
@@ -507,7 +507,7 @@ func (p *ExternalClusterProvider) CreateOrUpdateKubeOneManifestSecret(ctx contex
 	}
 
 	// add secret key selectors to cluster object
-	externalCluster.Spec.CloudSpec.KubeOne.ManifestReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.ManifestReference = credentialRef
 
 	return nil
 }
@@ -533,7 +533,7 @@ func (p *ExternalClusterProvider) CreateOrUpdateKubeOneSSHSecret(ctx context.Con
 	}
 
 	// add secret key selectors to cluster object
-	externalCluster.Spec.CloudSpec.KubeOne.SSHReference = *credentialRef
+	externalCluster.Spec.CloudSpec.KubeOne.SSHReference = credentialRef
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: 
Add KubeOneCluster to ExternalCluster API object:
- ProviderName
- Region
- ContainerRuntime

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
