### PR TITLE
Anexia: fix panic when configuring Node Pool with new Disks attribute

### DIFF
--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -628,7 +628,6 @@ func GetAnexiaProviderConfig(_ *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, d
 		TemplateID: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Anexia.TemplateID},
 		CPUs:       nodeSpec.Cloud.Anexia.CPUs,
 		Memory:     int(nodeSpec.Cloud.Anexia.Memory),
-		DiskSize:   int(*nodeSpec.Cloud.Anexia.DiskSize),
 		LocationID: providerconfig.ConfigVarString{Value: dc.Spec.Anexia.LocationID},
 	}
 
@@ -648,7 +647,7 @@ func GetAnexiaProviderConfig(_ *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, d
 		}
 	}
 
-	if config.DiskSize >= 0 && len(config.Disks) > 0 {
+	if config.DiskSize > 0 && len(config.Disks) > 0 {
 		return nil, anexiaProvider.ErrConfigDiskSizeAndDisks
 	}
 

--- a/modules/api/pkg/resources/machine/common_test.go
+++ b/modules/api/pkg/resources/machine/common_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	anexia "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia"
+	anexiatypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	"k8s.io/utils/pointer"
+)
+
+func TestGetAnexiaProviderSpec(t *testing.T) {
+	const (
+		vlanID     = "vlan-identifier"
+		templateID = "template-identifier"
+		locationID = "location-identifier"
+	)
+
+	tests := []struct {
+		name           string
+		anexiaNodeSpec apiv1.AnexiaNodeSpec
+		wantRawConf    *anexiatypes.RawConfig
+		wantErr        error
+	}{
+		{
+			name: "Anexia node spec with DiskSize attribute",
+			anexiaNodeSpec: apiv1.AnexiaNodeSpec{
+				VlanID:     vlanID,
+				TemplateID: templateID,
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   pointer.Int64(80),
+			},
+			wantRawConf: &anexiatypes.RawConfig{
+				VlanID:     providerconfigtypes.ConfigVarString{Value: vlanID},
+				TemplateID: providerconfigtypes.ConfigVarString{Value: templateID},
+				LocationID: providerconfigtypes.ConfigVarString{Value: locationID},
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   80,
+				Disks:      nil,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Anexia node spec with Disks attribute",
+			anexiaNodeSpec: apiv1.AnexiaNodeSpec{
+				VlanID:     vlanID,
+				TemplateID: templateID,
+				CPUs:       4,
+				Memory:     4096,
+				Disks: []apiv1.AnexiaDiskConfig{
+					{
+						Size:            80,
+						PerformanceType: pointer.String("ENT2"),
+					},
+				},
+			},
+			wantRawConf: &anexiatypes.RawConfig{
+				VlanID:     providerconfigtypes.ConfigVarString{Value: vlanID},
+				TemplateID: providerconfigtypes.ConfigVarString{Value: templateID},
+				LocationID: providerconfigtypes.ConfigVarString{Value: locationID},
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   0,
+				Disks: []anexiatypes.RawDisk{
+					{
+						Size:            80,
+						PerformanceType: providerconfigtypes.ConfigVarString{Value: "ENT2"},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Anexia node spec with both DiskSize and Disks attributes",
+			anexiaNodeSpec: apiv1.AnexiaNodeSpec{
+				VlanID:     vlanID,
+				TemplateID: templateID,
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   pointer.Int64(80),
+				Disks: []apiv1.AnexiaDiskConfig{
+					{
+						Size:            80,
+						PerformanceType: pointer.String("ENT2"),
+					},
+				},
+			},
+			wantRawConf: nil,
+			wantErr:     anexia.ErrConfigDiskSizeAndDisks,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dc := kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Anexia: &kubermaticv1.DatacenterSpecAnexia{
+						LocationID: locationID,
+					},
+				},
+			}
+
+			nodeSpec := apiv1.NodeSpec{
+				Cloud: apiv1.NodeCloudSpec{
+					Anexia: &test.anexiaNodeSpec,
+				},
+			}
+
+			result, err := getAnexiaProviderSpec(nodeSpec, &dc)
+
+			if test.wantErr != nil {
+				assert.Nil(t, result, "expected an error, not a result")
+				assert.ErrorIs(t, err, test.wantErr, "expected an error, not a result")
+			} else {
+				assert.NotNil(t, result)
+
+				resultRawConfig := anexiatypes.RawConfig{}
+				err := json.Unmarshal(result.Raw, &resultRawConfig)
+				assert.Nil(t, err)
+
+				assert.Equal(t, resultRawConfig.VlanID.Value, vlanID, "VLAN should be set correctly")
+				assert.Equal(t, resultRawConfig.TemplateID.Value, templateID, "Template should be set correctly")
+				assert.Equal(t, resultRawConfig.LocationID.Value, locationID, "Location should be set correctly")
+
+				assert.EqualValues(t, resultRawConfig.CPUs, test.anexiaNodeSpec.CPUs, "CPUs should be set correctly")
+				assert.EqualValues(t, resultRawConfig.Memory, test.anexiaNodeSpec.Memory, "Memory should be set correctly")
+
+				if test.anexiaNodeSpec.DiskSize != nil {
+					assert.EqualValues(t, resultRawConfig.DiskSize, *test.anexiaNodeSpec.DiskSize, "DiskSize should be set correctly")
+					assert.Nil(t, resultRawConfig.Disks, "Disks attribute should be nil")
+				} else {
+					assert.EqualValues(t, resultRawConfig.DiskSize, 0, "DiskSize should be set to 0")
+					assert.Len(t, resultRawConfig.Disks, len(test.anexiaNodeSpec.Disks), "Disks attribute should have correct length")
+
+					for i, dc := range test.anexiaNodeSpec.Disks {
+						assert.EqualValues(t, resultRawConfig.Disks[i].Size, dc.Size, "Disk entry should have correct size")
+
+						if dc.PerformanceType != nil {
+							assert.EqualValues(t, resultRawConfig.Disks[i].PerformanceType.Value, *dc.PerformanceType, "Disk entry should have correct performance type")
+						} else {
+							assert.Empty(t, resultRawConfig.Disks[i].PerformanceType.Value, "Disk entry should have no performance type")
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

There is another mistake in our new disk config handling code that slipped through in kubermatic/kubermatic#10816 and kubermatic/kubermatic#11050 - this fixes that.

When having a `MachineDeployment` in a user cluster with only the new `disks` attribute set, API panics due to a nil-pointer dereference.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
This is the [promised](https://github.com/kubermatic/kubermatic/pull/11602) PR for the new location of this code - maybe wait with reviewing until the linked PR is approved and merged, I will keep the changes in sync.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix API error in the extended disk configuration for provider Anexia
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
