### PR TITLE
Add support to migrate KubeOne cluster container runtime

### DIFF
--- a/modules/web/src/app/cluster/details/kubeone/component.ts
+++ b/modules/web/src/app/cluster/details/kubeone/component.ts
@@ -15,14 +15,14 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {ActivatedRoute, Router} from '@angular/router';
+import {KubeOneEditClusterDialogComponent} from '@app/cluster/details/kubeone/edit-cluster-dialog/component';
 import {AppConfigService} from '@app/config.service';
 import {View} from '@app/shared/entity/common';
 import {ClusterService} from '@core/services/cluster';
 import {ExternalClusterService} from '@core/services/external-cluster';
 import {PathParam} from '@core/services/params';
 import {UserService} from '@core/services/user';
-import {EditClusterConnectionDialogComponent} from '@shared/components/external-cluster-data-dialog/component';
-import {MasterVersion} from '@shared/entity/cluster';
+import {ContainerRuntime, MasterVersion} from '@shared/entity/cluster';
 import {Event} from '@shared/entity/event';
 import {ExternalCluster, ExternalClusterProvider, ExternalClusterState} from '@shared/entity/external-cluster';
 import {ExternalMachineDeployment} from '@shared/entity/external-machine-deployment';
@@ -41,6 +41,7 @@ import {switchMap, take, takeUntil, tap} from 'rxjs/operators';
 })
 export class KubeOneClusterDetailsComponent implements OnInit, OnDestroy {
   readonly Provider = ExternalClusterProvider;
+  readonly ContainerRuntime = ContainerRuntime;
   private readonly _refreshTime = 10;
   private readonly _metricsRefreshTime = 5;
   private _user: Member;
@@ -151,18 +152,18 @@ export class KubeOneClusterDetailsComponent implements OnInit, OnDestroy {
     return ExternalCluster.getStatusIcon(this.cluster);
   }
 
-  canEdit(): boolean {
-    return MemberUtils.hasPermission(this._user, this._currentGroupConfig, 'cluster', Permission.Edit);
-  }
-
-  edit(): void {
-    const dialog = this._matDialog.open(EditClusterConnectionDialogComponent);
-    dialog.componentInstance.projectId = this.projectID;
-    dialog.componentInstance.name = this.cluster.name;
-  }
-
   goBack(): void {
     this._router.navigate([`/projects/${this.projectID}/${View.KubeOneClusters}`]);
+  }
+
+  canEdit(): boolean {
+    return MemberUtils.hasPermission(this._user, this._currentGroupConfig, View.Clusters, Permission.Edit);
+  }
+
+  editCluster(): void {
+    const modal = this._matDialog.open(KubeOneEditClusterDialogComponent);
+    modal.componentInstance.cluster = this.cluster;
+    modal.componentInstance.projectID = this.projectID;
   }
 
   canDisconnect(): boolean {

--- a/modules/web/src/app/cluster/details/kubeone/edit-cluster-dialog/component.ts
+++ b/modules/web/src/app/cluster/details/kubeone/edit-cluster-dialog/component.ts
@@ -1,0 +1,102 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, Input, OnDestroy, OnInit} from '@angular/core';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
+import {MatDialogRef} from '@angular/material/dialog';
+import {ClusterService} from '@core/services/cluster';
+import {NotificationService} from '@core/services/notification';
+import {ContainerRuntime, END_OF_DOCKER_SUPPORT_VERSION} from '@shared/entity/cluster';
+import {ExternalCluster, ExternalClusterPatch, ExternalClusterSpecPatch} from '@shared/entity/external-cluster';
+import {Observable, Subject} from 'rxjs';
+import {startWith, take, takeUntil} from 'rxjs/operators';
+import * as semver from 'semver';
+
+enum Controls {
+  ContainerRuntime = 'containerRuntime',
+}
+
+@Component({
+  selector: 'km-kubeone-edit-cluster-dialog',
+  templateUrl: './template.html',
+})
+export class KubeOneEditClusterDialogComponent implements OnInit, OnDestroy {
+  readonly ContainerRuntime = ContainerRuntime;
+  readonly Controls = Controls;
+
+  @Input() cluster: ExternalCluster;
+  @Input() projectID: string;
+
+  form: FormGroup;
+
+  private readonly _unsubscribe = new Subject<void>();
+
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterService: ClusterService,
+    private readonly _matDialogRef: MatDialogRef<KubeOneEditClusterDialogComponent>,
+    private readonly _notificationService: NotificationService
+  ) {}
+
+  ngOnInit(): void {
+    this._initForm();
+    this._initSubscriptions();
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  getObservable(): Observable<ExternalCluster> {
+    const patch: ExternalClusterPatch = {
+      spec: {
+        containerRuntime: this.form.get(Controls.ContainerRuntime).value,
+      } as ExternalClusterSpecPatch,
+    } as ExternalClusterPatch;
+
+    return this._clusterService.patchExternalCluster(this.projectID, this.cluster.id, patch).pipe(take(1));
+  }
+
+  onNext(cluster: ExternalCluster): void {
+    this._matDialogRef.close(cluster);
+    this._clusterService.onExternalClusterUpdate.next();
+    this._notificationService.success(`Updated the ${this.cluster.name} cluster`);
+  }
+
+  private _initForm(): void {
+    this.form = this._builder.group({
+      [Controls.ContainerRuntime]: new FormControl(this.cluster.spec.containerRuntime || ContainerRuntime.Containerd, [
+        Validators.required,
+      ]),
+    });
+  }
+
+  private _initSubscriptions(): void {
+    this.form
+      .get(Controls.ContainerRuntime)
+      .valueChanges.pipe(startWith(this.form.get(Controls.ContainerRuntime).value), takeUntil(this._unsubscribe))
+      .subscribe(containerRuntime => {
+        if (
+          semver.valid(this.cluster.spec.version) &&
+          semver.gte(this.cluster.spec.version, END_OF_DOCKER_SUPPORT_VERSION) &&
+          containerRuntime === ContainerRuntime.Docker
+        ) {
+          this.form.get(Controls.ContainerRuntime).setErrors({dockerVersionCompatibility: true});
+        } else {
+          this.form.get(Controls.ContainerRuntime).setErrors(null);
+        }
+      });
+  }
+}

--- a/modules/web/src/app/cluster/details/kubeone/edit-cluster-dialog/template.html
+++ b/modules/web/src/app/cluster/details/kubeone/edit-cluster-dialog/template.html
@@ -1,0 +1,46 @@
+<!--
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<div id="km-kubeone-edit-cluster-dialog">
+  <km-dialog-title>Migrate Container Runtime</km-dialog-title>
+  <mat-dialog-content>
+    <p class="km-dialog-context-description">Migrate container runtime of <b>{{cluster.name}}</b> cluster</p>
+    <form [formGroup]="form"
+          fxLayout="column">
+      <mat-form-field class="km-dropdown-with-suffix"
+                      fxFlex>
+        <mat-label>Container Runtime</mat-label>
+        <mat-select [formControlName]="Controls.ContainerRuntime"
+                    class="km-select-ellipsis"
+                    disableOptionCentering
+                    required>
+          <mat-option [value]="ContainerRuntime.Containerd">containerd</mat-option>
+          <mat-option [value]="ContainerRuntime.Docker">docker</mat-option>
+        </mat-select>
+        <mat-error *ngIf="form.get(Controls.ContainerRuntime).hasError('dockerVersionCompatibility')">
+          Docker is not supported since v1.24.
+        </mat-error>
+      </mat-form-field>
+    </form>
+  </mat-dialog-content>
+  <mat-dialog-actions>
+    <km-button icon="km-icon-save"
+               label="Save Changes"
+               [disabled]="!form.valid"
+               [observable]="getObservable()"
+               (next)="onNext($event)">
+    </km-button>
+  </mat-dialog-actions>
+</div>

--- a/modules/web/src/app/cluster/details/kubeone/template.html
+++ b/modules/web/src/app/cluster/details/kubeone/template.html
@@ -47,8 +47,7 @@ limitations under the License.
               mat-flat-button
               type="button"
               kmThrottleClick
-              (throttleClick)="downloadKubeconfig()"
-              [disabled]="!isRunning()">
+              (throttleClick)="downloadKubeconfig()">
         <i class="km-icon-mask km-icon-download"></i>
         <span>Get Kubeconfig</span>
       </button>
@@ -61,6 +60,14 @@ limitations under the License.
         </button>
         <mat-menu #menu="matMenu"
                   class="km-provider-edit-settings">
+          <div
+            [matTooltip]="cluster?.spec?.containerRuntime !== ContainerRuntime.Docker ? 'KubeOne container runtime migration is only supported from docker to containerd.' : ''">
+            <button mat-menu-item
+                    (click)="editCluster()"
+                    [disabled]="!isRunning() || !canEdit() || cluster?.spec?.containerRuntime !== ContainerRuntime.Docker">
+              <span>Migrate Container Runtime</span>
+            </button>
+          </div>
           <button id="km-disconnect-external-cluster-btn"
                   mat-menu-item
                   (click)="disconnectCluster()"
@@ -94,6 +101,10 @@ limitations under the License.
           <div value>
             <span class="km-provider-logo km-provider-logo-{{cluster.cloud.kubeOne?.providerName}}"></span>
           </div>
+        </km-property>
+        <km-property *ngIf="cluster.spec.containerRuntime">
+          <div key>Container Runtime</div>
+          <div value>{{cluster.spec.containerRuntime}}</div>
         </km-property>
         <km-property *ngIf="cluster.labels">
           <div key>Labels</div>

--- a/modules/web/src/app/cluster/module.ts
+++ b/modules/web/src/app/cluster/module.ts
@@ -19,6 +19,7 @@ import {ExternalMachineDeploymentDetailsComponent} from '@app/cluster/details/ex
 import {ExternalAddMachineDeploymentDialogComponent} from '@app/cluster/details/external-cluster/external-cluster-add-machine-deployment/component';
 import {ExternalMachineDeploymentListComponent} from '@app/cluster/details/external-cluster/external-machine-deployment-list/component';
 import {KubeOneClusterDetailsComponent} from '@app/cluster/details/kubeone/component';
+import {KubeOneEditClusterDialogComponent} from '@app/cluster/details/kubeone/edit-cluster-dialog/component';
 import {KubeOneMachineDeploymentDetailsComponent} from '@app/cluster/details/kubeone/machine-deployment-details/component';
 import {KubeOneMachineDeploymentListComponent} from '@app/cluster/details/kubeone/machine-deployment-list/component';
 import {ClusterMetricsComponent} from '@app/cluster/details/shared/cluster-metrics/component';
@@ -145,6 +146,7 @@ const components: any[] = [
   KubeOneClusterDetailsComponent,
   KubeOneMachineDeploymentListComponent,
   KubeOneMachineDeploymentDetailsComponent,
+  KubeOneEditClusterDialogComponent,
   ClusterMetricsComponent,
   AddServiceAccountDialogComponent,
   AddServiceAccountBindingDialogComponent,

--- a/modules/web/src/app/shared/entity/external-cluster.ts
+++ b/modules/web/src/app/shared/entity/external-cluster.ts
@@ -15,7 +15,7 @@
 import {KubeOneClusterSpec} from '@shared/entity/kubeone-cluster';
 import {StatusIcon} from '@shared/utils/health-status';
 import _ from 'lodash';
-import {BringYourOwnCloudSpec} from './cluster';
+import {BringYourOwnCloudSpec, ContainerRuntime} from './cluster';
 import {AKSCloudSpec, AKSClusterSpec} from './provider/aks';
 import {EKSCloudSpec, EKSClusterSpec} from './provider/eks';
 import {GKECloudSpec, GKEClusterSpec} from './provider/gke';
@@ -121,6 +121,7 @@ export class ExternalClusterSpec {
   eksclusterSpec?: EKSClusterSpec;
   gkeclusterSpec?: GKEClusterSpec;
   version?: string;
+  containerRuntime?: ContainerRuntime;
 }
 
 export class ExternalCloudSpec {
@@ -162,6 +163,7 @@ export class ExternalClusterPatch {
 
 export class ExternalClusterSpecPatch {
   version?: string;
+  containerRuntime?: ContainerRuntime;
 }
 
 export class ExternalClusterModel {

--- a/modules/web/src/app/shared/entity/kubeone-cluster.ts
+++ b/modules/web/src/app/shared/entity/kubeone-cluster.ts
@@ -17,7 +17,6 @@ export class KubeOneClusterSpec {
   deletionTimestamp?: Date;
   id?: string;
   cloudSpec: KubeOneCloudSpec;
-  containerRuntime?: string;
   manifest: string;
   sshKey: KubeOneSSHKeySpec;
   providerName?: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to migrate KubeOne cluster container runtime from `docker` to `containerd`.

- A new `Migrate Container Runtime` menu option has been added which is only enabled when cluster container runtime is `docker`.

![screenshot-localhost_8000-2023 01 16-17_59_02](https://user-images.githubusercontent.com/13975988/212683960-b345d6e5-be01-446f-ab60-2e564f5aef8b.png)

**Migrate Container Runtime Dialog:**

![screenshot-localhost_8000-2023 01 16-17_59_18](https://user-images.githubusercontent.com/13975988/212683996-0f6b78b1-9cfa-4063-83c0-fa6bf4649bf0.png)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5490 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to migrate KubeOne cluster container runtime.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
