### PR TITLE
Add support to select preset in credentials step of KubeOne wizard

### DIFF
--- a/modules/web/src/app/cluster/list/external-cluster/component.spec.ts
+++ b/modules/web/src/app/cluster/list/external-cluster/component.spec.ts
@@ -18,6 +18,8 @@ import {BrowserModule, By} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ActivatedRoute, Router} from '@angular/router';
 import {AppConfigService} from '@app/config.service';
+import {ExternalClusterService} from '@core/services/external-cluster';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
 import {ActivatedRouteStub, RouterStub, RouterTestingModule} from '@test/services/router-stubs';
 import {AppConfigMockService} from '@test/services/app-config-mock';
 import {AuthMockService} from '@test/services/auth-mock';
@@ -51,6 +53,14 @@ describe('ExternalClusterListComponent', () => {
       defer(() => of([fakeCustomExternalCluster()], async))
     );
 
+    const kubeOnePresetsServiceMock = {
+      preset: jest.fn(),
+    };
+
+    const externalClusterServiceMock = {
+      showDisconnectClusterDialog: jest.fn(),
+    };
+
     TestBed.configureTestingModule({
       imports: [BrowserModule, HttpClientModule, NoopAnimationsModule, RouterTestingModule, SharedModule],
       declarations: [ExternalClusterListComponent],
@@ -63,6 +73,8 @@ describe('ExternalClusterListComponent', () => {
         {provide: AppConfigService, useClass: AppConfigMockService},
         {provide: ProjectService, useClass: ProjectMockService},
         {provide: SettingsService, useClass: SettingsMockService},
+        {provide: ExternalClusterService, useValue: externalClusterServiceMock},
+        {provide: KubeOnePresetsService, useValue: kubeOnePresetsServiceMock},
         EndOfLifeService,
       ],
     }).compileComponents();

--- a/modules/web/src/app/cluster/list/kubeone/component.ts
+++ b/modules/web/src/app/cluster/list/kubeone/component.ts
@@ -38,7 +38,7 @@ enum Column {
   Status = 'status',
   Name = 'name',
   Provider = 'provider',
-  Region = 'region',
+  Version = 'version',
   Imported = 'imported',
   Actions = 'actions',
 }

--- a/modules/web/src/app/cluster/list/kubeone/template.html
+++ b/modules/web/src/app/cluster/list/kubeone/template.html
@@ -82,13 +82,14 @@ limitations under the License.
         </td>
       </ng-container>
 
-      <ng-container [matColumnDef]="Column.Region">
+      <ng-container [matColumnDef]="Column.Version">
         <th mat-header-cell
             *matHeaderCellDef
-            class="km-header-cell p-20">Region
+            class="km-header-cell p-20">Version
         </th>
         <td mat-cell
             *matCellDef="let element">
+          {{element.spec.version}}
         </td>
       </ng-container>
 

--- a/modules/web/src/app/core/module.ts
+++ b/modules/web/src/app/core/module.ts
@@ -31,6 +31,7 @@ import {EndOfLifeService} from '@core/services/eol';
 import {GlobalModule} from '@core/services/global/module';
 import {HistoryService} from '@core/services/history';
 import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
 import {LabelService} from '@core/services/label';
 import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering';
 import {MLAService} from '@core/services/mla';
@@ -141,6 +142,7 @@ const services = [
   ApplicationService,
   OperatingSystemManagerService,
   KubeOneClusterSpecService,
+  KubeOnePresetsService,
 ];
 
 const interceptors = [

--- a/modules/web/src/app/core/services/external-cluster.ts
+++ b/modules/web/src/app/core/services/external-cluster.ts
@@ -19,6 +19,7 @@ import {Router} from '@angular/router';
 import {MasterVersion} from '@app/shared/entity/cluster';
 import {View} from '@app/shared/entity/common';
 import {GCPDiskType, GCPMachineSize} from '@app/shared/entity/provider/gcp';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
 import {NotificationService} from '@core/services/notification';
 import {environment} from '@environments/environment';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
@@ -54,6 +55,7 @@ export class ExternalClusterService {
   private _newRestRoot: string = environment.newRestRoot;
 
   constructor(
+    private readonly _kubeOnePresetsService: KubeOnePresetsService,
     private readonly _http: HttpClient,
     private readonly _matDialog: MatDialog,
     private readonly _notificationService: NotificationService,
@@ -338,6 +340,9 @@ export class ExternalClusterService {
         headers = this._getGKEHeaders();
         break;
       default:
+        if (ExternalCluster.getProvider(externalClusterModel.cloud) === ExternalClusterProvider.KubeOne) {
+          headers = this._getKubeOneHeaders();
+        }
         break;
     }
     return this._http.post<ExternalCluster>(url, externalClusterModel, {headers});
@@ -443,6 +448,16 @@ export class ExternalClusterService {
     if (releaseChannel) {
       headers = {...headers, ReleaseChannel: releaseChannel};
     }
+    return new HttpHeaders(headers);
+  }
+
+  private _getKubeOneHeaders(): HttpHeaders {
+    let headers = {};
+
+    if (this._kubeOnePresetsService.preset) {
+      headers = {Credential: this._kubeOnePresetsService.preset};
+    }
+
     return new HttpHeaders(headers);
   }
 }

--- a/modules/web/src/app/core/services/kubeone-wizard/kubeone-presets.ts
+++ b/modules/web/src/app/core/services/kubeone-wizard/kubeone-presets.ts
@@ -1,0 +1,49 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {environment} from '@environments/environment';
+import {PresetList} from '@shared/entity/preset';
+import {NodeProvider} from '@shared/model/NodeProviderConstants';
+import {Observable, Subject} from 'rxjs';
+
+@Injectable()
+export class KubeOnePresetsService {
+  // True - enabled, false - disabled
+  readonly presetStatusChanges = new Subject<boolean>();
+  readonly presetChanges = new Subject<string>();
+
+  constructor(private readonly _http: HttpClient) {}
+
+  private _preset: string;
+
+  get preset(): string {
+    return this._preset;
+  }
+
+  set preset(preset: string) {
+    this._preset = preset;
+    this.presetChanges.next(preset);
+  }
+
+  enablePresets(enable: boolean): void {
+    this.presetStatusChanges.next(enable);
+  }
+
+  presets(provider: NodeProvider): Observable<PresetList> {
+    const url = `${environment.newRestRoot}/providers/${provider}/presets?disabled=false`;
+    return this._http.get<PresetList>(url);
+  }
+}

--- a/modules/web/src/app/kubeone-wizard/module.ts
+++ b/modules/web/src/app/kubeone-wizard/module.ts
@@ -15,6 +15,7 @@
 import {NgModule} from '@angular/core';
 import {KubeOneClusterStepComponent} from '@app/kubeone-wizard/steps/cluster/component';
 import {KubeOneCredentialsStepComponent} from '@app/kubeone-wizard/steps/credentials/component';
+import {KubeOnePresetsComponent} from '@app/kubeone-wizard/steps/credentials/preset/component';
 import {KubeOneAWSCredentialsBasicComponent} from '@app/kubeone-wizard/steps/credentials/provider/basic/aws/component';
 import {KubeOneAzureCredentialsBasicComponent} from '@app/kubeone-wizard/steps/credentials/provider/basic/azure/component';
 import {KubeOneCredentialsBasicComponent} from '@app/kubeone-wizard/steps/credentials/provider/basic/component';
@@ -37,6 +38,7 @@ const components = [
   KubeOneAzureCredentialsBasicComponent,
   KubeOneClusterStepComponent,
   KubeOneSummaryStepComponent,
+  KubeOnePresetsComponent,
 ];
 
 @NgModule({

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/component.ts
@@ -23,7 +23,8 @@ import {takeUntil} from 'rxjs/operators';
 import {StepBase} from '../base';
 
 enum Controls {
-  Credentials = 'credentialsBasic',
+  Preset = 'preset',
+  CredentialsBasic = 'credentialsBasic',
 }
 
 @Component({
@@ -71,7 +72,8 @@ export class KubeOneCredentialsStepComponent extends StepBase implements OnInit 
 
   private _initForm(): void {
     this.form = this._builder.group({
-      [Controls.Credentials]: this._builder.control(''),
+      [Controls.Preset]: this._builder.control(''),
+      [Controls.CredentialsBasic]: this._builder.control(''),
     });
   }
 }

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/preset/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/preset/component.ts
@@ -1,0 +1,133 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
+import {FormBuilder, FormControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
+import {SimplePresetList} from '@shared/entity/preset';
+import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import _ from 'lodash';
+import {map, switchMap, takeUntil} from 'rxjs/operators';
+
+export enum Controls {
+  Preset = 'name',
+}
+
+export enum PresetsState {
+  Ready = 'Provider Preset',
+  Loading = 'Loading...',
+  Empty = 'No Provider Presets available',
+}
+
+@Component({
+  selector: 'km-kubeone-wizard-presets',
+  templateUrl: './template.html',
+  styleUrls: ['./style.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => KubeOnePresetsComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => KubeOnePresetsComponent),
+      multi: true,
+    },
+  ],
+})
+export class KubeOnePresetsComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  presetList = new SimplePresetList();
+  presetsLoaded = false;
+
+  readonly Controls = Controls;
+
+  private _state = PresetsState.Loading;
+
+  constructor(
+    private readonly _presetsService: KubeOnePresetsService,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _builder: FormBuilder
+  ) {
+    super('KubeOne Preset');
+  }
+
+  get label(): string {
+    return this._state;
+  }
+
+  get selectedPreset(): string {
+    return this._presetsService.preset;
+  }
+
+  set selectedPreset(preset: string) {
+    this.form.get(Controls.Preset).setValue(preset);
+    if (!preset) {
+      this.form.get(Controls.Preset).reset();
+    }
+
+    this._presetsService.preset = preset;
+  }
+
+  ngOnInit(): void {
+    this.form = this._builder.group({
+      [Controls.Preset]: new FormControl('', Validators.required),
+    });
+
+    this._clusterSpecService.providerChanges
+      .pipe(switchMap(_ => this._presetsService.presets(this._clusterSpecService.provider)))
+      .pipe(map(presetList => new SimplePresetList(...presetList.items.map(preset => preset.name))))
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(presetList => {
+        this.reset();
+        this.presetsLoaded = presetList.names ? !_.isEmpty(presetList.names) : false;
+        this._state = this.presetsLoaded ? PresetsState.Ready : PresetsState.Empty;
+        this.presetList = presetList;
+        this._enable(this._state !== PresetsState.Empty, Controls.Preset);
+      });
+
+    this.form
+      .get(Controls.Preset)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => {
+        this._presetsService.preset = preset;
+      });
+
+    this._presetsService.presetStatusChanges.pipe(takeUntil(this._unsubscribe)).subscribe(enable => {
+      if (this._state !== PresetsState.Empty) {
+        this._enable(enable, Controls.Preset);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  reset(): void {
+    this.selectedPreset = '';
+  }
+
+  private _enable(enable: boolean, name: Controls): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
+  }
+}

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/preset/style.scss
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/preset/style.scss
@@ -1,0 +1,23 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@use 'variables';
+
+:host {
+  margin-bottom: 30px;
+}
+
+.preset-dropdown {
+  margin-top: 42px;
+}

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/preset/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/preset/template.html
@@ -1,0 +1,53 @@
+<!--
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<form [formGroup]="form">
+  <mat-form-field fxFlex
+                  class="km-dropdown-with-suffix">
+    <mat-label>{{ label }}</mat-label>
+    <mat-select id="km-wizard-select-preset"
+                class="km-select-ellipsis"
+                [formControlName]="Controls.Preset"
+                panelClass="preset-dropdown"
+                disableOptionCentering
+                required>
+      <mat-option *ngFor="let presetName of presetList.names"
+                  [value]="presetName">{{presetName}}</mat-option>
+      <mat-select-trigger fxFlex
+                          fxLayout="row">
+        <div fxFlex
+             fxLayoutAlign="start">
+          {{selectedPreset}}
+        </div>
+
+        <div fxFlex
+             fxLayoutAlign="end"
+             class="km-select-trigger-button-wrapper">
+          <button *ngIf="selectedPreset"
+                  (click)="reset(); $event.stopPropagation()"
+                  matSuffix
+                  mat-icon-button
+                  aria-label="Clear">
+            <i class="km-icon-mask km-icon-remove"></i>
+          </button>
+        </div>
+      </mat-select-trigger>
+    </mat-select>
+    <mat-error *ngIf="form.get(Controls.Preset).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+    <mat-hint>Using provider presets will disable most of the other credential fields.</mat-hint>
+  </mat-form-field>
+</form>

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/aws/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/aws/component.ts
@@ -15,6 +15,7 @@
 import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
 import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
 import {KubeOneAWSCloudSpec, KubeOneCloudSpec, KubeOneClusterSpec} from '@shared/entity/kubeone-cluster';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
@@ -46,7 +47,11 @@ export enum Controls {
 export class KubeOneAWSCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
   readonly Controls = Controls;
 
-  constructor(private readonly _builder: FormBuilder, private readonly _clusterSpecService: KubeOneClusterSpecService) {
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {
     super('AWS Credentials Basic');
   }
 
@@ -72,10 +77,30 @@ export class KubeOneAWSCredentialsBasicComponent extends BaseFormValidator imple
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this.form.reset());
 
+    this.form.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ =>
+        this._presetsService.enablePresets(Object.values(Controls).every(control => !this.form.get(control).value))
+      );
+
+    this._presetsService.presetChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => Object.values(Controls).forEach(control => this._enable(!preset, control)));
+
     merge(this.form.get(Controls.AccessKeyID).valueChanges, this.form.get(Controls.AccessKeySecret).valueChanges)
       .pipe(distinctUntilChanged())
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _enable(enable: boolean, name: string): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
   }
 
   private _getClusterEntity(): ExternalCluster {

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/aws/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/aws/component.ts
@@ -93,7 +93,7 @@ export class KubeOneAWSCredentialsBasicComponent extends BaseFormValidator imple
       .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
   }
 
-  private _enable(enable: boolean, name: string): void {
+  private _enable(enable: boolean, name: Controls): void {
     if (enable && this.form.get(name).disabled) {
       this.form.get(name).enable();
     }

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/azure/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/azure/component.ts
@@ -102,7 +102,7 @@ export class KubeOneAzureCredentialsBasicComponent extends BaseFormValidator imp
       .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
   }
 
-  private _enable(enable: boolean, name: string): void {
+  private _enable(enable: boolean, name: Controls): void {
     if (enable && this.form.get(name).disabled) {
       this.form.get(name).enable();
     }

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/azure/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/azure/component.ts
@@ -15,6 +15,7 @@
 import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
 import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
 import {KubeOneAzureCloudSpec, KubeOneCloudSpec, KubeOneClusterSpec} from '@shared/entity/kubeone-cluster';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
@@ -48,7 +49,11 @@ export enum Controls {
 export class KubeOneAzureCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
   readonly Controls = Controls;
 
-  constructor(private readonly _builder: FormBuilder, private readonly _clusterSpecService: KubeOneClusterSpecService) {
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {
     super('Azure Credentials Basic');
   }
 
@@ -76,6 +81,16 @@ export class KubeOneAzureCredentialsBasicComponent extends BaseFormValidator imp
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this.form.reset());
 
+    this.form.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ =>
+        this._presetsService.enablePresets(Object.values(Controls).every(control => !this.form.get(control).value))
+      );
+
+    this._presetsService.presetChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => Object.values(Controls).forEach(control => this._enable(!preset, control)));
+
     merge(
       this.form.get(Controls.ClientID).valueChanges,
       this.form.get(Controls.ClientSecret).valueChanges,
@@ -85,6 +100,16 @@ export class KubeOneAzureCredentialsBasicComponent extends BaseFormValidator imp
       .pipe(distinctUntilChanged())
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _enable(enable: boolean, name: string): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
   }
 
   private _getClusterEntity(): ExternalCluster {

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/component.ts
@@ -15,6 +15,7 @@
 import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
 import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
 import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
 import {KubeOneCloudSpec, KubeOneClusterSpec, KubeOneGCPCloudSpec} from '@shared/entity/kubeone-cluster';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
@@ -45,7 +46,11 @@ export enum Controls {
 export class KubeOneGCPCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
   readonly Controls = Controls;
 
-  constructor(private readonly _builder: FormBuilder, private readonly _clusterSpecService: KubeOneClusterSpecService) {
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {
     super('GCP Credentials Basic');
   }
 
@@ -70,10 +75,30 @@ export class KubeOneGCPCredentialsBasicComponent extends BaseFormValidator imple
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this.form.reset());
 
+    this.form.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ =>
+        this._presetsService.enablePresets(Object.values(Controls).every(control => !this.form.get(control).value))
+      );
+
+    this._presetsService.presetChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => Object.values(Controls).forEach(control => this._enable(!preset, control)));
+
     merge(this.form.get(Controls.ServiceAccount).valueChanges)
       .pipe(distinctUntilChanged())
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _enable(enable: boolean, name: string): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
   }
 
   private _getClusterEntity(): ExternalCluster {

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/gcp/component.ts
@@ -91,7 +91,7 @@ export class KubeOneGCPCredentialsBasicComponent extends BaseFormValidator imple
       .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
   }
 
-  private _enable(enable: boolean, name: string): void {
+  private _enable(enable: boolean, name: Controls): void {
     if (enable && this.form.get(name).disabled) {
       this.form.get(name).enable();
     }

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/template.html
@@ -25,7 +25,8 @@ limitations under the License.
       <mat-card-header class="km-no-padding">
         <mat-card-title>{{providerDisplayName}} Settings</mat-card-title>
       </mat-card-header>
-      <km-kubeone-wizard-credentials-basic [formControl]="form.get(Control.Credentials)"></km-kubeone-wizard-credentials-basic>
+      <km-kubeone-wizard-presets [formControl]="form.get(Control.Preset)"></km-kubeone-wizard-presets>
+      <km-kubeone-wizard-credentials-basic [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-credentials-basic>
     </div>
   </div>
 </div>

--- a/modules/web/src/app/kubeone-wizard/steps/summary/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/summary/component.ts
@@ -15,6 +15,7 @@
 import {Component} from '@angular/core';
 import {StepRegistry} from '@app/kubeone-wizard/config';
 import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
 import {ExternalCluster} from '@shared/entity/external-cluster';
 import {KubeOneClusterSpec} from '@shared/entity/kubeone-cluster';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
@@ -28,7 +29,10 @@ export class KubeOneSummaryStepComponent {
   readonly StepRegistry = StepRegistry;
   readonly SECRET_MASK = 'xxxx';
 
-  constructor(private readonly _clusterSpecService: KubeOneClusterSpecService) {}
+  constructor(
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {}
 
   get provider(): NodeProvider {
     return this._clusterSpecService.provider;
@@ -40,5 +44,9 @@ export class KubeOneSummaryStepComponent {
 
   get kubeOneClusterSpec(): KubeOneClusterSpec {
     return this._clusterSpecService.cluster?.cloud?.kubeOne;
+  }
+
+  get preset(): string {
+    return this._presetsService.preset;
   }
 }

--- a/modules/web/src/app/kubeone-wizard/steps/summary/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/summary/template.html
@@ -34,43 +34,51 @@ limitations under the License.
       <div class="header counter-2">{{StepRegistry.Credentials}}</div>
       <div class="properties"
            fxLayout="row wrap">
-        <!-- AWS -->
-        <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.aws">
-          <km-property>
-            <div key>Access Key ID</div>
-            <div value>{{SECRET_MASK}}</div>
-          </km-property>
-          <km-property>
-            <div key>Secret Access Key</div>
-            <div value>{{SECRET_MASK}}</div>
-          </km-property>
-        </ng-container>
-        <!-- GCP -->
-        <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.gcp">
-          <km-property>
-            <div key>Service Account</div>
-            <div value>{{SECRET_MASK}}</div>
-          </km-property>
-        </ng-container>
-        <!-- Azure -->
-        <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.azure">
-          <km-property>
-            <div key>Client ID</div>
-            <div value>{{SECRET_MASK}}</div>
-          </km-property>
-          <km-property>
-            <div key>Client Secret</div>
-            <div value>{{SECRET_MASK}}</div>
-          </km-property>
-          <km-property>
-            <div key>Subscription ID</div>
-            <div value>{{SECRET_MASK}}</div>
-          </km-property>
-          <km-property>
-            <div key>Tenant ID</div>
-            <div value>{{SECRET_MASK}}</div>
-          </km-property>
-        </ng-container>
+
+        <km-property *ngIf="preset; else credentials">
+          <div key>Preset</div>
+          <div value>{{preset}}</div>
+        </km-property>
+
+        <ng-template #credentials>
+          <!-- AWS -->
+          <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.aws">
+            <km-property>
+              <div key>Access Key ID</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+            <km-property>
+              <div key>Secret Access Key</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+          </ng-container>
+          <!-- GCP -->
+          <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.gcp">
+            <km-property>
+              <div key>Service Account</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+          </ng-container>
+          <!-- Azure -->
+          <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.azure">
+            <km-property>
+              <div key>Client ID</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+            <km-property>
+              <div key>Client Secret</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+            <km-property>
+              <div key>Subscription ID</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+            <km-property>
+              <div key>Tenant ID</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+          </ng-container>
+        </ng-template>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to select preset in credentials step of KubeOne wizard.

**AWS:**

![screenshot-localhost_8000-2023 01 04-16_36_31](https://user-images.githubusercontent.com/13975988/210547814-33859c7f-6eda-48ea-9b84-025a9830fcc2.png)

**GCP:**

![screenshot-localhost_8000-2023 01 04-16_37_27](https://user-images.githubusercontent.com/13975988/210547847-dd26f251-4950-40c6-bb77-fa3ad7690355.png)

**Azure:**

![screenshot-localhost_8000-2023 01 04-16_38_02](https://user-images.githubusercontent.com/13975988/210547889-fd500e0b-908d-4c5f-a318-00df47c75478.png)

**Summary Step:**

![screenshot-localhost_8000-2023 01 04-16_36_54](https://user-images.githubusercontent.com/13975988/210547914-55de1891-99df-4d39-b225-fed41181138c.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5502 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to select preset in credentials step of KubeOne wizard.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
