### PR TITLE
Make Konnectivity generally available without feature gate

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -42,7 +42,6 @@ import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
 import {startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import * as semver from 'semver';
-import {FeatureGateService} from '@core/services/feature-gate';
 import {
   CLUSTER_DEFAULT_NODE_SELECTOR_HINT,
   CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE,
@@ -87,7 +86,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   podNodeSelectorAdmissionPluginConfig: Record<string, string>;
   eventRateLimitConfig: EventRateLimitConfig;
   admissionPlugins: string[] = [];
-  isKonnectivityEnabled = false;
   providerSettingsPatch: ProviderSettingsPatch = {
     isValid: true,
     cloudSpecPatch: {},
@@ -112,15 +110,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     private readonly _datacenterService: DatacenterService,
     private readonly _matDialogRef: MatDialogRef<EditClusterComponent>,
     private readonly _notificationService: NotificationService,
-    private readonly _settingsService: SettingsService,
-    private readonly _featureGatesService: FeatureGateService
+    private readonly _settingsService: SettingsService
   ) {}
 
   ngOnInit(): void {
-    this._featureGatesService.featureGates
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(featureGates => (this.isKonnectivityEnabled = !!featureGates?.konnectivityService));
-
     this.labels = _.cloneDeep(this.cluster.labels) as Record<string, string>;
     this.podNodeSelectorAdmissionPluginConfig = _.cloneDeep(
       this.cluster.spec.podNodeSelectorAdmissionPluginConfig

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -116,8 +116,7 @@ limitations under the License.
                     kmPatternError="Input has to be a valid IPv4 or IPv6 address">
       </km-chip-list>
 
-      <mat-checkbox *ngIf="isKonnectivityEnabled"
-                    [formControlName]="Controls.Konnectivity"
+      <mat-checkbox [formControlName]="Controls.Konnectivity"
                     [class.km-text-muted]="form.get(Controls.Konnectivity).disabled">
         Konnectivity
       </mat-checkbox>

--- a/modules/web/src/app/core/services/feature-gate.ts
+++ b/modules/web/src/app/core/services/feature-gate.ts
@@ -20,7 +20,6 @@ import {Observable, of, timer} from 'rxjs';
 import {catchError, shareReplay, switchMap} from 'rxjs/operators';
 
 export interface FeatureGates {
-  konnectivityService?: boolean;
   oidcKubeCfgEndpoint?: boolean;
   openIDAuthPlugin?: boolean;
 }

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -256,8 +256,7 @@ limitations under the License.
             <mat-checkbox [formControlName]="Controls.NodeLocalDNSCache">
               Node Local DNS Cache
             </mat-checkbox>
-            <mat-checkbox *ngIf="isKonnectivityEnabled"
-                          [formControlName]="Controls.Konnectivity"
+            <mat-checkbox [formControlName]="Controls.Konnectivity"
                           [class.km-text-muted]="control(Controls.Konnectivity).disabled">
               Konnectivity
             </mat-checkbox>


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `konnectivityService` feature gate and make Konnectivity always available.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5513 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make Konnectivity generally available without feature gate.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
