### PR TITLE
Default to IPv4 address family in the cluster default endpoint

### DIFF
--- a/modules/api/pkg/handler/v2/cluster_default/cluster_default.go
+++ b/modules/api/pkg/handler/v2/cluster_default/cluster_default.go
@@ -159,6 +159,7 @@ func mapNetworkDefaultsToCluster(networkDefaults apiv2.NetworkDefaults, cluster 
 	cluster.Spec.ClusterNetwork.TunnelingAgentIP = networkDefaults.TunnelingAgentIP
 	cluster.Spec.ClusterNetwork.ProxyMode = networkDefaults.ProxyMode
 	cluster.Spec.ClusterNetwork.NodeLocalDNSCacheEnabled = pointer.Bool(networkDefaults.NodeLocalDNSCacheEnabled)
+	cluster.Spec.ClusterNetwork.IPFamily = kubermaticv1.IPFamilyIPv4 // always use IPv4 as the default address family (even if IPv6 defaults are provided)
 
 	// Mapping for IPv4
 	if networkDefaults.IPv4 != nil {

--- a/modules/api/pkg/handler/v2/cluster_default/cluster_default_test.go
+++ b/modules/api/pkg/handler/v2/cluster_default/cluster_default_test.go
@@ -50,7 +50,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","aws":{}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4+IPv6","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","aws":{}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 		{
 			Name:     "Default cluster for Azure",
@@ -61,7 +61,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","azure":{"assignAvailabilitySet":null}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4+IPv6","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","azure":{"assignAvailabilitySet":null}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 		{
 			Name:     "Default cluster for vSphere",
@@ -72,7 +72,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","vsphere":{}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4+IPv6","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","vsphere":{}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 		{
 			Name:     "Default cluster for GCP",
@@ -83,7 +83,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","gcp":{}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4+IPv6","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","gcp":{}},"version":"v1.24.9","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true,"tunnelingAgentIP":"100.64.30.10"},"cniPlugin":{"type":"canal","version":"v3.24"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With the recent change in cluster defaulting in the UI, we now always default to dual-stack address family, which is not exactly what we want - we still want to default to IPv4 for all new clusters:


![image](https://user-images.githubusercontent.com/15926980/211531032-950c9b5c-6d4e-4a0a-a00f-53bb59c98a75.png)


This PR fixes the cluster's IP family to IPv4 in the cluster default endpoint, after the standard cluster defaulting logic is applied. As discussed with @Waseem826 it probably makes more sense to fix it in the endpoint than in the UI.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
