### PR TITLE
Remove references to the KonnectivityService feature gate

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -32140,10 +32140,6 @@
       "description": "FeatureGates represents an object holding feature gate settings",
       "type": "object",
       "properties": {
-        "konnectivityService": {
-          "type": "boolean",
-          "x-go-name": "KonnectivityService"
-        },
         "oidcKubeCfgEndpoint": {
           "type": "boolean",
           "x-go-name": "OIDCKubeCfgEndpoint"

--- a/modules/api/hack/run-api.sh
+++ b/modules/api/hack/run-api.sh
@@ -71,7 +71,6 @@ set -x
   -address=127.0.0.1:8080 \
   -oidc-url=https://dev.kubermatic.io/dex \
   -oidc-authenticator-client-id=kubermatic \
-  -feature-gates=KonnectivityService=true \
   -service-account-signing-key="$SERVICE_ACCOUNT_SIGNING_KEY" \
   -log-debug=$KUBERMATIC_DEBUG \
   -pprof-listen-address=":$PPROF_PORT" \

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1042,7 +1042,6 @@ type AKSNodePoolModes []string
 // FeatureGates represents an object holding feature gate settings
 // swagger:model FeatureGates
 type FeatureGates struct {
-	KonnectivityService    *bool `json:"konnectivityService,omitempty"`
 	OIDCKubeCfgEndpoint    *bool `json:"oidcKubeCfgEndpoint,omitempty"`
 	OperatingSystemManager *bool `json:"operatingSystemManager,omitempty"`
 	OpenIDAuthPlugin       *bool `json:"openIDAuthPlugin,omitempty"`

--- a/modules/api/pkg/handler/v2/feature_gates/feature_gates_test.go
+++ b/modules/api/pkg/handler/v2/feature_gates/feature_gates_test.go
@@ -53,7 +53,7 @@ func TestFeatureGatesEndpoint(t *testing.T) {
 			ExistingAPIUser:           test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode:    http.StatusOK,
 			ExpectedResponse: apiv2.FeatureGates{
-				KonnectivityService: &valTrue,
+				OIDCKubeCfgEndpoint: &valTrue,
 			},
 		},
 	}
@@ -68,7 +68,7 @@ func TestFeatureGatesEndpoint(t *testing.T) {
 				Versions: test.GenDefaultVersions(),
 			},
 			FeatureGates: map[string]bool{
-				features.KonnectivityService: true,
+				features.OIDCKubeCfgEndpoint: true,
 			},
 		},
 	}

--- a/modules/api/pkg/provider/kubernetes/featuregates.go
+++ b/modules/api/pkg/provider/kubernetes/featuregates.go
@@ -33,9 +33,6 @@ func NewFeatureGatesProvider(featureGates features.FeatureGate) provider.Feature
 func (fg featureGatesProvider) GetFeatureGates() (apiv2.FeatureGates, error) {
 	var f apiv2.FeatureGates
 
-	if v, ok := fg[features.KonnectivityService]; ok {
-		f.KonnectivityService = &v
-	}
 	if v, ok := fg[features.OIDCKubeCfgEndpoint]; ok {
 		f.OIDCKubeCfgEndpoint = &v
 	}

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/feature_gates.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/feature_gates.go
@@ -17,9 +17,6 @@ import (
 // swagger:model FeatureGates
 type FeatureGates struct {
 
-	// konnectivity service
-	KonnectivityService bool `json:"konnectivityService,omitempty"`
-
 	// o ID c kube cfg endpoint
 	OIDCKubeCfgEndpoint bool `json:"oidcKubeCfgEndpoint,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
`KonnectivityService` feature gate has been removed in https://github.com/kubermatic/kubermatic/pull/11643 & https://github.com/kubermatic/dashboard/pull/5520 , this PR removes the last references of it in the API code.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
