### PR TITLE
Unset `tunnelingAgentIP` if cluster expose strategy is not set to Tunneling

### DIFF
--- a/modules/web/src/app/shared/entity/cluster.ts
+++ b/modules/web/src/app/shared/entity/cluster.ts
@@ -352,6 +352,7 @@ export class ClusterNetwork {
   nodeCidrMaskSizeIPv6?: number;
   nodeLocalDNSCacheEnabled?: boolean;
   konnectivityEnabled?: boolean;
+  tunnelingAgentIP?: string;
 }
 
 export class CNIPluginConfig {

--- a/modules/web/src/app/wizard/component.ts
+++ b/modules/web/src/app/wizard/component.ts
@@ -24,7 +24,7 @@ import {NotificationService} from '@core/services/notification';
 import {ProjectService} from '@core/services/project';
 import {WizardService} from '@core/services/wizard/wizard';
 import {SaveClusterTemplateDialogComponent} from '@shared/components/save-cluster-template/component';
-import {Cluster, CreateClusterModel} from '@shared/entity/cluster';
+import {Cluster, CreateClusterModel, ExposeStrategy} from '@shared/entity/cluster';
 import {Project} from '@shared/entity/project';
 import {OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@shared/entity/machine-deployment';
 import {NodeData} from '@shared/model/NodeSpecChange';
@@ -205,6 +205,9 @@ export class WizardComponent implements OnInit, OnDestroy {
       },
       applications: applications,
     };
+    if (cluster.spec.exposeStrategy !== ExposeStrategy.tunneling) {
+      clusterModel.cluster.spec.clusterNetwork.tunnelingAgentIP = null;
+    }
     if (nodeData.operatingSystemProfile && cluster.spec.enableOperatingSystemManager) {
       clusterModel.nodeDeployment.annotations = {
         [this.operatingSystemProfileAnnotation]: nodeData.operatingSystemProfile,


### PR DESCRIPTION
**What this PR does / why we need it**:
Unset `tunnelingAgentIP` if cluster expose strategy is not set to Tunneling.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unset `tunnelingAgentIP` if cluster expose strategy is not set to Tunneling.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
