### PR TITLE
Add External Cluster label to KubeOne secrets

### DIFF
--- a/modules/api/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/modules/api/pkg/handler/v2/external_cluster/external_cluster.go
@@ -77,7 +77,7 @@ type createClusterReq struct {
 
 type body struct {
 	// Name is human readable name for the external cluster
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Kubeconfig Base64 encoded kubeconfig
 	Kubeconfig string                          `json:"kubeconfig,omitempty"`
 	Cloud      *apiv2.ExternalClusterCloudSpec `json:"cloud,omitempty"`
@@ -278,7 +278,7 @@ func CreateEndpoint(
 			if err := validatKubeOneReq(cloud.KubeOne); err != nil {
 				return nil, utilerrors.NewBadRequest(err.Error())
 			}
-			createdCluster, err := importKubeOneCluster(ctx, req.Body.Name, userInfoGetter, project, cloud, clusterProvider, privilegedClusterProvider)
+			createdCluster, err := importKubeOneCluster(ctx, userInfoGetter, project, cloud, clusterProvider, privilegedClusterProvider)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
 			}
@@ -1135,7 +1135,7 @@ func convertClusterToAPIWithStatus(ctx context.Context, masterClient ctrlruntime
 	if err != nil && apiCluster.Status.State == apiv2.RunningExternalClusterState {
 		apiCluster.Status = apiv2.ExternalClusterStatus{
 			State:         apiv2.ErrorExternalClusterState,
-			StatusMessage: "Can't access cluster via kubeconfig. Please check the credentials privileges.",
+			StatusMessage: "Can't access cluster via kubeconfig," + "error: " + err.Error(),
 		}
 	}
 	if version != nil {

--- a/modules/api/pkg/handler/v2/external_cluster/kubeone.go
+++ b/modules/api/pkg/handler/v2/external_cluster/kubeone.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func importKubeOneCluster(ctx context.Context, name string, userInfoGetter func(ctx context.Context, projectID string) (*provider.UserInfo, error), project *kubermaticv1.Project, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
+func importKubeOneCluster(ctx context.Context, userInfoGetter func(ctx context.Context, projectID string) (*provider.UserInfo, error), project *kubermaticv1.Project, cloud *apiv2.ExternalClusterCloudSpec, clusterProvider provider.ExternalClusterProvider, privilegedClusterProvider provider.PrivilegedExternalClusterProvider) (*kubermaticv1.ExternalCluster, error) {
 	kubeOneCluster, err := DecodeManifestFromKubeOneReq(cloud.KubeOne.Manifest)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: Add External Cluster label to KubeOne secrets
Introducing this change to make it easy to list KubeOne Secrets.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
