### PR TITLE
Changing Provider after choosing Kubeadm Break the wizard

### DIFF
--- a/modules/web/src/app/core/services/wizard/wizard.ts
+++ b/modules/web/src/app/core/services/wizard/wizard.ts
@@ -14,7 +14,7 @@
 
 import {EventEmitter, Injectable} from '@angular/core';
 import {MatStepper} from '@angular/material/stepper';
-import {StepRegistry, WizardStep} from '@app/wizard/config';
+import {StepRegistry, WizardStep, steps} from '@app/wizard/config';
 import {NodeDataService} from '@core/services/node-data/service';
 import {NodeProvider, OperatingSystem} from '@shared/model/NodeProviderConstants';
 import {ClusterSpecService} from '@core/services/cluster-spec';
@@ -33,22 +33,15 @@ export class WizardService {
     constructor(private _parent: WizardService) {}
 
     handleProviderChange(provider: NodeProvider): void {
+      this._parent.steps = steps;
       switch (provider) {
         case NodeProvider.BRINGYOUROWN:
           this._hideStep(StepRegistry.ProviderSettings);
           this._hideStep(StepRegistry.NodeSettings);
-          this._hideStep(StepRegistry.MachineNetwork);
-          break;
-        case NodeProvider.VSPHERE:
-          // Change to show the additional network step
-          this._showStep(StepRegistry.Summary);
-          this._showStep(StepRegistry.ProviderSettings);
-          this._showStep(StepRegistry.NodeSettings);
           break;
         default:
           this._showStep(StepRegistry.ProviderSettings);
           this._showStep(StepRegistry.NodeSettings);
-          this._hideStep(StepRegistry.MachineNetwork);
       }
     }
 
@@ -107,6 +100,10 @@ export class WizardService {
   set provider(provider: NodeProvider) {
     this._stepHandler.handleProviderChange(provider);
     this._clusterSpecService.provider = provider;
+  }
+
+  forceHandleProviderChange(provider: NodeProvider) {
+    this._stepHandler.handleProviderChange(provider);
   }
 
   reset(): void {

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -1023,7 +1023,7 @@ limitations under the License.
                 </km-property-boolean>
                 <km-property-boolean *ngIf="machineDeployment.spec.template.cloud?.aws?.spotInstancePersistentRequest !== undefined"
                                      label="Spot Instance Persistent Request"
-                                     [value]="machineDeployment.spec.template.cloud.aws.spotInstancePersistentRequest">
+                                     [value]="machineDeployment.spec.template.cloud?.aws?.spotInstancePersistentRequest">
                 </km-property-boolean>
                 <km-property-boolean *ngIf="machineDeployment.spec.template.cloud?.aws?.assignPublicIP !== undefined"
                                      label="Assign Public IP"

--- a/modules/web/src/app/wizard/component.ts
+++ b/modules/web/src/app/wizard/component.ts
@@ -286,6 +286,9 @@ export class WizardComponent implements OnInit, OnDestroy {
 
   private initializeWizard(): void {
     // Init steps for wizard
+    if (this.clusterTemplateID) {
+      this._wizard.forceHandleProviderChange(this._clusterSpecService.provider);
+    }
     this._wizard.steps = this.steps;
     this._wizard.stepper = this._stepper;
 


### PR DESCRIPTION
**What this PR does / why we need it**
fix displaying steps for wizard in case change provider after choosing kubeadm provider

**Which issue(s) this PR fixes**:
Fixes #5505 

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
