### PR TITLE
Fix health API request polling issue

### DIFF
--- a/modules/web/src/app/core/services/cluster.ts
+++ b/modules/web/src/app/core/services/cluster.ts
@@ -54,7 +54,6 @@ export class ClusterService {
   private _externalClusters$ = new Map<string, Observable<ExternalCluster[]>>();
   private _cluster$ = new Map<string, Observable<Cluster>>();
   private _externalCluster$ = new Map<string, Observable<ExternalCluster>>();
-  private _clusterHealth$ = new Map<string, Observable<Health>>();
   private _refreshTimer$ = timer(0, this._appConfig.getRefreshTimeBase() * this._refreshTime);
   private _onClustersUpdate = new Subject<void>();
   private _onExternalClustersUpdate = new Subject<void>();
@@ -285,16 +284,8 @@ export class ClusterService {
   }
 
   health(projectID: string, clusterID: string): Observable<Health> {
-    const mapKey = projectID + '-' + clusterID;
-    if (!this._clusterHealth$.has(mapKey)) {
-      const request$ = this._http
-        .get<Health>(`${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/health`)
-        .pipe(shareReplay({refCount: true, bufferSize: 1}));
-
-      this._clusterHealth$.set(mapKey, request$);
-    }
-
-    return this._clusterHealth$.get(mapKey);
+    const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}/health`;
+    return this._http.get<Health>(url).pipe(catchError(() => of<Health>({} as Health)));
   }
 
   upgradeMachineDeployments(projectID: string, clusterID: string, version: string): Observable<void> {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `shareReplay` operator for `health` API request to fix polling issue.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
This change was introduced in #5464 but since we call `health` method inside `combineLatest` operator so this causes old observable to be returned every time due to `shareReplay` operator.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
