### PR TITLE
update premmisions for service accounts and groups

### DIFF
--- a/modules/web/src/app/project-overview/component.ts
+++ b/modules/web/src/app/project-overview/component.ts
@@ -331,6 +331,7 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
 
   private _loadServiceAccounts(): void {
     merge(timer(0, this._refreshTime * this._appConfigService.getRefreshTimeBase()), this._projectChange)
+      .pipe(filter(() => this.project && this.hasPermission(View.Members)))
       .pipe(switchMap(() => (this.project ? this._serviceAccountService.get(this.project.id) : EMPTY)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(serviceAccounts => (this.serviceAccounts = serviceAccounts));

--- a/modules/web/src/app/shared/model/Config.ts
+++ b/modules/web/src/app/shared/model/Config.ts
@@ -51,6 +51,7 @@ export interface Viewable {
 export class GroupConfig {
   projects?: Projects;
   members?: Members;
+  groups?: Groups;
   sshkeys?: SSHKeys;
   clusters?: Clusters;
   nodes?: Nodes;
@@ -75,6 +76,12 @@ export class Members implements Viewable {
   create?: boolean;
 }
 
+export class Groups implements Viewable {
+  view?: boolean;
+  edit?: boolean;
+  delete?: boolean;
+  create?: boolean;
+}
 export class SSHKeys implements Viewable {
   view?: boolean;
   edit?: boolean;

--- a/modules/web/src/assets/config/userGroupConfig.json
+++ b/modules/web/src/assets/config/userGroupConfig.json
@@ -12,6 +12,12 @@
       "delete": true,
       "create": true
     },
+    "groups": {
+      "view": true,
+      "edit": true,
+      "delete": true,
+      "create": true
+    },
     "sshkeys": {
       "view": true,
       "edit": true,
@@ -80,6 +86,12 @@
       "delete": false,
       "create": false
     },
+    "groups": {
+      "view": false,
+      "edit": false,
+      "delete": false,
+      "create": false
+    },
     "sshkeys": {
       "view": true,
       "edit": true,
@@ -143,6 +155,12 @@
       "delete": false
     },
     "members": {
+      "view": false,
+      "edit": false,
+      "delete": false,
+      "create": false
+    },
+    "groups": {
       "view": false,
       "edit": false,
       "delete": false,


### PR DESCRIPTION
**What this PR does / why we need it**:
fix the premonitions errors for wrong role user for project overview and groups tabs**Which issue(s) this PR fixes**:
Fixes #5281

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
so else than the error for service account in the project over view page we have that error when we navigate to groups tab so in this PR we disable groups tab because it's not suppose to be active in editor and viewer role.

```release-note
NONE
```

```documentation
NONE
```
