### PR TITLE
Some fixes for RQ calculation

### DIFF
--- a/modules/api/pkg/ee/resource-quota/handler.go
+++ b/modules/api/pkg/ee/resource-quota/handler.go
@@ -322,11 +322,11 @@ func CalculateResourceQuotaUpdateForProject(ctx context.Context, request interfa
 	var msg string
 	if projectResourceQuota.Spec.Quota.CPU != nil && calculatedResources.CPU != nil &&
 		calculatedResources.CPU.Cmp(*projectResourceQuota.Spec.Quota.CPU) > 0 {
-		msg += fmt.Sprintf("Calculated cpu (%s) exceeds resource quota (%s)", calculatedResources.CPU, projectResourceQuota.Spec.Quota.CPU)
+		msg += fmt.Sprintf("Calculated cpu (%s) exceeds resource quota (%s)\n", calculatedResources.CPU, projectResourceQuota.Spec.Quota.CPU)
 	}
 	if projectResourceQuota.Spec.Quota.Memory != nil && calculatedResources.Memory != nil &&
 		calculatedResources.Memory.Cmp(*projectResourceQuota.Spec.Quota.Memory) > 0 {
-		msg += fmt.Sprintf("Calculated memory (%s) exceeds resource quota (%s)", calculatedResources.Memory, projectResourceQuota.Spec.Quota.Memory)
+		msg += fmt.Sprintf("Calculated memory (%s) exceeds resource quota (%s)\n", calculatedResources.Memory, projectResourceQuota.Spec.Quota.Memory)
 	}
 	if projectResourceQuota.Spec.Quota.Storage != nil && calculatedResources.Storage != nil &&
 		calculatedResources.Storage.Cmp(*projectResourceQuota.Spec.Quota.Storage) > 0 {
@@ -438,9 +438,14 @@ func getAnexiaResourceDetails(req calculateProjectResourceQuotaUpdate, nc *kuber
 	}
 
 	var diskSize int64
-	for _, disk := range req.Body.AnexiaNodeSpec.Disks {
-		diskSize += disk.Size
+	if req.Body.AnexiaNodeSpec.DiskSize != nil {
+		diskSize = *req.Body.AnexiaNodeSpec.DiskSize
+	} else {
+		for _, disk := range req.Body.AnexiaNodeSpec.Disks {
+			diskSize += disk.Size
+		}
 	}
+
 	if err := nc.WithStorage(int(diskSize), "G"); err != nil {
 		return err
 	}
@@ -596,7 +601,7 @@ func getNutanixResourceDetails(req calculateProjectResourceQuotaUpdate, nc *kube
 func getOpenstackResourceDetails(req calculateProjectResourceQuotaUpdate, nc *kubermaticprovider.NodeCapacity) error {
 	nc.WithCPUCount(req.Body.OpenstackSize.VCPUs)
 
-	if err := nc.WithMemory(req.Body.OpenstackSize.Memory, "G"); err != nil {
+	if err := nc.WithMemory(req.Body.OpenstackSize.Memory, "M"); err != nil {
 		return err
 	}
 	if err := nc.WithStorage(req.Body.OpenstackSize.Disk, "G"); err != nil {

--- a/modules/api/pkg/ee/resource-quota/handler_test.go
+++ b/modules/api/pkg/ee/resource-quota/handler_test.go
@@ -665,7 +665,7 @@ func TestCalculateResourceQuotaUpdate(t *testing.T) {
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			RequestBody: newCalcReq().
 				withReplicas(2).
-				withOpenstack(2, 3, 10).
+				withOpenstack(2, 3000, 10).
 				encode(t),
 			ExpectedHTTPStatusCode: http.StatusOK,
 			ExpectedResponse: newRQUpdateCalculationBuilder().


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes some calculation bugs:
- Openstack calculation used G instead of M
- Handle Anexia deprecated DiskSize field, it seems that its still used
- Format quota exceeded message with line breaks 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
