### PR TITLE
KubeVirt switch StorageClass config from annotation to DC

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -35018,7 +35018,7 @@
     "KubeVirtInfraStorageClass": {
       "type": "object",
       "properties": {
-        "isDefautClass": {
+        "isDefaultClass": {
           "description": "Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with:\nstorageclass.kubernetes.io/is-default-class : true\nIf missing or false, annotation will be:\nstorageclass.kubernetes.io/is-default-class : false",
           "type": "boolean",
           "x-go-name": "IsDefaultClass"
@@ -35091,7 +35091,7 @@
           "x-go-name": "ImageCloningEnabled"
         },
         "infraStorageClasses": {
-          "description": "InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for\ninitialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)",
+          "description": "Deprecated: in favor of InfraStorageClasses.\nInfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for\ninitialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)",
           "type": "array",
           "items": {
             "type": "string"

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -102,7 +102,7 @@ replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-2022081
 
 require (
 	github.com/pkg/errors v0.9.1
-	k8c.io/kubermatic/v2 v2.21.1-0.20230118103444-ee611be4f351
+	k8c.io/kubermatic/v2 v2.21.1-0.20230118134347-8b64fdaea27c
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1339,8 +1339,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.5.4 h1:+OUuz7zdLlRC6HTNKi1fAIUYimmVFwcCzDOu6TiBx9Q=
 k8c.io/kubeone v1.5.4/go.mod h1:xNlAertZO2iKVE8pL0Ruf/zjtM+EBeiZJtueuncyjxI=
-k8c.io/kubermatic/v2 v2.21.1-0.20230118103444-ee611be4f351 h1:PkPVavxSp6aoNcMN+0dzbR6W3bp5pCGerc3KqezLTZ8=
-k8c.io/kubermatic/v2 v2.21.1-0.20230118103444-ee611be4f351/go.mod h1:Y9vixzPlFiQd8pIjIqXWa7pLd+IX5tClavZNWbOJK/0=
+k8c.io/kubermatic/v2 v2.21.1-0.20230118134347-8b64fdaea27c h1:qJn8OjkoVOty3DZp2kKrX9shOYmM8LU05Z+3rWZJp+4=
+k8c.io/kubermatic/v2 v2.21.1-0.20230118134347-8b64fdaea27c/go.mod h1:Y9vixzPlFiQd8pIjIqXWa7pLd+IX5tClavZNWbOJK/0=
 k8c.io/operating-system-manager v1.1.2-0.20221201183812-4f7c5a687353 h1:d9GuR+62IjJkhk8v3aGg3ewRQPN1TxWKhCVlk8ZaYKg=
 k8c.io/operating-system-manager v1.1.2-0.20221201183812-4f7c5a687353/go.mod h1:NGru44utIUfEOCkX2FwlrR+lyEXB+x/DPqh5Eq+fd4A=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=

--- a/modules/api/pkg/provider/cloud/kubevirt/storage_class.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/storage_class.go
@@ -27,11 +27,6 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	// InfraStorageClassAnnotation represents a storage class that should be initialized on user clusters.
-	infraStorageClassAnnotation = "kubevirt-initialization.k8c.io/initialize-sc"
-)
-
 type storageClassAnnotationFilter func(map[string]string) bool
 
 // ListStorageClasses returns list of storage classes filtered by annotations.
@@ -50,19 +45,25 @@ func ListStorageClasses(ctx context.Context, client ctrlruntimeclient.Client, an
 	return res, nil
 }
 
-func updateInfraStorageClassesInfo(ctx context.Context, client ctrlruntimeclient.Client, spec *kubermaticv1.CloudSpec) error {
-	storageClassList, err := ListStorageClasses(ctx, client, func(m map[string]string) bool {
-		return m[infraStorageClassAnnotation] == "true"
-	})
+func updateInfraStorageClassesInfo(ctx context.Context, client ctrlruntimeclient.Client, spec *kubermaticv1.KubevirtCloudSpec, dc *kubermaticv1.DatacenterSpecKubevirt) error {
+	infraStorageClassList, err := ListStorageClasses(ctx, client, nil)
 	if err != nil {
 		return err
 	}
-	existingStorageClassSet := sets.New(spec.Kubevirt.InfraStorageClasses...)
+	existingInfraStorageClassSet := sets.New[string]()
+	for _, isc := range infraStorageClassList {
+		existingInfraStorageClassSet.Insert(isc.Name)
+	}
 
-	for _, sc := range storageClassList {
-		if !existingStorageClassSet.Has(sc.Name) {
-			spec.Kubevirt.InfraStorageClasses = append(spec.Kubevirt.InfraStorageClasses, sc.Name)
+	// Cluster will contain a list with only the StorageClasses
+	// that are in the DC configuration and also exist in the infra KubeVirt cluster.
+	storageClasses := make([]kubermaticv1.KubeVirtInfraStorageClass, 0)
+	for _, sc := range dc.InfraStorageClasses {
+		// if StorageClass exists in infra, keep it
+		if existingInfraStorageClassSet.Has(sc.Name) {
+			storageClasses = append(storageClasses, sc)
 		}
 	}
+	spec.StorageClasses = storageClasses
 	return nil
 }

--- a/modules/api/pkg/provider/cloud/provider.go
+++ b/modules/api/pkg/provider/cloud/provider.go
@@ -78,7 +78,7 @@ func Provider(
 		return fake.NewCloudProvider(), nil
 	}
 	if datacenter.Spec.Kubevirt != nil {
-		return kubevirt.NewCloudProvider(secretKeyGetter), nil
+		return kubevirt.NewCloudProvider(datacenter, secretKeyGetter)
 	}
 	if datacenter.Spec.Alibaba != nil {
 		return alibaba.NewCloudProvider(datacenter, secretKeyGetter)

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/kube_virt_infra_storage_class.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/kube_virt_infra_storage_class.go
@@ -21,7 +21,7 @@ type KubeVirtInfraStorageClass struct {
 	// storageclass.kubernetes.io/is-default-class : true
 	// If missing or false, annotation will be:
 	// storageclass.kubernetes.io/is-default-class : false
-	IsDefaultClass bool `json:"isDefautClass,omitempty"`
+	IsDefaultClass bool `json:"isDefaultClass,omitempty"`
 
 	// name
 	Name string `json:"name,omitempty"`

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
@@ -25,6 +25,7 @@ type KubevirtCloudSpec struct {
 	// ImageCloningEnabled flag enable/disable cloning for a cluster.
 	ImageCloningEnabled bool `json:"imageCloningEnabled,omitempty"`
 
+	// Deprecated: in favor of InfraStorageClasses.
 	// InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
 	InfraStorageClasses []string `json:"infraStorageClasses"`


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Last part to switch the configuration of StorageClasses to be deployed in the user  (tenant) cluster from infra cluster StorageClass annotations to proper DC configuration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes kubermatic/kubermatic#11689

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt switch StorageClass config from annotation to DataCenter.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
