### PR TITLE
Add functionality to edit initial values of Cilium application

### DIFF
--- a/modules/web/src/app/core/services/cluster-spec.ts
+++ b/modules/web/src/app/core/services/cluster-spec.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {EventEmitter, Injectable} from '@angular/core';
-import {CloudSpec, Cluster, EventRateLimitConfig} from '@shared/entity/cluster';
+import {CloudSpec, Cluster, ClusterAnnotation, EventRateLimitConfig} from '@shared/entity/cluster';
 import {SSHKey} from '@shared/entity/ssh-key';
 import {NodeProvider} from '@shared/model/NodeProviderConstants';
 import _ from 'lodash';
@@ -147,6 +147,12 @@ export class ClusterSpecService {
   initializeClusterFromClusterTemplate(template: ClusterTemplate): void {
     this.cluster = template.cluster;
     this.sshKeys = this.sshKeysFromClusterTemplateUserSSHKeys(template.userSshKeys);
+    if (template.annotations?.[ClusterAnnotation.InitialCNIValuesRequest]) {
+      this.cluster.annotations = {
+        ...(this.cluster.annotations || {}),
+        [ClusterAnnotation.InitialCNIValuesRequest]: template.annotations[ClusterAnnotation.InitialCNIValuesRequest],
+      };
+    }
     this.isCusterTemplateEditMode = true;
   }
 

--- a/modules/web/src/app/dynamic/enterprise/quotas/template.html
+++ b/modules/web/src/app/dynamic/enterprise/quotas/template.html
@@ -65,9 +65,11 @@ END OF TERMS AND CONDITIONS
             mat-sort-header>Project</th>
         <td mat-cell
             *matCellDef="let element">
-          <div fxLayoutAlign=" center" fxLayoutGap="10px">
+          <div fxLayoutAlign=" center"
+               fxLayoutGap="10px">
             <span>{{element?.subjectHumanReadableName || element?.name}}</span>
-            <span *ngIf="element.isDefault" class="km-label-primary">Default</span>
+            <span *ngIf="element.isDefault"
+                  class="km-label-primary">Default</span>
           </div>
         </td>
       </ng-container>

--- a/modules/web/src/app/project/edit-project/template.html
+++ b/modules/web/src/app/project/edit-project/template.html
@@ -38,7 +38,7 @@ limitations under the License.
                      [asyncKeyValidators]=asyncLabelValidators
                      [formControlName]="Controls.Labels"></km-label-form>
 
-      <ng-container  *ngIf="isEnterpriseEdition && projectQouta">
+      <ng-container *ngIf="isEnterpriseEdition && projectQouta">
         <mat-card-header>
           <mat-card-title>Quota</mat-card-title>
         </mat-card-header>

--- a/modules/web/src/app/shared/entity/cluster.ts
+++ b/modules/web/src/app/shared/entity/cluster.ts
@@ -80,6 +80,7 @@ export class Cluster {
   inheritedLabels?: object;
   credential?: string;
   machineDeploymentCount?: number;
+  annotations?: Record<ClusterAnnotation | string, string>;
 
   static isDualStackNetworkSelected(cluster: Cluster) {
     return cluster?.spec.clusterNetwork?.ipFamily === IPFamily.DualStack;
@@ -377,6 +378,10 @@ export class CNIPluginVersions {
   versions: string[];
 }
 
+export enum ClusterAnnotation {
+  InitialCNIValuesRequest = 'kubermatic.io/initial-cni-values-request',
+}
+
 export enum ProxyMode {
   ipvs = 'ipvs',
   iptables = 'iptables',
@@ -617,4 +622,5 @@ class ClusterModel {
   spec: ClusterSpec;
   labels?: object;
   credential?: string;
+  annotations?: Record<ClusterAnnotation | string, string>;
 }

--- a/modules/web/src/app/wizard/component.ts
+++ b/modules/web/src/app/wizard/component.ts
@@ -260,6 +260,7 @@ export class WizardComponent implements OnInit, OnDestroy {
         labels: cluster.labels,
         spec: cluster.spec,
         credential: cluster.credential,
+        annotations: cluster.annotations,
       },
       nodeDeployment: {
         name: nodeData.name,

--- a/modules/web/src/app/wizard/module.ts
+++ b/modules/web/src/app/wizard/module.ts
@@ -14,6 +14,7 @@
 
 import {NgModule} from '@angular/core';
 import {ApplicationsStepComponent} from '@app/wizard/step/applications/component';
+import {CiliumApplicationValuesDialogComponent} from '@app/wizard/step/cluster/cilium-application-values-dialog/component';
 import {OpenstackProviderExtendedAppCredentialsComponent} from '@app/wizard/step/provider-settings/provider/extended/openstack/application/component';
 import {OpenstackProviderExtendedDefaultCredentialsComponent} from '@app/wizard/step/provider-settings/provider/extended/openstack/default/component';
 import {OpenstackCredentialsTypeService} from '@app/wizard/step/provider-settings/provider/extended/openstack/service';
@@ -91,6 +92,7 @@ const components = [
   NutanixProviderExtendedComponent,
   VMwareCloudDirectorProviderBasicComponent,
   VMwareCloudDirectorProviderExtendedComponent,
+  CiliumApplicationValuesDialogComponent,
 ];
 
 @NgModule({

--- a/modules/web/src/app/wizard/step/cluster/cilium-application-values-dialog/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/cilium-application-values-dialog/component.ts
@@ -1,0 +1,113 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import {ApplicationService} from '@core/services/application';
+import * as y from 'js-yaml';
+import _ from 'lodash';
+import {Subject} from 'rxjs';
+import {finalize, takeUntil} from 'rxjs/operators';
+
+export interface CiliumApplicationValuesDialogData {
+  applicationValues?: string; // JSON encoded string
+}
+
+enum Controls {
+  Values = 'values',
+}
+
+@Component({
+  selector: 'km-cilium-application-values-dialog',
+  templateUrl: './template.html',
+  styleUrls: ['./style.scss'],
+})
+export class CiliumApplicationValuesDialogComponent implements OnInit, OnDestroy {
+  readonly Controls = Controls;
+
+  valuesConfig = '';
+  isValuesConfigValid = true;
+  isLoadingDetails: boolean;
+
+  private readonly _unsubscribe = new Subject<void>();
+  private readonly _applicationName = 'cilium';
+
+  constructor(
+    public dialogRef: MatDialogRef<CiliumApplicationValuesDialogComponent>,
+    private readonly _applicationService: ApplicationService,
+    @Inject(MAT_DIALOG_DATA) private data: CiliumApplicationValuesDialogData
+  ) {}
+
+  ngOnInit(): void {
+    if (this.data.applicationValues) {
+      this._initValuesConfig(this.data.applicationValues);
+    } else {
+      this._loadApplicationDefinitionDetails();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  onValuesConfigValidityChanged(isValid: boolean): void {
+    this.isValuesConfigValid = isValid;
+  }
+
+  onSave(): void {
+    this.dialogRef.close(this._getEncodedConfig());
+  }
+
+  private _loadApplicationDefinitionDetails() {
+    this.isLoadingDetails = true;
+    this._applicationService
+      .getApplicationDefinition(this._applicationName)
+      .pipe(
+        takeUntil(this._unsubscribe),
+        finalize(() => (this.isLoadingDetails = false))
+      )
+      .subscribe({
+        next: appDef => {
+          this._initValuesConfig(appDef.spec.defaultValues);
+        },
+        error: _ => {},
+      });
+  }
+
+  private _initValuesConfig(valuesConfig: string | object): void {
+    this.valuesConfig = '';
+    if (typeof valuesConfig === 'string') {
+      try {
+        valuesConfig = JSON.parse(valuesConfig);
+      } catch (_) {
+        this.valuesConfig = '';
+      }
+    }
+    if (!_.isEmpty(valuesConfig)) {
+      try {
+        this.valuesConfig = y.dump(valuesConfig);
+      } catch (e) {
+        this.valuesConfig = '';
+      }
+    }
+  }
+
+  private _getEncodedConfig(): string {
+    let raw = y.load(this.valuesConfig);
+    raw = !_.isEmpty(raw) ? raw : {};
+
+    return JSON.stringify(raw);
+  }
+}

--- a/modules/web/src/app/wizard/step/cluster/cilium-application-values-dialog/style.scss
+++ b/modules/web/src/app/wizard/step/cluster/cilium-application-values-dialog/style.scss
@@ -1,0 +1,28 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@use 'variables';
+
+.application-settings-desc {
+  font-size: variables.$font-size-body;
+}
+
+.application-values {
+  margin-bottom: 20px;
+
+  mat-hint,
+  mat-error {
+    font-size: 75%;
+  }
+}

--- a/modules/web/src/app/wizard/step/cluster/cilium-application-values-dialog/template.html
+++ b/modules/web/src/app/wizard/step/cluster/cilium-application-values-dialog/template.html
@@ -1,0 +1,47 @@
+<!--
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<km-dialog-title>Initial CNI Values</km-dialog-title>
+<mat-dialog-content>
+  <div fxLayoutAlign="center center">
+    <mat-spinner *ngIf="this.isLoadingDetails"
+                 [diameter]="25"></mat-spinner>
+  </div>
+  <div fxLayout="column">
+    <p class="application-settings-desc">
+      Use custom values to override the default configuration of the CNI.
+    </p>
+    <div class="application-values">
+      <km-editor [(model)]="valuesConfig"
+                 height="370px"
+                 header="values.yaml">
+      </km-editor>
+      <km-validate-json-or-yaml [data]="valuesConfig"
+                                [isOnlyYAML]="true"
+                                (dataValid)="onValuesConfigValidityChanged($event)"></km-validate-json-or-yaml>
+    </div>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-flat-button
+          fxLayoutAlign="center center"
+          [disabled]="valuesConfig && !isValuesConfigValid"
+          kmThrottleClick
+          (throttleClick)="onSave()">
+    <i class="km-icon-mask km-icon-save"></i>
+    <span>Save Changes</span>
+  </button>
+</mat-dialog-actions>

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -253,6 +253,16 @@ limitations under the License.
           <div fxLayout="column"
                fxFlex="100"
                fxLayoutGap="10px">
+            <div fxLayoutAlign="flex-start">
+              <button *ngIf="canEditCNIValues"
+                      mat-flat-button
+                      color="quaternary"
+                      fxLayoutAlign="center center"
+                      (click)="editCNIValues()">
+                <i class="km-icon-mask km-icon-edit"></i>
+                <span>Edit CNI Values</span>
+              </button>
+            </div>
             <mat-checkbox [formControlName]="Controls.NodeLocalDNSCache">
               Node Local DNS Cache
             </mat-checkbox>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add functionality to edit initial values of Cilium application when `Cilium` plugin is selected for cluster.

**Cluster Step:**

![screenshot-localhost_8000-2023 01 20-16_16_36](https://user-images.githubusercontent.com/13975988/213683789-dcd74ab3-0567-4231-892b-d464c6f087cf.png)

**Dialog:**

![screenshot-localhost_8000-2023 01 20-16_17_00](https://user-images.githubusercontent.com/13975988/213683885-4705a8f9-56aa-4b35-bcd9-b4569d20c9d3.png)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5524 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add functionality to edit initial values of Cilium application when Cilium plugin is selected.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
