### PR TITLE
add an option for restricting presets to projects

### DIFF
--- a/modules/web/src/app/settings/admin/presets/dialog/steps/preset/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/preset/template.html
@@ -48,6 +48,13 @@ limitations under the License.
                 fxFlex>
   </km-chip-list>
 
+  <km-select [label]="projectLabel"
+             [options]="projects"
+             hint="Restrict Preset to Projects"
+             isMultiple="true"
+             [formControlName]="controls.Projects">
+  </km-select>
+
   <mat-checkbox [formControlName]="controls.Disable"
                 class="km-disable-ripple">
     Hide upon creation

--- a/modules/web/src/app/shared/components/select/component.ts
+++ b/modules/web/src/app/shared/components/select/component.ts
@@ -45,6 +45,7 @@ export class SelectComponent extends BaseFormValidator implements OnInit, OnDest
   @Input() isLoading = false;
   @Input() hint: string;
   @Input() required: boolean;
+  @Input() isMultiple = false;
   @Input() validators: ValidatorFn[] = [];
 
   constructor(private readonly _builder: FormBuilder) {

--- a/modules/web/src/app/shared/components/select/template.html
+++ b/modules/web/src/app/shared/components/select/template.html
@@ -16,7 +16,9 @@ limitations under the License.
 <form [formGroup]="form">
   <mat-form-field>
     <mat-label *ngIf="label">{{label}}</mat-label>
-    <mat-select [formControlName]="Controls.Select">
+    <mat-select [formControlName]="Controls.Select"
+                [panelClass]="isMultiple ? 'km-multiple-values-dropdown' : ''"
+                [multiple]="isMultiple">
       <mat-option *ngFor="let option of options"
                   [value]="option">
         {{option}}

--- a/modules/web/src/app/shared/entity/preset.ts
+++ b/modules/web/src/app/shared/entity/preset.ts
@@ -79,6 +79,7 @@ export class CreatePresetSpec {
   vmwareclouddirector?: VMwareCloudDirectorPresetSpec;
 
   requiredEmails?: string[];
+  projects?: string[];
   enabled?: boolean;
 
   provider(): NodeProvider {


### PR DESCRIPTION
**What this PR does / why we need it**:
 on create preset first step (preset) Add an option under Optional Settings section to Restrict preset to projects

**Create Preset Dialog**:



**Which issue(s) this PR fixes**:
Fixes #5580

**What type of PR is this?**
/kind feature


```release-note
Add an option to Restrict preset to projects
```

**Documentation**:
```documentation
NONE
```
