### PR TITLE
Pass ReconciliationInterval & DeployOptions between internal and API ApplicationInstallation

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -29355,8 +29355,14 @@
         "applicationRef": {
           "$ref": "#/definitions/ApplicationRef"
         },
+        "deployOptions": {
+          "$ref": "#/definitions/DeployOptions"
+        },
         "namespace": {
           "$ref": "#/definitions/NamespaceSpec"
+        },
+        "reconciliationInterval": {
+          "$ref": "#/definitions/Duration"
         },
         "values": {
           "$ref": "#/definitions/RawExtension"

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1857,6 +1857,18 @@ type ApplicationInstallationSpec struct {
 	// ApplicationRef is a reference to identify which Application should be deployed
 	ApplicationRef apiv1.ApplicationRef `json:"applicationRef"`
 
+	// ReconciliationInterval is the interval at which to force the reconciliation of the application. By default, Applications are only reconciled
+	// on changes on spec, annotations, or the parent application definition. Meaning that if the user manually deletes the workload
+	// deployed by the application, nothing will happen until the application CR change.
+	//
+	// Setting a value greater than zero force reconciliation even if no changes occurred on application CR.
+	// Setting a value equal to 0 disables the force reconciliation of the application (default behavior).
+	// Setting this too low can cause a heavy load and may disrupt your application workload depending on the template method.
+	ReconciliationInterval metav1.Duration `json:"reconciliationInterval,omitempty"`
+
+	// DeployOptions holds the settings specific to the templating method used to deploy the application.
+	DeployOptions *appskubermaticv1.DeployOptions `json:"deployOptions,omitempty"`
+
 	// Values describe overrides for manifest-rendering. It's a free yaml field.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Values runtime.RawExtension `json:"values,omitempty"`

--- a/modules/api/pkg/handler/v2/application_installation/conversion.go
+++ b/modules/api/pkg/handler/v2/application_installation/conversion.go
@@ -45,7 +45,9 @@ func convertInternalToAPIApplicationInstallation(in *appskubermaticv1.Applicatio
 				Name:    in.Spec.ApplicationRef.Name,
 				Version: in.Spec.ApplicationRef.Version,
 			},
-			Values: in.Spec.Values,
+			ReconciliationInterval: in.Spec.ReconciliationInterval,
+			DeployOptions:          in.Spec.DeployOptions,
+			Values:                 in.Spec.Values,
 		},
 		Status: &apiv2.ApplicationInstallationStatus{
 			ApplicationVersion: in.Status.ApplicationVersion,
@@ -113,7 +115,9 @@ func convertAPItoInternalApplicationInstallationBody(app *apiv2.ApplicationInsta
 				Name:    app.Spec.ApplicationRef.Name,
 				Version: app.Spec.ApplicationRef.Version,
 			},
-			Values: app.Spec.Values,
+			ReconciliationInterval: app.Spec.ReconciliationInterval,
+			DeployOptions:          app.Spec.DeployOptions,
+			Values:                 app.Spec.Values,
 		},
 	}
 }

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_spec.go
@@ -21,8 +21,14 @@ type ApplicationInstallationSpec struct {
 	// application ref
 	ApplicationRef *ApplicationRef `json:"applicationRef,omitempty"`
 
+	// deploy options
+	DeployOptions *DeployOptions `json:"deployOptions,omitempty"`
+
 	// namespace
 	Namespace *NamespaceSpec `json:"namespace,omitempty"`
+
+	// reconciliation interval
+	ReconciliationInterval Duration `json:"reconciliationInterval,omitempty"`
 
 	// values
 	Values RawExtension `json:"values,omitempty"`
@@ -33,6 +39,10 @@ func (m *ApplicationInstallationSpec) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateApplicationRef(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDeployOptions(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -57,6 +67,25 @@ func (m *ApplicationInstallationSpec) validateApplicationRef(formats strfmt.Regi
 				return ve.ValidateName("applicationRef")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("applicationRef")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ApplicationInstallationSpec) validateDeployOptions(formats strfmt.Registry) error {
+	if swag.IsZero(m.DeployOptions) { // not required
+		return nil
+	}
+
+	if m.DeployOptions != nil {
+		if err := m.DeployOptions.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("deployOptions")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deployOptions")
 			}
 			return err
 		}
@@ -92,6 +121,10 @@ func (m *ApplicationInstallationSpec) ContextValidate(ctx context.Context, forma
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateDeployOptions(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateNamespace(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -110,6 +143,22 @@ func (m *ApplicationInstallationSpec) contextValidateApplicationRef(ctx context.
 				return ve.ValidateName("applicationRef")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("applicationRef")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ApplicationInstallationSpec) contextValidateDeployOptions(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.DeployOptions != nil {
+		if err := m.DeployOptions.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("deployOptions")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("deployOptions")
 			}
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Pass `ReconciliationInterval` & `DeployOptions` between internal and API `ApplicationInstallation`. Without this, this config is lost when editing the ApplicationInstallation via UI.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
