### PR TITLE
Move Labels in ApplicationInstallationListItem to the top level

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -29295,6 +29295,13 @@
           "type": "string",
           "x-go-name": "CreationTimestamp"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Labels"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
@@ -29314,14 +29321,6 @@
       "properties": {
         "applicationRef": {
           "$ref": "#/definitions/ApplicationRef"
-        },
-        "labels": {
-          "description": "Labels can contain metadata about the application, such as the owner who manages it.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "Labels"
         },
         "namespace": {
           "$ref": "#/definitions/NamespaceSpec"
@@ -34082,6 +34081,7 @@
           "x-go-name": "UserProjectsLimit"
         }
       },
+      "x-go-package": "k8c.io/dashboard/v2/pkg/api/v2",
       "$ref": "#/definitions/SettingSpec"
     },
     "GroupProjectBinding": {

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1809,6 +1809,8 @@ type ApplicationInstallationListItem struct {
 
 	CreationTimestamp apiv1.Time `json:"creationTimestamp,omitempty"`
 
+	Labels map[string]string `json:"labels,omitempty"`
+
 	Spec *ApplicationInstallationListItemSpec `json:"spec"`
 
 	Status *ApplicationInstallationListItemStatus `json:"status"`
@@ -1819,9 +1821,6 @@ type ApplicationInstallationListItem struct {
 type ApplicationInstallationListItemSpec struct {
 	// Namespace describe the desired state of the namespace where application will be created.
 	Namespace apiv1.NamespaceSpec `json:"namespace"`
-
-	// Labels can contain metadata about the application, such as the owner who manages it.
-	Labels map[string]string `json:"labels,omitempty"`
 
 	// ApplicationRef is a reference to identify which Application should be deployed
 	ApplicationRef apiv1.ApplicationRef `json:"applicationRef"`

--- a/modules/api/pkg/handler/v2/application_installation/conversion.go
+++ b/modules/api/pkg/handler/v2/application_installation/conversion.go
@@ -69,6 +69,7 @@ func convertInternalToAPIApplicationInstallationForList(in *appskubermaticv1.App
 	out := &apiv2.ApplicationInstallationListItem{
 		Name:              in.Name,
 		CreationTimestamp: apiv1.Time(in.CreationTimestamp),
+		Labels:            in.Labels,
 		Spec: &apiv2.ApplicationInstallationListItemSpec{
 			Namespace: apiv1.NamespaceSpec{
 				Name:        in.Spec.Namespace.Name,
@@ -76,7 +77,6 @@ func convertInternalToAPIApplicationInstallationForList(in *appskubermaticv1.App
 				Labels:      in.Spec.Namespace.Labels,
 				Annotations: in.Spec.Namespace.Annotations,
 			},
-			Labels: in.Labels,
 			ApplicationRef: apiv1.ApplicationRef{
 				Name:    in.Spec.ApplicationRef.Name,
 				Version: in.Spec.ApplicationRef.Version,

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_list_item.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_list_item.go
@@ -21,6 +21,9 @@ type ApplicationInstallationListItem struct {
 	// creation timestamp
 	CreationTimestamp string `json:"creationTimestamp,omitempty"`
 
+	// labels
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_list_item_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_list_item_spec.go
@@ -18,9 +18,6 @@ import (
 // swagger:model ApplicationInstallationListItemSpec
 type ApplicationInstallationListItemSpec struct {
 
-	// Labels can contain metadata about the application, such as the owner who manages it.
-	Labels map[string]string `json:"labels,omitempty"`
-
 	// application ref
 	ApplicationRef *ApplicationRef `json:"applicationRef,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Moves `Labels` in `ApplicationInstallationListItem` to the top level to match with `ApplicationInstallation`.

Pointed out to by @Waseem826 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
