### PR TITLE
Load category tags when new tag with category is added

### DIFF
--- a/modules/web/src/app/node-data/extended/provider/vsphere/tag-categories/component.ts
+++ b/modules/web/src/app/node-data/extended/provider/vsphere/tag-categories/component.ts
@@ -223,6 +223,10 @@ export class VSphereTagsComponent extends BaseFormValidator implements OnInit, O
         tagControl.setValue(null);
         this._loadCategoryTags(selectedCategory);
       });
+
+    if (tag?.categoryID) {
+      this._loadCategoryTags(tag.categoryID);
+    }
   }
 
   private _onControlValueChange(control: AbstractControl): void {
@@ -271,7 +275,7 @@ export class VSphereTagsComponent extends BaseFormValidator implements OnInit, O
     if (categoryTagControls.length) {
       categoryTagControls.forEach(control => {
         const tagControl = control.get(Controls.Tag);
-        if (!tags.find(tag => tag === tagControl.value)) {
+        if (!tags.find(tag => tag.name === tagControl.value)) {
           tagControl.setValue(null);
         }
       });


### PR DESCRIPTION
**What this PR does / why we need it**:
Load category tags when new tag with category is added in Edit Machine Deployment dialog.

![screenshot-localhost_8000-2023 02 02-15_43_00](https://user-images.githubusercontent.com/13975988/216303601-f69d8c11-0ad8-4571-b783-8aa04d98cbe6.png)


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
