### PR TITLE
Use router state to communicate `mode` value to cluster wizard

### DIFF
--- a/modules/web/src/app/cluster-template/component.ts
+++ b/modules/web/src/app/cluster-template/component.ts
@@ -205,7 +205,7 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
 
   create(): void {
     this._router.navigate([`/projects/${this._selectedProject.id}/wizard`], {
-      queryParams: {mode: WizardMode.CreateClusterTemplate},
+      state: {mode: WizardMode.CreateClusterTemplate},
     });
   }
 
@@ -267,7 +267,8 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
 
   editClusterTemplate(template: ClusterTemplate): void {
     this._router.navigate([`/projects/${this._selectedProject.id}/wizard`], {
-      queryParams: {clusterTemplateID: template.id, mode: WizardMode.EditClusterTemplate},
+      queryParams: {clusterTemplateID: template.id},
+      state: {mode: WizardMode.EditClusterTemplate},
     });
   }
 

--- a/modules/web/src/app/core/components/sidenav/component.spec.ts
+++ b/modules/web/src/app/core/components/sidenav/component.spec.ts
@@ -41,7 +41,6 @@ describe('SidenavComponent', () => {
   let component: SidenavComponent;
   let linkDes: DebugElement[];
   let links: RouterLinkStubDirective[];
-  let activatedRoute: ActivatedRouteStub;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -79,10 +78,6 @@ describe('SidenavComponent', () => {
     component = fixture.componentInstance;
     linkDes = fixture.debugElement.queryAll(By.directive(RouterLinkStubDirective));
     links = linkDes.map(de => de.injector.get(RouterLinkStubDirective) as RouterLinkStubDirective);
-    activatedRoute = fixture.debugElement.injector.get(ActivatedRoute) as any;
-    activatedRoute.testParamMap = {
-      clusterTemplateWizard: 'create',
-    };
   });
 
   it('should initialize', waitForAsync(() => {

--- a/modules/web/src/app/core/components/sidenav/component.ts
+++ b/modules/web/src/app/core/components/sidenav/component.ts
@@ -14,7 +14,7 @@
 
 import {Component, HostListener, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
-import {ActivatedRoute, Router} from '@angular/router';
+import {Router} from '@angular/router';
 import {ProjectService} from '@core/services/project';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
@@ -61,7 +61,6 @@ export class SidenavComponent implements OnInit, OnDestroy {
   constructor(
     public dialog: MatDialog,
     private _router: Router,
-    private _activatedRoute: ActivatedRoute,
     private readonly _projectService: ProjectService,
     private readonly _userService: UserService,
     private readonly _settingsService: SettingsService
@@ -114,8 +113,8 @@ export class SidenavComponent implements OnInit, OnDestroy {
     const selectedProjectID = this._selectedProject.id;
     const urlArray = this._router.routerState.snapshot.url.split('/');
     const isProjectAndUrlExists = !!urlArray.find(x => x === selectedProjectID) && !!urlArray.find(x => x === url);
+    const mode = window.history.state?.mode;
     if (url === View.ClusterTemplates) {
-      const mode = this._activatedRoute.snapshot.queryParams?.mode;
       return (
         isProjectAndUrlExists ||
         mode === WizardMode.CreateClusterTemplate ||
@@ -126,7 +125,7 @@ export class SidenavComponent implements OnInit, OnDestroy {
     if (url === View.Clusters) {
       return (
         (isProjectAndUrlExists && !urlArray.find(x => x === View.ExternalClusters || x === View.KubeOneClusters)) ||
-        !!urlArray.find(x => x === View.Wizard)
+        (!!urlArray.find(x => x === View.Wizard) && !mode)
       );
     } else if (url === View.ExternalClusters) {
       return isProjectAndUrlExists || !!urlArray.find(x => x === View.ExternalClusterWizard);

--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -50,7 +50,6 @@ import {ResourceQuotaCalculationPayload, ResourceQuotaCalculation} from '@shared
 import {END_OF_DYNAMIC_KUBELET_CONFIG_SUPPORT_VERSION} from '@shared/entity/cluster';
 import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 import {WizardMode} from '@app/wizard/types/wizard-mode';
-import {ActivatedRoute} from '@angular/router';
 
 enum Controls {
   Name = 'name',
@@ -142,8 +141,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     private readonly _projectService: ProjectService,
     private readonly _quotaCalculationService: QuotaCalculationService,
     private readonly _params: ParamsService,
-    private readonly _cdr: ChangeDetectorRef,
-    private readonly _route: ActivatedRoute
+    private readonly _cdr: ChangeDetectorRef
   ) {
     super();
   }
@@ -170,7 +168,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   }
 
   ngOnInit(): void {
-    this.wizardMode = this._route.snapshot.queryParams?.mode;
+    this.wizardMode = window.history.state?.mode;
     this.projectId = this._params.get(PathParam.ProjectID);
     this.selectedOperatingSystemProfile = this._nodeDataService.nodeData.operatingSystemProfile;
     this.isCusterTemplateEditMode = this._clusterSpecService.clusterTemplateEditMode;

--- a/modules/web/src/app/project-overview/component.ts
+++ b/modules/web/src/app/project-overview/component.ts
@@ -141,12 +141,14 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
 
   isEditEnabled(): boolean {
     return (
+      this.project &&
       MemberUtils.hasPermission(
         this.currentUser,
         this._userService.getCurrentUserGroupConfig(MemberUtils.getGroupInProject(this.currentUser, this.project.id)),
         View.Projects,
         Permission.Edit
-      ) && this.project.status !== ProjectStatus.Terminating
+      ) &&
+      this.project.status !== ProjectStatus.Terminating
     );
   }
 

--- a/modules/web/src/app/project-overview/create-resource-panel/component.ts
+++ b/modules/web/src/app/project-overview/create-resource-panel/component.ts
@@ -24,6 +24,7 @@ import {
   ViewChild,
   TemplateRef,
 } from '@angular/core';
+import {WizardMode} from '@app/wizard/types/wizard-mode';
 import {slideOut} from '@shared/animations/slide';
 import {Router} from '@angular/router';
 import {ClusterTemplate} from '@shared/entity/cluster-template';
@@ -39,7 +40,6 @@ import {
   AddClusterFromTemplateDialogComponent,
   AddClusterFromTemplateDialogData,
 } from '@shared/components/add-cluster-from-template-dialog/component';
-import {AddExternalClusterDialogComponent} from '@shared/components/add-external-cluster-dialog/component';
 import {
   AddAutomaticBackupDialogComponent,
   AddAutomaticBackupDialogConfig,
@@ -134,10 +134,6 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
     this._router.navigate([`/projects/${this.project.id}/external-cluster-wizard`]);
   }
 
-  openKubeOneClusterWizard(): void {
-    this._router.navigate(['/projects', this.project.id, View.KubeOneWizard]);
-  }
-
   createClusterFromTemplate(): void {
     this.close();
     const dialog = this._matDialog.open<AddClusterFromTemplateDialogComponent, AddClusterFromTemplateDialogData>(
@@ -153,19 +149,8 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
       .subscribe(_ => this.refreshClusters.next());
   }
 
-  importExternalCluster(): void {
-    this.close();
-    const dialog = this._matDialog.open(AddExternalClusterDialogComponent);
-    dialog.componentInstance.projectId = this.project.id;
-    dialog
-      .afterClosed()
-      .pipe(filter(confirmed => confirmed))
-      .pipe(take(1))
-      .subscribe(_ => this.refreshExternalClusters.next());
-  }
-
   createClusterTemplate(): void {
-    this._router.navigate([`/projects/${this.project.id}/wizard`]);
+    this._router.navigate([`/projects/${this.project.id}/wizard`], {state: {mode: WizardMode.CreateClusterTemplate}});
   }
 
   createAutomaticBackup(): void {

--- a/modules/web/src/app/shared/components/add-cluster-from-template-dialog/component.ts
+++ b/modules/web/src/app/shared/components/add-cluster-from-template-dialog/component.ts
@@ -123,7 +123,8 @@ export class AddClusterFromTemplateDialogComponent implements OnInit, OnDestroy 
 
     // We chose optional query params instead of creating new route or using state behind the curtain.
     this._router.navigate([`/projects/${this.data.projectId}/wizard`], {
-      queryParams: {clusterTemplateID: this.template.id, mode: WizardMode.CustomizeClusterTemplate},
+      queryParams: {clusterTemplateID: this.template.id},
+      state: {mode: WizardMode.CustomizeClusterTemplate},
     });
   }
 }

--- a/modules/web/src/app/shared/components/side-nav-field/component.ts
+++ b/modules/web/src/app/shared/components/side-nav-field/component.ts
@@ -68,7 +68,9 @@ export class SideNavExpansionMenuComponent implements AfterViewChecked, OnInit {
   isProjectExpandedActive(): boolean {
     switch (this.label) {
       case ProjectSidenavSection.Resources:
-        return this.checkUrl(View.Clusters) || this.checkUrl(View.ExternalClusters);
+        return (
+          this.checkUrl(View.Clusters) || this.checkUrl(View.ExternalClusters) || this.checkUrl(View.KubeOneClusters)
+        );
       case ProjectSidenavSection.Backups:
         return this.checkUrl(View.Backups) || this.checkUrl(View.Snapshots) || this.checkUrl(View.Restores);
       case ProjectSidenavSection.Access:
@@ -112,16 +114,16 @@ export class SideNavExpansionMenuComponent implements AfterViewChecked, OnInit {
   checkUrl(url: string): boolean {
     const urlArray = this._router.routerState.snapshot.url.split('/');
     const urlExists = !!urlArray.find(x => x === url);
+    const mode = window.history.state?.mode;
     if (url === View.Clusters) {
       return (
         (urlExists && !urlArray.find(x => x === View.ExternalClusters || x === View.KubeOneClusters)) ||
-        !!urlArray.find(x => x === View.Wizard)
+        (!!urlArray.find(x => x === View.Wizard) && !mode)
       );
     } else if (url === View.ExternalClusters) {
-      return (
-        urlExists ||
-        !!urlArray.find(x => x === View.ExternalClusterWizard || x === View.KubeOneClusters || x === View.KubeOneWizard)
-      );
+      return urlExists || !!urlArray.find(x => x === View.ExternalClusterWizard);
+    } else if (url === View.KubeOneClusters) {
+      return urlExists || !!urlArray.find(x => x === View.KubeOneWizard);
     }
     return urlExists;
   }

--- a/modules/web/src/app/wizard/component.ts
+++ b/modules/web/src/app/wizard/component.ts
@@ -57,7 +57,6 @@ export class WizardComponent implements OnInit, OnDestroy {
   quotaExceededWarning: boolean;
   private clusterTemplate: ClusterTemplate;
   readonly stepRegistry = StepRegistry;
-  readonly clusterTemplateType = WizardMode;
 
   private _stepper: MatStepper;
   private _unsubscribe: Subject<void> = new Subject<void>();
@@ -123,7 +122,7 @@ export class WizardComponent implements OnInit, OnDestroy {
 
     // Retrieve params
     this.clusterTemplateID = this._route.snapshot.queryParams?.clusterTemplateID;
-    this.wizardMode = this._route.snapshot.queryParams?.mode;
+    this.wizardMode = window.history.state?.mode;
 
     this.project.id = this._route.snapshot.paramMap.get(PathParam.ProjectID);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use router state to communicate `mode` value to cluster wizard. Previously we were using query params for `mode` which is not ideal since that information is not important for end user.


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
