### PR TITLE
hide the quota in edit project dialog for non-admin users

### DIFF
--- a/modules/web/src/app/project/edit-project/component.ts
+++ b/modules/web/src/app/project/edit-project/component.ts
@@ -95,7 +95,7 @@ export class EditProjectComponent implements OnInit {
   onNext(project: Project): void {
     this._matDialogRef.close(project);
 
-    if (this.isEnterpriseEdition) {
+    if (this.isEnterpriseEdition && this.user.isAdmin && this.projectQouta) {
       const quotaVariables = {
         cpu: this.form?.controls?.cpuQuota?.value,
         memory: this.form?.controls?.memoryQuota?.value,

--- a/modules/web/src/app/project/edit-project/template.html
+++ b/modules/web/src/app/project/edit-project/template.html
@@ -38,7 +38,7 @@ limitations under the License.
                      [asyncKeyValidators]=asyncLabelValidators
                      [formControlName]="Controls.Labels"></km-label-form>
 
-      <ng-container *ngIf="isEnterpriseEdition && projectQouta">
+      <ng-container *ngIf="isEnterpriseEdition && projectQouta && user.isAdmin">
         <mat-card-header>
           <mat-card-title>Quota</mat-card-title>
         </mat-card-header>


### PR DESCRIPTION
**What this PR does / why we need it**:
in https://app.zenhub.com/workspaces/work-in-progress---the-a-team-5fa971db111c0d0018ce0008/issues/gh/kubermatic/dashboard/4913
point 4 
we suppose to show the edit quota in the edit project dialog only for admins 
so in this PR we fix this point since the edit quota is an admin feature 
**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
