### PR TITLE
add template reference variable for instance type

### DIFF
--- a/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
+++ b/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/eks/template.html
@@ -104,7 +104,8 @@ limitations under the License.
         </mat-radio-button>
       </mat-radio-group>
 
-      <km-combobox filterBy="name"
+      <km-combobox #instanceTypeCombobox
+                   filterBy="name"
                    hint="Select the instance types for a node group."
                    inputLabel="Select instance type by name"
                    [multiple]="true"


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR fix the error that occur on switching between different architecture types for EKS MD, which prevent the get request for the instance types.

**Add MD in EKD**:
![Screenshot from 2023-02-07 08-19-41](https://user-images.githubusercontent.com/85109141/217155231-cc95b107-a4bd-4bae-8e90-f5ddf8af28ac.png)

**Which issue(s) this PR fixes**:
Fixes #5658

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
