### PR TITLE
Fix KubeVirt Node marshalling error

### DIFF
--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2051,7 +2051,8 @@ type TopologySpreadConstraint struct {
 func (spec *KubevirtNodeSpec) MarshalJSON() ([]byte, error) {
 	missing := make([]string, 0)
 
-	if spec.Instancetype == nil {
+	// keep FlavorName for backward compatibility
+	if spec.Instancetype == nil && spec.FlavorName == "" {
 		if len(spec.CPUs) == 0 {
 			missing = append(missing, "cpus")
 		}

--- a/modules/api/pkg/api/v1/types_test.go
+++ b/modules/api/pkg/api/v1/types_test.go
@@ -646,14 +646,16 @@ func TestKubevirtNodeSpec_MarshalJSON(t *testing.T) {
 			"{\"flavorName\":\"\",\"flavorProfile\":\"\",\"instancetype\":null,\"preference\":null,\"cpus\":\"1\",\"memory\":\"1\",\"primaryDiskOSImage\":\"test-url\",\"primaryDiskStorageClassName\":\"test-sc\",\"primaryDiskSize\":\"1\",\"secondaryDisks\":null,\"podAffinityPreset\":\"\",\"podAntiAffinityPreset\":\"\",\"nodeAffinityPreset\":{\"Type\":\"\",\"Key\":\"\",\"Values\":null},\"topologySpreadConstraints\":null}",
 		},
 		{
-			"case 8: should fail when cpu/memory is provided with vm-flavor",
+			"case 8: should marshal when cpu/memory is provided with vm-flavor",
 			&apiv1.KubevirtNodeSpec{
+				CPUs:                        "1",
+				Memory:                      "1",
 				FlavorName:                  "test-flavor",
 				PrimaryDiskOSImage:          "test-url",
 				PrimaryDiskStorageClassName: "test-sc",
 				PrimaryDiskSize:             "1",
 			},
-			"missing or invalid required parameter(s): cpus, memory",
+			"{\"flavorName\":\"test-flavor\",\"flavorProfile\":\"\",\"instancetype\":null,\"preference\":null,\"cpus\":\"1\",\"memory\":\"1\",\"primaryDiskOSImage\":\"test-url\",\"primaryDiskStorageClassName\":\"test-sc\",\"primaryDiskSize\":\"1\",\"secondaryDisks\":null,\"podAffinityPreset\":\"\",\"podAntiAffinityPreset\":\"\",\"nodeAffinityPreset\":{\"Type\":\"\",\"Key\":\"\",\"Values\":null},\"topologySpreadConstraints\":null}",
 		},
 		{
 			"case 9: should marshal when flavor is provided with affinity",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes marshalling error of KubeVirt node spec after upgrading from 2.21

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes [#11839](https://github.com/kubermatic/kubermatic/issues/11839)

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
