### PR TITLE
Mark KubeVirt node affinity preset key and values as required

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -180,8 +180,8 @@ export class KubeVirtBasicNodeDataComponent
       [Controls.PrimaryDiskStorageClassName]: this._builder.control('', Validators.required),
       [Controls.PrimaryDiskSize]: this._builder.control('10', Validators.required),
       [Controls.NodeAffinityPreset]: this._builder.control(''),
-      [Controls.NodeAffinityPresetKey]: this._builder.control(''),
-      [Controls.NodeAffinityPresetValues]: this._builder.control(''),
+      [Controls.NodeAffinityPresetKey]: this._builder.control('', Validators.required),
+      [Controls.NodeAffinityPresetValues]: this._builder.control('', Validators.required),
       [Controls.TopologySpreadConstraints]: this._builder.control(''),
     });
 

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
@@ -168,6 +168,7 @@ limitations under the License.
                   [tags]="nodeAffinityPresetValues"
                   (onChange)="onNodeAffinityPresetValuesChange($event)"
                   [formControlName]="Controls.NodeAffinityPresetValues"
+                  [kmRequired]="true"
                   [disabled]="form.get(Controls.NodeAffinityPresetValues).disabled"
                   placeholder="Add values..."
                   [kmPattern]="nodeAffinityPresetValuesPattern"


### PR DESCRIPTION
**What this PR does / why we need it**:
Mark KubeVirt node affinity preset key and values as required.

![screenshot-localhost_8000-2023 02 07-14_23_11](https://user-images.githubusercontent.com/13975988/217204620-54bc65be-ad56-4af3-8810-8d193e432a1c.png)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5650 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Mark KubeVirt node affinity preset key and values as required.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
