### PR TITLE
Persist annotations when upgrading a cluster

### DIFF
--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -1067,6 +1067,7 @@ func ConvertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, dat
 		ObjectMeta: apiv1.ObjectMeta{
 			ID:                internalCluster.Name,
 			Name:              internalCluster.Spec.HumanReadableName,
+			Annotations:       internalCluster.Annotations,
 			CreationTimestamp: apiv1.NewTime(internalCluster.CreationTimestamp.Time),
 			DeletionTimestamp: func() *apiv1.Time {
 				if internalCluster.DeletionTimestamp != nil {
@@ -1114,19 +1115,8 @@ func ConvertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, dat
 	if filterSystemLabels {
 		cluster.Labels = label.FilterLabels(label.ClusterResourceType, internalCluster.Labels)
 	}
-	cluster.Annotations = make(map[string]string)
-	if internalCluster.Annotations != nil {
-		// Add preset annotations
-		if value, ok := internalCluster.Annotations[kubermaticv1.PresetNameAnnotation]; ok {
-			cluster.Annotations[kubermaticv1.PresetNameAnnotation] = value
-		}
-		if value, ok := internalCluster.Annotations[kubermaticv1.PresetInvalidatedAnnotation]; ok {
-			cluster.Annotations[kubermaticv1.PresetInvalidatedAnnotation] = value
-		}
-		// Add initial CNI values request annotation
-		if value, ok := internalCluster.Annotations[kubermaticv1.InitialCNIValuesRequestAnnotation]; ok {
-			cluster.Annotations[kubermaticv1.InitialCNIValuesRequestAnnotation] = value
-		}
+	if cluster.Annotations == nil {
+		cluster.Annotations = make(map[string]string)
 	}
 
 	return cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures we persist annotations when converting internal to external cluster. This should ensure that we persist annotations when upgrading a cluster. There are two critical use cases for this:

* Users might apply custom annotations on Cluster objects. For example, additional metadata related to ownership and billing (https://github.com/kubermatic/kubermatic/issues/11832)
* We apply CCM/CSI migration needed annotations which are not persisted. After upgrading Kubernetes version, migrated clusters might start misbehaving (https://github.com/kubermatic/kubermatic/issues/11688)

**Which issue(s) this PR fixes**:
xref https://github.com/kubermatic/kubermatic/issues/11832
xref https://github.com/kubermatic/kubermatic/issues/11688 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Persist annotations when upgrading a cluster
```

**Documentation**:
```documentation
NONE
```

/assign @ahmedwaleedmalik 