### PR TITLE
Reset OS image value if there are no matches in dropdown options

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -559,6 +559,10 @@ export class KubeVirtBasicNodeDataComponent
           link: osVersions[version],
         }))
       : [];
+    const selectedOSImage = this.form.get(Controls.PrimaryDiskOSImage).value[ComboboxControls.Select];
+    if (selectedOSImage && !this.osImageDropdownOptions.find(osImage => osImage.link === selectedOSImage)) {
+      this._osImageCombobox.reset();
+    }
   }
 
   private _setOSImageLabel(): void {


### PR DESCRIPTION
**What this PR does / why we need it**:
Reset OS image value if there are no matches in dropdown options.

![screenshot-localhost_8000-2023 02 07-16_49_27](https://user-images.githubusercontent.com/13975988/217237922-8f829631-d480-4048-abf8-0ced451b1f44.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5671 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
