### PR TITLE
Assign provider value on initialize ProviderSettingsStepComponent

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/quotas/services/quota-calculation.ts
+++ b/modules/web/src/app/dynamic/enterprise/quotas/services/quota-calculation.ts
@@ -55,7 +55,7 @@ export class QuotaCalculationService {
       const request$ = merge(this._refresh$)
         .pipe(debounceTime(this._debounceTime))
         .pipe(startWith(this.quotaPayload))
-        .pipe(filter(() => this.quotaPayload !== null))
+        .pipe(filter(() => !!this.quotaPayload))
         .pipe(switchMap(_ => this.quotaCalculation(projectID, this.quotaPayload)))
         .pipe(shareReplay({refCount: true, bufferSize: 1}));
       this._requestMap.set(mapKey, request$);

--- a/modules/web/src/app/wizard/step/provider-settings/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/component.ts
@@ -61,6 +61,8 @@ export class ProviderSettingsStepComponent extends StepBase implements OnInit, O
   ngOnInit(): void {
     this._init();
 
+    this.provider = this._clusterSpecService.provider;
+
     this._clusterSpecService.providerChanges
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(provider => (this.provider = provider));


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR fix the issue that occur on provider change in the wizard from kubeadm to another provider on settings step the credentials are not displayed 

**Which issue(s) this PR fixes**:
Fixes #5670

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
