### PR TITLE
Mark KubeVirt node affinity preset values as optional

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -189,7 +189,7 @@ export class KubeVirtBasicNodeDataComponent
       [Controls.PrimaryDiskSize]: this._builder.control('10', Validators.required),
       [Controls.NodeAffinityPreset]: this._builder.control(''),
       [Controls.NodeAffinityPresetKey]: this._builder.control('', Validators.required),
-      [Controls.NodeAffinityPresetValues]: this._builder.control('', Validators.required),
+      [Controls.NodeAffinityPresetValues]: this._builder.control(''),
       [Controls.TopologySpreadConstraints]: this._builder.control(''),
     });
 

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
@@ -162,13 +162,15 @@ limitations under the License.
              [formControlName]="Controls.NodeAffinityPresetKey"
              type="text"
              autocomplete="off">
+      <mat-error *ngIf="form.get(Controls.NodeAffinityPresetKey).hasError('required')">
+        <strong>Required</strong>
+      </mat-error>
     </mat-form-field>
 
     <km-chip-list label="Node Affinity Preset Values"
                   [tags]="nodeAffinityPresetValues"
                   (onChange)="onNodeAffinityPresetValuesChange($event)"
                   [formControlName]="Controls.NodeAffinityPresetValues"
-                  [kmRequired]="true"
                   [disabled]="form.get(Controls.NodeAffinityPresetValues).disabled"
                   placeholder="Add values..."
                   [kmPattern]="nodeAffinityPresetValuesPattern"


### PR DESCRIPTION
**What this PR does / why we need it**:
Mark KubeVirt Node Affinity Preset Values as optional. An error message is also added for Node Affinity Preset Key field.

![screenshot-localhost_8000-2023 02 08-18_34_16](https://user-images.githubusercontent.com/13975988/217545123-c0054107-8268-4d2d-8eac-3245f613b915.png)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
