### PR TITLE
Update proxy mode options on initial page load

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -368,6 +368,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
     this._handleClusterSpecChanges();
     this._handleCNIPluginChanges();
+    this._updateAvailableProxyModes();
   }
 
   generateName(): void {


### PR DESCRIPTION
**What this PR does / why we need it**:
When editing/customizing a template, if `Cilium` plugin is selected then Proxy Mode dropdown displays wrong options. This has been fixed by updating proxy mode options on page load.

**Before:**

![screenshot-dev kubermatic io-2023 02 08-19_30_18](https://user-images.githubusercontent.com/13975988/217560605-927a9453-63ff-474c-ab42-5a0dae48445e.png)

**After:**

![screenshot-localhost_8000-2023 02 08-19_30_48](https://user-images.githubusercontent.com/13975988/217560646-c06e4c69-9d1a-4371-b7c4-b214a2d6c53a.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Found this while testing https://github.com/kubermatic/dashboard/issues/5343

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
