### PR TITLE
Hotfix: Populate OSP annotation for cluster templates

### DIFF
--- a/modules/web/src/app/shared/components/save-cluster-template/component.ts
+++ b/modules/web/src/app/shared/components/save-cluster-template/component.ts
@@ -27,6 +27,7 @@ import {SSHKey} from '@shared/entity/ssh-key';
 import _ from 'lodash';
 import {Observable} from 'rxjs';
 import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
+import {OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@app/shared/entity/machine-deployment';
 
 class SaveClusterTemplateDialogData {
   cluster: Cluster;
@@ -53,6 +54,7 @@ export class SaveClusterTemplateDialogComponent implements OnInit {
   control = Control;
   form: FormGroup;
   user: Member;
+  operatingSystemProfileAnnotation = OPERATING_SYSTEM_PROFILE_ANNOTATION;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: SaveClusterTemplateDialogData,
@@ -91,12 +93,20 @@ export class SaveClusterTemplateDialogComponent implements OnInit {
   }
 
   private _getClusterTemplate(): ClusterTemplate {
+    let annotations = null;
+    if (this.data.nodeData.operatingSystemProfile && this.data.cluster.spec.enableOperatingSystemManager) {
+      annotations = {
+        [this.operatingSystemProfileAnnotation]: this.data.nodeData.operatingSystemProfile,
+      };
+    }
+
     return {
       name: this.form.get(Control.Name).value,
       scope: this.form.get(Control.Scope).value,
       cluster: this.data.cluster,
       nodeDeployment: {
         name: this.data.nodeData.name,
+        annotations: annotations,
         spec: {
           template: this.data.nodeData.spec,
           replicas: this.data.nodeData.count,


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
This PR fixes a bug where the annotation to specify operating system profile was not being persisted for Cluster Templates.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
