### PR TITLE
Display creation date in cluster template list view

### DIFF
--- a/modules/web/src/app/cluster-template/component.ts
+++ b/modules/web/src/app/cluster-template/component.ts
@@ -53,7 +53,7 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
   templateDatacenterMap: Map<string, Datacenter> = new Map<string, Datacenter>();
   isInitializing = true;
   currentUser: Member;
-  displayedColumns: string[] = ['name', 'scope', 'provider', 'region', 'actions'];
+  displayedColumns: string[] = ['name', 'scope', 'provider', 'region', 'created', 'actions'];
   dataSource = new MatTableDataSource<any>();
   isGroupConfigLoading: boolean;
   projectViewOnlyToolTip =

--- a/modules/web/src/app/cluster-template/template.html
+++ b/modules/web/src/app/cluster-template/template.html
@@ -82,13 +82,24 @@ limitations under the License.
       <ng-container matColumnDef="region">
         <th mat-header-cell
             *matHeaderCellDef
-            class="km-header-cell p-30">Region
+            class="km-header-cell p-15">Region
         </th>
         <td mat-cell
             *matCellDef="let element">
           <ng-container *ngIf="!!templateDatacenterMap[element.id]">
             {{templateDatacenterMap[element.id].spec.country}} ({{templateDatacenterMap[element.id].spec.location}})
           </ng-container>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="created">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-15">Created
+        </th>
+        <td mat-cell
+            *matCellDef="let element">
+          <km-relative-time [date]="element.creationTimestamp"></km-relative-time>
         </td>
       </ng-container>
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
We need to show the cluster template creation date to stay consistent with our layouts. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
