### PR TITLE
Add periodic "ping to client" to keep the Web Terminal connection alive

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -34315,7 +34315,6 @@
           "x-go-name": "UserProjectsLimit"
         }
       },
-      "x-go-package": "k8c.io/dashboard/v2/pkg/api/v2",
       "$ref": "#/definitions/SettingSpec"
     },
     "GroupProjectBinding": {

--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -34315,6 +34315,7 @@
           "x-go-name": "UserProjectsLimit"
         }
       },
+      "x-go-package": "k8c.io/dashboard/v2/pkg/api/v2",
       "$ref": "#/definitions/SettingSpec"
     },
     "GroupProjectBinding": {

--- a/modules/api/pkg/handler/routes_v1_websocket.go
+++ b/modules/api/pkg/handler/routes_v1_websocket.go
@@ -283,7 +283,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 		userProjectClusterUniqueKey := fmt.Sprintf("%s-%s-%s", projectID, clusterID, authenticatedUser.Email)
 		if connectionsPerUser.getActiveConnections(userProjectClusterUniqueKey) >= maxNumberOfConnections {
 			log.Logger.Debug("reached the maximum number of terminal active connections for the user")
-			wsh.SendMessage(ws, string(wsh.ConnectionPoolExceeded))
+			_ = wsh.SendMessage(ws, string(wsh.ConnectionPoolExceeded))
 			return
 		}
 		connectionsPerUser.increaseActiveConnections(userProjectClusterUniqueKey)
@@ -299,7 +299,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 				return true
 			}
 			log.Logger.Debug(err)
-			wsh.SendMessage(ws, string(wsh.KubeconfigSecretMissing))
+			_ = wsh.SendMessage(ws, string(wsh.KubeconfigSecretMissing))
 			return false
 		}) {
 			return

--- a/modules/api/pkg/handler/websocket/terminal.go
+++ b/modules/api/pkg/handler/websocket/terminal.go
@@ -61,6 +61,8 @@ const (
 	expirationCheckInterval           = 1 * time.Minute // should be lesser than "remainingExpirationTimeForWarning"
 	expirationTimestampKey            = "ExpirationTimestamp"
 	expirationRefreshesKey            = "ExpirationRefreshes"
+	pingInterval                      = 30 * time.Second
+	pingMessage                       = "PING"
 
 	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.3.0"
 	webTerminalContainerKubeconfigPath = "/etc/kubernetes/kubeconfig/kubeconfig"
@@ -189,7 +191,7 @@ func (t TerminalSession) extendExpirationTime(ctx context.Context) error {
 	}
 
 	if currentNumberOfRefreshes >= maxNumberOfExpirationRefreshes {
-		SendMessage(t.websocketConn, string(RefreshesLimitExceeded))
+		_ = SendMessage(t.websocketConn, string(RefreshesLimitExceeded))
 		return nil
 	}
 
@@ -242,6 +244,17 @@ func getWebTerminalExpirationValues(ctx context.Context, clusterClient ctrlrunti
 	}
 
 	return expirationTime, expirationRefreshes, nil
+}
+
+func pingRoutine(websocketConn *websocket.Conn) {
+	for {
+		time.Sleep(pingInterval)
+		// Message to check if connection with client is active.
+		if err := SendMessage(websocketConn, pingMessage); err != nil {
+			// connection is already closed, so just return
+			return
+		}
+	}
 }
 
 func expirationCheckRoutine(ctx context.Context, clusterClient ctrlruntimeclient.Client, userEmailID string, websocketConn *websocket.Conn) {
@@ -322,11 +335,13 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 		default:
 			status = fmt.Sprintf("pod in %s phase", pod.Status.Phase)
 		}
-		SendMessage(websocketConn, status)
+		_ = SendMessage(websocketConn, status)
 		return false
 	}) {
 		return fmt.Errorf("the WEB terminal Pod is not ready")
 	}
+
+	go pingRoutine(websocketConn)
 
 	go expirationCheckRoutine(ctx, client, userEmailID, websocketConn)
 
@@ -726,8 +741,8 @@ func WaitFor(interval time.Duration, timeout time.Duration, callback func() bool
 
 // SendMessage sends TerminalMessage to the client. It usually contains a context related
 // to the status of background tasks responsible for setting up the terminal.
-func SendMessage(wsConn *websocket.Conn, message string) {
-	_ = wsConn.WriteJSON(TerminalMessage{
+func SendMessage(wsConn *websocket.Conn, message string) error {
+	return wsConn.WriteJSON(TerminalMessage{
 		Op:   "msg",
 		Data: message,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a periodic (30s) ping message to the Web Terminal client via the websocket connection to avoid inactivity timeout.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5683

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
