### PR TITLE
Remove dynamic kubelet config setting and set it to always disabled

### DIFF
--- a/modules/web/src/app/node-data/dialog/template.html
+++ b/modules/web/src/app/node-data/dialog/template.html
@@ -26,11 +26,25 @@ limitations under the License.
     </km-node-data>
   </mat-dialog-content>
   <mat-dialog-actions>
-    <div *ngIf="isRecreationWarningVisible"
-         fxFlex
-         fxLayoutAlign="start center">
-      <i class="km-icon-warning"></i>
-      <div>Changed node settings, Nodes will be recreated.</div>
+    <div fxFlex
+         fxLayout="column"
+         fxLayoutAlign="start"
+         fxLayoutGap="10px">
+      <div *ngIf="isRecreationWarningVisible"
+           fxFlex
+           fxLayoutAlign="start center">
+        <i class="km-icon-warning"></i>
+        <div>Changed node settings, Nodes will be recreated.</div>
+      </div>
+      <div *ngIf="isDynamicKubeletConfigWarningVisible"
+           fxFlex
+           fxLayoutAlign="start center">
+        <i class="km-icon-warning"></i>
+        <div>
+          Kubernetes v{{endOfDynamicKubeletConfigSupportVersion}} and higher do not support dynamic kubelet
+          configuration. This setting will be disabled.
+        </div>
+      </div>
     </div>
     <button mat-flat-button
             (click)="onConfirm()"

--- a/modules/web/src/app/node-data/template.html
+++ b/modules/web/src/app/node-data/template.html
@@ -162,13 +162,6 @@ limitations under the License.
                         [formControlName]="Controls.DisableAutoUpdate">Disable auto-update
           </mat-checkbox>
         </div>
-
-        <div class="os-options">
-          <mat-checkbox [id]="Controls.DynamicConfig"
-                        [matTooltip]="isDynamicKubeletConfigSupported? '' : 'Kubernetes version '+endOfDynamicKubeletConfigSupportVersion+' and higher do not support dynamic kubelet configuration.'"
-                        [formControlName]="Controls.DynamicConfig">Dynamic kubelet config
-          </mat-checkbox>
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove dynamic kubelet config setting and set it to always disabled. In Edit MD dialog, if a kubelet version of MD is less than `1.24` and `dynamicConfig` is enabled than a warning message is displayed about disabling this setting.

![screenshot-localhost_8000-2023 02 09-15_25_39](https://user-images.githubusercontent.com/13975988/217788047-5dc0176c-437a-4f50-9ab0-a9c4f7a5adce.png)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove dynamic kubelet config setting and set it to always disabled.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
