### PR TITLE
Fix sorting on provider overview table

### DIFF
--- a/modules/web/src/app/settings/admin/seed-configurations/seed-configurations-details/component.ts
+++ b/modules/web/src/app/settings/admin/seed-configurations/seed-configurations-details/component.ts
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {Subject} from 'rxjs';
 import {finalize, takeUntil} from 'rxjs/operators';
+import {MatSort} from '@angular/material/sort';
 import {SeedOverview} from '@shared/entity/datacenter';
 import {DatacenterService} from '@core/services/datacenter';
 import {MatTableDataSource} from '@angular/material/table';
@@ -59,9 +60,27 @@ export class SeedConfigurationDetailsComponent implements OnInit {
     private readonly _router: Router
   ) {}
 
+  @ViewChild(MatSort, {static: false}) set matSort(ms: MatSort) {
+    if (!ms) {
+      return;
+    }
+    this.dataSource.sortingDataAccessor = (item: ProviderDetail, property: string) => {
+      switch (property) {
+        case Column.Provider:
+          return item.provider;
+        case Column.Datacenters:
+          return item.datacentersCount;
+        case Column.Clusters:
+          return item.clustersCount;
+        default:
+          return item[property];
+      }
+    };
+    this.dataSource.sort = ms;
+  }
+
   ngOnInit(): void {
     this.seedName = this._route.snapshot.params.seedName;
-
     this.isLoadingDetails = true;
     this._datacenterService
       .getSeedOverview(this.seedName)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes sorting on Seed Configuration Overview table to sort data by `Provider, Datacenters, Clusters`


https://user-images.githubusercontent.com/17727069/217809327-8423c09e-5fdb-4c16-b334-0ef72c84aa58.mp4



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #
https://github.com/kubermatic/dashboard/issues/5286#issuecomment-1409350941

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Sorting is applied on overview table where all providers are listed for a particular seed.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
