### PR TITLE
Fix Initial Value for Projects in Create Preset 

### DIFF
--- a/modules/web/src/app/settings/admin/presets/dialog/steps/preset/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/preset/component.ts
@@ -109,8 +109,8 @@ export class PresetStepComponent extends BaseFormValidator implements OnInit {
   private _initForm(): void {
     this.form = this._builder.group({
       [Controls.Name]: this._builder.control('', [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]),
-      [Controls.Domains]: this._builder.control(''),
-      [Controls.Projects]: this._builder.control(''),
+      [Controls.Domains]: this._builder.control([]),
+      [Controls.Projects]: this._builder.control([]),
       [Controls.Disable]: this._builder.control(''),
     });
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix initial value for projects in create preset to be an empty array instead of empty string.

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
