### PR TITLE
Only take single subscription of project quota API request

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/quotas/service.ts
+++ b/modules/web/src/app/dynamic/enterprise/quotas/service.ts
@@ -25,6 +25,7 @@ import {Quota, QuotaDetails, QuotaVariables} from '@shared/entity/quota';
 import {merge, Observable, of, Subject, timer} from 'rxjs';
 import {catchError, map, shareReplay, switchMap, startWith, tap} from 'rxjs/operators';
 import {AppConfigService} from '@app/config.service';
+import _ from 'lodash';
 
 @Injectable({
   providedIn: 'root',
@@ -94,7 +95,7 @@ export class QuotaService {
       this._quotaMap.set(projectId, quota$);
     }
 
-    if (this._previousQuotaMap.has(projectId)) {
+    if (!_.isEmpty(this._previousQuotaMap.get(projectId))) {
       return this._quotaMap.get(projectId).pipe(startWith(this._previousQuotaMap.get(projectId)));
     }
     return this._quotaMap.get(projectId);

--- a/modules/web/src/app/project/template.html
+++ b/modules/web/src/app/project/template.html
@@ -149,7 +149,8 @@ limitations under the License.
                 <td mat-cell
                     *matCellDef="let element"
                     class="km-project-item-quota">
-                  <router-outlet name="quota-widget"
+                  <router-outlet *ngIf="element.status === ProjectStatus.Active"
+                                 name="quota-widget"
                                  (activate)="onActivate($event, element.id, false, 'table')"></router-outlet>
                 </td>
               </ng-container>
@@ -314,7 +315,8 @@ limitations under the License.
 
               <div *ngIf="hasQuota"
                    fxLayoutAlign="start start">
-                <router-outlet name="quota-widget"
+                <router-outlet *ngIf="project.status === ProjectStatus.Active"
+                               name="quota-widget"
                                (activate)="onActivate($event, project.id, true, 'cards')"></router-outlet>
               </div>
             </mat-card-content>


### PR DESCRIPTION
**What this PR does / why we need it**:
Only take single subscription of project quota API request to prevent continuous polling even after a project's deletion. This issue was caused for non-admin users when they delete a project.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
