### PR TITLE
Add unknown status for installed applications

### DIFF
--- a/modules/web/src/app/shared/components/application-list/component.ts
+++ b/modules/web/src/app/shared/components/application-list/component.ts
@@ -312,6 +312,7 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
         this.applicationsMethodMap = {};
         this.applicationsSourceMap = {};
         this.applicationsStatusMap = {};
+        // eslint-disable-next-line complexity
         this.applications.forEach(application => {
           const applicationRef = application.spec.applicationRef;
           const status = application.status;
@@ -348,12 +349,19 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
             }
             if (status.conditions?.length) {
               const failingCondition = status.conditions.find(condition => condition.status === 'False');
+              const unknownCondition = status.conditions.find(condition => condition.status === 'Unknown');
               if (failingCondition) {
                 icon = StatusIcon.Error;
                 const error = failingCondition.message;
                 message = `${error} ${
                   error || !error.endsWith('.') ? '.' : ''
                 } Please check your configuration or contact your KKP Administrator.`;
+              } else if (unknownCondition) {
+                icon = StatusIcon.Warning;
+                const warning = unknownCondition.message;
+                message = `${warning} ${
+                  warning || !warning.endsWith('.') ? '.' : ''
+                } Application is in an unknown state.`;
               } else {
                 icon = StatusIcon.Running;
                 message = 'Ready';


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Display unknown status for installed applications instead of marking them as "ready".

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5714

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
