### PR TITLE
Add image for web-terminal

### DIFF
--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.13
+LABEL maintainer="support@kubermatic.com"
+
+ENV KUBECTL_VERSION=v1.25.6 \
+  HELM_VERSION=v3.10.3
+
+ARG ARCH=amd64
+
+RUN apk add --no-cache -U \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  jq \
+  make \
+  openssh-client \
+  unzip \
+  tar
+
+RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl && \
+  chmod +x /usr/bin/kubectl && \
+  kubectl version --short --client
+
+RUN curl --fail -L https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz | tar -xzO linux-${ARCH}/helm > /usr/local/bin/helm && \
+  chmod +x /usr/local/bin/helm && \
+  helm version --short

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/../../..
+source hack/lib.sh
+
+REPOSITORY=quay.io/kubermatic/web-terminal
+VERSION=0.6.0
+SUFFIX=""
+ARCHITECTURES=${ARCHITECTURES:-amd64 arm64}
+IMAGE="${REPOSITORY}:${VERSION}${SUFFIX}"
+MANIFEST=${MANIFEST:-${IMAGE}}
+
+# build multi-arch images
+buildah manifest create ${MANIFEST}
+for ARCH in ${ARCHITECTURES}; do
+  echodate "Building image for $ARCH..."
+
+  time buildah bud \
+    --tag "${REPOSITORY}-${ARCH}:${VERSION}${SUFFIX}" \
+    --build-arg "ARCH=${ARCH}" \
+    --arch "$ARCH" \
+    --override-arch "$ARCH" \
+    --format=docker \
+    --file hack/images/web-terminal/Dockerfile \
+    .
+  buildah manifest add $MANIFEST "${REPOSITORY}-${ARCH}:${VERSION}${SUFFIX}"
+
+done
+echodate "Successfully built for all architectures."
+
+buildah manifest push --all ${MANIFEST} "docker://${IMAGE}"
+
+echodate "Successfully pushed images for all architectures."

--- a/modules/api/pkg/handler/websocket/terminal.go
+++ b/modules/api/pkg/handler/websocket/terminal.go
@@ -64,7 +64,7 @@ const (
 	pingInterval                      = 30 * time.Second
 	pingMessage                       = "PING"
 
-	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.5.0"
+	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.6.0"
 	webTerminalContainerKubeconfigPath = "/etc/kubernetes/kubeconfig/kubeconfig"
 )
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Add mult-arch support for web-terminal image and move it from https://github.com/kubermatic/kubermatic to dashboard. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/11876 , https://github.com/kubermatic/kubermatic/issues/11884

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
