### PR TITLE
Keep WS connection alive by exchange of messages

### DIFF
--- a/modules/web/src/app/shared/components/terminal/component.ts
+++ b/modules/web/src/app/shared/components/terminal/component.ts
@@ -63,6 +63,7 @@ enum ErrorOperations {
   WebTerminalPodPending = 'WEBTERMINAL_POD_PENDING',
   ConnectionPoolExceeded = 'CONNECTION_POOL_EXCEEDED',
   RefreshesLimitExceeded = 'REFRESHES_LIMIT_EXCEEDED',
+  Ping = 'PING',
 }
 
 @Component({
@@ -196,8 +197,8 @@ export class TerminalComponent implements OnChanges, OnInit, OnDestroy, AfterVie
     this.terminal.open(containerElement);
 
     const clusterName = this.cluster && this.cluster.name;
-    this.terminal.write('\x1b[37mWelcome to Web Terminal! Type "help" to get started.\r\n');
-    this.terminal.write(`\x1b[37mYour KKP cluster in this session is set to \x1b[1;34m${clusterName}\x1B[0m\n\n\r`);
+    this._logToTerminal('\x1b[37mWelcome to Web Terminal! Type "help" to get started.\r\n');
+    this._logToTerminal(`\x1b[37mYour KKP cluster in this session is set to \x1b[1;34m${clusterName}\x1B[0m\n\n\r`);
 
     const delayFn = debounce(() => {
       fitAddon.fit();
@@ -262,7 +263,7 @@ export class TerminalComponent implements OnChanges, OnInit, OnDestroy, AfterVie
       // Initialize terminal on WS connection success.
       this._initializeTerminalOnSuccess.next(true);
       this._initializeTerminalOnSuccess.complete();
-      this.terminal.write(frame.Data);
+      this._logToTerminal(frame.Data);
     } else if (frame.Op === Operations.Msg) {
       if (frame.Data === ErrorOperations.KubeConfigSecretMissing) {
         if (!this.isDexAuthenticationPageOpened) {
@@ -270,22 +271,39 @@ export class TerminalComponent implements OnChanges, OnInit, OnDestroy, AfterVie
           window.open(url, '_blank');
           this.isDexAuthenticationPageOpened = true;
         }
-
         this.message = 'Please wait, authenticate in order to access web terminal...';
       } else if (frame.Data === ErrorOperations.WebTerminalPodPending) {
         this.message = 'Please wait, provisioning your Web Terminal pod...';
       } else if (frame.Data === ErrorOperations.ConnectionPoolExceeded) {
-        this.terminal.write(
-          `Oops! There could be ${this.MAX_SESSION_SUPPORTED} concurrent session per user. Please either discard or close other sessions.`
-        );
+        const message = `Oops! There could be ${this.MAX_SESSION_SUPPORTED} concurrent session per user. Please either discard or close other sessions`;
+        if (this.terminal) {
+          this._logToTerminal(message);
+        } else {
+          this.message = message;
+        }
       } else if (frame.Data === ErrorOperations.RefreshesLimitExceeded) {
         const clusterName = this.cluster && this.cluster.name;
-        this.terminal.write(
+        this._logToTerminal(
           `Oops! Max limit of ${this.MAX_EXPIRATION_REFRESHES} refreshes is reached. You are not allowed to extend the session for \x1b[1;34m${clusterName}\x1B[0m\n\n\r`
         );
+      } else if (frame.Data === ErrorOperations.Ping) {
+        if (this.terminal) {
+          // Note: Periodic exchange of messages with server to keep the web Terminal connection alive
+          this._onTerminalSendString('PONG');
+        }
       }
     } else if (frame.Op === Operations.Expiration) {
       this.isSessionExpiring = true;
+    }
+  }
+
+  private _logToTerminal(message: string): void {
+    if (this.terminal) {
+      const pongRegex = /pong/i;
+      const containsPong = pongRegex.test(message);
+      if (!containsPong) {
+        this.terminal.write(message);
+      }
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR keeps WS connection alive by exchange of messages from `be->fe ping` and `fe->be pong` to let backend . In order to avoid session get timeout.

![c7a34fb0526c5a24006bcd51f402ebc9](https://user-images.githubusercontent.com/17727069/218712280-6d3ee711-ca7b-4a15-a704-3ac9be22e056.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #
Handle changes for
[PR#5696](https://github.com/kubermatic/dashboard/pull/5696)
[PR#5727](https://github.com/kubermatic/dashboard/pull/5727)

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

Previously WS connection was lost due to middleware proxy layer could be nginx or any reverse proxy so in order to let client/server that communication is still alive we need to keep web-terminal connection to alive

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
