### PR TITLE
cherrypick hide external cluster from project overview

### DIFF
--- a/src/app/project-overview/create-resource-panel/component.ts
+++ b/src/app/project-overview/create-resource-panel/component.ts
@@ -33,6 +33,7 @@ import {
   AddAutomaticBackupDialogConfig,
 } from '@app/backup/list/automatic-backup/add-dialog/component';
 import {AddSnapshotDialogComponent, AddSnapshotDialogConfig} from '@app/backup/list/snapshot/add-dialog/component';
+import {SettingsService} from '@app/core/services/settings';
 
 @Component({
   selector: 'km-create-resource-panel',
@@ -47,6 +48,7 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
   @Output() refreshClusterTemplates = new EventEmitter<void>();
   @Output() refreshBackups = new EventEmitter<void>();
 
+  areExternalClustersEnabled = false;
   projectViewOnlyToolTip =
     'You do not have permission to perform this action. Contact the project owner to change your membership role';
 
@@ -59,7 +61,8 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
     private readonly _elementRef: ElementRef,
     private readonly _router: Router,
     private readonly _matDialog: MatDialog,
-    private readonly _userService: UserService
+    private readonly _userService: UserService,
+    private readonly _settingsService: SettingsService
   ) {}
 
   ngOnInit(): void {
@@ -69,6 +72,10 @@ export class CreateResourcePanelComponent implements OnInit, OnDestroy {
       .getCurrentUserGroup(this.project.id)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(userGroup => (this._currentGroupConfig = this._userService.getCurrentUserGroupConfig(userGroup)));
+
+    this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
+      this.areExternalClustersEnabled = settings.enableExternalClusterImport;
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/project-overview/create-resource-panel/template.html
+++ b/src/app/project-overview/create-resource-panel/template.html
@@ -35,7 +35,8 @@ limitations under the License.
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Create Cluster</span>
     </div>
-    <div class="entry"
+    <div *ngIf="areExternalClustersEnabled"
+         class="entry"
          [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"
          fxLayoutAlign=" center"
          fxLayoutGap="14px"
@@ -48,7 +49,8 @@ limitations under the License.
          [ngClass]="{'km-muted-bg': !canCreateCluster}"></i>
       <span>Import External Cluster</span>
     </div>
-    <div class="entry"
+    <div *ngIf="areExternalClustersEnabled"
+         class="entry"
          [ngClass]="{'km-text-muted': !canCreateCluster, 'km-hover-bg km-pointer': canCreateCluster}"
          fxLayoutAlign=" center"
          fxLayoutGap="14px"


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherrypick of #5572 
also hide the import external cluster
**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
