### PR TITLE
Fix IP ranges pattern error message + labels

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -107,14 +107,14 @@ limitations under the License.
 
       <km-chip-list *ngIf="isExposeStrategyLoadBalancer()"
                     class="tag-list"
-                    label="Allowed IP Range for API server"
-                    placeholder="IPs..."
+                    label="Allowed IP Ranges for API server"
+                    placeholder="IP CIDRs..."
                     description="Use commas, space or enter key as the separators."
                     (onChange)="onAPIServerAllowIPRangeChange($event)"
                     [tags]="apiServerAllowedIPRanges"
                     [formControlName]="Controls.APIServerAllowedIPRanges"
                     [kmPattern]="ipv4AndIPv6CidrRegex"
-                    kmPatternError="Input has to be a valid IPv4 or IPv6 address">
+                    kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">
       </km-chip-list>
 
       <mat-checkbox [formControlName]="Controls.Konnectivity"

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -243,7 +243,7 @@ limitations under the License.
               </km-property>
 
               <km-property *ngIf="cluster.spec.apiServerAllowedIPRanges?.cidrBlocks?.length">
-                <div key>Allowed IP Range for API server</div>
+                <div key>Allowed IP Ranges for API server</div>
                 <div value>
                   <km-labels [labels]="cluster.spec.apiServerAllowedIPRanges.cidrBlocks"></km-labels>
                 </div>

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -107,7 +107,7 @@ limitations under the License.
             </km-property>
 
             <km-property *ngIf="cluster.spec?.apiServerAllowedIPRanges?.cidrBlocks?.length">
-              <div key>Allowed IP Range for API server</div>
+              <div key>Allowed IP Ranges for API server</div>
               <div value>
                 <km-labels [labels]="cluster.spec.apiServerAllowedIPRanges.cidrBlocks"></km-labels>
               </div>

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -138,12 +138,12 @@ limitations under the License.
           </mat-form-field>
           <km-chip-list *ngIf="isExposeStrategyLoadBalancer()"
                         class="tag-list"
-                        label="Allowed IP Range for API server"
-                        placeholder="IPs..."
+                        label="Allowed IP Ranges for API server"
+                        placeholder="IP CIDRs..."
                         description="Use commas, space or enter key as the separators."
                         [formControlName]="Controls.APIServerAllowedIPRanges"
                         [kmPattern]="ipv4AndIPv6CidrRegex"
-                        kmPatternError="Input has to be a valid IPv4 or IPv6 address">
+                        kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">
           </km-chip-list>
           <div fxLayout="row"
                fxLayoutGap="50px"


### PR DESCRIPTION
**What this PR does / why we need it**:

Single IP address cannot be configured in the "Allowed IP Ranges for apiserver". It is correctly guarded by a pattern, but the error message "Input has to be a valid IPv4 or IPv6 address" is wrong - it fact it cannot be an IP address, but must be an IP address CIDR:

![image](https://user-images.githubusercontent.com/15926980/218787005-973f2c67-d72b-432a-af89-24959397c7ba.png)

This PR fixes it + makes "IP Range" plural "IP Ranges"

**Which issue(s) this PR fixes**:

<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
