### PR TITLE
5728 cluster patch skip skew validation

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -10449,6 +10449,12 @@
             "schema": {
               "type": "object"
             }
+          },
+          {
+            "type": "boolean",
+            "x-go-name": "SkipKubeletVersionValidation",
+            "name": "skip_kubelet_version_validation",
+            "in": "query"
           }
         ],
         "responses": {

--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -462,6 +462,7 @@ func PatchEndpoint(
 	caBundle *x509.CertPool,
 	configGetter provider.KubermaticConfigurationGetter,
 	features features.FeatureGate,
+	skipKubeletVersionValidation bool,
 ) (interface{}, error) {
 	clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 	privilegedClusterProvider := ctx.Value(middleware.PrivilegedClusterProviderContextKey).(provider.PrivilegedClusterProvider)
@@ -547,12 +548,17 @@ func PatchEndpoint(
 	newInternalCluster.Spec.KubernetesDashboard = patchedCluster.Spec.KubernetesDashboard
 	newInternalCluster.Spec.APIServerAllowedIPRanges = patchedCluster.Spec.APIServerAllowedIPRanges
 
-	incompatibleKubelets, err := common.CheckClusterVersionSkew(ctx, userInfoGetter, clusterProvider, newInternalCluster, projectID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check existing nodes' version skew: %w", err)
-	}
-	if len(incompatibleKubelets) > 0 {
-		return nil, utilerrors.NewBadRequest("Cluster contains nodes running the following incompatible kubelet versions: %v. Upgrade your nodes before you upgrade the cluster.", incompatibleKubelets)
+	// Checking kubelet versions on user cluster machines requires network connection between kubermatic-api and user cluster api-server.
+	// In case where the connction is blocked, we still want to be able to send a patch request. This can be achieved with an additional
+	// query param attached to the patch request - "?skip_cluster_version_skew_check=true"
+	if !skipKubeletVersionValidation {
+		incompatibleKubelets, err := common.CheckClusterVersionSkew(ctx, userInfoGetter, clusterProvider, newInternalCluster, projectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check existing nodes' version skew: %w", err)
+		}
+		if len(incompatibleKubelets) > 0 {
+			return nil, utilerrors.NewBadRequest("Cluster contains nodes running the following incompatible kubelet versions: %v. Upgrade your nodes before you upgrade the cluster.", incompatibleKubelets)
+		}
 	}
 
 	// find the defaulting template

--- a/modules/api/pkg/handler/v1/cluster/cluster.go
+++ b/modules/api/pkg/handler/v1/cluster/cluster.go
@@ -84,7 +84,7 @@ func PatchEndpoint(projectProvider provider.ProjectProvider, privilegedProjectPr
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(PatchReq)
 		return handlercommon.PatchEndpoint(ctx, userInfoGetter, req.ProjectID, req.ClusterID, req.Patch, seedsGetter,
-			projectProvider, privilegedProjectProvider, caBundle, configGetter, features)
+			projectProvider, privilegedProjectProvider, caBundle, configGetter, features, false)
 	}
 }
 

--- a/modules/api/pkg/test/e2e/utils/apiclient/client/project/patch_cluster_v2_parameters.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/client/project/patch_cluster_v2_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewPatchClusterV2Params creates a new PatchClusterV2Params object,
@@ -69,6 +70,9 @@ type PatchClusterV2Params struct {
 
 	// ProjectID.
 	ProjectID string
+
+	// SkipKubeletVersionValidation.
+	SkipKubeletVersionValidation *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -156,6 +160,17 @@ func (o *PatchClusterV2Params) SetProjectID(projectID string) {
 	o.ProjectID = projectID
 }
 
+// WithSkipKubeletVersionValidation adds the skipKubeletVersionValidation to the patch cluster v2 params
+func (o *PatchClusterV2Params) WithSkipKubeletVersionValidation(skipKubeletVersionValidation *bool) *PatchClusterV2Params {
+	o.SetSkipKubeletVersionValidation(skipKubeletVersionValidation)
+	return o
+}
+
+// SetSkipKubeletVersionValidation adds the skipKubeletVersionValidation to the patch cluster v2 params
+func (o *PatchClusterV2Params) SetSkipKubeletVersionValidation(skipKubeletVersionValidation *bool) {
+	o.SkipKubeletVersionValidation = skipKubeletVersionValidation
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PatchClusterV2Params) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -177,6 +192,23 @@ func (o *PatchClusterV2Params) WriteToRequest(r runtime.ClientRequest, reg strfm
 	// path param project_id
 	if err := r.SetPathParam("project_id", o.ProjectID); err != nil {
 		return err
+	}
+
+	if o.SkipKubeletVersionValidation != nil {
+
+		// query param skip_kubelet_version_validation
+		var qrSkipKubeletVersionValidation bool
+
+		if o.SkipKubeletVersionValidation != nil {
+			qrSkipKubeletVersionValidation = *o.SkipKubeletVersionValidation
+		}
+		qSkipKubeletVersionValidation := swag.FormatBool(qrSkipKubeletVersionValidation)
+		if qSkipKubeletVersionValidation != "" {
+
+			if err := r.SetQueryParam("skip_kubelet_version_validation", qSkipKubeletVersionValidation); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -353,7 +353,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       patch.spec.apiServerAllowedIPRanges = this.getAPIServerAllowedIPRange();
     }
 
-    return this._clusterService.patch(this.projectID, this.cluster.id, patch).pipe(take(1));
+    return this._clusterService.patch(this.projectID, this.cluster.id, patch, true).pipe(take(1));
   }
 
   onNext(cluster: Cluster): void {

--- a/modules/web/src/app/core/services/cluster.ts
+++ b/modules/web/src/app/core/services/cluster.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {HttpClient, HttpHeaders} from '@angular/common/http';
+import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
 import {Injectable} from '@angular/core';
 import {AppConfigService} from '@app/config.service';
 
@@ -50,6 +50,7 @@ export class ClusterService {
   private _restRoot: string = environment.restRoot;
   private _newRestRoot: string = environment.newRestRoot;
   private _headers: HttpHeaders = new HttpHeaders();
+  private _params: HttpParams = new HttpParams();
   private _clusters$ = new Map<string, Observable<Cluster[]>>();
   private _externalClusters$ = new Map<string, Observable<ExternalCluster[]>>();
   private _cluster$ = new Map<string, Observable<Cluster>>();
@@ -137,9 +138,12 @@ export class ClusterService {
     return this._http.post<Cluster>(url, createClusterModel);
   }
 
-  patch(projectID: string, clusterID: string, patch: ClusterPatch): Observable<Cluster> {
+  patch(projectID: string, clusterID: string, patch: ClusterPatch, skipKubeletValidation: boolean = false): Observable<Cluster> {
     const url = `${this._newRestRoot}/projects/${projectID}/clusters/${clusterID}`;
-    return this._http.patch<Cluster>(url, patch);
+    if (skipKubeletValidation) {
+      this._params = this._params.set("skip_kubelet_version_validation", skipKubeletValidation);
+    }
+    return this._http.patch<Cluster>(url, patch, {params: this._params});
   }
 
   patchExternalCluster(projectID: string, clusterID: string, patch: ExternalClusterPatch): Observable<ExternalCluster> {


### PR DESCRIPTION
**What this PR does / why we need it**:
Checking kubelet versions on user cluster machines requires network connection between kubermatic-api and user cluster api-server. In case where the connection is blocked, we still want to be able to send a patch request. This can be achieved with an additional query param attached to the patch request - "?skip_cluster_version_skew_check=true"

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5728 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design
Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `skip_cluster_version_skew_check` query param to `api/v2/projects/<project>/clusters/<cluster>` PATCH to enable switching off kubelet version validation.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
