### PR TITLE
Update conditions to disable download KubeOne kubeconfig button

### DIFF
--- a/modules/web/src/app/cluster/details/kubeone/component.ts
+++ b/modules/web/src/app/cluster/details/kubeone/component.ts
@@ -136,6 +136,22 @@ export class KubeOneClusterDetailsComponent implements OnInit, OnDestroy {
     return this.cluster?.status?.state === ExternalClusterState.Running;
   }
 
+  enableDownloadKubeconfigButton(): boolean {
+    const clusterState = this.cluster?.status.state;
+    if (!clusterState) {
+      return false;
+    }
+    switch (clusterState) {
+      case ExternalClusterState.Deleting:
+      case ExternalClusterState.Error:
+      case ExternalClusterState.Provisioning:
+      case ExternalClusterState.Unknown:
+        return false;
+      default:
+        return true;
+    }
+  }
+
   downloadKubeconfig(): void {
     window.open(this._clusterService.getExternalKubeconfigURL(this.projectID, this.cluster.id), '_blank');
   }

--- a/modules/web/src/app/cluster/details/kubeone/template.html
+++ b/modules/web/src/app/cluster/details/kubeone/template.html
@@ -46,6 +46,7 @@ limitations under the License.
               fxLayoutAlign="center center"
               mat-flat-button
               type="button"
+              [disabled]="!enableDownloadKubeconfigButton()"
               kmThrottleClick
               (throttleClick)="downloadKubeconfig()">
         <i class="km-icon-mask km-icon-download"></i>


### PR DESCRIPTION
**What this PR does / why we need it**:
Update conditions to disable `Get Kubeconfig` button of KubeOne cluster.

<img width="1545" alt="Screenshot 2023-02-15 at 3 23 05 PM" src="https://user-images.githubusercontent.com/13975988/219001373-15f40162-8f5a-4a4b-bd7a-31a2c270728f.png">

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
