### PR TITLE
Display documentation link under Allowed IP Ranges field

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/style.scss
@@ -58,5 +58,6 @@ mat-button-toggle-group[group='auditLogging'] {
 }
 
 .tag-list {
-  padding-bottom: 6px;
+  display: block;
+  padding-bottom: 25px;
 }

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -109,12 +109,18 @@ limitations under the License.
                     class="tag-list"
                     label="Allowed IP Ranges for API server"
                     placeholder="IP CIDRs..."
-                    description="Use commas, space or enter key as the separators."
+                    description=""
                     (onChange)="onAPIServerAllowIPRangeChange($event)"
                     [tags]="apiServerAllowedIPRanges"
                     [formControlName]="Controls.APIServerAllowedIPRanges"
                     [kmPattern]="ipv4AndIPv6CidrRegex"
                     kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">
+        <ng-container hint>
+          Use commas, space or enter key as the separators. This feature is dependent on cloud provider capabilities.
+          Check the documentation for more information&nbsp;<a target="_blank"
+                                                               rel="noopener"
+                                                               href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/apiserver-policies/#api-server-allowed-source-ip-ranges">here</a>.
+        </ng-container>
       </km-chip-list>
 
       <mat-checkbox [formControlName]="Controls.Konnectivity"

--- a/modules/web/src/app/shared/components/chip-list/template.html
+++ b/modules/web/src/app/shared/components/chip-list/template.html
@@ -37,7 +37,12 @@ limitations under the License.
              [matChipInputAddOnBlur]="true"
              (matChipInputTokenEnd)="addTag($event)">
     </mat-chip-list>
-    <mat-hint>{{description}}</mat-hint>
+    <mat-hint *ngIf="!description; else defaultHint">
+      <ng-content select="[hint]"></ng-content>
+    </mat-hint>
+    <ng-template #defaultHint>
+      <mat-hint>{{description}}</mat-hint>
+    </ng-template>
     <mat-error *ngIf="form.get(controls.Tags).hasError('unique')">
       Value already exists.
     </mat-error>

--- a/modules/web/src/app/wizard/step/cluster/style.scss
+++ b/modules/web/src/app/wizard/step/cluster/style.scss
@@ -87,5 +87,6 @@ mat-button-toggle-group[group='cniPluginTypeGroup'] {
 }
 
 .tag-list {
-  padding-bottom: 6px;
+  display: block;
+  padding-bottom: 25px;
 }

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -140,10 +140,16 @@ limitations under the License.
                         class="tag-list"
                         label="Allowed IP Ranges for API server"
                         placeholder="IP CIDRs..."
-                        description="Use commas, space or enter key as the separators."
+                        description=""
                         [formControlName]="Controls.APIServerAllowedIPRanges"
                         [kmPattern]="ipv4AndIPv6CidrRegex"
                         kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">
+            <ng-container hint>
+              Use commas, space or enter key as the separators. This feature is dependent on cloud provider capabilities.
+              Check the documentation for more information&nbsp;<a target="_blank"
+                 rel="noopener"
+                 href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/apiserver-policies/#api-server-allowed-source-ip-ranges">here</a>.
+            </ng-container>
           </km-chip-list>
           <div fxLayout="row"
                fxLayoutGap="50px"


### PR DESCRIPTION
**What this PR does / why we need it**:
Display documentation link under `Allowed IP Ranges for API server` field.

**Cluster Wizard:**

![screenshot-localhost_8000-2023 02 15-16_12_16](https://user-images.githubusercontent.com/13975988/219014927-595a17ba-9457-4218-8ed4-de0e4b514f8b.png)

**Edit Cluster Dialog:**

![screenshot-localhost_8000-2023 02 15-16_22_27](https://user-images.githubusercontent.com/13975988/219014980-211b6b38-fed6-4630-9226-b497f7e0b985.png)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
