### PR TITLE
Fix fetching of resources base on preset or manually entering credentials

### DIFF
--- a/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -295,6 +295,10 @@ export class AKSClusterSettingsComponent
           });
         });
     } else {
+      this._getAKSKubernetesVersions();
+      this._getAKSLocations();
+      this._getAKSResourceGroups();
+
       this.control(Controls.Location)
         .valueChanges.pipe(debounceTime(this._debounceTime))
         .pipe(tap(_ => this._clearVmSize()))

--- a/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
+++ b/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/component.ts
@@ -40,7 +40,7 @@ import {
 import {GKECloudSpec, GKEClusterSpec, GKEZone, GKENodeConfig} from '@app/shared/entity/provider/gke';
 import {ExternalClusterService} from '@core/services/external-cluster';
 import {merge} from 'rxjs';
-import {debounceTime, takeUntil, tap} from 'rxjs/operators';
+import {debounceTime, filter, takeUntil, tap} from 'rxjs/operators';
 import {GKE_POOL_NAME_VALIDATOR} from '@app/shared/validators/others';
 import {NodeDataService} from '@app/core/services/node-data/service';
 import {ExternalMachineDeploymentService} from '@app/core/services/external-machine-deployment';
@@ -298,6 +298,15 @@ export class GKEClusterSettingsComponent
             this._getGKEDiskTypes(zoneValue);
             this._getGKEMachineTypes(zoneValue);
           }
+        });
+
+      this._externalClusterService.presetChanges
+        .pipe(
+          filter(preset => !!preset),
+          takeUntil(this._unsubscribe)
+        )
+        .subscribe(_ => {
+          this._getGKEZones();
         });
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fetches resources required in Settings step of external clusters to in order to populate dropdown values
currently, it was not fetching when user manually entered credentials.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5740 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
