### PR TITLE
Consider AKS cluster with warning state as a running cluster.

### DIFF
--- a/modules/web/src/app/cluster/details/external-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/external-cluster/component.ts
@@ -104,7 +104,7 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
         }),
         switchMap(_ =>
           forkJoin([
-            this.hasUpgrades() ? this._clusterService.externalClusterUpgrades(this.projectID, clusterID) : of([]),
+            this.isRunning() ? this._clusterService.externalClusterUpgrades(this.projectID, clusterID) : of([]),
             this.isRunning() ? this._clusterService.externalClusterNodes(this.projectID, clusterID) : of([]),
             this.isRunning() ? this._clusterService.externalMachineDeployments(this.projectID, clusterID) : of([]),
           ])
@@ -148,7 +148,10 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
   }
 
   isRunning(): boolean {
-    return this.cluster?.status?.state === ExternalClusterState.Running;
+    return (
+      this.cluster?.status?.state === ExternalClusterState.Running ||
+      this.cluster?.status?.state === ExternalClusterState.Warning
+    );
   }
 
   isKubeConfigButtonDisabled(): boolean {
@@ -169,10 +172,6 @@ export class ExternalClusterDetailsComponent implements OnInit, OnDestroy {
 
   downloadKubeconfig(): void {
     window.open(this._clusterService.getExternalKubeconfigURL(this.projectID, this.cluster.id), '_blank');
-  }
-
-  hasUpgrades(): boolean {
-    return this.isRunning();
   }
 
   getStatus(): string {

--- a/modules/web/src/app/cluster/details/external-cluster/external-machine-deployment-list/component.ts
+++ b/modules/web/src/app/cluster/details/external-cluster/external-machine-deployment-list/component.ts
@@ -17,7 +17,7 @@ import {MatPaginator} from '@angular/material/paginator';
 import {MatTableDataSource} from '@angular/material/table';
 import {Router} from '@angular/router';
 import {UserService} from '@core/services/user';
-import {ExternalCluster, ExternalClusterState} from '@shared/entity/external-cluster';
+import {ExternalCluster} from '@shared/entity/external-cluster';
 import {getOperatingSystem} from '@shared/entity/node';
 import _ from 'lodash';
 import {Subject} from 'rxjs';
@@ -103,17 +103,6 @@ export class ExternalMachineDeploymentListComponent implements OnInit, OnChanges
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
-  }
-
-  isAddMachineDeploymentDisabled(): boolean {
-    switch (this.cluster?.status?.state) {
-      case ExternalClusterState.Running:
-      case ExternalClusterState.Warning:
-        return false;
-
-      default:
-        return true;
-    }
   }
 
   getHealthStatus(md: ExternalMachineDeployment): HealthStatus {

--- a/modules/web/src/app/cluster/details/external-cluster/external-machine-deployment-list/template.html
+++ b/modules/web/src/app/cluster/details/external-cluster/external-machine-deployment-list/template.html
@@ -20,7 +20,7 @@ limitations under the License.
             mat-flat-button
             fxLayoutAlign="center center"
             type="button"
-            [disabled]="isAddMachineDeploymentDisabled()"
+            [disabled]="!isClusterRunning"
             (click)="addExternalMachineDeployment()">
       <i class="km-icon-mask km-icon-add"></i>
       <span>Add Machine Deployment</span>

--- a/modules/web/src/app/cluster/details/external-cluster/template.html
+++ b/modules/web/src/app/cluster/details/external-cluster/template.html
@@ -85,7 +85,7 @@ limitations under the License.
         <km-version-picker [cluster]="cluster"
                            [isClusterRunning]="isRunning()"
                            [upgrades]="canEdit() ? upgrades : []"
-                           [hasUpgradeOptions]="hasUpgrades()"
+                           [hasUpgradeOptions]="isRunning()"
                            [isClusterExternal]="true"
                            *ngIf="cluster?.spec?.version"></km-version-picker>
         <km-property>


### PR DESCRIPTION
**What this PR does / why we need it**:
in AKS clusters with warning state the MD list is not shown and a loading spin is displayed while in the warning state we should consider the cluster as running cluster and show the MD list 


**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
