### PR TITLE
Disable deletion for default project quotas

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -118,8 +118,8 @@ limitations under the License.
         <ng-container hint>
           Use commas, space or enter key as the separators. This feature is dependent on cloud provider capabilities.
           Check the documentation for more information&nbsp;<a target="_blank"
-                                                               rel="noopener"
-                                                               href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/apiserver-policies/#api-server-allowed-source-ip-ranges">here</a>.
+             rel="noopener"
+             href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/apiserver-policies/#api-server-allowed-source-ip-ranges">here</a>.
         </ng-container>
       </km-chip-list>
 

--- a/modules/web/src/app/dynamic/enterprise/quotas/template.html
+++ b/modules/web/src/app/dynamic/enterprise/quotas/template.html
@@ -147,6 +147,7 @@ END OF TERMS AND CONDITIONS
         <td mat-cell
             *matCellDef="let element">
           <div class="km-table-actions"
+               [matTooltip]="element.isDefault ? 'Removing this Quota is not allowed since project has been assigned the default project quota. This can be overridden by updating the quota values for this project or by removing the default(global) project quota.' : null"
                fxLayoutAlign="end">
             <button mat-icon-button
                     (click)="editQuota(element)">
@@ -154,6 +155,7 @@ END OF TERMS AND CONDITIONS
             </button>
 
             <button mat-icon-button
+                    [disabled]="element.isDefault"
                     (click)="deleteQuota(element)"
                     [attr.id]="'km-quota-delete-btn-' + element.name">
               <i class="km-icon-mask km-icon-delete"></i>


### PR DESCRIPTION
**What this PR does / why we need it**:
User should not be permitted to delete the default resource quotas for a particular project. This leads to inconsistency since the controller will try to recreate these resources anyways.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
