### PR TITLE
Fix method to deduce the KKP git hash

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -378,7 +378,7 @@ kubermatic_git_hash() {
 
   # in most cases this gives us something like "v2.21.1-0.20221111113237-e6c193aeffb0",
   # but this can also be a tagged release
-  selector="$(go list -json -m k8c.io/kubermatic/v2 | jq -r '.Version')"
+  selector="$(go list -json -m k8c.io/kubermatic/v2 | jq -r '.Replace.Version // .Version')"
 
   # parse Go's pseudo version and extract git hash if possible
   if ! [[ "$selector" =~ ^v.+-.+-([a-f0-9]+)$ ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the way we calculate the git hash for KKP in CI. In most cases, we'd like to add a replacement for `k8c.io/kubermatic/v2` dependency so that we can pin it to a specific version. This PR would check if replacement is there and use it, if not, it would default to the original version.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
