### PR TITLE
Update k8c.io/kubermatic/v2 dependency to latest

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -65,7 +65,7 @@ require (
 	google.golang.org/api v0.105.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8c.io/kubeone v1.5.4
+	k8c.io/kubeone v1.6.0-rc.1.0.20230223102440-e8f511e983d1
 	k8c.io/operating-system-manager v1.2.0
 	k8c.io/reconciler v0.3.1
 	k8s.io/api v0.26.1
@@ -102,7 +102,7 @@ replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-2022081
 
 replace (
 	k8c.io/kubeone => k8c.io/kubeone v1.5.0-beta.0.0.20230216134849-7f23d49b8002
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.22.0-rc.1.0.20230222155138-2ce03c27f21a
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.22.0-rc.1.0.20230223123550-022ca1e74a2a
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1342,8 +1342,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.5.0-beta.0.0.20230216134849-7f23d49b8002 h1:x94uM0sD4hyXbubuxu1qjtJHm30Qt+OnpcwL8EWbHCc=
 k8c.io/kubeone v1.5.0-beta.0.0.20230216134849-7f23d49b8002/go.mod h1:uPtvJZ2qS1Xxi+frzrW0CNB1GNsT6PQJsZBtHG2leEg=
-k8c.io/kubermatic/v2 v2.22.0-rc.1.0.20230222155138-2ce03c27f21a h1:dVTy9S1xBjpzuTruHfKuFfV+Ck/sUjIkK9hDdpjgiC8=
-k8c.io/kubermatic/v2 v2.22.0-rc.1.0.20230222155138-2ce03c27f21a/go.mod h1:zdF4w3eTRs4CImuST2qFzY2z9xh6Dg6lJH9lA4qVI64=
+k8c.io/kubermatic/v2 v2.22.0-rc.1.0.20230223123550-022ca1e74a2a h1:3uYtKJHo77mLycG1cIODMdkDUq1IgqleeZE/hyVdv/w=
+k8c.io/kubermatic/v2 v2.22.0-rc.1.0.20230223123550-022ca1e74a2a/go.mod h1:XiURzSlzU3PUr5sDkOn95HfSnaRH07uOdwX1jc+MDu4=
 k8c.io/operating-system-manager v1.2.0 h1:xqqM4x6In2pHsoOo4BIft8VwYHtRD/pgaZ2ZJsIU6SM=
 k8c.io/operating-system-manager v1.2.0/go.mod h1:POlB8/WtJ+RJUrnA3Nfbzej+23PlMx9OUvpSnM4fJcU=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the k8c.io/kubermatic/v2 dependency to https://github.com/kubermatic/kubermatic/commit/022ca1e74a2aec8636fb77079433daa97c8b7a25, which is planned to be the `v2.22.0` tag target.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
