### PR TITLE
Remove Welcome Message for Projectview

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -86,7 +86,7 @@ limitations under the License.
                   class="km-provider-edit-settings">
           <span [matTooltip]="!isEditEnabled() ? 'This action is not available for viewer role users.' : ''">
             <button mat-menu-item
-            [ngClass]="{'remove-hover': !isClusterRunning || !isEditEnabled()}"
+                    [ngClass]="{'remove-hover': !isClusterRunning || !isEditEnabled()}"
                     (click)="editCluster()"
                     [disabled]="!isClusterRunning || !isEditEnabled()">
               <span>Edit Cluster</span>

--- a/modules/web/src/app/project-overview/component.ts
+++ b/modules/web/src/app/project-overview/component.ts
@@ -36,7 +36,6 @@ import {ClusterTemplate} from '@shared/entity/cluster-template';
 import {BackupService} from '@core/services/backup';
 import {EtcdBackupConfig} from '@shared/entity/backup';
 import {Health} from '@shared/entity/health';
-import {CookieService} from 'ngx-cookie-service';
 import {View} from '@shared/entity/common';
 import {MemberUtils, Permission} from '@shared/utils/member';
 import {UserService} from '@core/services/user';
@@ -76,7 +75,6 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
   externalClustersChange = new Subject<void>();
   clusterTemplatesChange = new Subject<void>();
   backupsChange = new Subject<void>();
-  firstVisitToOverviewPage: string;
   projectQuota: Quota;
   isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   isLoadingClusters = true;
@@ -89,7 +87,6 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
   private _unsubscribeLoadMembers = new Subject<void>();
   private _currentGroupConfig: GroupConfig;
   private readonly _refreshTime = 15;
-  private readonly _cookieName = 'firstVisit';
 
   constructor(
     private readonly _userService: UserService,
@@ -104,7 +101,6 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
     private readonly _appConfigService: AppConfigService,
     private readonly _machineDeploymentService: MachineDeploymentService,
     private readonly _params: ParamsService,
-    private readonly _cookieService: CookieService,
     private readonly _matDialog: MatDialog
   ) {
     if (this.isEnterpriseEdition) {
@@ -122,10 +118,6 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
     this._unsubscribe.next();
     this._unsubscribe.complete();
     this._unsubscribeLoadMembers.complete();
-  }
-
-  hideFirstVisitToOverviewPageMessage(): void {
-    this.firstVisitToOverviewPage = this._cookieService.get(this._cookieName);
   }
 
   hasPermission(view: View): boolean {
@@ -198,7 +190,6 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
     this._loadSSHKeys();
     this._loadMembers();
     this._loadServiceAccounts();
-    this._checkFirstVisitToOverviewPageMessage();
 
     if (this.isEnterpriseEdition) {
       this._loadGroups();
@@ -357,11 +348,5 @@ export class ProjectOverviewComponent implements OnInit, OnDestroy {
       .subscribe(quota => {
         this.projectQuota = quota;
       });
-  }
-
-  private _checkFirstVisitToOverviewPageMessage(): void {
-    this._cookieService.get(this._cookieName)
-      ? this.hideFirstVisitToOverviewPageMessage()
-      : this._cookieService.set(this._cookieName, 'visited', null, '/', window.location.hostname, false, 'Lax');
   }
 }

--- a/modules/web/src/app/project-overview/style.scss
+++ b/modules/web/src/app/project-overview/style.scss
@@ -28,16 +28,6 @@
   }
 }
 
-.first-visit-overview-message {
-  margin-bottom: 20px;
-  padding: 10px 10px 10px 30px;
-
-  .km-icon-close {
-    position: fixed;
-    right: 40px;
-  }
-}
-
 .edit-button {
   height: 45px;
   margin: 0 10px;

--- a/modules/web/src/app/project-overview/template.html
+++ b/modules/web/src/app/project-overview/template.html
@@ -13,14 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<mat-card class="first-visit-overview-message km-text"
-          *ngIf="!firstVisitToOverviewPage">
-  Welcome to the new Project Overview! You can change your project landing page in
-  <a class="km-text-muted"
-     href="/account">User Settings.</a>
-  <i class="km-icon-close km-pointer"
-     (click)="hideFirstVisitToOverviewPageMessage()"></i>
-</mat-card>
+
 <div fxLayout="column"
      fxLayoutGap="20px">
   <mat-card>


### PR DESCRIPTION
**What this PR does / why we need it**:
remove the welcome message that been add to inform users that they can make project overview page as there project landing page from user settings, the message been there for more than enough time. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5604 

**What type of PR is this?**
/kind cleanup

```release-note
NONE
```
```documentation
NONE
```
