### PR TITLE
Add a Back Button to Preset Dialog

### DIFF
--- a/modules/web/src/app/settings/admin/presets/dialog/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/component.ts
@@ -48,6 +48,7 @@ enum StepRegistry {
 @Component({
   selector: 'km-preset-dialog',
   templateUrl: './template.html',
+  styleUrls: ['./style.scss'],
 })
 export class PresetDialogComponent implements OnInit, OnDestroy {
   readonly stepRegistry = StepRegistry;
@@ -166,6 +167,12 @@ export class PresetDialogComponent implements OnInit, OnDestroy {
       .pipe(filter(provider => !!provider))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._stepper.next());
+
+    this._stepper.selectionChange.pipe(takeUntil(this._unsubscribe)).subscribe(selection => {
+      if (selection.previouslySelectedIndex > selection.selectedIndex) {
+        selection.previouslySelectedStep.reset();
+      }
+    });
   }
 
   ngOnDestroy(): void {

--- a/modules/web/src/app/settings/admin/presets/dialog/style.scss
+++ b/modules/web/src/app/settings/admin/presets/dialog/style.scss
@@ -1,0 +1,17 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.create-button {
+  margin-left: 10px;
+}

--- a/modules/web/src/app/settings/admin/presets/dialog/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/template.html
@@ -53,29 +53,35 @@ limitations under the License.
   </mat-step>
 </mat-horizontal-stepper>
 
-<mat-dialog-actions>
-  <div>
-    <mat-spinner fxFlexAlign="center"
-                 [diameter]="30"
-                 color="accent"
-                 *ngIf="creating"></mat-spinner>
-    <button mat-flat-button
-            type="button"
-            id="km-settings-preset-next-btn"
-            (click)="stepper.next()"
-            [disabled]="invalid"
-            *ngIf="!last">
-      <i class="km-icon-mask km-icon-next"></i>
-      <span>Next</span>
-    </button>
-    <km-button *ngIf="last"
-               [ngSwitch]="data.mode"
-               id="km-settings-preset-create-btn"
-               [icon]="icon"
-               [label]="label"
-               [disabled]="creating || invalid"
-               [observable]="getObservable()"
-               (next)="onNext($event)">
-    </km-button>
-  </div>
+<mat-dialog-actions class="preset-dialog-action">
+  <mat-spinner [diameter]="30"
+               color="accent"
+               *ngIf="creating"></mat-spinner>
+  <button mat-flat-button
+          type="button"
+          color="tertiary"
+          (click)="stepper.previous()"
+          *ngIf="!first">
+    <i class="km-icon-mask km-icon-back"></i>
+    <span>Back</span>
+  </button>
+  <button mat-flat-button
+          type="button"
+          id="km-settings-preset-next-btn"
+          (click)="stepper.next()"
+          [disabled]="invalid"
+          *ngIf="!last">
+    <i class="km-icon-mask km-icon-next"></i>
+    <span>Next</span>
+  </button>
+  <km-button *ngIf="last"
+             class="create-button"
+             [ngSwitch]="data.mode"
+             id="km-settings-preset-create-btn"
+             [icon]="icon"
+             [label]="label"
+             [disabled]="creating || invalid"
+             [observable]="getObservable()"
+             (next)="onNext($event)">
+  </km-button>
 </mat-dialog-actions>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a back button to preset dialog to navigate between steps.

![image](https://user-images.githubusercontent.com/85109141/223201888-70313550-3096-4d0a-a305-5b454809404b.png)

![image](https://user-images.githubusercontent.com/85109141/223202136-4f046ca9-f38a-49d1-b102-6803317a57c6.png)


**Which issue(s) this PR fixes**:
Fixes #5676 

**What type of PR is this?**
/kind design

-->
```release-note
NONE
```

```documentation
NONE
```
