### PR TITLE
Apply Disabled Style for the Disabled Preset 

### DIFF
--- a/modules/web/src/app/core/components/sidenav/style.scss
+++ b/modules/web/src/app/core/components/sidenav/style.scss
@@ -55,9 +55,3 @@
     margin: variables.$sidenav-item-margin 0 variables.$sidenav-item-margin variables.$sidenav-item-margin;
   }
 }
-
-.km-disabled {
-  cursor: default;
-  opacity: 40%;
-  pointer-events: none;
-}

--- a/modules/web/src/app/settings/admin/presets/template.html
+++ b/modules/web/src/app/settings/admin/presets/template.html
@@ -115,7 +115,8 @@ limitations under the License.
             mat-sort-header>Name
         </th>
         <td mat-cell
-            *matCellDef="let element">{{element.name}}</td>
+            *matCellDef="let element"
+            [ngClass]="{'km-disabled': !element?.enabled}">{{element.name}}</td>
       </ng-container>
 
       <ng-container matColumnDef="associatedClusters">
@@ -124,6 +125,7 @@ limitations under the License.
             mat-header-cell>Linked Clusters
         </th>
         <td *matCellDef="let element"
+            [ngClass]="{'km-disabled': !element?.enabled}"
             mat-cell>{{element.associatedClusters}}</td>
       </ng-container>
 
@@ -133,6 +135,7 @@ limitations under the License.
             mat-header-cell>Linked Templates
         </th>
         <td *matCellDef="let element"
+            [ngClass]="{'km-disabled': !element?.enabled}"
             mat-cell>{{element.associatedClusterTemplates}}</td>
       </ng-container>
 
@@ -148,11 +151,12 @@ limitations under the License.
             class="providers-column">
           <ng-container *ngFor="let provider of getDisplayedProviders(element.providers)">
             <span class="km-provider-logo km-provider-logo-{{provider.name}}"
-                  [ngClass]="provider.enabled ? '' : 'disabled'">
+                  [ngClass]="provider.enabled && element?.enabled ? '' : 'km-disabled disabled'">
             </span>
           </ng-container>
           <span *ngIf="element.providers.length > displayedProviders"
                 class="km-text km-pointer"
+                [ngClass]="{'km-disabled': !element?.enabled}"
                 (click)="editPreset(element)">
             +{{element.providers.length - displayedProviders}}
           </span>
@@ -169,7 +173,7 @@ limitations under the License.
             <div fxFlexAlign="center"
                  fxLayoutAlign="center"
                  class="km-icon-info km-pointer tooltip"
-                 matTooltip="Shows if the Preset is enabled or disabled. Disabled Presets cannot be used to create new clusters."></div>
+                 matTooltip="Shows if the Preset is shown or hidden. Hidden Presets cannot be used to create new clusters."></div>
           </div>
         </th>
         <td mat-cell

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -713,6 +713,12 @@ km-cni-version {
   }
 }
 
+.km-disabled {
+  cursor: default;
+  opacity: 40%;
+  pointer-events: none;
+}
+
 // side-nav-field content styling
 
 .collapse-sidenav {


### PR DESCRIPTION
**What this PR does / why we need it**:
change the the color and opacity for all providers in a disabled preset and add the disapled style for the disabled preset and adjust the tool tip for show and hide preset.

![Screenshot from 2023-03-07 11-42-41](https://user-images.githubusercontent.com/85109141/223373498-b6f74835-9424-490a-b1d3-080143ccbf88.png)

**Which issue(s) this PR fixes**:
Fixes #5680

**What type of PR is this?**

/kind design

```release-note
NONE
```

```documentation
NONE
```
