### PR TITLE
Allow updating of clusterNetwork.proxyMode via the KKP API

### DIFF
--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -542,6 +542,7 @@ func PatchEndpoint(
 	newInternalCluster.Spec.MLA = patchedCluster.Spec.MLA
 	newInternalCluster.Spec.ContainerRuntime = patchedCluster.Spec.ContainerRuntime
 	newInternalCluster.Spec.ClusterNetwork.KonnectivityEnabled = patchedCluster.Spec.ClusterNetwork.KonnectivityEnabled
+	newInternalCluster.Spec.ClusterNetwork.ProxyMode = patchedCluster.Spec.ClusterNetwork.ProxyMode
 	newInternalCluster.Spec.CNIPlugin = patchedCluster.Spec.CNIPlugin
 	newInternalCluster.Spec.ExposeStrategy = patchedCluster.Spec.ExposeStrategy
 	newInternalCluster.Spec.EnableOperatingSystemManager = patchedCluster.Spec.EnableOperatingSystemManager


### PR DESCRIPTION
**What this PR does / why we need it**:
As documented in [KKP docs](https://docs.kubermatic.com/kubermatic/v2.21/tutorials-howtos/networking/cni-migration/#changing-the-kube-proxy-mode), under certain conditions, the `clusterNetwork.proxyMode` can be updated. This was not possible via the cluster PATCH API endpoint - this PR fixes it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/11994

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow updating of the `clusterNetwork.proxyMode` via the KKP API (PATCH endpoint).
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
