### PR TITLE
Change kubeconfig context name from default to cluster ID

### DIFF
--- a/modules/api/pkg/handler/common/kubeconfig.go
+++ b/modules/api/pkg/handler/common/kubeconfig.go
@@ -127,8 +127,8 @@ func GetKubeconfigEndpoint(ctx context.Context, cluster *kubermaticv1.ExternalCl
 	return &encodeKubeConifgResponse{clientCfg: cfg, filePrefix: filePrefix}, nil
 }
 
-// GetClusterSAKubeconigEndpoint returns the kubeconfig associated to a service account in the cluster.
-func GetClusterSAKubeconigEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string, clusterID string, serviceAccountNamespace, serviceAccountName string, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider) (interface{}, error) {
+// GetClusterSAKubeconfigEndpoint returns the kubeconfig associated to a service account in the cluster.
+func GetClusterSAKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID string, clusterID string, serviceAccountNamespace, serviceAccountName string, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider) (interface{}, error) {
 	clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
 	cluster, err := GetCluster(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, projectID, clusterID, nil)
 	if err != nil {
@@ -180,8 +180,8 @@ func GetClusterSAKubeconigEndpoint(ctx context.Context, userInfoGetter provider.
 	clientCmdCtx := clientcmdapi.NewContext()
 	clientCmdCtx.Cluster = clusterID
 	clientCmdCtx.AuthInfo = userName
-	saKubeConfig.Contexts[defaultCtx] = clientCmdCtx
-	saKubeConfig.CurrentContext = defaultCtx
+	saKubeConfig.Contexts[clusterID] = clientCmdCtx
+	saKubeConfig.CurrentContext = clusterID
 
 	return &encodeKubeConifgResponse{clientCfg: saKubeConfig, filePrefix: userName}, nil
 }
@@ -341,8 +341,8 @@ func CreateOIDCKubeconfigEndpoint(
 			clientCmdCtx := clientcmdapi.NewContext()
 			clientCmdCtx.Cluster = req.ClusterID
 			clientCmdCtx.AuthInfo = claims.Email
-			oidcKubeCfg.Contexts[defaultCtx] = clientCmdCtx
-			oidcKubeCfg.CurrentContext = defaultCtx
+			oidcKubeCfg.Contexts[req.ClusterID] = clientCmdCtx
+			oidcKubeCfg.CurrentContext = req.ClusterID
 		}
 
 		// prepare final rsp that holds kubeconfig
@@ -477,8 +477,8 @@ func CreateOIDCKubeconfigSecretEndpoint(
 			clientCmdCtx := clientcmdapi.NewContext()
 			clientCmdCtx.Cluster = req.ClusterID
 			clientCmdCtx.AuthInfo = claims.Email
-			oidcKubeCfg.Contexts[defaultCtx] = clientCmdCtx
-			oidcKubeCfg.CurrentContext = defaultCtx
+			oidcKubeCfg.Contexts[req.ClusterID] = clientCmdCtx
+			oidcKubeCfg.CurrentContext = req.ClusterID
 		}
 
 		// prepare final rsp that holds kubeconfig

--- a/modules/api/pkg/handler/common/kubeconfig.go
+++ b/modules/api/pkg/handler/common/kubeconfig.go
@@ -60,9 +60,6 @@ const (
 	csrfCookieName = "csrf_token"
 	cookieMaxAge   = 180
 	oidc           = "oidc"
-
-	// defaultCtx is the name of the default context in kubeconfig.
-	defaultCtx = "default"
 )
 
 func GetAdminKubeconfigEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectID, clusterID string, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider) (interface{}, error) {

--- a/modules/api/pkg/handler/test/helper.go
+++ b/modules/api/pkg/handler/test/helper.go
@@ -813,13 +813,13 @@ contexts:
 - context:
     cluster: %s
     user: default
-  name: default
-current-context: default
+  name: %s
+current-context: %s
 kind: Config
 users:
 - name: default
   user:
-    token: %s`, clusterID, clusterID, token)
+    token: %s`, clusterID, clusterID, clusterID, clusterID, token)
 }
 
 // APIUserToKubermaticUser simply converts apiv1.User to kubermaticv1.User type.

--- a/modules/api/pkg/handler/v1/cluster/kubeconfig_test.go
+++ b/modules/api/pkg/handler/v1/cluster/kubeconfig_test.go
@@ -57,8 +57,8 @@ contexts:
 - context:
     cluster: AbcClusterID
     user: bob@acme.com
-  name: default
-current-context: default
+  name: AbcClusterID
+current-context: AbcClusterID
 kind: Config
 preferences: {}
 users:
@@ -82,8 +82,8 @@ contexts:
 - context:
     cluster: AbcClusterID
     user: john@acme.com
-  name: default
-current-context: default
+  name: AbcClusterID
+current-context: AbcClusterID
 kind: Config
 preferences: {}
 users:
@@ -338,7 +338,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("john", "john@acme.com"),
-			ExpectedResponseString: genToken(test.IDToken),
+			ExpectedResponseString: genToken("cluster-foo", test.IDToken),
 		},
 		{
 			Name:         "scenario 2: viewer gets viewer kubeconfig",
@@ -368,7 +368,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("john", "john@acme.com"),
-			ExpectedResponseString: genToken(test.IDViewerToken),
+			ExpectedResponseString: genToken("cluster-foo", test.IDViewerToken),
 		},
 		{
 			Name:         "scenario 3: the admin gets master kubeconfig for any cluster",
@@ -399,7 +399,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("bob", "bob@acme.com"),
-			ExpectedResponseString: genToken(test.IDToken),
+			ExpectedResponseString: genToken("cluster-foo", test.IDToken),
 		},
 		{
 			Name:         "scenario 4: the user Bob can not get John's kubeconfig",
@@ -492,7 +492,7 @@ func getSecureCookie() *securecookie.SecureCookie {
 	return securecookie.New([]byte(""), nil)
 }
 
-func genToken(tokenID string) string {
+func genToken(clusterID, tokenID string) string {
 	return fmt.Sprintf(`apiVersion: v1
 clusters:
 - cluster:
@@ -502,12 +502,12 @@ contexts:
 - context:
     cluster: cluster-foo
     user: default
-  name: default
-current-context: default
+  name: %s
+current-context: %s
 kind: Config
 preferences: {}
 users:
 - name: default
   user:
-    token: %s`, tokenID)
+    token: %s`, clusterID, clusterID, tokenID)
 }

--- a/modules/api/pkg/handler/v2/cluster/kubeconfig.go
+++ b/modules/api/pkg/handler/v2/cluster/kubeconfig.go
@@ -51,9 +51,9 @@ func GetClusterOidcEndpoint(projectProvider provider.ProjectProvider, privileged
 	}
 }
 
-func GetClusterSAKubeconigEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
+func GetClusterSAKubeconfigEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(ClusterSAReq)
-		return handlercommon.GetClusterSAKubeconigEndpoint(ctx, userInfoGetter, req.ProjectID, req.ClusterID, req.Namespace, req.ServiceAccountID, projectProvider, privilegedProjectProvider)
+		return handlercommon.GetClusterSAKubeconfigEndpoint(ctx, userInfoGetter, req.ProjectID, req.ClusterID, req.Namespace, req.ServiceAccountID, projectProvider, privilegedProjectProvider)
 	}
 }

--- a/modules/api/pkg/handler/v2/cluster/kubeconfig_test.go
+++ b/modules/api/pkg/handler/v2/cluster/kubeconfig_test.go
@@ -73,7 +73,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("john", "john@acme.com"),
-			ExpectedResponseString: genToken("default", test.IDToken),
+			ExpectedResponseString: genToken("cluster-foo", "default", test.IDToken),
 		},
 		{
 			Name:         "scenario 2: viewer gets viewer kubeconfig",
@@ -103,7 +103,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("john", "john@acme.com"),
-			ExpectedResponseString: genToken("default", test.IDViewerToken),
+			ExpectedResponseString: genToken("cluster-foo", "default", test.IDViewerToken),
 		},
 		{
 			Name:         "scenario 3: the admin gets master kubeconfig for any cluster",
@@ -134,7 +134,7 @@ func TestGetMasterKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("bob", "bob@acme.com"),
-			ExpectedResponseString: genToken("default", test.IDToken),
+			ExpectedResponseString: genToken("cluster-foo", "default", test.IDToken),
 		},
 		{
 			Name:         "scenario 4: the user Bob can not get John's kubeconfig",
@@ -239,7 +239,7 @@ func TestGetClusterSAKubeconfig(t *testing.T) {
 				},
 			},
 			ExistingAPIUser:        *test.GenAPIUser("john", "john@acme.com"),
-			ExpectedResponseString: genToken("sa-test", "fake-sa-token"),
+			ExpectedResponseString: genToken("cluster-foo", "sa-test", "fake-sa-token"),
 		},
 		{
 			Name:                    "scenario 2: error is returned if service account has no secret (may happen in k8s >= 1.24 if secret is not annoated)",
@@ -372,7 +372,7 @@ func TestGetClusterSAKubeconfig(t *testing.T) {
 	}
 }
 
-func genToken(userName string, tokenID string) string {
+func genToken(clusterID string, userName string, tokenID string) string {
 	return fmt.Sprintf(`apiVersion: v1
 clusters:
 - cluster:
@@ -382,12 +382,12 @@ contexts:
 - context:
     cluster: cluster-foo
     user: %s
-  name: default
-current-context: default
+  name: %s
+current-context: %s
 kind: Config
 preferences: {}
 users:
 - name: %s
   user:
-    token: %s`, userName, userName, tokenID)
+    token: %s`, userName, clusterID, clusterID, userName, tokenID)
 }

--- a/modules/api/pkg/handler/v2/routes_v2.go
+++ b/modules/api/pkg/handler/v2/routes_v2.go
@@ -10151,7 +10151,7 @@ func (r Routing) getClusterServiceAccountKubeconfig() http.Handler {
 			middleware.UserSaver(r.userProvider),
 			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
-		)(cluster.GetClusterSAKubeconigEndpoint(r.projectProvider, r.privilegedProjectProvider, r.userInfoGetter)),
+		)(cluster.GetClusterSAKubeconfigEndpoint(r.projectProvider, r.privilegedProjectProvider, r.userInfoGetter)),
 		cluster.DecodeClusterSAReq,
 		cluster.EncodeKubeconfig,
 		r.defaultServerOptions()...,


### PR DESCRIPTION
**What this PR does / why we need it**:
Assign a unique identifier i.e. cluster ID for the `context` specified in the OIDC kubeconfig. Having it set as `default` makes it difficult to differentiate and switch context between multiple clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5745

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The context name for OIDC Kubeconfig has been changed to the cluster ID from `default`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
