### PR TITLE
Enable concurrency for golangci-lint

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -88,7 +88,7 @@ presubmits:
           resources:
             requests:
               memory: 10Gi
-              cpu: 3
+              cpu: 4
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/modules/api/.golangci.yml
+++ b/modules/api/.golangci.yml
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 run:
-  # concurrency=1 lowers memory usage a bit
-  concurrency: 1
   modules-download-mode: readonly
   deadline: 20m
   build-tags:


### PR DESCRIPTION
**What this PR does / why we need it**:
`golangci-lint` keeps timing out every now and then. Since we are already assigning it 10 Gigs of memory it makes sense to run the tests concurrently.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
