### PR TITLE
Add support to import digitalocean kubeone cluster

### DIFF
--- a/modules/web/src/app/kubeone-wizard/module.ts
+++ b/modules/web/src/app/kubeone-wizard/module.ts
@@ -27,6 +27,7 @@ import {SharedModule} from '@shared/module';
 import {NODE_DATA_CONFIG, NodeDataConfig, NodeDataMode} from '../node-data/config';
 import {KubeOneWizardComponent} from './component';
 import {Routing} from './routing';
+import {KubeOneDigitaloceanCredentialsBasicComponent} from './steps/credentials/provider/basic/digitalocean/component';
 
 const components = [
   KubeOneWizardComponent,
@@ -36,6 +37,7 @@ const components = [
   KubeOneAWSCredentialsBasicComponent,
   KubeOneGCPCredentialsBasicComponent,
   KubeOneAzureCredentialsBasicComponent,
+  KubeOneDigitaloceanCredentialsBasicComponent,
   KubeOneClusterStepComponent,
   KubeOneSummaryStepComponent,
   KubeOnePresetsComponent,

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/digitalocean/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/digitalocean/component.ts
@@ -1,0 +1,115 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
+import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
+import {KubeOneCloudSpec, KubeOneClusterSpec, KubeOneDigitalOceanCloudSpec} from '@shared/entity/kubeone-cluster';
+import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
+
+export enum Controls {
+  Token = 'token',
+}
+
+@Component({
+  selector: 'km-kubeone-wizard-digitalocean-credentials-basic',
+  templateUrl: './template.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => KubeOneDigitaloceanCredentialsBasicComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => KubeOneDigitaloceanCredentialsBasicComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KubeOneDigitaloceanCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  readonly Controls = Controls;
+
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {
+    super('Digitalocean Credentials Basic');
+  }
+
+  ngOnInit(): void {
+    this._initForm();
+    this._initSubscriptions();
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  private _initForm(): void {
+    this.form = this._builder.group({
+      [Controls.Token]: this._builder.control('', [Validators.required]),
+    });
+  }
+
+  private _initSubscriptions(): void {
+    this._clusterSpecService.providerChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => this.form.reset());
+
+    this.form.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ =>
+        this._presetsService.enablePresets(Object.values(Controls).every(control => !this.form.get(control).value))
+      );
+
+    this._presetsService.presetChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => Object.values(Controls).forEach(control => this._enable(!preset, control)));
+
+    this.form
+      .get(Controls.Token)
+      .valueChanges.pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _enable(enable: boolean, name: Controls): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
+  }
+
+  private _getClusterEntity(): ExternalCluster {
+    return {
+      cloud: {
+        kubeOne: {
+          cloudSpec: {
+            digitalocean: {
+              token: this.form.get(Controls.Token).value,
+            } as KubeOneDigitalOceanCloudSpec,
+          } as KubeOneCloudSpec,
+        } as KubeOneClusterSpec,
+      } as ExternalCloudSpec,
+    } as ExternalCluster;
+  }
+}

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/digitalocean/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/digitalocean/template.html
@@ -1,0 +1,31 @@
+<!--
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<form [formGroup]="form"
+      fxLayout="column"
+      fxLayoutGap="8px">
+  <mat-form-field fxFlex>
+    <mat-label>Token</mat-label>
+    <input matInput
+           [formControlName]="Controls.Token"
+           [name]="Controls.Token"
+           kmInputPassword
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.Token).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+</form>

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
@@ -21,4 +21,6 @@ limitations under the License.
                                            [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-gcp-credentials-basic>
   <km-kubeone-wizard-azure-credentials-basic *ngSwitchCase="NodeProvider.AZURE"
                                              [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-azure-credentials-basic>
+  <km-kubeone-wizard-digitalocean-credentials-basic *ngSwitchCase="NodeProvider.DIGITALOCEAN"
+                                                    [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-digitalocean-credentials-basic>
 </div>

--- a/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
@@ -43,7 +43,12 @@ enum Controls {
   ],
 })
 export class KubeOneProviderStepComponent extends StepBase implements OnInit {
-  readonly providers: NodeProvider[] = [NodeProvider.AWS, NodeProvider.GCP, NodeProvider.AZURE];
+  readonly providers: NodeProvider[] = [
+    NodeProvider.AWS,
+    NodeProvider.GCP,
+    NodeProvider.AZURE,
+    NodeProvider.DIGITALOCEAN,
+  ];
   readonly controls = Controls;
 
   constructor(

--- a/modules/web/src/app/kubeone-wizard/steps/summary/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/summary/template.html
@@ -78,6 +78,13 @@ limitations under the License.
               <div value>{{SECRET_MASK}}</div>
             </km-property>
           </ng-container>
+          <!-- DigitalOcean -->
+          <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.digitalocean">
+            <km-property>
+              <div key>Token</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+          </ng-container>
         </ng-template>
       </div>
     </div>

--- a/modules/web/src/app/shared/entity/kubeone-cluster.ts
+++ b/modules/web/src/app/shared/entity/kubeone-cluster.ts
@@ -37,6 +37,7 @@ export class KubeOneCloudSpec {
   aws?: KubeOneAWSCloudSpec;
   gcp?: KubeOneGCPCloudSpec;
   azure?: KubeOneAzureCloudSpec;
+  digitalOcean?: KubeOneDigitalOceanCloudSpec;
 }
 
 export class KubeOneAWSCloudSpec {
@@ -53,4 +54,8 @@ export class KubeOneAzureCloudSpec {
   clientSecret: string;
   subscriptionID: string;
   tenantID: string;
+}
+
+export class KubeOneDigitalOceanCloudSpec {
+  token: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to import digitalocean KubeOne cluster.

**Provider Step:**
![image](https://user-images.githubusercontent.com/85109141/224819037-84ef3cc2-9499-4167-a278-8364553ee794.png)

**Credentials Step:**
![image](https://user-images.githubusercontent.com/85109141/224819186-5c680408-f459-410b-a46d-5c603f116f8f.png)

**Summary Step:**
![image](https://user-images.githubusercontent.com/85109141/224819567-d572566e-7092-4e41-9d80-dc3114316afd.png)


**Which issue(s) this PR fixes**:
Fixes #5820

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Add support to import digitalocean KubeOne cluster
```

```documentation
NONE
```
