### PR TITLE
Add support to import hetzner kubeone cluster

### DIFF
--- a/modules/web/src/app/kubeone-wizard/module.ts
+++ b/modules/web/src/app/kubeone-wizard/module.ts
@@ -28,6 +28,7 @@ import {NODE_DATA_CONFIG, NodeDataConfig, NodeDataMode} from '../node-data/confi
 import {KubeOneWizardComponent} from './component';
 import {Routing} from './routing';
 import {KubeOneDigitaloceanCredentialsBasicComponent} from './steps/credentials/provider/basic/digitalocean/component';
+import {KubeOneHetznerCredentialsBasicComponent} from './steps/credentials/provider/basic/hetzner/component';
 
 const components = [
   KubeOneWizardComponent,
@@ -38,6 +39,7 @@ const components = [
   KubeOneGCPCredentialsBasicComponent,
   KubeOneAzureCredentialsBasicComponent,
   KubeOneDigitaloceanCredentialsBasicComponent,
+  KubeOneHetznerCredentialsBasicComponent,
   KubeOneClusterStepComponent,
   KubeOneSummaryStepComponent,
   KubeOnePresetsComponent,

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/hetzner/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/hetzner/component.ts
@@ -1,0 +1,115 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
+import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
+import {KubeOneCloudSpec, KubeOneClusterSpec, KubeOneHetznerCloudSpec} from '@shared/entity/kubeone-cluster';
+import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
+
+export enum Controls {
+  Token = 'token',
+}
+
+@Component({
+  selector: 'km-kubeone-wizard-hetzner-credentials-basic',
+  templateUrl: './template.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => KubeOneHetznerCredentialsBasicComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => KubeOneHetznerCredentialsBasicComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KubeOneHetznerCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  readonly Controls = Controls;
+
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {
+    super('Hetzner Credentials Basic');
+  }
+
+  ngOnInit(): void {
+    this._initForm();
+    this._initSubscriptions();
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  private _initForm(): void {
+    this.form = this._builder.group({
+      [Controls.Token]: this._builder.control('', [Validators.required]),
+    });
+  }
+
+  private _initSubscriptions(): void {
+    this._clusterSpecService.providerChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => this.form.reset());
+
+    this.form.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ =>
+        this._presetsService.enablePresets(Object.values(Controls).every(control => !this.form.get(control).value))
+      );
+
+    this._presetsService.presetChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => Object.values(Controls).forEach(control => this._enable(!preset, control)));
+
+    this.form
+      .get(Controls.Token)
+      .valueChanges.pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _enable(enable: boolean, name: Controls): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
+  }
+
+  private _getClusterEntity(): ExternalCluster {
+    return {
+      cloud: {
+        kubeOne: {
+          cloudSpec: {
+            hetzner: {
+              token: this.form.get(Controls.Token).value,
+            } as KubeOneHetznerCloudSpec,
+          } as KubeOneCloudSpec,
+        } as KubeOneClusterSpec,
+      } as ExternalCloudSpec,
+    } as ExternalCluster;
+  }
+}

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/hetzner/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/hetzner/template.html
@@ -1,0 +1,34 @@
+<!--
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<form [formGroup]="form"
+      fxLayout="column"
+      fxLayoutGap="8px">
+  <mat-form-field fxFlex>
+    <mat-label>Token</mat-label>
+    <input matInput
+           [formControlName]="Controls.Token"
+           [name]="Controls.Token"
+           kmInputPassword
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.Token).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+    <mat-error *ngIf="form.get(Controls.Token).hasError('minlength') || form.get(Controls.Token).hasError('maxlength')">
+      Tokens must be exactly <strong>64</strong> characters long.
+    </mat-error>
+  </mat-form-field>
+</form>

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
@@ -23,4 +23,6 @@ limitations under the License.
                                              [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-azure-credentials-basic>
   <km-kubeone-wizard-digitalocean-credentials-basic *ngSwitchCase="NodeProvider.DIGITALOCEAN"
                                                     [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-digitalocean-credentials-basic>
+  <km-kubeone-wizard-hetzner-credentials-basic *ngSwitchCase="NodeProvider.HETZNER"
+                                               [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-hetzner-credentials-basic>
 </div>

--- a/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
@@ -48,6 +48,7 @@ export class KubeOneProviderStepComponent extends StepBase implements OnInit {
     NodeProvider.GCP,
     NodeProvider.AZURE,
     NodeProvider.DIGITALOCEAN,
+    NodeProvider.HETZNER,
   ];
   readonly controls = Controls;
 

--- a/modules/web/src/app/kubeone-wizard/steps/summary/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/summary/template.html
@@ -85,6 +85,13 @@ limitations under the License.
               <div value>{{SECRET_MASK}}</div>
             </km-property>
           </ng-container>
+          <!-- Hetzner -->
+          <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.hetzner">
+            <km-property>
+              <div key>Token</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+          </ng-container>
         </ng-template>
       </div>
     </div>

--- a/modules/web/src/app/shared/entity/kubeone-cluster.ts
+++ b/modules/web/src/app/shared/entity/kubeone-cluster.ts
@@ -38,6 +38,7 @@ export class KubeOneCloudSpec {
   gcp?: KubeOneGCPCloudSpec;
   azure?: KubeOneAzureCloudSpec;
   digitalOcean?: KubeOneDigitalOceanCloudSpec;
+  hetzner?: KubeOneHetznerCloudSpec;
 }
 
 export class KubeOneAWSCloudSpec {
@@ -57,5 +58,8 @@ export class KubeOneAzureCloudSpec {
 }
 
 export class KubeOneDigitalOceanCloudSpec {
+  token: string;
+}
+export class KubeOneHetznerCloudSpec {
   token: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to import hetzner KubeOne cluster.

**Provider Step:**
![image](https://user-images.githubusercontent.com/85109141/224948293-0b1e47d3-bc9c-4c0e-9726-b3f5e722b5df.png)


**Credentials Step:**
![image](https://user-images.githubusercontent.com/85109141/224948654-265b30c8-205e-4ba2-b3c1-e71afcd57520.png)

**Summary Step:**
![image](https://user-images.githubusercontent.com/85109141/235906527-22fe53ad-5e69-48da-9ffb-3a74941aee60.png)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5819

**What type of PR is this?**
/kind feature

```release-note
Add support to import hetzner KubeOne cluster
```

```documentation
NONE
```
