### PR TITLE
Correctly handle MD health if no replicas are configured

### DIFF
--- a/modules/web/src/app/shared/utils/health-status.ts
+++ b/modules/web/src/app/shared/utils/health-status.ts
@@ -86,7 +86,8 @@ export function getMachineDeploymentHealthStatus(md: MachineDeployment): HealthS
   } else if (
     md.status &&
     (md.status.availableReplicas || 0) === md.spec.replicas &&
-    md.status.availableReplicas === md.status.updatedReplicas) {
+    md.status.availableReplicas === md.status.updatedReplicas
+  ) {
     return new HealthStatus(StatusMassage.Running, StatusIcon.Running);
   } else if (md.status && md.status.updatedReplicas !== md.spec.replicas) {
     return new HealthStatus(StatusMassage.Updating, StatusIcon.Pending);

--- a/modules/web/src/app/shared/utils/health-status.ts
+++ b/modules/web/src/app/shared/utils/health-status.ts
@@ -85,9 +85,8 @@ export function getMachineDeploymentHealthStatus(md: MachineDeployment): HealthS
     return new HealthStatus(StatusMassage.Deleting, StatusIcon.Error);
   } else if (
     md.status &&
-    md.status &&
     (md.status.availableReplicas || 0) === md.spec.replicas &&
-    md.status.availableReplicas === md.status.updatedReplicas
+    md.status.availableReplicas === md.status.updatedReplicas) {
     return new HealthStatus(StatusMassage.Running, StatusIcon.Running);
   } else if (md.status && md.status.updatedReplicas !== md.spec.replicas) {
     return new HealthStatus(StatusMassage.Updating, StatusIcon.Pending);

--- a/modules/web/src/app/shared/utils/health-status.ts
+++ b/modules/web/src/app/shared/utils/health-status.ts
@@ -85,9 +85,9 @@ export function getMachineDeploymentHealthStatus(md: MachineDeployment): HealthS
     return new HealthStatus(StatusMassage.Deleting, StatusIcon.Error);
   } else if (
     md.status &&
-    md.status.availableReplicas === md.spec.replicas &&
-    md.status.availableReplicas === md.status.updatedReplicas
-  ) {
+    ((md.status.availableReplicas === md.spec.replicas &&
+    md.status.availableReplicas === md.status.updatedReplicas) ||
+    (md.spec.replicas === 0 && !md.status.availableReplicas && !md.status.updatedReplicas))) {
     return new HealthStatus(StatusMassage.Running, StatusIcon.Running);
   } else if (md.status && md.status.updatedReplicas !== md.spec.replicas) {
     return new HealthStatus(StatusMassage.Updating, StatusIcon.Pending);

--- a/modules/web/src/app/shared/utils/health-status.ts
+++ b/modules/web/src/app/shared/utils/health-status.ts
@@ -85,9 +85,9 @@ export function getMachineDeploymentHealthStatus(md: MachineDeployment): HealthS
     return new HealthStatus(StatusMassage.Deleting, StatusIcon.Error);
   } else if (
     md.status &&
-    ((md.status.availableReplicas === md.spec.replicas &&
-    md.status.availableReplicas === md.status.updatedReplicas) ||
-    (md.spec.replicas === 0 && !md.status.availableReplicas && !md.status.updatedReplicas))) {
+    md.status &&
+    (md.status.availableReplicas || 0) === md.spec.replicas &&
+    md.status.availableReplicas === md.status.updatedReplicas
     return new HealthStatus(StatusMassage.Running, StatusIcon.Running);
   } else if (md.status && md.status.updatedReplicas !== md.spec.replicas) {
     return new HealthStatus(StatusMassage.Updating, StatusIcon.Pending);


### PR DESCRIPTION
**What this PR does / why we need it**:

When a MachineDeployment has zero replicas, the returned status does not contain any information about replica health (since the value is zero and is omitted by the backend's struct definition) and thus, the dashboard shows it as "Updating".

Since we cannot change the backend code (it uses the cluster-api definition of MachineDeployment status), I tried fixing this in the frontend; I couldn't think of a better way to handle this than including a "special case" in the if condition. If there's a way to simplify it that I've missed, I'm very open to suggestions.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5834

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Show correct health information for Machine Deployments with no replicas
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
