### PR TITLE
Bump k8c.io/kubermatic/v2 dependency

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -66,7 +66,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.6.0
-	k8c.io/operating-system-manager v1.2.0
+	k8c.io/operating-system-manager v1.2.1-0.20230316111943-fefdb70fecee
 	k8c.io/reconciler v0.3.1
 	k8s.io/api v0.26.2
 	k8s.io/apiextensions-apiserver v0.26.2
@@ -102,7 +102,7 @@ replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-2022081
 
 replace (
 	k8c.io/kubeone => k8c.io/kubeone v1.6.0-rc.2.0.20230228113747-15c597a27192
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.22.1-0.20230310120154-14237970eb80
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.22.1-0.20230321135351-890805d15997
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1344,10 +1344,10 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.6.0-rc.2.0.20230228113747-15c597a27192 h1:Gu4VHZiFH+0bq9MnCHJ/+GUiwx8aBkCfvua4ZphGlUY=
 k8c.io/kubeone v1.6.0-rc.2.0.20230228113747-15c597a27192/go.mod h1:uPtvJZ2qS1Xxi+frzrW0CNB1GNsT6PQJsZBtHG2leEg=
-k8c.io/kubermatic/v2 v2.22.1-0.20230310120154-14237970eb80 h1:N1ctqMGLeHB/3CjjK3WLo5pk+FplOEmGPPbGAIvm8Ik=
-k8c.io/kubermatic/v2 v2.22.1-0.20230310120154-14237970eb80/go.mod h1:1cuLz45t+G+7iXqZ0oi//7SsapUzoVzPnVSTv9ZGNRs=
-k8c.io/operating-system-manager v1.2.0 h1:xqqM4x6In2pHsoOo4BIft8VwYHtRD/pgaZ2ZJsIU6SM=
-k8c.io/operating-system-manager v1.2.0/go.mod h1:POlB8/WtJ+RJUrnA3Nfbzej+23PlMx9OUvpSnM4fJcU=
+k8c.io/kubermatic/v2 v2.22.1-0.20230321135351-890805d15997 h1:Q+43O1MsoQCyPSqyaigU+sczW8xBgiLLDRFc9dWXfoo=
+k8c.io/kubermatic/v2 v2.22.1-0.20230321135351-890805d15997/go.mod h1:wW0I/vB2+9GxL7coxdf9LeXo1tbrHxdENgodE372nqw=
+k8c.io/operating-system-manager v1.2.1-0.20230316111943-fefdb70fecee h1:qdSGk80RKDY+5iLiEKp2hyqgZ5bhveasnp2KfxGzoUY=
+k8c.io/operating-system-manager v1.2.1-0.20230316111943-fefdb70fecee/go.mod h1:3XV941fPDTht11LFxn+xzg5Z8kj01/PQXEYtT3qKcGE=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=
 k8c.io/reconciler v0.3.1/go.mod h1:tEnGL+1N4TmlbgvXYgtZerhVU221NnmlUcK3WdOHzLo=
 k8s.io/api v0.26.2 h1:dM3cinp3PGB6asOySalOZxEG4CZ0IAdJsrYZXE/ovGQ=


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps the `k8c.io/kubermatic/v2` dependency so Cilium 1.13.1 is available from the frontend (https://github.com/kubermatic/kubermatic/commit/890805d15997d5269dfb6411f0087baa45a2587a).


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
