### PR TITLE
api: fix logger error fmt mismatch

### DIFF
--- a/modules/api/cmd/kubermatic-api/main.go
+++ b/modules/api/cmd/kubermatic-api/main.go
@@ -154,7 +154,7 @@ func main() {
 		log.Fatalw("failed to construct manager", zap.Error(err))
 	}
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &corev1.Event{}, common.EventFieldIndexerKey, common.EventIndexer()); err != nil {
-		log.Fatalw("failed to add index on Event involvedObject name: %w", err)
+		log.Fatalw("failed to add index on Event involvedObject name", zap.Error(err))
 	}
 
 	providers, err := createInitProviders(ctx, options, masterCfg, mgr, log)
@@ -362,7 +362,7 @@ func createInitProviders(ctx context.Context, options serverRunOptions, masterCf
 
 	oidcIssuerVerifier, err := createOIDCClients(options.oidcIssuerConfiguration, options.oidcIssuerRedirectURI, options.caBundle)
 	if err != nil {
-		log.Fatalw("failed to create an openid authenticator - issuer: %q, oidcClientID: %q: %v", options.oidcURL, options.oidcAuthenticatorClientID, err)
+		log.Fatalw("failed to create an openid authenticator", zap.Any("issuer", options.oidcURL), zap.Any("oidcClientID", options.oidcAuthenticatorClientID), zap.Error(err))
 	}
 
 	oidcIssuerVerifierProviderGetter := auth2.OIDCIssuerVerifierProviderFactory(


### PR DESCRIPTION
**What this PR does / why we need it**:
quick fix for logger error formating mismatch, some calls were using `log.Fatalw` but included formatting 'verbs' instead key/val args.

```
$ grep . -nre 'Fatalw.*%'
./modules/api/cmd/kubermatic-api/main.go:157:           log.Fatalw("failed to add index on Event involvedObject name: %w", err)
./modules/api/cmd/kubermatic-api/main.go:365:           log.Fatalw("failed to create an openid authenticator - issuer: %q, oidcClientID: %q: %v", options.oidcURL, options.oidcAuthenticatorClientID, err)
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
none, stumbled upon it when testing https://docs.kubermatic.com/kubermatic/v2.22/installation/install-kkp-ce/ and accidentally misconfigured `values.yaml` to observe `kubermatic-api` in `CrashLoopBackOff` with:
```
{"level":"fatal","time":"2023-03-24T09:44:27.845Z","caller":"kubermatic-api/main.go:365","msg":"failed to create an openid authenticator - issuer: %q, oidcClientID: %q: %v","https://cluster.example.dev/dex":"kubermatic","error":"Get \"https://cluster.example.dev/dex/.well-known/openid-configuration\": dial tcp: lookup cluster.example.dev on 10.96.0.10:53: no such host"}
```

**What type of PR is this?**
/kind cleanup
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
