### PR TITLE
Configure OpenStack ingress cluster settings

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/openstack/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/openstack/component.ts
@@ -242,6 +242,10 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
     return this.form.get(Controls.UseFloatingIP).disabled;
   }
 
+  isDiskSizeRequired(): boolean {
+    return this.form.get(Controls.CustomDiskSize).hasValidator(Validators.required);
+  }
+
   onFlavorChange(flavor: string): void {
     this._nodeDataService.nodeData.spec.cloud.openstack.flavor = flavor;
     this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);

--- a/modules/web/src/app/node-data/basic/provider/openstack/template.html
+++ b/modules/web/src/app/node-data/basic/provider/openstack/template.html
@@ -48,6 +48,7 @@ limitations under the License.
                      [formControlName]="Controls.CustomDiskSize"
                      mode="errors"
                      label="Disk Size in GB"
+                     [required]="isDiskSizeRequired()"
                      hint="An additional network storage volume will be created and used as the disk for the VM."
                      min="10"
                      max="16000">

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -407,6 +407,13 @@ limitations under the License.
               <div key>IPv6 Subnet Pool</div>
               <div value>{{cluster.spec.cloud?.openstack.ipv6SubnetPool}}</div>
             </km-property>
+            <km-property-boolean label="Enable Ingress Hostname"
+                                 [value]="cluster.spec.cloud?.openstack.enableIngressHostname">
+            </km-property-boolean>
+            <km-property *ngIf="cluster.spec.cloud?.openstack.ingressHostnameSuffix">
+              <div key>Ingress Hostname Suffix</div>
+              <div value>{{cluster.spec.cloud?.openstack.ingressHostnameSuffix}}</div>
+            </km-property>
           </ng-container>
 
           <!-- Equinix -->

--- a/modules/web/src/app/shared/entity/cluster.ts
+++ b/modules/web/src/app/shared/entity/cluster.ts
@@ -260,9 +260,18 @@ export class OpenstackCloudSpec extends ExtraCloudSpecOptions {
   subnetID: string;
   ipv6SubnetID: string;
   ipv6SubnetPool: string;
+  enableIngressHostname?: boolean;
+  ingressHostnameSuffix?: string;
 
   static isEmpty(spec: OpenstackCloudSpec): boolean {
-    return _.difference(Object.keys(spec), Object.keys(ExtraCloudSpecOptions.new(spec))).every(key => !spec[key]);
+    return _.difference(
+      OpenstackCloudSpec.getKeysToCompare(spec),
+      OpenstackCloudSpec.getKeysToCompare(ExtraCloudSpecOptions.new(spec))
+    ).every(key => !spec[key]);
+  }
+
+  private static getKeysToCompare(spec: ExtraCloudSpecOptions): string[] {
+    return Object.keys(spec).filter(key => key !== 'enableIngressHostname' && key !== 'ingressHostnameSuffix');
   }
 }
 

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/component.ts
@@ -18,10 +18,16 @@ import {
   CredentialsType,
   OpenstackCredentialsTypeService,
 } from '@app/wizard/step/provider-settings/provider/extended/openstack/service';
+import {ClusterSpecService} from '@core/services/cluster-spec';
+import {CloudSpec, Cluster, ClusterSpec, OpenstackCloudSpec} from '@shared/entity/cluster';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import {merge} from 'rxjs';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
 
 enum Controls {
   Credentials = 'credentials',
+  EnableIngressHostname = 'enableIngressHostname',
+  IngressHostnameSuffix = 'ingressHostnameSuffix',
 }
 
 @Component({
@@ -50,6 +56,7 @@ export class OpenstackProviderExtendedComponent extends BaseFormValidator implem
 
   constructor(
     private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: ClusterSpecService,
     private readonly _credentialsTypeService: OpenstackCredentialsTypeService
   ) {
     super('Openstack Provider Extended');
@@ -58,11 +65,52 @@ export class OpenstackProviderExtendedComponent extends BaseFormValidator implem
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.Credentials]: this._builder.control(''),
+      [Controls.EnableIngressHostname]: this._builder.control(false),
+      [Controls.IngressHostnameSuffix]: this._builder.control({value: '', disabled: true}),
     });
+
+    this.form
+      .get(Controls.EnableIngressHostname)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(value => {
+        this._enable(value, Controls.IngressHostnameSuffix);
+      });
+
+    merge(
+      this.form.get(Controls.EnableIngressHostname).valueChanges,
+      this.form.get(Controls.IngressHostnameSuffix).valueChanges
+    )
+      .pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
   }
 
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
+  }
+
+  private _getClusterEntity(): Cluster {
+    return {
+      spec: {
+        cloud: {
+          openstack: {
+            enableIngressHostname: this.form.get(Controls.EnableIngressHostname).value || null,
+            ingressHostnameSuffix: this.form.get(Controls.IngressHostnameSuffix).value || null,
+          } as OpenstackCloudSpec,
+        } as CloudSpec,
+      } as ClusterSpec,
+    } as Cluster;
+  }
+
+  private _enable(enable: boolean, name: string): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).reset();
+      this.form.get(name).disable();
+    }
   }
 }

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/template.html
@@ -16,7 +16,7 @@ limitations under the License.
 
 <form [formGroup]="form"
       fxLayout="column"
-      fxLayoutGap="8px">
+      fxLayoutGap="15px">
   <ng-container *ngIf="credentialsType === CredentialsType.Default">
     <km-wizard-openstack-provider-extended-default-credentials [formControl]="form.get(Controls.Credentials)"></km-wizard-openstack-provider-extended-default-credentials>
   </ng-container>
@@ -24,4 +24,28 @@ limitations under the License.
   <ng-container *ngIf="credentialsType === CredentialsType.Application">
     <km-wizard-openstack-provider-extended-app-credentials [formControl]="form.get(Controls.Credentials)"></km-wizard-openstack-provider-extended-app-credentials>
   </ng-container>
+
+  <mat-checkbox [formControlName]="Controls.EnableIngressHostname"
+                [name]="Controls.EnableIngressHostname">
+    <div fxLayoutGap="8px"
+         fxLayoutAlign=" center">
+      <span>Enable Ingress Hostname</span>
+      <i class="km-pointer km-icon-info"
+         matTooltip="Enable the &quot;enable-ingress-hostname&quot; cloud provider option on the Openstack CCM."></i>
+    </div>
+  </mat-checkbox>
+
+  <mat-form-field fxFlex>
+    <mat-label>Ingress Hostname Suffix</mat-label>
+    <input matInput
+           [formControlName]="Controls.IngressHostnameSuffix"
+           [name]="Controls.IngressHostnameSuffix"
+           type="text"
+           autocomplete="off">
+    <mat-hint>
+      Set a specific suffix for the hostnames used for the PROXY protocol
+      workaround that is enabled by <code>EnableIngressHostname</code>. The suffix
+      is set to <code>nip.io</code> by default.
+    </mat-hint>
+  </mat-form-field>
 </form>


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow configuration of `enableIngressHostname` and `ingressHostnameSuffix` settings of OpenStack provider.

![screenshot-localhost_8000-2023 03 28-22_22_21](https://user-images.githubusercontent.com/13975988/228319179-c00875d9-4f48-4f98-b2aa-eb76bd41b75c.png)

Additionally 2 more issues are fixed:
- Load security group, network and subnet pool dropdown options only when cluster credentials are updated.
- Visually mark Disk Size field (on Initial Nodes step) as required when form control is marked as required.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5856 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Configure Ingress Hostname cluster settings of OpenStack provider.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://docs.kubermatic.com/kubermatic/main/references/crds/#openstackcloudspec
```
