### PR TITLE
dashboard: allow http for cookie store

### DIFF
--- a/modules/web/src/app/core/services/auth/service.ts
+++ b/modules/web/src/app/core/services/auth/service.ts
@@ -47,7 +47,11 @@ export class Auth {
       if (this.compareNonceWithToken(token, nonce)) {
         // remove URL fragment with token, so that users can't accidentally copy&paste it and send it to others
         this._removeFragment();
-        this._cookieService.set(this._cookie.token, token, 1, '/', null, true, 'Lax');
+        let secure = true;
+        if (location.protocol === 'http:') {
+          secure = false;
+        }
+        this._cookieService.set(this._cookie.token, token, 1, '/', null, secure, 'Lax');
         // localhost is only served via http, though secure cookie is not possible
         // following line will only work when domain is localhost
         this._cookieService.set(this._cookie.token, token, 1, '/', 'localhost', false, 'Lax');
@@ -140,7 +144,11 @@ export class Auth {
     const nonceStr = nonceRegExp.exec(this.getOIDCProviderURL());
     const minLen = 2;
     if (!!nonceStr && nonceStr.length >= minLen && !!nonceStr[1]) {
-      this._cookieService.set(this._cookie.nonce, nonceStr[1], null, '/', null, true, 'Lax');
+      let secure = true;
+      if (location.protocol === 'http:') {
+        secure = false;
+      }
+      this._cookieService.set(this._cookie.nonce, nonceStr[1], null, '/', null, secure, 'Lax');
       // localhost is only served via http, though secure cookie is not possible
       // following line will only work when domain is localhost
       this._cookieService.set(this._cookie.nonce, nonceStr[1], null, '/', 'localhost', false, 'Lax');


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a desire for DNS-less KKP installation without TLS certificates for the KKP dashboard. This ensures the cookie storage works over HTTP as well as HTTPS.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
relevant for: https://github.com/kubermatic/kubermatic/issues/12023

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
