### PR TITLE
Fix 'v' prefix removal by removing character instead of slicing string

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -539,7 +539,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           [Controls.Name]: this._clusterSpecService?.cluster?.name ?? this.controlValue(Controls.Name),
           // remove the 'v' prefix from the version
           [Controls.Version]:
-            (clusterSpec?.version && clusterSpec?.version.slice(1)) ?? this.controlValue(Controls.Version),
+            (clusterSpec?.version && clusterSpec?.version.replace('v','')) ?? this.controlValue(Controls.Version),
           [Controls.ContainerRuntime]: clusterSpec?.containerRuntime ?? this.controlValue(Controls.ContainerRuntime),
           [Controls.AuditLogging]: clusterSpec?.auditLogging?.enabled ?? this.controlValue(Controls.AuditLogging),
           [Controls.AuditPolicyPreset]:

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -539,7 +539,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           [Controls.Name]: this._clusterSpecService?.cluster?.name ?? this.controlValue(Controls.Name),
           // remove the 'v' prefix from the version
           [Controls.Version]:
-            (clusterSpec?.version && clusterSpec?.version.replace('v','')) ?? this.controlValue(Controls.Version),
+            (clusterSpec?.version && clusterSpec?.version.replace('v', '')) ?? this.controlValue(Controls.Version),
           [Controls.ContainerRuntime]: clusterSpec?.containerRuntime ?? this.controlValue(Controls.ContainerRuntime),
           [Controls.AuditLogging]: clusterSpec?.auditLogging?.enabled ?? this.controlValue(Controls.AuditLogging),
           [Controls.AuditPolicyPreset]:


### PR DESCRIPTION
**What this PR does / why we need it**:
The frontend code made the assumption that there will always be a `v` prefix for versions. That is however not the case, for example when you configure versions on your own in `KubermaticConfiguration`. This PR makes sure we remove a `v` string from the version instead, so it doesn't do anything if the version is not set.

Technically, versions could have a string suffix that could include `v`, but this is not the case for Kubernetes versions and I couldn't get a regex to work here. So if you're from the future stumbling into this PR, I'm sorry I made an incorrect assumption. Otherwise, feel free to discard this comment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5871

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix cluster wizard not selecting a default version if custom versions are configured in `KubermaticConfiguration`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
