### PR TITLE
Fetch AWS VPC id from request header

### DIFF
--- a/modules/api/pkg/handler/v2/provider/aws.go
+++ b/modules/api/pkg/handler/v2/provider/aws.go
@@ -135,6 +135,7 @@ func DecodeAWSCommonReq(c context.Context, r *http.Request) (interface{}, error)
 	req.Credential = r.Header.Get("Credential")
 	req.AssumeRoleARN = r.Header.Get("AssumeRoleARN")
 	req.AssumeRoleExternalID = r.Header.Get("AssumeRoleExternalID")
+	req.VPC = r.Header.Get("VPC")
 
 	return req, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When we added project-scoped API endpoints for AWS in #5441, we apparently forgot to also fetch the VPC id from the header `VPC` if it was set. This meant that not using presets was broken for AWS user cluster setups. See linked issue for details.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5882

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AWS subnets are fetched correctly if credentials are provided directly instead of using a preset
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
