### PR TITLE
[release/v2.20] Bump version to v2.20.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 KUBERMATIC_EDITION?=ee
-KUBERMATIC_VERSION?=v2.20.14
+KUBERMATIC_VERSION?=v2.20.15
 REPO=quay.io/kubermatic/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && echo "\-${KUBERMATIC_EDITION}" )
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')
 CC=npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "v2.20.14",
+  "version": "v2.20.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "v2.20.14",
+      "version": "v2.20.15",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kubermatic-dashboard",
   "private": true,
   "type": "module",
-  "version": "v2.20.14",
+  "version": "v2.20.15",
   "description": "Kubermatic Dashboard",
   "repository": "https://github.com/kubermatic/dashboard",
   "license": "proprietary",

--- a/src/assets/config/changelog.json
+++ b/src/assets/config/changelog.json
@@ -1,17 +1,13 @@
 {
-  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.20.md#v22014",
+  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.20.md#v22015",
   "entries": [
     {
         "category": "fixed",
-        "description": "Fix partially deployed CSI validating webhook on CCM/CSI migrated clusters on vSphere."
+        "description": "Pull konnectivity images from registry.k8s.io instead of legacy GCR registry."
     },
     {
         "category": "fixed",
-        "description": "Set proper NodePort range in Cilium config if non-default range is used."
-    },
-    {
-        "category": "fixed",
-        "description": "Include tunneling agent IP in apiserver's TLS cert SANs."
+        "description": "Fix calculation of node CPU utilisation in MLA Grafana dashboards."
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the dashboard version to v2.20.15 in preparation of April patch releases.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
