### PR TITLE
Add functionality to configure metering schedule report types

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/component.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/material/legacy-dialog';
 import {NotificationService} from '@app/core/services/notification';
 import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering';
-import {MeteringReportConfiguration} from '@app/shared/entity/datacenter';
+import {MeteringReportConfiguration, MeteringReportType} from '@app/shared/entity/datacenter';
 import {KmValidators} from '@app/shared/validators/validators';
 import {Observable, Subject, take, takeUntil} from 'rxjs';
 import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
@@ -41,6 +41,7 @@ enum Controls {
   Group = 'group',
   Interval = 'interval',
   Retention = 'retention',
+  Types = 'types',
 }
 
 enum DefaultScheduleOption {
@@ -76,6 +77,7 @@ export class MeteringScheduleAddDialog implements OnInit, OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
   readonly controls = Controls;
   readonly ScheduleOption = DefaultScheduleOption;
+  readonly reportTypes: MeteringReportType[] = Object.values(MeteringReportType);
   form: FormGroup;
 
   private get _group(): DefaultScheduleOption {
@@ -136,6 +138,7 @@ export class MeteringScheduleAddDialog implements OnInit, OnDestroy {
       [Controls.Schedule]: this._builder.control(DefaultSchedule.Daily),
       [Controls.Interval]: this._builder.control('1', Validators.min(1)),
       [Controls.Retention]: this._builder.control(null, Validators.min(1)),
+      [Controls.Types]: this._builder.control(this.reportTypes, Validators.required),
     });
 
     this.form
@@ -177,11 +180,17 @@ export class MeteringScheduleAddDialog implements OnInit, OnDestroy {
   }
 
   private _toMeteringScheduleConfiguration(): MeteringReportConfiguration {
-    return {
+    const config = {
       name: this.form.get(Controls.Name).value,
       schedule: this._schedule,
       interval: this._interval,
       retention: this._retention,
-    };
+    } as MeteringReportConfiguration;
+
+    if (this._group === DefaultScheduleOption.Custom) {
+      config.types = this.form.get(Controls.Types).value;
+    }
+
+    return config;
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/add-dialog/template.html
@@ -109,6 +109,26 @@ END OF TERMS AND CONDITIONS
                target="_blank">here. </a> Please note that specifying seconds is not supported.
           </mat-hint>
         </mat-form-field>
+
+        <mat-form-field>
+          <mat-label>Report Types</mat-label>
+          <mat-select [formControlName]="controls.Types"
+                      multiple
+                      panelClass="km-multiple-values-dropdown"
+                      disableOptionCentering
+                      required>
+            <mat-option *ngFor="let type of reportTypes"
+                        [value]="type">
+              {{type}}
+            </mat-option>
+          </mat-select>
+          <mat-hint>
+            Types of reports to generate. By default, all types of reports are generated.
+          </mat-hint>
+          <mat-error *ngIf="form.get(controls.Types).hasError('required')">
+            <strong>Required</strong>
+          </mat-error>
+        </mat-form-field>
       </div>
     </form>
   </mat-dialog-content>

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/component.spec.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/component.spec.ts
@@ -95,6 +95,7 @@ describe('MeteringScheduleConfigComponent', () => {
         scheduleName: fakeSchedule.name,
         schedule: fakeSchedule.schedule,
         interval: fakeSchedule.interval,
+        types: fakeSchedule.types,
       },
     });
   });

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/component.ts
@@ -37,6 +37,7 @@ enum Column {
   retention = 'retention',
   interval = 'interval',
   schedule = 'schedule',
+  types = 'types',
   actions = 'actions',
 }
 
@@ -92,6 +93,7 @@ export class MeteringScheduleConfigComponent implements OnInit {
         schedule: config.schedule,
         interval: config.interval,
         retention: config.retention,
+        types: config.types,
       },
     };
     this._dialogModeService.isEditDialog = true;

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/edit-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/edit-dialog/component.ts
@@ -26,7 +26,7 @@ import {
 } from '@angular/material/legacy-dialog';
 import {NotificationService} from '@app/core/services/notification';
 import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering';
-import {MeteringReportConfiguration} from '@app/shared/entity/datacenter';
+import {MeteringReportConfiguration, MeteringReportType} from '@app/shared/entity/datacenter';
 import {KmValidators} from '@app/shared/validators/validators';
 import {Observable, Subject, take} from 'rxjs';
 
@@ -36,6 +36,7 @@ export interface MeteringScheduleEditDialogConfig {
   schedule: string;
   interval: number;
   retention: number;
+  types: MeteringReportType[];
 }
 
 enum Controls {
@@ -43,6 +44,7 @@ enum Controls {
   Schedule = 'schedule',
   Interval = 'interval',
   Retention = 'retention',
+  Types = 'types',
 }
 
 @Component({
@@ -52,6 +54,7 @@ enum Controls {
 export class MeteringScheduleEditDialog implements OnInit, OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
   readonly controls = Controls;
+  readonly reportTypes: MeteringReportType[] = Object.values(MeteringReportType);
   form: FormGroup;
 
   constructor(
@@ -70,6 +73,7 @@ export class MeteringScheduleEditDialog implements OnInit, OnDestroy {
         KmValidators.cronExpression(),
         Validators.required,
       ]),
+      [Controls.Types]: this._builder.control(this.data.types, Validators.required),
     });
   }
 
@@ -94,6 +98,7 @@ export class MeteringScheduleEditDialog implements OnInit, OnDestroy {
       schedule: this.form.get(Controls.Schedule).value,
       interval: this.form.get(Controls.Interval).value,
       retention: this.form.get(Controls.Retention).value,
+      types: this.form.get(Controls.Types).value,
     };
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/edit-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/edit-dialog/template.html
@@ -59,6 +59,27 @@ END OF TERMS AND CONDITIONS
              target="_blank">here. </a> Please note that specifying seconds is not supported.
         </mat-hint>
       </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Report Types</mat-label>
+        <mat-select [formControlName]="controls.Types"
+                    multiple
+                    panelClass="km-multiple-values-dropdown"
+                    disableOptionCentering
+                    required
+                    kmValueChangedIndicator>
+          <mat-option *ngFor="let type of reportTypes"
+                      [value]="type">
+            {{type}}
+          </mat-option>
+        </mat-select>
+        <mat-hint>
+          Types of reports to generate. By default, all types of reports are generated.
+        </mat-hint>
+        <mat-error *ngIf="form.get(controls.Types).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
+      </mat-form-field>
     </div>
   </form>
 </mat-dialog-content>

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/template.html
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/template.html
@@ -56,7 +56,7 @@ END OF TERMS AND CONDITIONS
       <ng-container [matColumnDef]="column.retention">
         <th mat-header-cell
             *matHeaderCellDef
-            class="km-header-cell p-20"
+            class="km-header-cell p-15"
             mat-sort-header>
           <div fxLayout="row"
                fxLayoutGap="4px"
@@ -75,7 +75,7 @@ END OF TERMS AND CONDITIONS
       <ng-container [matColumnDef]="column.interval">
         <th mat-header-cell
             *matHeaderCellDef
-            class="km-header-cell p-20"
+            class="km-header-cell p-15"
             mat-sort-header>
           <div fxLayout="row"
                fxLayoutGap="4px"
@@ -105,6 +105,22 @@ END OF TERMS AND CONDITIONS
         </th>
         <td mat-cell
             *matCellDef="let element">{{element.schedule}}</td>
+      </ng-container>
+
+      <ng-container [matColumnDef]="column.types">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-20">
+          <div fxLayout="row"
+               fxLayoutGap="4px"
+               fxLayoutAlign=" center">
+            <span>Report Types</span>
+            <div class="km-icon-info km-pointer tooltip"
+                 matTooltip="Types of reports to generate."></div>
+          </div>
+        </th>
+        <td mat-cell
+            *matCellDef="let element">{{element.types.join(', ')}}</td>
       </ng-container>
 
       <ng-container [matColumnDef]="column.actions">

--- a/modules/web/src/app/dynamic/enterprise/metering/service/metering.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/service/metering.ts
@@ -69,11 +69,8 @@ export class MeteringService {
 
   addScheduleConfiguration(configuration: MeteringReportConfiguration): Observable<any> {
     const url = `${this._restRoot}/admin/metering/configurations/reports/${configuration.name}`;
-    return this._http.post(url, {
-      schedule: configuration.schedule,
-      interval: configuration.interval,
-      retention: configuration.retention,
-    });
+    const {name, ...body} = configuration;
+    return this._http.post(url, body);
   }
 
   updateScheduleConfiguration(configuration: MeteringReportConfiguration): Observable<any> {
@@ -82,6 +79,7 @@ export class MeteringService {
       schedule: configuration.schedule,
       interval: configuration.interval,
       retention: configuration.retention,
+      types: configuration.types,
     });
   }
 

--- a/modules/web/src/app/shared/entity/datacenter.ts
+++ b/modules/web/src/app/shared/entity/datacenter.ts
@@ -168,6 +168,13 @@ export class MeteringReportConfiguration {
   // create any lifecycle rule which results in keeping reports forever. Please note that this functionality works only
   // for object storage that supports an object lifecycle management mechanism.
   retention?: number;
+  // Types of reports to generate. By default, all types of reports are generated.
+  types?: MeteringReportType[];
+}
+
+export enum MeteringReportType {
+  Cluster = 'cluster',
+  Namespace = 'namespace',
 }
 
 export class MLA {

--- a/modules/web/src/test/data/metering.ts
+++ b/modules/web/src/test/data/metering.ts
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {MeteringReportConfiguration} from '@app/shared/entity/datacenter';
+import {MeteringReportConfiguration, MeteringReportType} from '@app/shared/entity/datacenter';
 
 export function fakeScheduleConfiguration(name: string): MeteringReportConfiguration {
   return {
     name,
     schedule: '0 1 * * *',
     interval: 7,
+    types: [MeteringReportType.Cluster, MeteringReportType.Namespace],
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add functionality to configure report types in metering schedule configuration:

- **Schedules List:**

![screenshot-localhost_8000-2023 04 10-15_35_40](https://user-images.githubusercontent.com/13975988/230886177-d130acc1-58e5-48b5-8ee9-11f11a2444d4.png)

- **Create Schedule Dialog**

![screenshot-localhost_8000-2023 04 10-15_31_19](https://user-images.githubusercontent.com/13975988/230886240-09016b13-c0c3-47c7-a560-dec5b7fa6779.png)

- **Edit Schedule Dialog:**

![screenshot-localhost_8000-2023 04 10-15_31_43](https://user-images.githubusercontent.com/13975988/230886271-6cefc2ec-9e4d-40f0-b746-a94e9b610037.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4871 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Configure report types in schedule configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
