### PR TITLE
Add support to disable changelog popup

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -34352,6 +34352,11 @@
         "defaultQuota": {
           "$ref": "#/definitions/ProjectResourceQuota"
         },
+        "disableChangelogPopup": {
+          "description": "DisableChangelogPopup disables the changelog popup in KKP dashboard.",
+          "type": "boolean",
+          "x-go-name": "DisableChangelogPopup"
+        },
         "displayAPIDocs": {
           "description": "DisplayDemoInfo controls whether a a link to the KKP API documentation is shown in the footer.",
           "type": "boolean",

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -102,12 +102,12 @@ replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-2022081
 
 replace (
 	k8c.io/kubeone => k8c.io/kubeone v1.6.0-rc.2.0.20230228113747-15c597a27192
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.22.1-0.20230413103140-8243a5d86430
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.22.1-0.20230413132950-8ab5786f88ab
 )
 
 require (
 	github.com/pkg/errors v0.9.1
-	k8c.io/kubermatic/v2 v2.22.1-0.20230406111832-e4bc5b558e94
+	k8c.io/kubermatic/v2 v2.22.1-0.20230413132950-8ab5786f88ab
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1342,8 +1342,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.6.0-rc.2.0.20230228113747-15c597a27192 h1:Gu4VHZiFH+0bq9MnCHJ/+GUiwx8aBkCfvua4ZphGlUY=
 k8c.io/kubeone v1.6.0-rc.2.0.20230228113747-15c597a27192/go.mod h1:uPtvJZ2qS1Xxi+frzrW0CNB1GNsT6PQJsZBtHG2leEg=
-k8c.io/kubermatic/v2 v2.22.1-0.20230413103140-8243a5d86430 h1:8K2P9azCt8cMIut0oxGWiElMGHKSe7nUNhZwAxeSmPE=
-k8c.io/kubermatic/v2 v2.22.1-0.20230413103140-8243a5d86430/go.mod h1:o2xeOsGUf+H2Ytdyh687jChwcfq78Sdin5Ej465htFA=
+k8c.io/kubermatic/v2 v2.22.1-0.20230413132950-8ab5786f88ab h1:lyoQk39yXHIshQva6Mpn9Im1Qdrmo9qrzRWeVa6Wxmc=
+k8c.io/kubermatic/v2 v2.22.1-0.20230413132950-8ab5786f88ab/go.mod h1:o2xeOsGUf+H2Ytdyh687jChwcfq78Sdin5Ej465htFA=
 k8c.io/operating-system-manager v1.2.1-0.20230316111943-fefdb70fecee h1:qdSGk80RKDY+5iLiEKp2hyqgZ5bhveasnp2KfxGzoUY=
 k8c.io/operating-system-manager v1.2.1-0.20230316111943-fefdb70fecee/go.mod h1:3XV941fPDTht11LFxn+xzg5Z8kj01/PQXEYtT3qKcGE=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -2072,6 +2072,9 @@ type GlobalSettings struct {
 
 	// +optional
 	MachineDeploymentOptions kubermaticv1.MachineDeploymentOptions `json:"machineDeploymentOptions,omitempty"`
+
+	// DisableChangelogPopup disables the changelog popup in KKP dashboard.
+	DisableChangelogPopup bool `json:"disableChangelogPopup,omitempty"`
 }
 
 // VSphereTagCategory is the object representing a vsphere tag category.

--- a/modules/api/pkg/handler/v1/admin/settings.go
+++ b/modules/api/pkg/handler/v1/admin/settings.go
@@ -141,6 +141,7 @@ func convertAPISettingsToSettingsSpec(settings *apiv2.GlobalSettings) (kubermati
 		ProviderConfiguration:            settings.ProviderConfiguration,
 		MachineDeploymentVMResourceQuota: settings.MachineDeploymentVMResourceQuota,
 		MachineDeploymentOptions:         settings.MachineDeploymentOptions,
+		DisableChangelogPopup:            settings.DisableChangelogPopup,
 	}
 
 	if settings.DefaultProjectResourceQuota != nil {
@@ -177,6 +178,7 @@ func ConvertCRDSettingsToAPISettingsSpec(settings *kubermaticv1.SettingSpec) api
 		ProviderConfiguration:            settings.ProviderConfiguration,
 		MachineDeploymentVMResourceQuota: settings.MachineDeploymentVMResourceQuota,
 		MachineDeploymentOptions:         settings.MachineDeploymentOptions,
+		DisableChangelogPopup:            settings.DisableChangelogPopup,
 	}
 
 	if settings.DefaultProjectResourceQuota != nil {

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/global_settings.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/global_settings.go
@@ -21,6 +21,9 @@ type GlobalSettings struct {
 	// DefaultNodeCount is the default number of replicas for the initial MachineDeployment.
 	DefaultNodeCount int8 `json:"defaultNodeCount,omitempty"`
 
+	// DisableChangelogPopup disables the changelog popup in KKP dashboard.
+	DisableChangelogPopup bool `json:"disableChangelogPopup,omitempty"`
+
 	// DisplayDemoInfo controls whether a a link to the KKP API documentation is shown in the footer.
 	DisplayAPIDocs bool `json:"displayAPIDocs,omitempty"`
 

--- a/modules/web/src/app/core/components/help-panel/component.ts
+++ b/modules/web/src/app/core/components/help-panel/component.ts
@@ -78,7 +78,9 @@ export class HelpPanelComponent implements OnInit, OnDestroy {
   }
 
   openChangelog(): void {
-    this._changelogService.open();
+    if (this.settings && !this.settings.disableChangelogPopup) {
+      this._changelogService.open();
+    }
     this._isOpen = false;
   }
 
@@ -97,7 +99,7 @@ export class HelpPanelComponent implements OnInit, OnDestroy {
 
   shouldShowPanel(): boolean {
     return (
-      this.hasChangelog() ||
+      (!this.settings.disableChangelogPopup && this.hasChangelog()) ||
       this.settings.displayAPIDocs ||
       this.settings.customLinks.some(link => link.location === CustomLinkLocation.HelpPanel)
     );

--- a/modules/web/src/app/core/components/help-panel/template.html
+++ b/modules/web/src/app/core/components/help-panel/template.html
@@ -21,7 +21,7 @@ limitations under the License.
           fxLayoutAlign="center center"
           (click)="toggle()">
     <i class="km-icon-mask km-icon-help"></i>
-    <i *ngIf="hasChangelog() && hasNewChangelog()"
+    <i *ngIf="!settings?.disableChangelogPopup && hasChangelog() && hasNewChangelog()"
        class="km-icon-circle km-new-bg"></i>
   </button>
 
@@ -41,7 +41,7 @@ limitations under the License.
 
     <div class="menu"
          fxLayout="column">
-      <div *ngIf="hasChangelog()"
+      <div *ngIf="!settings?.disableChangelogPopup && hasChangelog()"
            class="km-option-hover-bg"
            matRipple
            (click)="openChangelog()"

--- a/modules/web/src/app/settings/admin/customization/component.ts
+++ b/modules/web/src/app/settings/admin/customization/component.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Component, OnDestroy, OnInit} from '@angular/core';
+import {MatLegacyCheckboxChange} from '@angular/material/legacy-checkbox';
 import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
@@ -69,6 +70,11 @@ export class CustomizationComponent implements OnInit, OnDestroy {
     this._unsubscribe.complete();
   }
 
+  onChangelogSettingsChange(event: MatLegacyCheckboxChange) {
+    this.settings.disableChangelogPopup = !event.checked;
+    this._settingsChange.next();
+  }
+
   onSettingsChange(): void {
     this._settingsChange.next();
   }
@@ -81,7 +87,8 @@ export class CustomizationComponent implements OnInit, OnDestroy {
     return (
       this.isEqual(this.settings.displayAPIDocs, this.apiSettings.displayAPIDocs) &&
       this.isEqual(this.settings.displayDemoInfo, this.apiSettings.displayDemoInfo) &&
-      this.isEqual(this.settings.displayTermsOfService, this.apiSettings.displayTermsOfService)
+      this.isEqual(this.settings.displayTermsOfService, this.apiSettings.displayTermsOfService) &&
+      this.isEqual(this.settings.disableChangelogPopup, this.apiSettings.disableChangelogPopup)
     );
   }
 

--- a/modules/web/src/app/settings/admin/customization/template.html
+++ b/modules/web/src/app/settings/admin/customization/template.html
@@ -54,6 +54,10 @@ limitations under the License.
                           id="km-demo-info-setting"
                           (change)="onSettingsChange()">Display Demo Information
             </mat-checkbox>
+            <mat-checkbox [checked]="!settings.disableChangelogPopup"
+                          id="km-changelog-setting"
+                          (change)="onChangelogSettingsChange($event)">Display What's New
+            </mat-checkbox>
             <km-spinner-with-confirmation [isSaved]="isDisplayLinksEqual()"></km-spinner-with-confirmation>
           </div>
         </div>

--- a/modules/web/src/app/shared/entity/settings.ts
+++ b/modules/web/src/app/shared/entity/settings.ts
@@ -49,6 +49,7 @@ export interface AdminSettings {
   providerConfiguration?: ProviderConfiguration;
   defaultQuota?: DefaultProjectQuota;
   machineDeploymentOptions: MachineDeploymentOptions;
+  disableChangelogPopup?: boolean;
 }
 
 export interface MachineDeploymentVMResourceQuota {
@@ -205,4 +206,5 @@ export const DEFAULT_ADMIN_SETTINGS: AdminSettings = {
   defaultQuota: {
     quota: {},
   },
+  disableChangelogPopup: false,
 };


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to disable changelog (What's new) popup. When this setting (`disableChangelogPopup`) is set, it will also hide the `What's New` option from Help menu.

[screencast-localhost_8000-2023.04.17-14_30_02.webm](https://user-images.githubusercontent.com/13975988/232464616-9651fb59-b05c-4182-8d89-7eb05191fc52.webm)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #4751 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to disable changelog popup.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
