### PR TITLE
Add margin between placeholder text and `Add Project` button

### DIFF
--- a/modules/web/src/app/project/style.scss
+++ b/modules/web/src/app/project/style.scss
@@ -34,6 +34,8 @@ $project-card-width: 330px;
   }
 
   & .placeholder-text {
+    margin-bottom: 10px;
+
     & p {
       margin: 0 0 10px;
     }

--- a/modules/web/src/app/project/template.html
+++ b/modules/web/src/app/project/template.html
@@ -354,7 +354,6 @@ limitations under the License.
           Learn more in our documentation >
         </a>
       </div>
-      <br />
       <ng-container *ngTemplateOutlet="addProjectButton"></ng-container>
     </div>
   </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix spacing between placeholder text and `Add Project` button for Firefox.

<img width="498" alt="Screenshot 2023-04-20 at 4 39 11 PM" src="https://user-images.githubusercontent.com/13975988/233355923-76c0e8bf-21a6-4695-9217-06ac3b0047c8.png">

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #5511 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
