### PR TITLE
Hide enable kubernetes dashboard on cluster creation

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -102,6 +102,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   private _seedSettings: SeedSettings;
   private _unsubscribe = new Subject<void>();
 
+  get isKubernetesDashboardEnable(): boolean {
+    return this._settings.enableDashboard;
+  }
+
   constructor(
     private readonly _builder: FormBuilder,
     private readonly _clusterService: ClusterService,

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -187,7 +187,8 @@ limitations under the License.
            matTooltip="User Cluster Monitoring is enforced by your admin."></i>
       </mat-checkbox>
 
-      <mat-checkbox [formControlName]="Controls.KubernetesDashboardEnabled"
+      <mat-checkbox *ngIf="isKubernetesDashboardEnable"
+                    [formControlName]="Controls.KubernetesDashboardEnabled"
                     kmValueChangedIndicator>
         Kubernetes Dashboard
       </mat-checkbox>

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -163,6 +163,10 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   private readonly _canalDualStackMinimumSupportedVersion = '3.22.0';
   private readonly _cniInitialValuesMinimumSupportedVersion = '1.13.0';
 
+  get isKubernetesDashboardEnable(): boolean {
+    return this._settings.enableDashboard;
+  }
+
   constructor(
     private readonly _builder: FormBuilder,
     private readonly _cdr: ChangeDetectorRef,
@@ -201,6 +205,9 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.get(Controls.OPAIntegration).setValue(this._settings.opaOptions.enabled);
       if (this._settings.opaOptions.enforced) {
         this.form.get(Controls.OPAIntegration).disable();
+      }
+      if (!settings.enableDashboard) {
+        this.form.get(Controls.KubernetesDashboardEnabled).setValue(false);
       }
       this.form.updateValueAndValidity();
     });
@@ -552,7 +559,8 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
             clusterSpec?.clusterNetwork?.konnectivityEnabled ?? this.controlValue(Controls.Konnectivity),
           [Controls.MLALogging]: clusterSpec?.mla?.loggingEnabled ?? this.controlValue(Controls.MLALogging),
           [Controls.KubernetesDashboardEnabled]:
-            clusterSpec?.kubernetesDashboard?.enabled ?? this.controlValue(Controls.KubernetesDashboardEnabled),
+            (this.isKubernetesDashboardEnable && clusterSpec?.kubernetesDashboard?.enabled) ??
+            this.controlValue(Controls.KubernetesDashboardEnabled),
           [Controls.MLAMonitoring]: clusterSpec?.mla?.monitoringEnabled ?? this.controlValue(Controls.MLAMonitoring),
           [Controls.AdmissionPlugins]: clusterSpec?.admissionPlugins ?? this.controlValue(Controls.AdmissionPlugins),
           [Controls.EventRateLimitConfig]:

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -437,7 +437,8 @@ limitations under the License.
               </mat-checkbox>
             </ng-container>
 
-            <mat-checkbox [formControlName]="Controls.KubernetesDashboardEnabled">
+            <mat-checkbox [formControlName]="Controls.KubernetesDashboardEnabled"
+                          *ngIf="isKubernetesDashboardEnable">
               Kubernetes Dashboard
             </mat-checkbox>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable `Kubernetes Dashboard` option on cluster creation in the cluster step if `Enable Kubernetes Dashboard` is disable in the admin panel.
![image](https://user-images.githubusercontent.com/85109141/234628146-b70254cb-901d-4a4d-a360-db70e0fabcc1.png)

**Which issue(s) this PR fixes**:
Fixes #5904 

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
