### PR TITLE
Add cut off shadow to dialogs

### DIFF
--- a/modules/web/src/assets/css/global/_theme.scss
+++ b/modules/web/src/assets/css/global/_theme.scss
@@ -298,6 +298,10 @@
     background-color: transparent;
   }
 
+  .mat-dialog-content {
+    border-bottom: 1px solid map.get($colors, divider);
+  }
+
   .km-notification {
     &.mat-snack-bar-container {
       background-color: map.get($colors, option-background);


### PR DESCRIPTION
**What this PR does / why we need it**:
add a cut off shadow to indelicate the action area in dialog
**Which issue(s) this PR fixes**:
Fixes #5202 
**light mode dialog**:

![image](https://user-images.githubusercontent.com/85109141/235139016-f8463c76-ecff-4e20-b3a0-f4cefa4599f3.png)


**dark mode dialog**:

![image](https://user-images.githubusercontent.com/85109141/235138604-3db6b97b-d175-4e2f-95b8-bb78a8c49f8b.png)


**What type of PR is this?**
/kind design

```release-note
NONE
```

```documentation
NONE
```
