### PR TITLE
Hide the show advanced settings option

### DIFF
--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -123,6 +123,10 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     return this.wizardMode === WizardMode.CustomizeClusterTemplate || !this.wizardMode;
   }
 
+  get nodeHasAdvanceSettings(): boolean {
+    return NodeProviderConstants.nodeHasAdvanceSettings(this._clusterSpecService.provider);
+  }
+
   constructor(
     private readonly _builder: FormBuilder,
     private readonly _nameGenerator: NameGeneratorService,

--- a/modules/web/src/app/node-data/template.html
+++ b/modules/web/src/app/node-data/template.html
@@ -185,13 +185,13 @@ limitations under the License.
       </span>
     </km-autocomplete>
 
-    <div *ngIf="isDialogView()">
+    <div *ngIf="isDialogView() && nodeHasAdvanceSettings">
       <km-expansion-panel expandLabel="Advanced Settings"
                           collapseLabel="Advanced Settings">
         <ng-container>
-          <mat-card-title class="provider-options">{{ providerDisplayName }} Options</mat-card-title>
+          <mat-card-title class="provider-options">{{ providerDisplayName }} Settings</mat-card-title>
           <km-extended-node-data [provider]="provider"
-                                 [visible]="true"
+                                 [visible]="nodeHasAdvanceSettings"
                                  [formControlName]="Controls.ProviderExtended"></km-extended-node-data>
         </ng-container>
       </km-expansion-panel>

--- a/modules/web/src/app/shared/model/NodeProviderConstants.ts
+++ b/modules/web/src/app/shared/model/NodeProviderConstants.ts
@@ -98,6 +98,19 @@ export namespace NodeProviderConstants {
     }
   }
 
+  export function nodeHasAdvanceSettings(provider: NodeProvider): boolean {
+    return [
+      NodeProvider.ALIBABA,
+      NodeProvider.AWS,
+      NodeProvider.AZURE,
+      NodeProvider.DIGITALOCEAN,
+      NodeProvider.EQUINIX,
+      NodeProvider.GCP,
+      NodeProvider.OPENSTACK,
+      NodeProvider.VSPHERE,
+    ].includes(provider);
+  }
+
   export function getOperatingSystemSpecName(spec: NodeSpec) {
     if (spec.operatingSystem.ubuntu) {
       return OperatingSystem.Ubuntu;


### PR DESCRIPTION
**What this PR does / why we need it**:
Hide the show advanced settings option in the MD dialog for the providers that don't have a advanced settings 

**Hetzner MD dialog**:

before :

![edited-screenshot](https://user-images.githubusercontent.com/85109141/235627432-256a955a-f1b6-4e74-9df2-6ab043128139.png)

after:

![image](https://user-images.githubusercontent.com/85109141/235625910-c19c7933-0d70-4244-a4ce-93c6de011498.png)


**What type of PR is this?**
/kind bug


```release-note
NONE
```

```documentation
NONE
```
