### PR TITLE
Credentials configuration for KubeOne clusters on Hetzner and Digital Ocean

### DIFF
--- a/modules/api/pkg/handler/v2/external_cluster/kubeone.go
+++ b/modules/api/pkg/handler/v2/external_cluster/kubeone.go
@@ -254,6 +254,10 @@ func setKubeOneCloudCredentials(preset *kubermaticv1.Preset, providerName string
 		return setGCPCredentials(preset, kubeOneCloudSpec)
 	case providerName == resources.KubeOneAzure:
 		return setAzureCredentials(preset, kubeOneCloudSpec)
+	case providerName == resources.KubeOneHetzner:
+		return setHetznerCredentials(preset, kubeOneCloudSpec)
+	case providerName == resources.KubeOneDigitalOcean:
+		return setDigitalOceanCredentials(preset, kubeOneCloudSpec)
 	}
 
 	return nil, fmt.Errorf("Provider %s not supported", providerName)
@@ -308,6 +312,36 @@ func setAzureCredentials(preset *kubermaticv1.Preset, kubeOneCloudSpec apiv2.Kub
 	kubeOneCloudSpec.Azure.TenantID = credentials.TenantID
 	kubeOneCloudSpec.Azure.ClientSecret = credentials.ClientSecret
 	kubeOneCloudSpec.Azure.SubscriptionID = credentials.SubscriptionID
+
+	return &kubeOneCloudSpec, nil
+}
+
+func setHetznerCredentials(preset *kubermaticv1.Preset, kubeOneCloudSpec apiv2.KubeOneCloudSpec) (*apiv2.KubeOneCloudSpec, error) {
+	if preset.Spec.Hetzner == nil {
+		return nil, emptyCredentialError(preset.Name, "Hetzner")
+	}
+
+	credentials := preset.Spec.Hetzner
+
+	if kubeOneCloudSpec.Hetzner == nil {
+		kubeOneCloudSpec.Hetzner = &apiv2.KubeOneHetznerCloudSpec{}
+	}
+	kubeOneCloudSpec.Hetzner.Token = credentials.Token
+
+	return &kubeOneCloudSpec, nil
+}
+
+func setDigitalOceanCredentials(preset *kubermaticv1.Preset, kubeOneCloudSpec apiv2.KubeOneCloudSpec) (*apiv2.KubeOneCloudSpec, error) {
+	if preset.Spec.Digitalocean == nil {
+		return nil, emptyCredentialError(preset.Name, "Digitalocean")
+	}
+
+	credentials := preset.Spec.Digitalocean
+
+	if kubeOneCloudSpec.DigitalOcean == nil {
+		kubeOneCloudSpec.DigitalOcean = &apiv2.KubeOneDigitalOceanCloudSpec{}
+	}
+	kubeOneCloudSpec.DigitalOcean.Token = credentials.Token
 
 	return &kubeOneCloudSpec, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We are missing credentials processing/configuration for KubeOne clusters on Hetzner and Digital Ocean.

Required to unblock:
- https://github.com/kubermatic/dashboard/pull/5830
- https://github.com/kubermatic/dashboard/pull/5827

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
