### PR TITLE
Span applications table to full width

### DIFF
--- a/modules/web/src/app/shared/components/application-list/style.scss
+++ b/modules/web/src/app/shared/components/application-list/style.scss
@@ -40,6 +40,11 @@ $application-card-width: 320px;
 
 .applications-container {
   margin-top: 20px;
+
+  &.table-view {
+    margin-left: -30px;
+    margin-right: -30px;
+  }
 }
 
 .system-applications-toggle {

--- a/modules/web/src/app/shared/components/application-list/template.html
+++ b/modules/web/src/app/shared/components/application-list/template.html
@@ -62,7 +62,8 @@ limitations under the License.
 </div>
 
 <div *ngIf="isClusterReady"
-     class="applications-container">
+     class="applications-container"
+     [ngClass]="{'table-view': !showCards}">
   <div *ngIf="showCards || !applicationsDataSource.data?.length; else applicationsTable">
     <div class="application-cards-view"
          fxFlex


### PR DESCRIPTION
**What this PR does / why we need it**:
Make applications table span full width of the card.

![screenshot-localhost_8000-2023 05 04-15_44_49](https://user-images.githubusercontent.com/13975988/236183027-7bcb5992-df50-436d-b29a-b44dc393c19e.png)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref: https://github.com/kubermatic/dashboard/issues/4914

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
