### PR TITLE
Add secondary color to form field required indicator

### DIFF
--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -168,6 +168,10 @@
     }
   }
 
+  .mat-form-field-empty.mat-form-field-label .mat-form-field-required-marker {
+    color: map.get($colors, secondary);
+  }
+
   div.mat-form-field-outline.mat-form-field-outline-thick {
     color: map.get($colors, secondary);
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add secondary color to required indicator of untouched and empty required form fields.

![screenshot-localhost_8000-2023 05 04-16_20_22](https://user-images.githubusercontent.com/13975988/236190263-ad203837-b97c-4ce1-9cfc-577663cdc6b3.png)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5297 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add color to required indicator of untouched and empty required form fields.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
