### PR TITLE
Add option to clear VSphere tags category

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/topology-spread-contraint-form/component.ts
@@ -126,7 +126,9 @@ export class TopologySpreadConstraintFormComponent extends BaseFormValidator imp
   }
 
   deleteConstraint(index: number): void {
-    this.removedConstraints?.push(this.constraints[index]);
+    if (this._dialogModeService.isEditDialog) {
+      this.removedConstraints?.push(this.constraints[index]);
+    }
 
     this.constraintArray.removeAt(index);
     this._updateConstraints();

--- a/modules/web/src/app/node-data/basic/provider/nutanix/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/nutanix/component.ts
@@ -283,10 +283,12 @@ export class NutanixBasicNodeDataComponent extends BaseFormValidator implements 
   }
 
   removeCategory(index: number): void {
-    this.removedCategories?.push({
-      category: this.categoriesFormArray.value[index].category.select,
-      categoryValue: this.categoriesFormArray.value[index].categoryValue.select,
-    });
+    if (this._dialogModeService.isEditDialog) {
+      this.removedCategories?.push({
+        category: this.categoriesFormArray.value[index].category.select,
+        categoryValue: this.categoriesFormArray.value[index].categoryValue.select,
+      });
+    }
 
     const selectedCategory = this.categoriesFormArray.at(index).get(Controls.Category).value[ComboboxControls.Select];
     this.categoriesFormArray.removeAt(index);

--- a/modules/web/src/app/node-data/extended/provider/vsphere/tag-categories/component.ts
+++ b/modules/web/src/app/node-data/extended/provider/vsphere/tag-categories/component.ts
@@ -169,7 +169,7 @@ export class VSphereTagsComponent extends BaseFormValidator implements OnInit, O
   }
 
   private static _isFilled(tag: AbstractControl): boolean {
-    return tag.get(Controls.Category).value && tag.get(Controls.Tag).value;
+    return tag.get(Controls.Category).value || tag.get(Controls.Tag).value;
   }
 
   private get _categoriesObservable(): Observable<VSphereTagCategory[]> {

--- a/modules/web/src/app/shared/components/label-form/component.ts
+++ b/modules/web/src/app/shared/components/label-form/component.ts
@@ -228,7 +228,9 @@ export class LabelFormComponent implements OnChanges, OnInit, OnDestroy, Control
   }
 
   deleteLabel(index: number): void {
-    this.removedLabels.push(this.labelArray.value[index]);
+    if (this._dialogModeService.isEditDialog) {
+      this.removedLabels.push(this.labelArray.value[index]);
+    }
 
     this.labelArray.removeAt(index);
     this._updateLabelsObject();

--- a/modules/web/src/app/shared/components/taint-form/component.ts
+++ b/modules/web/src/app/shared/components/taint-form/component.ts
@@ -97,13 +97,15 @@ export class TaintFormComponent implements OnInit {
   }
 
   deleteTaint(index: number): void {
-    this.removedTaints?.push(this.taints[index]);
+    if (this._dialogModeService.isEditDialog) {
+      this.removedTaints?.push(this.taints[index]);
+    }
     this.taintArray.removeAt(index);
     this._updateTaints();
   }
 
-  isRemovable(): boolean {
-    return this.taintArray.length > 1;
+  isRemovable(index: number): boolean {
+    return index < this.taintArray.length - 1;
   }
 
   check(index: number): void {

--- a/modules/web/src/app/shared/components/taint-form/template.html
+++ b/modules/web/src/app/shared/components/taint-form/template.html
@@ -78,7 +78,7 @@ limitations under the License.
       </mat-form-field>
       <button mat-icon-button
               class="delete-button"
-              *ngIf="isRemovable()"
+              *ngIf="isRemovable(i)"
               (click)="deleteTaint(i)">
         <i class="km-icon-mask km-icon-delete"></i>
       </button>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an option to clear VSphere tags category so it doesn't get stuck when there are no tags.
Moreover, this PR also fixes an issue which was displaying removed labels even when creating cluster or machine deployment.

![screenshot-localhost_8000-2023 05 04-17_44_57](https://user-images.githubusercontent.com/13975988/236208985-cee0c99f-bf46-48f7-9e0c-eb77cc90e382.png)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5815 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add an option to clear VSphere tags category so it doesn't get stuck when there are no tags.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
