### PR TITLE
Fix recreate nodes warning on edit MD dialog 

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -559,7 +559,7 @@ export class KubeVirtBasicNodeDataComponent
           link: osVersions[version],
         }))
       : [];
-    const selectedOSImage = this.form.get(Controls.PrimaryDiskOSImage).value[ComboboxControls.Select];
+    const selectedOSImage = this.form.get(Controls.PrimaryDiskOSImage).value[ComboboxControls?.Select];
     if (selectedOSImage && !this.osImageDropdownOptions.find(osImage => osImage.link === selectedOSImage)) {
       this._osImageCombobox.reset();
     }
@@ -642,20 +642,18 @@ export class KubeVirtBasicNodeDataComponent
     const cpus = this.form.get(Controls.CPUs).value;
     const memory = this.form.get(Controls.Memory).value;
     const nodeAffinityPreset = this.form.get(Controls.NodeAffinityPreset).value;
-    const nodeAffinityPresetData: KubeVirtNodeAffinityPreset = !nodeAffinityPreset
-      ? null
-      : {
-          Type: nodeAffinityPreset,
-          Key: this.form.get(Controls.NodeAffinityPresetKey).value,
-          Values: this.nodeAffinityPresetValues,
-        };
+    const nodeAffinityPresetData: KubeVirtNodeAffinityPreset = {
+      Type: nodeAffinityPreset ? nodeAffinityPreset : '',
+      Key: nodeAffinityPreset ? this.form.get(Controls.NodeAffinityPresetKey).value : '',
+      Values: nodeAffinityPreset ? this.nodeAffinityPresetValues : [],
+    };
 
     return {
       spec: {
         cloud: {
           kubevirt: {
-            cpus: !instanceType && cpus ? `${cpus}` : null,
-            memory: !instanceType && memory ? `${memory}M` : null,
+            cpus: !instanceType && cpus ? `${cpus}` : '',
+            memory: !instanceType && memory ? `${memory}M` : '',
             primaryDiskStorageClassName: this.form.get(Controls.PrimaryDiskStorageClassName).value[
               ComboboxControls.Select
             ],

--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -283,11 +283,13 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
           : settings.defaultNodeCount;
 
       this.form.get(Controls.Count).setValue(replicas);
-      this.form.get(Controls.UpgradeOnBoot).setValue(autoUpdatesEnabled);
-      this.form.get(Controls.DisableAutoUpdate).setValue(!autoUpdatesEnabled);
-      if (settings.machineDeploymentOptions.autoUpdatesEnforced) {
-        this.form.get(Controls.UpgradeOnBoot).disable();
-        this.form.get(Controls.DisableAutoUpdate).disable();
+      if (!this.dialogEditMode) {
+        this.form.get(Controls.UpgradeOnBoot).setValue(autoUpdatesEnabled);
+        this.form.get(Controls.DisableAutoUpdate).setValue(!autoUpdatesEnabled);
+        if (settings.machineDeploymentOptions.autoUpdatesEnforced) {
+          this.form.get(Controls.UpgradeOnBoot).disable();
+          this.form.get(Controls.DisableAutoUpdate).disable();
+        }
       }
     });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
the `autoupdateEnable` option in the admin panel shouldn't apply on the edit dialog that's why we see the warning for recreate nodes for all provider .

for kubevirt there was an issue with setting some `null` values in case there is no value for that field, while the value for them in the MD object that come from the api is `""` (empty string), so that cause the warning to show cause the initial data that been add to the editdialog come from the api 
**Which issue(s) this PR fixes**:
Fixes #5932 

**What type of PR is this?**
/kind bug

```release-note
NONE
```
```documentation
NONE
```
