### PR TITLE
Use version as query param to cache bust theme styles

### DIFF
--- a/modules/web/src/app/component.ts
+++ b/modules/web/src/app/component.ts
@@ -57,13 +57,13 @@ export class KubermaticComponent implements OnInit, OnDestroy {
     private readonly _pageTitleService: PageTitleService,
     @Inject(DOCUMENT) private readonly _document: Document
   ) {
+    this.version = this.appConfigService.getGitVersion();
     this._registerRouterWatch();
     this._loadDefaultTheme();
   }
 
   ngOnInit(): void {
     this.config = this.appConfigService.getConfig();
-    this.version = this.appConfigService.getGitVersion();
     if (this.config.google_analytics_code) {
       this.googleAnalyticsService.activate(
         this.config.google_analytics_code,
@@ -118,7 +118,7 @@ export class KubermaticComponent implements OnInit, OnDestroy {
     const retryDelay = 500;
     const defaultThemeName = 'light';
     const defaultThemeClass = `km-style-${defaultThemeName}`;
-    const defaultThemePath = `${defaultThemeName}.css`;
+    const defaultThemePath = `${defaultThemeName}.css?${this.version.tag}`;
     const positionElement = this._document.head.querySelector('link[rel="stylesheet"]:last-of-type');
     const themeElement: HTMLLinkElement = this._document.createElement('link');
     themeElement.setAttribute('rel', 'stylesheet');

--- a/modules/web/src/app/dynamic/enterprise/theming/services/manager.ts
+++ b/modules/web/src/app/dynamic/enterprise/theming/services/manager.ts
@@ -20,6 +20,7 @@
 
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable} from '@angular/core';
+import {AppConfigService} from '@app/config.service';
 import {ThemeInformerService} from '@core/services/theme-informer';
 import {UserService} from '@core/services/user';
 import {UserSettings} from '@shared/entity/settings';
@@ -39,7 +40,8 @@ export class ThemeManagerService {
     private readonly _colorSchemeService: ColorSchemeService,
     private readonly _themeService: ThemeService,
     private readonly _userService: UserService,
-    private readonly _themeInformerService: ThemeInformerService
+    private readonly _themeInformerService: ThemeInformerService,
+    private readonly _appConfigService: AppConfigService
   ) {}
 
   get isSystemDefaultThemeDark(): boolean {
@@ -90,7 +92,9 @@ export class ThemeManagerService {
 
   private readonly _themeClassName = themeName => `km-style-${themeName}`;
 
-  private readonly _themesPath = themeName => `${themeName}.css`;
+  private readonly _themesPath = themeName => {
+    return `${themeName}.css?${this._appConfigService.getGitVersion().tag}`;
+  };
 
   private _isThemeDark(name: string): boolean {
     if (name === this.systemDefaultOption) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since theme files (`dark.scss`, `light.scss`, `custom.scss`) don't have any hash in their names (like `styles.*.scss`) and we have to load them manually on the basis of selected theme, these files are cached by browser and sometimes lead to unexpected behaviour.
This PR adds current release `tag` inside the file URL to bust the cache and load latest version of these files.

For example (note file size):

**v2.22.0:**

<img width="1722" alt="Screenshot 2023-05-08 at 4 11 35 PM" src="https://user-images.githubusercontent.com/13975988/236809865-f1790337-432d-437a-a474-d852baf5001e.png">

**v2.22.2:**
<img width="1722" alt="Screenshot 2023-05-08 at 4 11 48 PM" src="https://user-images.githubusercontent.com/13975988/236809874-53fceb49-5699-453a-8b6d-10feb49a940c.png">


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5583 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add cache busting mechanism for theme styles.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
