### PR TITLE
Add support to import openstack kubeone cluster

### DIFF
--- a/modules/api/pkg/handler/v2/external_cluster/kubeone.go
+++ b/modules/api/pkg/handler/v2/external_cluster/kubeone.go
@@ -258,6 +258,8 @@ func setKubeOneCloudCredentials(preset *kubermaticv1.Preset, providerName string
 		return setHetznerCredentials(preset, kubeOneCloudSpec)
 	case providerName == resources.KubeOneDigitalOcean:
 		return setDigitalOceanCredentials(preset, kubeOneCloudSpec)
+	case providerName == resources.KubeOneOpenStack:
+		return setOpenStackCredentials(preset, kubeOneCloudSpec)
 	}
 
 	return nil, fmt.Errorf("Provider %s not supported", providerName)
@@ -342,6 +344,26 @@ func setDigitalOceanCredentials(preset *kubermaticv1.Preset, kubeOneCloudSpec ap
 		kubeOneCloudSpec.DigitalOcean = &apiv2.KubeOneDigitalOceanCloudSpec{}
 	}
 	kubeOneCloudSpec.DigitalOcean.Token = credentials.Token
+
+	return &kubeOneCloudSpec, nil
+}
+
+func setOpenStackCredentials(preset *kubermaticv1.Preset, kubeOneCloudSpec apiv2.KubeOneCloudSpec) (*apiv2.KubeOneCloudSpec, error) {
+	if preset.Spec.Openstack == nil {
+		return nil, emptyCredentialError(preset.Name, "OpenStack")
+	}
+
+	credentials := preset.Spec.Openstack
+
+	if kubeOneCloudSpec.OpenStack == nil {
+		kubeOneCloudSpec.OpenStack = &apiv2.KubeOneOpenStackCloudSpec{}
+	}
+
+	kubeOneCloudSpec.OpenStack.Username = credentials.Username
+	kubeOneCloudSpec.OpenStack.Password = credentials.Password
+	kubeOneCloudSpec.OpenStack.Domain = credentials.Domain
+	kubeOneCloudSpec.OpenStack.Project = credentials.Project
+	kubeOneCloudSpec.OpenStack.ProjectID = credentials.ProjectID
 
 	return &kubeOneCloudSpec, nil
 }

--- a/modules/web/src/app/kubeone-wizard/module.ts
+++ b/modules/web/src/app/kubeone-wizard/module.ts
@@ -29,6 +29,7 @@ import {KubeOneWizardComponent} from './component';
 import {Routing} from './routing';
 import {KubeOneDigitaloceanCredentialsBasicComponent} from './steps/credentials/provider/basic/digitalocean/component';
 import {KubeOneHetznerCredentialsBasicComponent} from './steps/credentials/provider/basic/hetzner/component';
+import {KubeOneOpenstackCredentialsBasicComponent} from './steps/credentials/provider/basic/openstack/component';
 
 const components = [
   KubeOneWizardComponent,
@@ -40,6 +41,7 @@ const components = [
   KubeOneAzureCredentialsBasicComponent,
   KubeOneDigitaloceanCredentialsBasicComponent,
   KubeOneHetznerCredentialsBasicComponent,
+  KubeOneOpenstackCredentialsBasicComponent,
   KubeOneClusterStepComponent,
   KubeOneSummaryStepComponent,
   KubeOnePresetsComponent,

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/openstack/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/openstack/component.ts
@@ -1,0 +1,141 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
+import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
+import {KubeOneCloudSpec, KubeOneClusterSpec, KubeOneOpenstackCloudSpec} from '@shared/entity/kubeone-cluster';
+import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import {merge} from 'rxjs';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
+
+export enum Controls {
+  AuthURL = 'authURL',
+  Username = 'username',
+  Password = 'password',
+  Domain = 'domain',
+  Project = 'project',
+  ProjectID = 'projectID',
+  Region = 'region',
+}
+
+@Component({
+  selector: 'km-kubeone-wizard-openstack-credentials-basic',
+  templateUrl: './template.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => KubeOneOpenstackCredentialsBasicComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => KubeOneOpenstackCredentialsBasicComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KubeOneOpenstackCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  readonly Controls = Controls;
+
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {
+    super('Openstack Credentials Basic');
+  }
+
+  ngOnInit(): void {
+    this._initForm();
+    this._initSubscriptions();
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  private _initForm(): void {
+    this.form = this._builder.group({
+      [Controls.AuthURL]: this._builder.control('', [Validators.required]),
+      [Controls.Username]: this._builder.control('', [Validators.required]),
+      [Controls.Password]: this._builder.control('', [Validators.required]),
+      [Controls.Domain]: this._builder.control('', [Validators.required]),
+      [Controls.Project]: this._builder.control('', [Validators.required]),
+      [Controls.ProjectID]: this._builder.control('', [Validators.required]),
+      [Controls.Region]: this._builder.control('', [Validators.required]),
+    });
+  }
+
+  private _initSubscriptions(): void {
+    this._clusterSpecService.providerChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => this.form.reset());
+
+    this.form.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ =>
+        this._presetsService.enablePresets(Object.values(Controls).every(control => !this.form.get(control).value))
+      );
+
+    this._presetsService.presetChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => Object.values(Controls).forEach(control => this._enable(!preset, control)));
+
+    merge(
+      this.form.get(Controls.AuthURL).valueChanges,
+      this.form.get(Controls.Username).valueChanges,
+      this.form.get(Controls.Password).valueChanges,
+      this.form.get(Controls.Domain).valueChanges,
+      this.form.get(Controls.Project).valueChanges,
+      this.form.get(Controls.ProjectID).valueChanges,
+      this.form.get(Controls.Region).valueChanges
+    )
+      .pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _enable(enable: boolean, name: Controls): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
+  }
+
+  private _getClusterEntity(): ExternalCluster {
+    return {
+      cloud: {
+        kubeOne: {
+          cloudSpec: {
+            openstack: {
+              authURL: this.form.get(Controls.AuthURL).value,
+              username: this.form.get(Controls.Username).value,
+              password: this.form.get(Controls.Password).value,
+              domain: this.form.get(Controls.Domain).value,
+              project: this.form.get(Controls.Project).value,
+              projectID: this.form.get(Controls.ProjectID).value,
+              region: this.form.get(Controls.Region).value,
+            } as KubeOneOpenstackCloudSpec,
+          } as KubeOneCloudSpec,
+        } as KubeOneClusterSpec,
+      } as ExternalCloudSpec,
+    } as ExternalCluster;
+  }
+}

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/openstack/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/openstack/template.html
@@ -1,0 +1,103 @@
+<!--
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<form [formGroup]="form"
+      fxLayout="column"
+      fxLayoutGap="8px">
+  <mat-form-field fxFlex>
+    <mat-label>AuthURL</mat-label>
+    <input [formControlName]="Controls.AuthURL"
+           [name]="Controls.AuthURL"
+           matInput
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.AuthURL).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Username</mat-label>
+    <input [formControlName]="Controls.Username"
+           [name]="Controls.Username"
+           matInput
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.Username).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Password</mat-label>
+    <input [formControlName]="Controls.Password"
+           [name]="Controls.Password"
+           matInput
+           kmInputPassword
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.Password).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Domain</mat-label>
+    <input [formControlName]="Controls.Domain"
+           [name]="Controls.Domain"
+           matInput
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.Domain).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Project Name</mat-label>
+    <input [formControlName]="Controls.Project"
+           [name]="Controls.Project"
+           matInput
+           autocomplete="off"
+           required>
+    <mat-error *ngIf="form.get(Controls.Project).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Project ID</mat-label>
+    <input [formControlName]="Controls.ProjectID"
+           [name]="Controls.ProjectID"
+           required
+           matInput
+           autocomplete="off">
+    <mat-error *ngIf="form.get(Controls.ProjectID).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Region</mat-label>
+    <input [formControlName]="Controls.Region"
+           [name]="Controls.Region"
+           required
+           matInput
+           autocomplete="off">
+    <mat-error *ngIf="form.get(Controls.Region).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+</form>

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
@@ -25,4 +25,7 @@ limitations under the License.
                                                     [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-digitalocean-credentials-basic>
   <km-kubeone-wizard-hetzner-credentials-basic *ngSwitchCase="NodeProvider.HETZNER"
                                                [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-hetzner-credentials-basic>
+  <km-kubeone-wizard-openstack-credentials-basic *ngSwitchCase="NodeProvider.OPENSTACK"
+                                                 [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-openstack-credentials-basic>
+
 </div>

--- a/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
@@ -49,6 +49,7 @@ export class KubeOneProviderStepComponent extends StepBase implements OnInit {
     NodeProvider.AZURE,
     NodeProvider.DIGITALOCEAN,
     NodeProvider.HETZNER,
+    NodeProvider.OPENSTACK,
   ];
   readonly controls = Controls;
 

--- a/modules/web/src/app/kubeone-wizard/steps/summary/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/summary/template.html
@@ -92,6 +92,37 @@ limitations under the License.
               <div value>{{SECRET_MASK}}</div>
             </km-property>
           </ng-container>
+          <!-- OpenStack -->
+          <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.openstack">
+            <km-property>
+              <div key>AuthURL</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.openstack?.authURL}}</div>
+            </km-property>
+            <km-property>
+              <div key>Username</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.openstack?.username}}</div>
+            </km-property>
+            <km-property>
+              <div key>Password</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+            <km-property>
+              <div key>Domain</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.openstack?.domain}}</div>
+            </km-property>
+            <km-property>
+              <div key>Project Name</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.openstack?.project}}</div>
+            </km-property>
+            <km-property>
+              <div key>Project ID</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.openstack?.projectID}}</div>
+            </km-property>
+            <km-property>
+              <div key>Region</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.openstack?.region}}</div>
+            </km-property>
+          </ng-container>
         </ng-template>
       </div>
     </div>

--- a/modules/web/src/app/shared/entity/kubeone-cluster.ts
+++ b/modules/web/src/app/shared/entity/kubeone-cluster.ts
@@ -39,6 +39,7 @@ export class KubeOneCloudSpec {
   azure?: KubeOneAzureCloudSpec;
   digitalOcean?: KubeOneDigitalOceanCloudSpec;
   hetzner?: KubeOneHetznerCloudSpec;
+  openstack?: KubeOneOpenstackCloudSpec;
 }
 
 export class KubeOneAWSCloudSpec {
@@ -62,4 +63,14 @@ export class KubeOneDigitalOceanCloudSpec {
 }
 export class KubeOneHetznerCloudSpec {
   token: string;
+}
+
+export class KubeOneOpenstackCloudSpec {
+  authURL: string;
+  username: string;
+  password: string;
+  domain: string;
+  project: string;
+  projectID: string;
+  region: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
add openstack provider to the kubeone import wizard and set the credentials in the api    
**Which issue(s) this PR fixes**:
Fixes #5804 

**Provider Step**:

![image](https://github.com/kubermatic/dashboard/assets/85109141/06def2e3-4968-456d-b5b9-0a97e025392f)

**Credentials Step**:

![image](https://github.com/kubermatic/dashboard/assets/85109141/6deac5e8-4ae5-4017-9b84-f30cc7673406)


**Summary Step**:

![image](https://github.com/kubermatic/dashboard/assets/85109141/2bf43515-4934-4078-976c-8bdd2edeaa4d)



**What type of PR is this?**
/kind feature

```release-note
Add support to import openstack kubeone cluster
```

```documentation
NONE
```
