### PR TITLE
Rework vSphere credentials UI/UX

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/component.ts
@@ -39,10 +39,10 @@ export class VSphereProviderSettingsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Control.InfraManagementUsername]: this._builder.control('', Validators.required),
-      [Control.InfraManagementPassword]: this._builder.control('', Validators.required),
       [Control.Username]: this._builder.control('', Validators.required),
       [Control.Password]: this._builder.control('', Validators.required),
+      [Control.InfraManagementUsername]: this._builder.control(''),
+      [Control.InfraManagementPassword]: this._builder.control(''),
     });
 
     merge(

--- a/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/template.html
@@ -18,13 +18,12 @@ limitations under the License.
   <mat-form-field fxFlex>
     <mat-label>Username</mat-label>
     <input matInput
-           [formControlName]="Control.InfraManagementUsername"
-           [name]="Control.InfraManagementUsername"
+           [formControlName]="Control.Username"
            type="text"
            autocomplete="off"
            required
-           kmValueChangedIndicator>
-    <mat-error *ngIf="form.get(Control.InfraManagementUsername).hasError('required')">
+           kmValueChangedIndicator />
+    <mat-error *ngIf="form.get(Control.Username).hasError('required')">
       <strong>Required</strong>
     </mat-error>
   </mat-form-field>
@@ -32,13 +31,12 @@ limitations under the License.
   <mat-form-field fxFlex>
     <mat-label>Password</mat-label>
     <input matInput
-           [formControlName]="Control.InfraManagementPassword"
-           [name]="Control.InfraManagementPassword"
+           [formControlName]="Control.Password"
            kmInputPassword
            autocomplete="off"
            required
-           kmValueChangedIndicator>
-    <mat-error *ngIf="form.get(Control.InfraManagementPassword).hasError('required')">
+           kmValueChangedIndicator />
+    <mat-error *ngIf="form.get(Control.Password).hasError('required')">
       <strong>Required</strong>
     </mat-error>
   </mat-form-field>
@@ -46,22 +44,20 @@ limitations under the License.
   <mat-form-field fxFlex>
     <mat-label>VSphere Cloud Provider Username</mat-label>
     <input matInput
-           [formControlName]="Control.Username"
-           [name]="Control.Username"
+           [formControlName]="Control.InfraManagementUsername"
            type="text"
            autocomplete="off"
            required
-           kmValueChangedIndicator>
+           kmValueChangedIndicator />
   </mat-form-field>
 
   <mat-form-field fxFlex>
     <mat-label>VSphere Cloud Provider Password</mat-label>
     <input matInput
-           [formControlName]="Control.Password"
-           [name]="Control.Password"
+           [formControlName]="Control.InfraManagementPassword"
            kmInputPassword
            autocomplete="off"
            required
-           kmValueChangedIndicator>
+           kmValueChangedIndicator />
   </mat-form-field>
 </form>

--- a/modules/web/src/app/wizard/step/provider-settings/provider/basic/vsphere/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/basic/vsphere/template.html
@@ -17,48 +17,56 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column"
       fxLayoutGap="8px">
+  <mat-card-header class="km-no-padding"
+                   *ngIf="useCustomCloudCredentials">
+    <mat-card-title>Credentials for CCM and CSI drivers</mat-card-title>
+  </mat-card-header>
   <mat-form-field fxFlex>
     <mat-label>Username</mat-label>
     <input matInput
-           [formControlName]="Controls.InfraManagementUsername"
-           [name]="Controls.InfraManagementUsername"
+           [formControlName]="Controls.Username"
            type="text"
            autocomplete="off"
-           required>
-    <mat-error *ngIf="form.get(Controls.InfraManagementUsername).hasError('required')">
+           required />
+    <mat-error *ngIf="form.get(Controls.Username).hasError('required')">
       <strong>Required</strong>
     </mat-error>
   </mat-form-field>
 
-  <div fxLayout="column">
-    <mat-form-field fxFlex>
-      <mat-label>Password</mat-label>
-      <input matInput
-             [formControlName]="Controls.InfraManagementPassword"
-             [name]="Controls.InfraManagementUsername"
-             kmInputPassword
-             autocomplete="off"
-             required>
-      <mat-error *ngIf="form.get(Controls.InfraManagementPassword).hasError('required')">
-        <strong>Required</strong>
-      </mat-error>
-    </mat-form-field>
-    <mat-checkbox [formControlName]="Controls.UseCustomCloudCredentials"
-                  [name]="Controls.UseCustomCloudCredentials">
-      Use dedicated credentials to provision vSphere resources
-    </mat-checkbox>
-  </div>
+  <mat-form-field fxFlex>
+    <mat-label>Password</mat-label>
+    <input matInput
+           [formControlName]="Controls.Password"
+           kmInputPassword
+           autocomplete="off"
+           required />
+    <mat-error *ngIf="form.get(Controls.Password).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-checkbox [formControlName]="Controls.UseCustomCloudCredentials"
+                [name]="Controls.UseCustomCloudCredentials">
+    Use dedicated credentials to provision vSphere resources
+    <div fxFlex
+         class="km-icon-info km-pointer p-10"
+         matTooltip="These credentials will be used for managing resources like tags, folders, networks etc. For cloud provider functionality i.e. external CCM and CSI drivers, the credentials specified above will be used."></div>
+  </mat-checkbox>
+
+  <mat-card-header class="km-no-padding"
+                   *ngIf="useCustomCloudCredentials">
+    <mat-card-title>Credentials for provisioning vSphere resources</mat-card-title>
+  </mat-card-header>
 
   <ng-container *ngIf="useCustomCloudCredentials">
     <mat-form-field fxFlex>
       <mat-label>VSphere Cloud Provider Username</mat-label>
       <input matInput
-             [formControlName]="Controls.Username"
-             [name]="Controls.Username"
+             [formControlName]="Controls.InfraManagementUsername"
              type="text"
              autocomplete="off"
-             required>
-      <mat-error *ngIf="form.get(Controls.Username).hasError('required')">
+             required />
+      <mat-error *ngIf="form.get(Controls.InfraManagementUsername).hasError('required')">
         <strong>Required</strong>
       </mat-error>
     </mat-form-field>
@@ -66,12 +74,11 @@ limitations under the License.
     <mat-form-field fxFlex>
       <mat-label>VSphere Cloud Provider Password</mat-label>
       <input matInput
-             [formControlName]="Controls.Password"
-             [name]="Controls.Password"
+             [formControlName]="Controls.InfraManagementPassword"
              kmInputPassword
              autocomplete="off"
-             required>
-      <mat-error *ngIf="form.get(Controls.Password).hasError('required')">
+             required />
+      <mat-error *ngIf="form.get(Controls.InfraManagementPassword).hasError('required')">
         <strong>Required</strong>
       </mat-error>
     </mat-form-field>


### PR DESCRIPTION
**What this PR does / why we need it**:
Through https://github.com/kubermatic/dashboard/issues/5952, we found two major issues with the credentials handling for vSphere:
1. The difference is ambiguous and needs more coherence
2. By default we are setting the credentials for `infra management user` and by additionally specifying "dedicated credentials" we configure the username/password for vSphere. In reality, this is completely the opposite of how it should work. 

This PR fixes both of these issues and tries to improve the UX as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5952

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
* UI/UX improvements for vSphere credentials in provider settings step
* By default, username/password will be configured and dedicated credentials will be used to configure infra management user for vSphere
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
