### PR TITLE
Add functionality to delete disabled label

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -213,6 +213,7 @@ limitations under the License.
                      [labels]="labels"
                      [disabledLabel]="clusterDefaultNodeSelectorNamespace"
                      [disabledLabelTooltip]="CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP"
+                     [canDeleteDisabledLabel]="true"
                      [inheritedLabels]="cluster.inheritedLabels"
                      [asyncKeyValidators]=asyncLabelValidators
                      [formControlName]="Controls.Labels"></km-label-form>

--- a/modules/web/src/app/settings/admin/opa/default-constraints/template.html
+++ b/modules/web/src/app/settings/admin/opa/default-constraints/template.html
@@ -105,11 +105,12 @@ limitations under the License.
         *matCellDef="let element">
       <span class="provider-wrapper">
         <ng-container *ngFor="let provider of element.spec?.selector?.providers; let i = index">
-          <i *ngIf="i < displayedProvidersLimit || isShowProviders[element.name]"  class="km-provider-logo km-provider-logo-{{provider}} provider-logo {{provider}}"></i>
+          <i *ngIf="i < displayedProvidersLimit || isShowProviders[element.name]"
+             class="km-provider-logo km-provider-logo-{{provider}} provider-logo {{provider}}"></i>
         </ng-container>
       </span>
       <km-labels [labels]="element.spec?.selector?.labelSelector?.matchLabels"
-      class="labels-wrapper"></km-labels>
+                 class="labels-wrapper"></km-labels>
       <ng-container *ngIf="hasNoMatches(element.spec.selector)">All</ng-container>
       <span *ngIf="numberOfProviders(element) >  displayedProvidersLimit"
             class="num-of-extra-providers"

--- a/modules/web/src/app/shared/components/label-form/component.ts
+++ b/modules/web/src/app/shared/components/label-form/component.ts
@@ -43,6 +43,7 @@ import {KeyValueEntry} from '@shared/types/common';
 import {LabelFormValidators} from '../../validators/label-form.validators';
 import {ControlsOf} from '../../model/shared';
 import {DialogModeService} from '@app/core/services/dialog-mode';
+import _ from 'lodash';
 
 @Component({
   selector: 'km-label-form',
@@ -68,6 +69,7 @@ export class LabelFormComponent implements OnChanges, OnInit, OnDestroy, Control
   @Input() labels: Record<string, string>;
   @Input() disabledLabel: KeyValueEntry;
   @Input() disabledLabelTooltip: string;
+  @Input() canDeleteDisabledLabel: boolean;
   @Input() labelHint: string;
   @Input() labelHintKey: string;
   @Input() inheritedLabels: object = {};
@@ -113,12 +115,6 @@ export class LabelFormComponent implements OnChanges, OnInit, OnDestroy, Control
     if (!this.form) {
       this._initForm();
     }
-    if (changes && changes.keyName) {
-      this.keyName = changes.keyName.currentValue;
-    }
-    if (changes && changes.valueName) {
-      this.valueName = changes.valueName.currentValue;
-    }
     if (changes?.disabledLabel) {
       const [key = '', value = ''] = this.disabledLabel ?? [];
 
@@ -139,6 +135,10 @@ export class LabelFormComponent implements OnChanges, OnInit, OnDestroy, Control
         if (removeLabelIndex >= 0) {
           this.labelArray.removeAt(removeLabelIndex);
         }
+      }
+
+      if (key || value || !_.isEmpty(this.labels)) {
+        this._updateLabelsObject();
       }
     }
   }
@@ -236,6 +236,18 @@ export class LabelFormComponent implements OnChanges, OnInit, OnDestroy, Control
     this._updateLabelsObject();
   }
 
+  deleteDisabledLabel(): void {
+    const key = this.disabledLabelFormGroup?.value.key;
+    const value = this.disabledLabelFormGroup?.value.value;
+    if (this._dialogModeService.isEditDialog) {
+      this.removedLabels.push({key, value});
+    }
+    this.disabledLabelFormGroup = null;
+    this.disabledLabel = null;
+
+    this._updateLabelsObject();
+  }
+
   check(index: number): void {
     this._addLabelIfNeeded();
     this._validateKey(index);
@@ -305,6 +317,9 @@ export class LabelFormComponent implements OnChanges, OnInit, OnDestroy, Control
         return true;
       }
     }
+    if (this.disabledLabelFormGroup?.value.key && this.disabledLabelFormGroup?.value.key === currentKey) {
+      return true;
+    }
     return false;
   }
 
@@ -319,12 +334,20 @@ export class LabelFormComponent implements OnChanges, OnInit, OnDestroy, Control
       }
     });
 
-    // Nullify initial labels data (it is needed to make edit work as it uses JSON Merge Patch).
-    Object.keys(this.initialLabels).forEach(initialKey => {
-      if (!Object.prototype.hasOwnProperty.call(labelsObject, initialKey)) {
-        labelsObject[initialKey] = null;
-      }
-    });
+    if (this.initialLabels) {
+      // Nullify initial labels data (it is needed to make edit work as it uses JSON Merge Patch).
+      Object.keys(this.initialLabels).forEach(initialKey => {
+        if (!Object.prototype.hasOwnProperty.call(labelsObject, initialKey)) {
+          labelsObject[initialKey] = null;
+        }
+      });
+    }
+
+    const disabledLabelKey = this.disabledLabelFormGroup?.value.key;
+    const disabledLabelValue = this.disabledLabelFormGroup?.value.value;
+    if (disabledLabelKey && disabledLabelValue) {
+      labelsObject[disabledLabelKey] = disabledLabelValue;
+    }
 
     // Update labels object.
     this.labels = labelsObject;

--- a/modules/web/src/app/shared/components/label-form/template.html
+++ b/modules/web/src/app/shared/components/label-form/template.html
@@ -37,7 +37,8 @@ limitations under the License.
         <button mat-icon-button
                 type="button"
                 class="delete-button"
-                [disabled]="true">
+                [disabled]="!canDeleteDisabledLabel"
+                (click)="deleteDisabledLabel()">
           <i class="km-icon-mask km-icon-delete"
              aria-hidden="true"></i>
         </button>

--- a/modules/web/src/app/shared/utils/cluster.ts
+++ b/modules/web/src/app/shared/utils/cluster.ts
@@ -13,30 +13,12 @@
 // limitations under the License.
 
 import {MachineDeployment, MachineDeploymentStatus} from '@shared/entity/machine-deployment';
-import {KeyValueEntry} from '../types/common';
 
 export const CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE = 'clusterDefaultNodeSelector';
 export const CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP =
   'Namespace clusterDefaultNodeSelector requires nodes with the labels defined in the Label Selector to start the cluster. The labels are enforced. Edit the label in the Label Selector.';
 export const CLUSTER_DEFAULT_NODE_SELECTOR_HINT =
   'Namespace <b>clusterDefaultNodeSelector</b> requires nodes with the labels defined in the Label Selector to start the cluster. The labels are enforced.';
-
-export function handleClusterDefaultNodeSelector(
-  labels: Record<string, string>,
-  nodeConfig: Record<string, string>,
-  previousClusterDefaultNodeSelectorNamespace: KeyValueEntry,
-  onComplete: (entry: KeyValueEntry, labels: Record<string, string>) => void
-): void {
-  const [prevKey] = previousClusterDefaultNodeSelectorNamespace ?? [];
-
-  if (Object.hasOwnProperty.call(labels, prevKey)) {
-    delete labels[prevKey];
-  }
-
-  const [currKey, currValue] = nodeConfig[CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE]?.split('=') ?? [];
-
-  onComplete(currKey && currValue ? [currKey, currValue] : null, labels);
-}
 
 export function getClusterMachinesCount(machineDeployments: MachineDeployment[]): MachineDeploymentStatus {
   const mdStatus: MachineDeploymentStatus = {

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -458,12 +458,13 @@ limitations under the License.
                  matTooltip="Enable to use OSM for creating and managing worker node configurations. Disable this to use legacy machine-controller userdata, its usage in production environment is not recommended."></i>
             </mat-checkbox>
 
-            <km-label-form title="Labels"
+            <km-label-form [title]="'Labels'"
                            [labels]="labels"
                            [asyncKeyValidators]="asyncLabelValidators"
                            [formControlName]="Controls.Labels"
                            [disabledLabel]="clusterDefaultNodeSelectorNamespace"
                            [disabledLabelTooltip]="CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP"
+                           [canDeleteDisabledLabel]="true"
                            (labelsChange)="onLabelsChange($event)"
                            fxFlex="100">
             </km-label-form>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add functionality to delete disabled label especially when `PodNodeSelector` admission plugin and `clusterDefaultNodeSelector` namespace is set.

![screenshot-localhost_8000-2023 05 25-20_35_08](https://github.com/kubermatic/dashboard/assets/13975988/7d32bf6e-2de3-4e13-9707-1deaa0f7d410)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5979 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow removing cluster label when PodNodeSelector admission plugin and clusterDefaultNodeSelector namespace are set.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
