### PR TITLE
[release/v2.22] Add functionality to delete disabled label

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -44,7 +44,6 @@ import {
   CLUSTER_DEFAULT_NODE_SELECTOR_HINT,
   CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE,
   CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP,
-  handleClusterDefaultNodeSelector,
 } from '@shared/utils/cluster';
 import {KeyValueEntry} from '@shared/types/common';
 import {IPV4_IPV6_CIDR_PATTERN} from '@shared/validators/others';
@@ -184,6 +183,20 @@ export class EditClusterComponent implements OnInit, OnDestroy {
 
     this.checkForLegacyAdmissionPlugins();
 
+    this.form
+      .get(Controls.AdmissionPlugins)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(() => {
+        const selectedPlugins = this.form.get(Controls.AdmissionPlugins).value;
+        if (
+          !selectedPlugins.includes(AdmissionPlugin.PodSecurityPolicy) &&
+          !_.isEmpty(this.podNodeSelectorAdmissionPluginConfig)
+        ) {
+          this.form.get(Controls.PodNodeSelectorAdmissionPluginConfig).reset();
+          this.onPodNodeSelectorAdmissionPluginConfigChange(null);
+        }
+      });
+
     const [initialClusterDefaultNodeSelectorKey] =
       this.podNodeSelectorAdmissionPluginConfig?.[this.CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE]?.split('=') ?? [];
 
@@ -204,16 +217,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   onLabelsChange(labels: Record<string, string>): void {
-    const [key, value] = this.clusterDefaultNodeSelectorNamespace ?? [];
-
-    if (key && value) {
-      labels = {...labels, [key]: value};
-    }
-
-    if (!Object.hasOwnProperty.call(labels, this.initialClusterDefaultNodeSelectorKey)) {
-      labels = {...labels, [this.initialClusterDefaultNodeSelectorKey]: null};
-    }
-
     this.labels = labels;
   }
 
@@ -363,15 +366,8 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   private _handleClusterDefaultNodeSelector(config: Record<string, string>): void {
-    handleClusterDefaultNodeSelector(
-      this.labels ?? {},
-      config,
-      this.clusterDefaultNodeSelectorNamespace,
-      (entry, labels): void => {
-        this.clusterDefaultNodeSelectorNamespace = entry;
-        this.onLabelsChange(labels);
-      }
-    );
+    const [currKey, currValue] = config?.[CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE]?.split('=') ?? [];
+    this.clusterDefaultNodeSelectorNamespace = [currKey, currValue];
   }
 
   private getAPIServerAllowedIPRange(): NetworkRanges {

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -194,6 +194,7 @@ limitations under the License.
                      [labels]="labels"
                      [disabledLabel]="clusterDefaultNodeSelectorNamespace"
                      [disabledLabelTooltip]="CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP"
+                     [canDeleteDisabledLabel]="true"
                      [inheritedLabels]="cluster.inheritedLabels"
                      [asyncKeyValidators]=asyncLabelValidators
                      [formControlName]="Controls.Labels"></km-label-form>

--- a/modules/web/src/app/shared/components/label-form/template.html
+++ b/modules/web/src/app/shared/components/label-form/template.html
@@ -37,7 +37,8 @@ limitations under the License.
         <button mat-icon-button
                 type="button"
                 class="delete-button"
-                [disabled]="true">
+                [disabled]="!canDeleteDisabledLabel"
+                (click)="deleteDisabledLabel()">
           <i class="km-icon-mask km-icon-delete"
              aria-hidden="true"></i>
         </button>

--- a/modules/web/src/app/shared/utils/cluster.ts
+++ b/modules/web/src/app/shared/utils/cluster.ts
@@ -13,30 +13,12 @@
 // limitations under the License.
 
 import {MachineDeployment, MachineDeploymentStatus} from '@shared/entity/machine-deployment';
-import {KeyValueEntry} from '../types/common';
 
 export const CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE = 'clusterDefaultNodeSelector';
 export const CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP =
   'Namespace clusterDefaultNodeSelector requires nodes with the labels defined in the Label Selector to start the cluster. The labels are enforced. Edit the label in the Label Selector.';
 export const CLUSTER_DEFAULT_NODE_SELECTOR_HINT =
   'Namespace <b>clusterDefaultNodeSelector</b> requires nodes with the labels defined in the Label Selector to start the cluster. The labels are enforced.';
-
-export function handleClusterDefaultNodeSelector(
-  labels: Record<string, string>,
-  nodeConfig: Record<string, string>,
-  previousClusterDefaultNodeSelectorNamespace: KeyValueEntry,
-  onComplete: (entry: KeyValueEntry, labels: Record<string, string>) => void
-): void {
-  const [prevKey] = previousClusterDefaultNodeSelectorNamespace ?? [];
-
-  if (Object.hasOwnProperty.call(labels, prevKey)) {
-    delete labels[prevKey];
-  }
-
-  const [currKey, currValue] = nodeConfig[CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE]?.split('=') ?? [];
-
-  onComplete(currKey && currValue ? [currKey, currValue] : null, labels);
-}
 
 export function getClusterMachinesCount(machineDeployments: MachineDeployment[]): MachineDeploymentStatus {
   const mdStatus: MachineDeploymentStatus = {

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -68,10 +68,10 @@ import {
   CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE,
   CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP,
   CLUSTER_DEFAULT_NODE_SELECTOR_HINT,
-  handleClusterDefaultNodeSelector,
 } from '@shared/utils/cluster';
 import {KeyValueEntry} from '@shared/types/common';
 import {getEditionVersion} from '@shared/utils/common';
+import _ from 'lodash';
 
 enum Controls {
   Name = 'name',
@@ -248,7 +248,17 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
     this.control(Controls.AdmissionPlugins)
       .valueChanges.pipe(takeUntil(this._unsubscribe))
-      .subscribe(() => (this._clusterSpecService.admissionPlugins = this.form.get(Controls.AdmissionPlugins).value));
+      .subscribe(() => {
+        const selectedPlugins = this.form.get(Controls.AdmissionPlugins).value;
+        this._clusterSpecService.admissionPlugins = selectedPlugins;
+        if (
+          !selectedPlugins.includes(AdmissionPlugin.PodSecurityPolicy) &&
+          !_.isEmpty(this.podNodeSelectorAdmissionPluginConfig)
+        ) {
+          this.control(Controls.PodNodeSelectorAdmissionPluginConfig).reset();
+          this.onPodNodeSelectorAdmissionPluginConfigChange({});
+        }
+      });
 
     merge(this.form.get(Controls.CNIPlugin).valueChanges, this.form.get(Controls.IPFamily).valueChanges)
       .pipe(switchMap(() => this._clusterService.getCNIPluginVersions(this.form.get(Controls.CNIPlugin).value)))
@@ -355,12 +365,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   onLabelsChange(labels: Record<string, string>): void {
-    const [key, value] = this.clusterDefaultNodeSelectorNamespace ?? [];
-
-    if (key && value) {
-      labels = {...labels, [key]: value};
-    }
-
     this.labels = labels;
     this._clusterSpecService.labels = labels;
   }
@@ -369,15 +373,8 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     this.podNodeSelectorAdmissionPluginConfig = config;
     this._clusterSpecService.podNodeSelectorAdmissionPluginConfig = this.podNodeSelectorAdmissionPluginConfig;
 
-    handleClusterDefaultNodeSelector(
-      this.labels ?? {},
-      config,
-      this.clusterDefaultNodeSelectorNamespace,
-      (entry, labels) => {
-        this.clusterDefaultNodeSelectorNamespace = entry;
-        this.onLabelsChange(labels);
-      }
-    );
+    const [currKey, currValue] = config[CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE]?.split('=') ?? [];
+    this.clusterDefaultNodeSelectorNamespace = [currKey, currValue];
   }
 
   isEnforced(control: Controls): boolean {

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -447,12 +447,13 @@ limitations under the License.
                  matTooltip="Enable to use OSM for creating and managing worker node configurations. Disable this to use legacy machine-controller userdata, its usage in production environment is not recommended."></i>
             </mat-checkbox>
 
-            <km-label-form title="Labels"
+            <km-label-form [title]="'Labels'"
                            [labels]="labels"
                            [asyncKeyValidators]="asyncLabelValidators"
                            [formControlName]="Controls.Labels"
                            [disabledLabel]="clusterDefaultNodeSelectorNamespace"
                            [disabledLabelTooltip]="CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP"
+                           [canDeleteDisabledLabel]="true"
                            (labelsChange)="onLabelsChange($event)"
                            fxFlex="100">
             </km-label-form>


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry pick of #5981 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow removing cluster label when PodNodeSelector admission plugin and clusterDefaultNodeSelector namespace are set.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
