### PR TITLE
Add support to import a vsphere kubeone cluster

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -107,7 +107,7 @@ replace (
 
 require (
 	github.com/pkg/errors v0.9.1
-	k8c.io/kubermatic/v2 v2.22.1-0.20230427083914-b575ef223b19
+	k8c.io/kubermatic/v2 v2.22.1-0.20230525110947-fcae2c473ece
 )
 
 require (

--- a/modules/api/pkg/handler/v2/external_cluster/kubeone.go
+++ b/modules/api/pkg/handler/v2/external_cluster/kubeone.go
@@ -260,6 +260,8 @@ func setKubeOneCloudCredentials(preset *kubermaticv1.Preset, providerName string
 		return setDigitalOceanCredentials(preset, kubeOneCloudSpec)
 	case providerName == resources.KubeOneOpenStack:
 		return setOpenStackCredentials(preset, kubeOneCloudSpec)
+	case providerName == resources.KubeOneVSphere:
+		return setVsphereCredentials(preset, kubeOneCloudSpec)
 	}
 
 	return nil, fmt.Errorf("Provider %s not supported", providerName)
@@ -364,6 +366,23 @@ func setOpenStackCredentials(preset *kubermaticv1.Preset, kubeOneCloudSpec apiv2
 	kubeOneCloudSpec.OpenStack.Domain = credentials.Domain
 	kubeOneCloudSpec.OpenStack.Project = credentials.Project
 	kubeOneCloudSpec.OpenStack.ProjectID = credentials.ProjectID
+
+	return &kubeOneCloudSpec, nil
+}
+
+func setVsphereCredentials(preset *kubermaticv1.Preset, kubeOneCloudSpec apiv2.KubeOneCloudSpec) (*apiv2.KubeOneCloudSpec, error) {
+	if preset.Spec.VSphere == nil {
+		return nil, emptyCredentialError(preset.Name, "VSphere")
+	}
+
+	credentials := preset.Spec.VSphere
+
+	if kubeOneCloudSpec.VSphere == nil {
+		kubeOneCloudSpec.VSphere = &apiv2.KubeOneVSphereCloudSpec{}
+	}
+
+	kubeOneCloudSpec.VSphere.Username = credentials.Username
+	kubeOneCloudSpec.VSphere.Password = credentials.Password
 
 	return &kubeOneCloudSpec, nil
 }

--- a/modules/web/src/app/kubeone-wizard/module.ts
+++ b/modules/web/src/app/kubeone-wizard/module.ts
@@ -30,6 +30,7 @@ import {Routing} from './routing';
 import {KubeOneDigitaloceanCredentialsBasicComponent} from './steps/credentials/provider/basic/digitalocean/component';
 import {KubeOneHetznerCredentialsBasicComponent} from './steps/credentials/provider/basic/hetzner/component';
 import {KubeOneOpenstackCredentialsBasicComponent} from './steps/credentials/provider/basic/openstack/component';
+import {KubeOneVSphereCredentialsBasicComponent} from './steps/credentials/provider/basic/vsphere/component';
 
 const components = [
   KubeOneWizardComponent,
@@ -42,6 +43,7 @@ const components = [
   KubeOneDigitaloceanCredentialsBasicComponent,
   KubeOneHetznerCredentialsBasicComponent,
   KubeOneOpenstackCredentialsBasicComponent,
+  KubeOneVSphereCredentialsBasicComponent,
   KubeOneClusterStepComponent,
   KubeOneSummaryStepComponent,
   KubeOnePresetsComponent,

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/template.html
@@ -27,5 +27,7 @@ limitations under the License.
                                                [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-hetzner-credentials-basic>
   <km-kubeone-wizard-openstack-credentials-basic *ngSwitchCase="NodeProvider.OPENSTACK"
                                                  [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-openstack-credentials-basic>
+  <km-kubeone-wizard-vsphere-credentials-basic *ngSwitchCase="NodeProvider.VSPHERE"
+                                               [formControl]="form.get(Control.CredentialsBasic)"></km-kubeone-wizard-vsphere-credentials-basic>
 
 </div>

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/vsphere/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/vsphere/component.ts
@@ -1,0 +1,125 @@
+// Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChangeDetectionStrategy, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
+import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
+import {KubeOneClusterSpecService} from '@core/services/kubeone-cluster-spec';
+import {KubeOnePresetsService} from '@core/services/kubeone-wizard/kubeone-presets';
+import {ExternalCloudSpec, ExternalCluster} from '@shared/entity/external-cluster';
+import {KubeOneCloudSpec, KubeOneClusterSpec, KubeOneVSphereCloudSpec} from '@shared/entity/kubeone-cluster';
+import {BaseFormValidator} from '@shared/validators/base-form.validator';
+import {merge} from 'rxjs';
+import {distinctUntilChanged, takeUntil} from 'rxjs/operators';
+
+export enum Controls {
+  Username = 'username',
+  Password = 'password',
+  Server = 'server',
+}
+
+@Component({
+  selector: 'km-kubeone-wizard-vsphere-credentials-basic',
+  templateUrl: './template.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => KubeOneVSphereCredentialsBasicComponent),
+      multi: true,
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => KubeOneVSphereCredentialsBasicComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KubeOneVSphereCredentialsBasicComponent extends BaseFormValidator implements OnInit, OnDestroy {
+  readonly Controls = Controls;
+
+  constructor(
+    private readonly _builder: FormBuilder,
+    private readonly _clusterSpecService: KubeOneClusterSpecService,
+    private readonly _presetsService: KubeOnePresetsService
+  ) {
+    super('VSphere Credentials Basic');
+  }
+
+  ngOnInit(): void {
+    this._initForm();
+    this._initSubscriptions();
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
+  }
+
+  private _initForm(): void {
+    this.form = this._builder.group({
+      [Controls.Username]: this._builder.control('', [Validators.required]),
+      [Controls.Password]: this._builder.control('', [Validators.required]),
+      [Controls.Server]: this._builder.control('', [Validators.required]),
+    });
+  }
+
+  private _initSubscriptions(): void {
+    this._clusterSpecService.providerChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => this.form.reset());
+
+    this.form.valueChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ =>
+        this._presetsService.enablePresets(Object.values(Controls).every(control => !this.form.get(control).value))
+      );
+
+    this._presetsService.presetChanges
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(preset => Object.values(Controls).forEach(control => this._enable(!preset, control)));
+
+    merge(
+      this.form.get(Controls.Username).valueChanges,
+      this.form.get(Controls.Password).valueChanges,
+      this.form.get(Controls.Server).valueChanges
+    )
+      .pipe(distinctUntilChanged())
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(_ => (this._clusterSpecService.cluster = this._getClusterEntity()));
+  }
+
+  private _enable(enable: boolean, name: Controls): void {
+    if (enable && this.form.get(name).disabled) {
+      this.form.get(name).enable();
+    }
+
+    if (!enable && this.form.get(name).enabled) {
+      this.form.get(name).disable();
+    }
+  }
+
+  private _getClusterEntity(): ExternalCluster {
+    return {
+      cloud: {
+        kubeOne: {
+          cloudSpec: {
+            vsphere: {
+              username: this.form.get(Controls.Username).value,
+              password: this.form.get(Controls.Password).value,
+              server: this.form.get(Controls.Server).value,
+            } as KubeOneVSphereCloudSpec,
+          } as KubeOneCloudSpec,
+        } as KubeOneClusterSpec,
+      } as ExternalCloudSpec,
+    } as ExternalCluster;
+  }
+}

--- a/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/vsphere/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/provider/basic/vsphere/template.html
@@ -1,0 +1,57 @@
+<!--
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<form [formGroup]="form"
+      fxLayout="column"
+      fxLayoutGap="8px">
+  <!-- <mat-card-header class="km-no-padding"
+                   *ngIf="useCustomCloudCredentials">
+    <mat-card-title>Credentials for CCM and CSI drivers</mat-card-title>
+  </mat-card-header> -->
+  <mat-form-field fxFlex>
+    <mat-label>Username</mat-label>
+    <input matInput
+           [formControlName]="Controls.Username"
+           type="text"
+           autocomplete="off"
+           required />
+    <mat-error *ngIf="form.get(Controls.Username).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Password</mat-label>
+    <input matInput
+           [formControlName]="Controls.Password"
+           kmInputPassword
+           autocomplete="off"
+           required />
+    <mat-error *ngIf="form.get(Controls.Password).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field fxFlex>
+    <mat-label>Server URL</mat-label>
+    <input matInput
+           [formControlName]="Controls.Server"
+           autocomplete="off"
+           required />
+    <mat-error *ngIf="form.get(Controls.Server).hasError('required')">
+      <strong>Required</strong>
+    </mat-error>
+  </mat-form-field>
+</form>

--- a/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
+++ b/modules/web/src/app/kubeone-wizard/steps/provider/component.ts
@@ -50,6 +50,7 @@ export class KubeOneProviderStepComponent extends StepBase implements OnInit {
     NodeProvider.DIGITALOCEAN,
     NodeProvider.HETZNER,
     NodeProvider.OPENSTACK,
+    NodeProvider.VSPHERE,
   ];
   readonly controls = Controls;
 

--- a/modules/web/src/app/kubeone-wizard/steps/summary/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/summary/template.html
@@ -123,6 +123,21 @@ limitations under the License.
               <div value>{{kubeOneClusterSpec?.cloudSpec?.openstack?.region}}</div>
             </km-property>
           </ng-container>
+          <!-- VSphere -->
+          <ng-container *ngIf="kubeOneClusterSpec?.cloudSpec?.vsphere">
+            <km-property>
+              <div key>Username</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.vsphere?.username}}</div>
+            </km-property>
+            <km-property>
+              <div key>Password</div>
+              <div value>{{SECRET_MASK}}</div>
+            </km-property>
+            <km-property>
+              <div key>Server URL</div>
+              <div value>{{kubeOneClusterSpec?.cloudSpec?.vsphere?.server}}</div>
+            </km-property>
+          </ng-container>
         </ng-template>
       </div>
     </div>

--- a/modules/web/src/app/shared/entity/kubeone-cluster.ts
+++ b/modules/web/src/app/shared/entity/kubeone-cluster.ts
@@ -40,6 +40,7 @@ export class KubeOneCloudSpec {
   digitalOcean?: KubeOneDigitalOceanCloudSpec;
   hetzner?: KubeOneHetznerCloudSpec;
   openstack?: KubeOneOpenstackCloudSpec;
+  vsphere?: KubeOneVSphereCloudSpec;
 }
 
 export class KubeOneAWSCloudSpec {
@@ -73,4 +74,10 @@ export class KubeOneOpenstackCloudSpec {
   project: string;
   projectID: string;
   region: string;
+}
+
+export class KubeOneVSphereCloudSpec {
+  username: string;
+  password: string;
+  server: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
add VSphere provider to the kubeone import wizard and set the credentials in the api

**Provider Step**:
![image](https://github.com/kubermatic/dashboard/assets/85109141/cf1831b0-6705-4c00-b410-cc91093c7b2e)

**Credentials Step**:
![image](https://github.com/kubermatic/dashboard/assets/85109141/a127c29c-e777-4fb4-b641-95e03ab92dca)

**Summary Step**:
![image](https://github.com/kubermatic/dashboard/assets/85109141/6aafb1f2-5210-4e5a-9859-77fa7a5a328c)

**Which issue(s) this PR fixes**:
Fixes #5806 

**What type of PR is this?**
/kind feature

```release-note
Add support to import VSphere kubeone cluster
```

```documentation
NONE
```
