### PR TITLE
Migrate Angular Material Snackbar component from legacy to v15

### DIFF
--- a/modules/web/src/app/core/components/notification/component.ts
+++ b/modules/web/src/app/core/components/notification/component.ts
@@ -14,7 +14,7 @@
 
 import {DOCUMENT} from '@angular/common';
 import {AfterViewInit, Component, ElementRef, Inject, OnDestroy, OnInit} from '@angular/core';
-import {MatLegacySnackBarRef as MatSnackBarRef} from '@angular/material/legacy-snack-bar';
+import {MatSnackBarRef} from '@angular/material/snack-bar';
 import {EMPTY, fromEvent, interval, merge, Subject, takeWhile} from 'rxjs';
 import {map, scan, startWith, switchMap, takeUntil} from 'rxjs/operators';
 

--- a/modules/web/src/app/core/services/cluster.spec.ts
+++ b/modules/web/src/app/core/services/cluster.spec.ts
@@ -16,7 +16,7 @@ import {HttpClientTestingModule, HttpTestingController} from '@angular/common/ht
 import {TestBed} from '@angular/core/testing';
 import {lastValueFrom} from 'rxjs';
 import {MatDialogModule} from '@angular/material/dialog';
-import {MatLegacySnackBarModule as MatSnackBarModule} from '@angular/material/legacy-snack-bar';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {RouterTestingModule} from '@angular/router/testing';
 
 import {AppConfigService} from '@app/config.service';

--- a/modules/web/src/app/core/services/node.spec.ts
+++ b/modules/web/src/app/core/services/node.spec.ts
@@ -14,7 +14,7 @@
 
 import {fakeAsync, flush, inject, TestBed, tick} from '@angular/core/testing';
 import {MatDialog} from '@angular/material/dialog';
-import {MatLegacySnackBarModule as MatSnackBarModule} from '@angular/material/legacy-snack-bar';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {GoogleAnalyticsService} from '@app/google-analytics.service';
 import {fakeDigitaloceanCluster} from '@test/data/cluster';

--- a/modules/web/src/app/core/services/notification.ts
+++ b/modules/web/src/app/core/services/notification.ts
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 import {Injectable} from '@angular/core';
-import {
-  MatLegacySnackBar as MatSnackBar,
-  MatLegacySnackBarConfig as MatSnackBarConfig,
-  MatLegacySnackBarDismiss as MatSnackBarDismiss,
-} from '@angular/material/legacy-snack-bar';
+import {MatSnackBar, MatSnackBarConfig, MatSnackBarDismiss} from '@angular/material/snack-bar';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {delay, filter, map, take, tap} from 'rxjs/operators';
 import {NotificationComponent, NotificationType} from '../components/notification/component';

--- a/modules/web/src/app/shared/components/terminal/component.spec.ts
+++ b/modules/web/src/app/shared/components/terminal/component.spec.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {MatLegacySnackBarModule as MatSnackBarModule} from '@angular/material/legacy-snack-bar';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {BrowserModule} from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {ActivatedRoute} from '@angular/router';

--- a/modules/web/src/app/shared/module.ts
+++ b/modules/web/src/app/shared/module.ts
@@ -45,7 +45,7 @@ import {MatLegacySelectModule as MatSelectModule} from '@angular/material/legacy
 import {MatSidenavModule} from '@angular/material/sidenav';
 import {MatLegacySlideToggleModule as MatSlideToggleModule} from '@angular/material/legacy-slide-toggle';
 import {MatLegacySliderModule as MatSliderModule} from '@angular/material/legacy-slider';
-import {MatLegacySnackBarModule as MatSnackBarModule} from '@angular/material/legacy-snack-bar';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatSortModule} from '@angular/material/sort';
 import {MatStepperModule} from '@angular/material/stepper';
 import {MatLegacyTableModule as MatTableModule} from '@angular/material/legacy-table';

--- a/modules/web/src/assets/css/_variables.scss
+++ b/modules/web/src/assets/css/_variables.scss
@@ -25,7 +25,7 @@ $dialog-width: 660px;
 $dialog-content-max-height: 60vh;
 $notification-width: 400px;
 $notification-min-height: 60px;
-$notification-max-height: 160px;
+$notification-max-height: 200px;
 $notification-margin: 0 24px 80px 0;
 $notification-shadow: 0 5px 5px rgb(0 0 0 / 20%), 0 8px 10px rgb(0 0 0 / 14%), 0 3px 14px rgb(0 0 0 / 12%);
 $border-box-shadow: 0 1px 3px rgb(0 0 0 / 12%);

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -229,7 +229,7 @@ hr {
   right: 32px;
 
   .km-notification {
-    &.mat-snack-bar-container {
+    &.mat-mdc-snack-bar-container {
       border-radius: variables.$border-radius;
       box-shadow: variables.$notification-shadow;
       margin: 0;
@@ -242,6 +242,16 @@ hr {
 
       div {
         height: 100%;
+      }
+
+      /* stylelint-disable-next-line selector-class-pattern */
+      .mdc-snackbar__surface {
+        padding: 0;
+        width: 100%;
+
+        .mat-mdc-snack-bar-label {
+          padding: 0;
+        }
       }
     }
   }

--- a/modules/web/src/assets/css/global/_theme.scss
+++ b/modules/web/src/assets/css/global/_theme.scss
@@ -314,12 +314,6 @@
     border-bottom: 1px solid map.get($colors, divider);
   }
 
-  .km-notification {
-    &.mat-snack-bar-container {
-      background-color: map.get($colors, option-background);
-    }
-  }
-
   .mat-progress-bar.mat-accent {
     .mat-progress-bar-buffer {
       background: map.get($colors, divider);

--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -33,7 +33,7 @@
 
   // Dialogs.
   .mat-mdc-dialog-container {
-    --mdc-dialog-supporting-text-color: map.get($colors, text);
+    --mdc-dialog-supporting-text-color: #{map.get($colors, text)};
 
     color: map.get($colors, text);
   }
@@ -426,5 +426,10 @@
     .mat-tab-header {
       border-bottom: 1px solid map.get($colors, tab-divider);
     }
+  }
+
+  // Snackbar
+  .mat-mdc-snack-bar-container {
+    --mdc-snackbar-container-color: #{map.get($colors, option-background)};
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR migrates Angular Material `Snackbar` component from legacy to v15.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #5864 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
