### PR TITLE
Ignore notification outside click if target element is toggle button

### DIFF
--- a/modules/web/src/app/core/components/notification-panel/component.ts
+++ b/modules/web/src/app/core/components/notification-panel/component.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, ElementRef, HostListener, OnDestroy, OnInit} from '@angular/core';
+import {Component, ElementRef, HostListener, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {MatLegacyButton} from '@angular/material/legacy-button';
 import {NavigationStart, Router} from '@angular/router';
 import {NotificationType} from '@core/components/notification/component';
 import {Notification, NotificationService} from '@core/services/notification';
@@ -32,6 +33,7 @@ export class NotificationPanelComponent implements OnInit, OnDestroy {
   private _filter: NotificationType = undefined;
   private _isAnimating = false;
   private _unsubscribe: Subject<void> = new Subject<void>();
+  @ViewChild('toggleButton') toggleButton: MatLegacyButton;
   notifications: Notification[] = [];
   unseenNotificationsCount = 0;
   readonly NotificationType = NotificationType;
@@ -73,7 +75,11 @@ export class NotificationPanelComponent implements OnInit, OnDestroy {
 
   @HostListener('document:click', ['$event'])
   onOutsideClick(event: Event): void {
-    if (!this._elementRef.nativeElement.contains(event.target) && this.isOpen()) {
+    if (
+      this.isOpen() &&
+      !this._elementRef.nativeElement.contains(event.target) &&
+      this.toggleButton._elementRef.nativeElement !== event.target
+    ) {
       this.close();
     }
   }

--- a/modules/web/src/app/core/components/notification-panel/template.html
+++ b/modules/web/src/app/core/components/notification-panel/template.html
@@ -15,6 +15,7 @@ limitations under the License.
 -->
 <div class="km-panel">
   <button mat-icon-button
+          #toggleButton
           class="root-button"
           fxLayoutAlign="center center"
           (click)="toggle()">


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an issue with notification panel where it would immediately close the panel because of outside click handler hence making it look like that click event is ignored. This PR fixes it by ignoring the outside click event if target element is notification toggle button.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
