### PR TITLE
Migrate Angular Material progress bar and progress spinner components from legacy to v15

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/quotas/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/quotas/component.ts
@@ -19,6 +19,7 @@
 // END OF TERMS AND CONDITIONS
 
 import {Component, OnInit, ViewChild} from '@angular/core';
+import {ThemePalette} from '@angular/material/core';
 import {MatLegacyTableDataSource as MatTableDataSource} from '@angular/material/legacy-table';
 import {MatLegacyPaginator as MatPaginator} from '@angular/material/legacy-paginator';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
@@ -50,7 +51,7 @@ enum ResourceType {
 }
 
 interface progressBarData {
-  color: string;
+  color: ThemePalette;
   value: number;
   usageQuota: string;
 }
@@ -142,7 +143,7 @@ export class QuotasComponent implements OnInit {
   getProgressBarData(projectId: string, resourceType: string): progressBarData {
     const quota = this.quotas.find(quota => quota.subjectName === projectId);
     const progressBar: progressBarData = {
-      color: '',
+      color: 'primary',
       value: 0,
       usageQuota: '',
     };

--- a/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
@@ -72,6 +72,8 @@
     padding-top: 9px;
 
     .property-usage-bar {
+      --mdc-linear-progress-track-height: 5px;
+
       border-radius: variables.$border-radius;
       height: 5px;
     }
@@ -129,14 +131,12 @@
       width: 100%;
 
       .property-usage-bar {
+        --mdc-linear-progress-track-height: 6px;
+
         border-radius: variables.$border-radius;
         height: 6px;
         margin: 8px 0;
         min-width: 100px;
-
-        & svg {
-          animation: none;
-        }
       }
     }
   }

--- a/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/theme.scss
+++ b/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/theme.scss
@@ -1,19 +1,11 @@
 @use 'sass:map';
 
 @mixin theme-quota-widget-component($colors) {
-  .km-quota-percentages {
-    .property-usage-bar {
-      & svg {
-        background-color: map.get($colors, divider);
-        fill: map.get($colors, divider) !important;
-      }
-    }
-  }
-
   .extended-progress {
     .property-usage-bar:not(.mat-warn) {
-      .mat-progress-bar-buffer {
-        background-color: map.get($colors, estimate-quota-bar) !important;
+      /* stylelint-disable-next-line selector-class-pattern */
+      .mdc-linear-progress__buffer-bar {
+        background-color: map.get($colors, estimate-quota-bar);
       }
     }
   }

--- a/modules/web/src/app/shared/components/property-usage/style.scss
+++ b/modules/web/src/app/shared/components/property-usage/style.scss
@@ -22,6 +22,8 @@
 .property-usage-bar {
   @include mixins.size(280px, 6px, true);
 
+  --mdc-linear-progress-track-height: 6px;
+
   border-radius: variables.$border-radius;
   margin: 6px 0;
 }

--- a/modules/web/src/app/shared/components/property-usage/theme.scss
+++ b/modules/web/src/app/shared/components/property-usage/theme.scss
@@ -16,12 +16,9 @@
 
 @mixin theme-property-usage-component($colors) {
   .property-usage-bar {
-    .mat-progress-bar-buffer {
+    /* stylelint-disable-next-line selector-class-pattern */
+    .mat-mdc-progress-bar .mdc-linear-progress__buffer-bar {
       background-color: map.get($colors, divider);
-    }
-
-    .mat-progress-bar-fill::after {
-      background-color: map.get($colors, primary);
     }
   }
 }

--- a/modules/web/src/app/shared/module.ts
+++ b/modules/web/src/app/shared/module.ts
@@ -39,7 +39,7 @@ import {
   MatLegacyPaginatorModule as MatPaginatorModule,
 } from '@angular/material/legacy-paginator';
 import {MatLegacyProgressBarModule as MatProgressBarModule} from '@angular/material/legacy-progress-bar';
-import {MatLegacyProgressSpinnerModule as MatProgressSpinnerModule} from '@angular/material/legacy-progress-spinner';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatLegacyRadioModule as MatRadioModule} from '@angular/material/legacy-radio';
 import {MatLegacySelectModule as MatSelectModule} from '@angular/material/legacy-select';
 import {MatSidenavModule} from '@angular/material/sidenav';

--- a/modules/web/src/app/shared/module.ts
+++ b/modules/web/src/app/shared/module.ts
@@ -38,7 +38,7 @@ import {
   MAT_LEGACY_PAGINATOR_DEFAULT_OPTIONS,
   MatLegacyPaginatorModule as MatPaginatorModule,
 } from '@angular/material/legacy-paginator';
-import {MatLegacyProgressBarModule as MatProgressBarModule} from '@angular/material/legacy-progress-bar';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatLegacyRadioModule as MatRadioModule} from '@angular/material/legacy-radio';
 import {MatLegacySelectModule as MatSelectModule} from '@angular/material/legacy-select';

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -655,10 +655,6 @@ km-cni-version {
       }
     }
   }
-
-  .mat-progress-bar .mat-progress-bar-fill {
-    transition: none;
-  }
 }
 
 .km-quota-extended-progress-bar-tooltip {

--- a/modules/web/src/assets/css/global/_theme.scss
+++ b/modules/web/src/assets/css/global/_theme.scss
@@ -314,16 +314,6 @@
     border-bottom: 1px solid map.get($colors, divider);
   }
 
-  .mat-progress-bar.mat-accent {
-    .mat-progress-bar-buffer {
-      background: map.get($colors, divider);
-    }
-
-    .mat-progress-bar-fill::after {
-      background-color: map.get($colors, indicator-orange);
-    }
-  }
-
   .km-quota-widget-container {
     .km-icon-circle {
       background-color: map.get($colors, indicator-red);

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -734,3 +734,9 @@ mat-tooltip-component .mat-tooltip {
 .mat-optgroup .mat-option:not(.mat-option-multiple) {
   padding-left: 16px !important;
 }
+
+// Progress bar
+/* stylelint-disable-next-line selector-class-pattern */
+.mat-mdc-progress-bar .mdc-linear-progress__buffer-dots {
+  animation: none;
+}

--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -432,4 +432,21 @@
   .mat-mdc-snack-bar-container {
     --mdc-snackbar-container-color: #{map.get($colors, option-background)};
   }
+
+  // Progress bar
+  .mat-mdc-progress-bar, .mat-mdc-progress-bar.mat-accent {
+    /* stylelint-disable-next-line selector-class-pattern */
+    .mdc-linear-progress__buffer-bar, .mdc-linear-progress__buffer-dots {
+      background-color: map.get($colors, divider);
+    }
+
+    /* stylelint-disable-next-line selector-class-pattern */
+    .mdc-linear-progress__buffer-dots {
+      background-image: none;
+    }
+  }
+
+  .mat-mdc-progress-bar.mat-accent {
+    --mdc-linear-progress-active-indicator-color: #{map.get($colors, indicator-orange)};
+  }
 }

--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -416,8 +416,8 @@
   }
 
   // Spinners.
-  .mat-progress-spinner circle,
-  .mat-spinner circle {
+  .mat-mdc-progress-spinner circle,
+  .mat-mdc-spinner circle {
     stroke: map.get($colors, primary-hover);
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR migrates Angular Material `progress bar` and `progress spinner` components from legacy to v15.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #5864 

**What type of PR is this?**
<!--
Add one of qthe following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
