### PR TITLE
Disable preset support for `openstack` and `vsphere` providers

### DIFF
--- a/modules/web/src/app/kubeone-wizard/steps/credentials/preset/template.html
+++ b/modules/web/src/app/kubeone-wizard/steps/credentials/preset/template.html
@@ -48,6 +48,13 @@ limitations under the License.
     <mat-error *ngIf="form.get(Controls.Preset).hasError('required')">
       <strong>Required</strong>
     </mat-error>
-    <mat-hint>Using provider presets will disable most of the other credential fields.</mat-hint>
+    <mat-hint>
+      <ng-container *ngIf="isPresetSupported(); else presetNotSupported">
+        Using provider presets will disable most of the other credential fields.
+      </ng-container>
+      <ng-template #presetNotSupported>
+        Preset support for this provider is not added yet.
+      </ng-template>
+    </mat-hint>
   </mat-form-field>
 </form>


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable preset support for `openstack` and `vsphere` providers until its fixed on the backend.

![screenshot-localhost_8000-2023 06 05-17_17_39](https://github.com/kubermatic/dashboard/assets/13975988/105cbeb4-1784-4547-bf79-2b3e17f1125f)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
