### PR TITLE
Fix accelerated networking value in edit MD dialog

### DIFF
--- a/modules/web/src/app/node-data/extended/provider/azure/component.ts
+++ b/modules/web/src/app/node-data/extended/provider/azure/component.ts
@@ -93,6 +93,11 @@ export class AzureExtendedNodeDataComponent extends BaseFormValidator implements
 
       const assignPublicIP = this.nodeData.name ? this.nodeData.spec.cloud.azure.assignPublicIP : false;
       this.form.get(Controls.AssignPublicIP).setValue(assignPublicIP);
+
+      const acceleratedNetworking = this.nodeData.name
+        ? this.nodeData.spec.cloud.azure.enableAcceleratedNetworking
+        : false;
+      this.form.get(Controls.AcceleratedNetworking).setValue(acceleratedNetworking);
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
set the value for the accelerated networking from the node data object in edit MD dialog

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
