### PR TITLE
Take custom disk size into resource quota calculation for Openstack

### DIFF
--- a/modules/api/pkg/ee/resource-quota/handler.go
+++ b/modules/api/pkg/ee/resource-quota/handler.go
@@ -648,9 +648,18 @@ func getOpenstackResourceDetails(provider ProviderNodeTemplate, nc *kubermaticpr
 	if err := nc.WithMemory(provider.OpenstackSize.Memory, "M"); err != nil {
 		return err
 	}
-	if err := nc.WithStorage(provider.OpenstackSize.Disk, "G"); err != nil {
-		return err
+
+	if provider.DiskSizeGB == 0 {
+		if err := nc.WithStorage(provider.OpenstackSize.Disk, "G"); err != nil {
+			return err
+		}
+	} else {
+		// Setting custom disk size
+		if err := nc.WithStorage(provider.DiskSizeGB, "G"); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Custom disk size wasn't included in the Openstack resource quota calculation.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
