### PR TITLE
Clear AWS subnets dropdown when there are no subnets available

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/aws/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/aws/component.ts
@@ -280,6 +280,9 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
   }
 
   private _setDefaultSubnet(subnets: AWSSubnet[]): void {
+    this._subnets = subnets;
+    this._subnetMap = {};
+
     if (subnets.length === 0) {
       this.selectedSubnet = '';
       this.subnetLabel = SubnetState.Empty;
@@ -287,8 +290,6 @@ export class AWSBasicNodeDataComponent extends BaseFormValidator implements OnIn
       return;
     }
 
-    this._subnets = subnets;
-    this._subnetMap = {};
     this.selectedSubnet = this._nodeDataService.nodeData.spec.cloud.aws.subnetID;
 
     if (this._subnets.length && !this._subnets.find(subnet => subnet.id === this.selectedSubnet)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in AWS provider where if there are subnets available and then a new new API request has no subnets then subnets dropdown was not cleared.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
