### PR TITLE
Prevent calling availability zone api request if assign availability set

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/azure/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/azure/component.ts
@@ -189,7 +189,7 @@ export class AzureBasicNodeDataComponent extends BaseFormValidator implements On
   onSizeChange(size: string): void {
     this._nodeDataService.nodeData.spec.cloud.azure.size = size;
     this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
-    this._sizeChanges.emit(!!size);
+    this._sizeChanges.emit(!!size && this.isZoneEnabled());
   }
 
   isZoneEnabled(): boolean {


### PR DESCRIPTION
**What this PR does / why we need it**:

there is an issue that in azure md dialog (add/edit), the availability zones still show `zone loading` label even though the assign availability set is not enabled and it keep like that for more than 30 seconds cause the label wait for the api response, so we shouldn't even do that api request if the field already disabled .

![Screenshot from 2023-06-16 13-09-53](https://github.com/kubermatic/dashboard/assets/85109141/98c0c768-2cd8-4101-949e-5c32047b99ab)

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
