### PR TITLE
Use `async` pipe to handle quota calculation observable in template

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/component.ts
@@ -32,7 +32,7 @@ import {
 } from '@angular/core';
 import {QuotaCalculationService} from '../services/quota-calculation';
 import {debounceTime, take, takeUntil, map, filter} from 'rxjs/operators';
-import {BehaviorSubject, Subject} from 'rxjs';
+import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {QuotaDetails, QuotaVariables, ResourceQuotaCalculation} from '@shared/entity/quota';
 import {getPercentage} from '@shared/utils/common';
 import {Member} from '@shared/entity/member';
@@ -72,10 +72,10 @@ export class QuotaWidgetComponent implements OnInit, OnChanges, OnDestroy {
   estimatedQuotaPercentage: QuotaVariables;
   isEstimatedQuotaExceeded: boolean;
   quotaDetails: QuotaDetails;
-  isEstimationInProgress: boolean;
   showWarning: boolean;
   isWidgetApplicableForExternalOrImportedCluster: boolean;
   showDetails$ = this._showDetails$.asObservable().pipe(debounceTime(this._debounce));
+  calculationInProgress$: Observable<boolean>;
   isCollapsed: boolean;
   getProgressBarAccent = getProgressBarAccent;
 
@@ -126,6 +126,7 @@ export class QuotaWidgetComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnInit(): void {
     this.isCollapsed = window.innerWidth <= quotaWidgetCollapsibleWidth && this.collapsible;
+    this.calculationInProgress$ = this._quotaCalculationService.calculationInProgress;
     this._initSubscriptions();
     this._setShowNotApplicableText();
   }
@@ -200,10 +201,6 @@ export class QuotaWidgetComponent implements OnInit, OnChanges, OnDestroy {
 
       this._subscribeToQuotaDetails();
     });
-
-    this._quotaCalculationService.calculationInProgress
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(inProgress => (this.isEstimationInProgress = inProgress));
   }
 
   private _subscribeToQuotaDetails(): void {

--- a/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/template.html
+++ b/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/template.html
@@ -208,7 +208,7 @@ END OF TERMS AND CONDITIONS
       <div *ngIf="showIcon"
            class="km-quota-heading"
            fxLayoutAlign=" center">
-        <mat-spinner *ngIf="isEstimationInProgress; else quotaIcon"
+        <mat-spinner *ngIf="calculationInProgress$ | async; else quotaIcon"
                      [diameter]="25"></mat-spinner>
         <ng-template #quotaIcon>
           <i class="km-icon-mask km-icon-quota"></i>

--- a/modules/web/src/app/node-data/dialog/component.ts
+++ b/modules/web/src/app/node-data/dialog/component.ts
@@ -17,7 +17,7 @@ import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {NodeDataService} from '@core/services/node-data/service';
 import _ from 'lodash';
-import {merge, of} from 'rxjs';
+import {merge, Observable, of} from 'rxjs';
 import {delay, takeUntil} from 'rxjs/operators';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {Cluster, END_OF_DYNAMIC_KUBELET_CONFIG_SUPPORT_VERSION} from '@shared/entity/cluster';
@@ -77,7 +77,7 @@ export class NodeDataDialogComponent extends BaseFormValidator implements OnInit
   isRecreationWarningVisible = false;
   isDynamicKubeletConfigWarningVisible = false;
   isQuotaExceeded: boolean;
-  isCalculatingQuota: boolean;
+  quotaCalculationInProgress$: Observable<boolean>;
   mode = Mode.Add;
 
   readonly Control = Controls;
@@ -134,6 +134,7 @@ export class NodeDataDialogComponent extends BaseFormValidator implements OnInit
 
     const key = `${this._data.projectID}-${this.provider}`;
     this._quotaCalculationService.reset(key);
+    this.quotaCalculationInProgress$ = this._quotaCalculationService.calculationInProgress;
 
     merge(this._nodeDataService.nodeDataChanges, this._nodeDataService.operatingSystemChanges)
       .pipe(takeUntil(this._unsubscribe))
@@ -153,10 +154,6 @@ export class NodeDataDialogComponent extends BaseFormValidator implements OnInit
       .subscribe(isQuotaExceeded => {
         this.isQuotaExceeded = isQuotaExceeded;
       });
-
-    this._quotaCalculationService.calculationInProgress.pipe(takeUntil(this._unsubscribe)).subscribe(value => {
-      this.isCalculatingQuota = value;
-    });
   }
 
   ngOnDestroy() {

--- a/modules/web/src/app/node-data/dialog/template.html
+++ b/modules/web/src/app/node-data/dialog/template.html
@@ -48,9 +48,9 @@ limitations under the License.
     </div>
     <button mat-flat-button
             (click)="onConfirm()"
-            [disabled]="form.invalid || isQuotaExceeded || isCalculatingQuota"
+            [disabled]="form.invalid || isQuotaExceeded || (quotaCalculationInProgress$ | async)"
             class="btn btn-primary">
-      <i [ngClass]="isCalculatingQuota ? 'km-icon-mask km-icon-pending i-24' : getIconClass()"></i>
+      <i [ngClass]="(quotaCalculationInProgress$ | async) ? 'km-icon-mask km-icon-pending i-24' : getIconClass()"></i>
       <span>{{getConfirmButtonText()}}</span>
     </button>
   </mat-dialog-actions>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a small issue in Add/Edit machine deployment dialog where the Save Changes button remains disabled even after quota calculation API request is complete. This was caused by change detection not running.

<img width="257" alt="Screenshot 2023-06-19 at 6 30 38 PM" src="https://github.com/kubermatic/dashboard/assets/13975988/92d3a09e-f1fb-4a65-b7f4-bf20e51b1f5d">


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
