### PR TITLE
disable all button in cluster detail page on cluster deletion

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -47,6 +47,8 @@ limitations under the License.
       <km-button color="alternative"
                  icon="km-icon-download"
                  label="Get Kubeconfig"
+                 [disabled]="isDeletingState"
+                 [matTooltip]="isDeletingState ? clusterDeletionTooltip : ''"
                  [observable]="getObservable()"
                  (next)="onNext($event)">
       </km-button>
@@ -58,8 +60,8 @@ limitations under the License.
          target="_blank"
          rel="noopener noreferrer"
          mat-flat-button
-         [disabled]="!isKubernetesDashboardHealthy"
-         [matTooltip]="isKubernetesDashboardHealthy ? '' : cluster?.spec?.kubernetesDashboard?.enabled ? 'Kubernetes Dashboard is not running' : 'Kubernetes Dashboard is disabled'"
+         [disabled]="!isKubernetesDashboardHealthy || isDeletingState"
+         [matTooltip]="getOpenDashboardTooltip()"
          *ngIf="adminSettings.enableDashboard">
         <i class="km-icon-mask km-icon-external-link"></i>
         <span>Open Dashboard</span>
@@ -72,7 +74,7 @@ limitations under the License.
               [disabled]="!isWebTerminalEnabled()"
               (click)="toggleTerminal()">
         <i class="km-icon-mask km-icon-terminal"></i>
-        <span [matTooltip]="isWebTerminalEnabled() ? '' : 'At least one machine should be running to enable Web Terminal'">Web Terminal</span>
+        <span [matTooltip]="getWebTerminalTooltip()">Web Terminal</span>
       </button>
 
       <div class="provider-menu">


### PR DESCRIPTION
**What this PR does / why we need it**:
disables (Get Kubeconfig, Open Dashboard, Web Terminal) buttons in cluster details page, when the cluster on deleting state

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
