### PR TITLE
Bump kubermatic/build image

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - './hack/ci/run-api-e2e.sh'
           env:
@@ -60,7 +60,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - make
           args:
@@ -81,7 +81,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - make
             - api-lint
@@ -101,7 +101,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - make
             - api-verify

--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/ci/verify.sh
           resources:

--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -215,7 +215,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - make
             - web-check-dependencies
@@ -231,7 +231,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - make
             - web-lint
@@ -251,7 +251,7 @@ presubmits:
       preset-goproxy: 'true'
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - make
             - web-check

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-7 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-8 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/modules/api/hack/update-swagger.sh
+++ b/modules/api/hack/update-swagger.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-7 containerize ./$API/hack/update-swagger.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-8 containerize ./$API/hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd $API/cmd/kubermatic-api/

--- a/modules/api/hack/verify-licenses.sh
+++ b/modules/api/hack/verify-licenses.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-7 containerize ./$API/hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-8 containerize ./$API/hack/verify-licenses.sh
 
 cd $API
 go mod vendor

--- a/modules/web/containers/chrome-headless/Dockerfile
+++ b/modules/web/containers/chrome-headless/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
 
 LABEL maintainer="support@kubermatic.com"
 

--- a/modules/web/containers/custom-dashboard/Dockerfile
+++ b/modules/web/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures that the dashboard uses the same image as KKP itself. There are no changes in this image compared to the -7 variant, it's just a rebuild to make 100000% sure we get the bookworm-based golang image.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
