### PR TITLE
Add VM anti-affinity setting for vSphere machine deployments

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -40460,6 +40460,11 @@
         "template": {
           "type": "string",
           "x-go-name": "Template"
+        },
+        "vmAntiAffinity": {
+          "description": "Automatically create anti affinity rules for machines.",
+          "type": "boolean",
+          "x-go-name": "VMAntiAffinity"
         }
       },
       "x-go-package": "k8c.io/dashboard/v2/pkg/api/v1"

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -1652,6 +1652,8 @@ type VSphereNodeSpec struct {
 	// Additional metadata to set
 	// required: false
 	Tags []VSphereTag `json:"tags,omitempty"`
+	// Automatically create anti affinity rules for machines.
+	VMAntiAffinity *bool `json:"vmAntiAffinity"`
 }
 
 // VSphereTag represents vsphere tag.
@@ -1687,17 +1689,19 @@ func (spec *VSphereNodeSpec) MarshalJSON() ([]byte, error) {
 	}
 
 	res := struct {
-		CPUs       int          `json:"cpus"`
-		Memory     int          `json:"memory"`
-		DiskSizeGB *int64       `json:"diskSizeGB,omitempty"`
-		Template   string       `json:"template"`
-		Tags       []VSphereTag `json:"tags,omitempty"`
+		CPUs           int          `json:"cpus"`
+		Memory         int          `json:"memory"`
+		DiskSizeGB     *int64       `json:"diskSizeGB,omitempty"`
+		Template       string       `json:"template"`
+		Tags           []VSphereTag `json:"tags,omitempty"`
+		VMAntiAffinity *bool        `json:"vmAntiAffinity"`
 	}{
-		CPUs:       spec.CPUs,
-		Memory:     spec.Memory,
-		DiskSizeGB: spec.DiskSizeGB,
-		Template:   spec.Template,
-		Tags:       spec.Tags,
+		CPUs:           spec.CPUs,
+		Memory:         spec.Memory,
+		DiskSizeGB:     spec.DiskSizeGB,
+		Template:       spec.Template,
+		Tags:           spec.Tags,
+		VMAntiAffinity: spec.VMAntiAffinity,
 	}
 
 	return json.Marshal(&res)

--- a/modules/api/pkg/api/v1/types_test.go
+++ b/modules/api/pkg/api/v1/types_test.go
@@ -338,7 +338,7 @@ func TestVSphereNodeSpec_MarshalJSON(t *testing.T) {
 				DiskSizeGB: &[]int64{1}[0],
 				Template:   "test-template",
 			},
-			"{\"cpus\":1,\"memory\":1,\"diskSizeGB\":1,\"template\":\"test-template\"}",
+			"{\"cpus\":1,\"memory\":1,\"diskSizeGB\":1,\"template\":\"test-template\",\"vmAntiAffinity\":null}",
 		},
 	}
 

--- a/modules/api/pkg/machine/convert.go
+++ b/modules/api/pkg/machine/convert.go
@@ -224,10 +224,11 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			return nil, fmt.Errorf("failed to parse vsphere config: %w", err)
 		}
 		cloudSpec.VSphere = &apiv1.VSphereNodeSpec{
-			CPUs:       int(config.CPUs),
-			Memory:     int(config.MemoryMB),
-			DiskSizeGB: config.DiskSizeGB,
-			Template:   config.TemplateVMName.Value,
+			CPUs:           int(config.CPUs),
+			Memory:         int(config.MemoryMB),
+			DiskSizeGB:     config.DiskSizeGB,
+			Template:       config.TemplateVMName.Value,
+			VMAntiAffinity: config.VMAntiAffinity.Value,
 		}
 		for _, v := range config.Tags {
 			cloudSpec.VSphere.Tags = append(cloudSpec.VSphere.Tags, apiv1.VSphereTag{

--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -234,6 +234,7 @@ func GetVSphereProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		Folder:           providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.Folder},
 		AllowInsecure:    providerconfig.ConfigVarBool{Value: pointer.Bool(dc.Spec.VSphere.AllowInsecure)},
 		ResourcePool:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.ResourcePool},
+		VMAntiAffinity:   providerconfig.ConfigVarBool{Value: nodeSpec.Cloud.VSphere.VMAntiAffinity},
 	}
 
 	config.Tags = []vsphere.Tag{}

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/v_sphere_node_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/v_sphere_node_spec.go
@@ -33,6 +33,9 @@ type VSphereNodeSpec struct {
 
 	// template
 	Template string `json:"template,omitempty"`
+
+	// Automatically create anti affinity rules for machines.
+	VMAntiAffinity bool `json:"vmAntiAffinity,omitempty"`
 }
 
 // Validate validates this v sphere node spec

--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -361,6 +361,9 @@ limitations under the License.
               <div key>VM Template</div>
               <div value>{{element.spec.cloud.vsphere.template}}</div>
             </km-property>
+            <km-property-boolean label="VM Anti Affinity"
+                                 [value]="element.spec.cloud.vsphere?.vmAntiAffinity">
+            </km-property-boolean>
 
             <km-property *ngIf="element.spec.cloud.anexia?.cpus">
               <div key>Number of CPU's</div>

--- a/modules/web/src/app/node-data/extended/provider/vsphere/template.html
+++ b/modules/web/src/app/node-data/extended/provider/vsphere/template.html
@@ -17,6 +17,17 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column"
       fxLayoutGap="8px">
+  <mat-checkbox [formControlName]="controls.VMAntiAffinity"
+                fxFlex
+                kmValueChangedIndicator>
+    <div fxLayoutAlign=" center"
+         fxLayoutGap="5px">
+      <span>VM Anti Affinity</span>
+      <i class="km-icon-info km-pointer"
+         matTooltip="Automatically create anti affinity rules for machines."></i>
+    </div>
+  </mat-checkbox>
+
   <km-vsphere-tags [formControlName]="controls.Tags"
                    [tags]="tags"
                    (tagsChange)="onTagsChange($event)"></km-vsphere-tags>

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -946,6 +946,9 @@ limitations under the License.
                 <div key>Template</div>
                 <div value>{{machineDeployment.spec.template.cloud?.vsphere?.template}}</div>
               </km-property>
+              <km-property-boolean label="VM Anti Affinity"
+                                   [value]="machineDeployment.spec.template.cloud?.vsphere?.vmAntiAffinity">
+              </km-property-boolean>
             </ng-container>
 
             <!-- Anexia Nodes -->

--- a/modules/web/src/app/shared/entity/node.ts
+++ b/modules/web/src/app/shared/entity/node.ts
@@ -267,6 +267,7 @@ export class VSphereNodeSpec {
   template: string;
   diskSizeGB?: number;
   tags?: VSphereTag[];
+  vmAntiAffinity: boolean;
 }
 
 export class VSphereTag {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to configure `vmAntiAffinity` setting for vSphere Machine Deployments.

**Create Cluster Wizard:**

<img width="686" alt="Screenshot 2023-07-04 at 3 04 07 PM" src="https://github.com/kubermatic/dashboard/assets/13975988/9511dd7d-f710-4d71-bb73-4ad2fea170cf">

**Add Machine Deployment Dialog:**

![screenshot-localhost_8000-2023 07 04-15_08_21](https://github.com/kubermatic/dashboard/assets/13975988/85f82740-24c5-4142-87f0-988293c4214c)

**Cluster Summary Page:**

![screenshot-localhost_8000-2023 07 04-15_04_52](https://github.com/kubermatic/dashboard/assets/13975988/49366e84-bd4e-4997-a6b5-8bc197901d25)



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6050 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VM anti-affinity setting for vSphere machine deployments.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
