### PR TITLE
Fix project scoped endpoints for GCP

### DIFF
--- a/modules/api/pkg/handler/v2/provider/gcp.go
+++ b/modules/api/pkg/handler/v2/provider/gcp.go
@@ -322,13 +322,17 @@ func ListProjectGCPDiskTypes(presetProvider provider.PresetProvider, userInfoGet
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
-		if err := listReq.Validate(); err != nil {
+		var err error
+		if err = listReq.Validate(); err != nil {
 			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
-		sa, err := getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, listReq.GetProjectID())
-		if err != nil {
-			return nil, err
+		sa := listReq.ServiceAccount
+		if listReq.Credential != "" {
+			sa, err = getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, listReq.GetProjectID())
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return providercommon.ListGCPDiskTypes(ctx, sa, listReq.Zone)
@@ -342,14 +346,18 @@ func ListProjectGCPZones(presetProvider provider.PresetProvider, userInfoGetter 
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
-		if err := projectReq.Validate(); err != nil {
+		var err error
+		if err = projectReq.Validate(); err != nil {
 			return nil, utilerrors.NewBadRequest(err.Error())
 		}
 
 		projectID := projectReq.GetProjectID()
-		sa, err := getSAFromPreset(ctx, userInfoGetter, presetProvider, projectReq.Credential, projectID)
-		if err != nil {
-			return nil, err
+		sa := projectReq.ServiceAccount
+		if projectReq.Credential != "" {
+			sa, err = getSAFromPreset(ctx, userInfoGetter, presetProvider, projectReq.Credential, projectID)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		userInfo, err := userInfoGetter(ctx, projectID)
@@ -368,13 +376,18 @@ func ListProjectGCPNetworks(presetProvider provider.PresetProvider, userInfoGett
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
-		if err := listReq.Validate(); err != nil {
+		var err error
+
+		if err = listReq.Validate(); err != nil {
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
-		sa, err := getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, listReq.GetProjectID())
-		if err != nil {
-			return nil, err
+		sa := listReq.ServiceAccount
+		if listReq.Credential != "" {
+			sa, err = getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, listReq.GetProjectID())
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return providercommon.ListGCPNetworks(ctx, sa)
@@ -385,7 +398,8 @@ func ListProjectGCPSubnetworks(presetProvider provider.PresetProvider, userInfoG
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		listReq := request.(GCPProjectSubnetReq)
 
-		if err := listReq.Validate(); err != nil {
+		var err error
+		if err = listReq.Validate(); err != nil {
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
@@ -395,9 +409,12 @@ func ListProjectGCPSubnetworks(presetProvider provider.PresetProvider, userInfoG
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
-		sa, err := getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, projectID)
-		if err != nil {
-			return nil, err
+		sa := listReq.ServiceAccount
+		if listReq.Credential != "" {
+			sa, err = getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, projectID)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return providercommon.ListGCPSubnetworks(ctx, userInfo, listReq.DC, sa, listReq.Network, seedGetter)
@@ -422,9 +439,12 @@ func ListProjectGCPVMSizes(presetProvider provider.PresetProvider, userInfoGette
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		sa, err := getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, projectID)
-		if err != nil {
-			return nil, err
+		sa := listReq.ServiceAccount
+		if listReq.Credential != "" {
+			sa, err = getSAFromPreset(ctx, userInfoGetter, presetProvider, listReq.Credential, listReq.GetProjectID())
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		settings, err := settingsProvider.GetGlobalSettings(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/kubermatic/dashboard/pull/5330, we introduced project-scoped endpoints for GCP and later on we switched to using those endpoints instead of the default ones in the UI. Although this broke the usage of these endpoints with `credentials` instead of `presets`. 

The following endpoints were affected:
* `/projects/{project_id}/providers/gcp/disktypes`
* `/projects/{project_id}/providers/gcp/sizes`
* `/projects/{project_id}/providers/gcp/{dc}/zones`
* `/projects/{project_id}/providers/gcp/networks`
* `/projects/{project_id}/providers/gcp/{dc}/subnetworks`

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where project scope endpoints for GCP were working only with the presets instead of one of presets or credentials
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
