### PR TITLE
[release/v2.22] update changelog.json, remove some non-user-facing changes from it

### DIFF
--- a/modules/web/src/assets/config/changelog.json
+++ b/modules/web/src/assets/config/changelog.json
@@ -3,23 +3,11 @@
   "entries": [
     {
         "category": "changed",
-        "description": "Use buildx instead of Buildah to create multi-architecture KKP container images."
+        "description": "Update machine-controller to v1.56.4."
     },
     {
         "category": "changed",
         "description": "Metrics server write timeout increased."
-    },
-    {
-        "category": "changed",
-        "description": "Update to Golang 1.19.10."
-    },
-    {
-        "category": "fixed",
-        "description": "Fix default url configuration of Blackbox exporter."
-    },
-    {
-        "category": "fixed",
-        "description": "Alertmanager now allows blackbox exporter to perform healthcheck API call without AuthFailure."
     },
     {
         "category": "fixed",


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the changelog.json. I would consider some of the changes in the changelog to be of no consequence for users, so I removed them (what is a KKP _user_ supposed to do with the info that we now use buildx?).

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
