### PR TITLE
Add vertical scroll in dialogs with material horizontal stepper

### DIFF
--- a/modules/web/src/app/shared/components/cluster-from-template/content/style.scss
+++ b/modules/web/src/app/shared/components/cluster-from-template/content/style.scss
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.content-wrapper {
-  margin-right: -24px;
-  max-height: 60vh;
-  overflow-y: auto;
-  padding-right: 24px;
-}
-
 .cluster-summary {
   margin-top: 20px;
 }

--- a/modules/web/src/app/shared/components/cluster-from-template/content/template.html
+++ b/modules/web/src/app/shared/components/cluster-from-template/content/template.html
@@ -14,8 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div fxLayout="column"
-     class="content-wrapper">
+<div fxLayout="column">
   <p class="km-dialog-context-description">Create Clusters from <b>{{template.name}}</b> template</p>
   <form [formGroup]="form"
         fxLayout="column"

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -137,6 +137,15 @@ km-wizard {
 
   .km-stepper-in-dialog {
     padding: 20px 24px;
+
+  }
+
+  .mat-stepper-horizontal .mat-horizontal-content-container {
+    margin-right: -24px;
+    max-height: 60vh;
+    overflow-y: auto;
+    padding-left: 1px; // To avoid clipping of tiles border in dialog e.g. install addon dialog
+    padding-right: 24px;
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where dialogs with material horizontal stepper would not display vertical scrollbar if content was long.

![screenshot-localhost_8000-2023 07 26-19_51_27](https://github.com/kubermatic/dashboard/assets/13975988/27ed87df-f0f6-46c6-88c7-887aa5229393)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6093 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add vertical scroll to the install Addon dialog.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
