### PR TITLE
Add support for encrypted root volumes in AWS

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -28356,6 +28356,11 @@
           "format": "int32",
           "x-go-name": "VolumeSize"
         },
+        "ebsVolumeEncrypted": {
+          "description": "EBSVolumeEncrypted indicates whether EBS volume encryption is enabled.",
+          "type": "boolean",
+          "x-go-name": "EBSVolumeEncrypted"
+        },
         "instanceType": {
           "type": "string",
           "x-go-name": "InstanceType",

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -1835,6 +1835,8 @@ type AWSNodeSpec struct {
 	// Using an external ID can help to prevent the "confused deputy problem".
 	// required: false
 	AssumeRoleExternalID string `json:"assumeRoleExternalID"`
+	// EBSVolumeEncrypted indicates whether EBS volume encryption is enabled.
+	EBSVolumeEncrypted *bool `json:"ebsVolumeEncrypted"`
 }
 
 func (spec *AWSNodeSpec) MarshalJSON() ([]byte, error) {
@@ -1869,6 +1871,7 @@ func (spec *AWSNodeSpec) MarshalJSON() ([]byte, error) {
 		SpotInstanceMaxPrice             *string           `json:"spotInstanceMaxPrice,omitempty"`
 		SpotInstancePersistentRequest    *bool             `json:"spotInstancePersistentRequest,omitempty"`
 		SpotInstanceInterruptionBehavior *string           `json:"spotInstanceInterruptionBehavior,omitempty"`
+		EBSVolumeEncrypted               *bool             `json:"ebsVolumeEncrypted"`
 	}{
 		InstanceType:                     spec.InstanceType,
 		VolumeSize:                       spec.VolumeSize,
@@ -1882,6 +1885,7 @@ func (spec *AWSNodeSpec) MarshalJSON() ([]byte, error) {
 		SpotInstanceMaxPrice:             spec.SpotInstanceMaxPrice,
 		SpotInstancePersistentRequest:    spec.SpotInstancePersistentRequest,
 		SpotInstanceInterruptionBehavior: spec.SpotInstanceInterruptionBehavior,
+		EBSVolumeEncrypted:               spec.EBSVolumeEncrypted,
 	}
 
 	return json.Marshal(&res)

--- a/modules/api/pkg/api/v1/types_test.go
+++ b/modules/api/pkg/api/v1/types_test.go
@@ -457,7 +457,7 @@ func TestAWSNodeSpec_MarshalJSON(t *testing.T) {
 				VolumeSize:   1,
 				VolumeType:   "test-volume",
 			},
-			"{\"instanceType\":\"test-instance\",\"diskSize\":1,\"volumeType\":\"test-volume\",\"ami\":\"\",\"tags\":null,\"availabilityZone\":\"\",\"subnetID\":\"\",\"assignPublicIP\":null,\"isSpotInstance\":null}",
+			"{\"instanceType\":\"test-instance\",\"diskSize\":1,\"volumeType\":\"test-volume\",\"ami\":\"\",\"tags\":null,\"availabilityZone\":\"\",\"subnetID\":\"\",\"assignPublicIP\":null,\"isSpotInstance\":null,\"ebsVolumeEncrypted\":null}",
 		},
 	}
 

--- a/modules/api/pkg/machine/convert.go
+++ b/modules/api/pkg/machine/convert.go
@@ -156,6 +156,7 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 			SpotInstanceInterruptionBehavior: spotInstanceInterruptionBehavior,
 			AssumeRoleARN:                    config.AssumeRoleARN.Value,
 			AssumeRoleExternalID:             config.AssumeRoleExternalID.Value,
+			EBSVolumeEncrypted:               config.EBSVolumeEncrypted.Value,
 		}
 	case providerconfig.CloudProviderAzure:
 		config := &azure.RawConfig{}

--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -133,7 +133,7 @@ func GetAWSProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *
 		SpotInstanceConfig:   spotConfig,
 		AssumeRoleARN:        providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.AssumeRoleARN},
 		AssumeRoleExternalID: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.AssumeRoleExternalID},
-		EBSVolumeEncrypted:   providerconfig.ConfigVarBool{Value: pointer.Bool(false)},
+		EBSVolumeEncrypted:   providerconfig.ConfigVarBool{Value: nodeSpec.Cloud.AWS.EBSVolumeEncrypted},
 	}
 	if config.DiskType.Value == "" {
 		config.DiskType.Value = string(ec2types.VolumeTypeGp2)

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/a_w_s_node_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/a_w_s_node_spec.go
@@ -37,6 +37,9 @@ type AWSNodeSpec struct {
 	// Availability zone in which to place the node. It is coupled with the subnet to which the node will belong.
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// EBSVolumeEncrypted indicates whether EBS volume encryption is enabled.
+	EBSVolumeEncrypted bool `json:"ebsVolumeEncrypted,omitempty"`
+
 	// instance type
 	// Example: t2.micro
 	// Required: true

--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -512,6 +512,10 @@ limitations under the License.
                                  label="Spot Instance Persistent Request"
                                  [value]="element.spec.cloud.aws.spotInstancePersistentRequest">
             </km-property-boolean>
+            <km-property-boolean *ngIf="element.spec.cloud.aws"
+                                 label="EBS Volume Encryption"
+                                 [value]="element.spec.cloud.aws.ebsVolumeEncrypted">
+            </km-property-boolean>
             <!-- End of boolean properties. -->
 
             <div *ngIf="getMetrics(element.name)"

--- a/modules/web/src/app/node-data/extended/provider/aws/component.ts
+++ b/modules/web/src/app/node-data/extended/provider/aws/component.ts
@@ -29,6 +29,7 @@ enum Controls {
   SpotInstanceMaxPrice = 'spotInstanceMaxPrice',
   SpotInstancePersistentRequest = 'spotInstancePersistentRequest',
   Tags = 'tags',
+  EBSVolumeEncrypted = 'ebsVolumeEncrypted',
 }
 
 @Component({
@@ -73,6 +74,7 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
       [Controls.Tags]: this._builder.control(''),
       [Controls.SpotInstanceMaxPrice]: this._builder.control('', [KmValidators.largerThan(0)]),
       [Controls.SpotInstancePersistentRequest]: this._builder.control(false),
+      [Controls.EBSVolumeEncrypted]: this._builder.control(false),
     });
 
     this._init();
@@ -82,7 +84,8 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
       this.form.get(Controls.AssignPublicIP).valueChanges,
       this.form.get(Controls.IsSpotInstance).valueChanges,
       this.form.get(Controls.SpotInstanceMaxPrice).valueChanges,
-      this.form.get(Controls.SpotInstancePersistentRequest).valueChanges
+      this.form.get(Controls.SpotInstancePersistentRequest).valueChanges,
+      this.form.get(Controls.EBSVolumeEncrypted).valueChanges,
     )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => (this._nodeDataService.nodeData = this._getNodeData()));
@@ -127,6 +130,9 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
 
         const spotInstancePersistentRequest = this.nodeData.spec.cloud.aws.spotInstancePersistentRequest ?? false;
         this.form.get(Controls.SpotInstancePersistentRequest).setValue(spotInstancePersistentRequest);
+
+        const ebsVolumeEncrypted = this.nodeData.spec.cloud.aws.ebsVolumeEncrypted ?? false;
+        this.form.get(Controls.EBSVolumeEncrypted).setValue(ebsVolumeEncrypted);
       }
     }
   }
@@ -140,6 +146,7 @@ export class AWSExtendedNodeDataComponent extends BaseFormValidator implements O
             isSpotInstance: this.form.get(Controls.IsSpotInstance).value,
             spotInstanceMaxPrice: `${this.form.get(Controls.SpotInstanceMaxPrice).value}`,
             spotInstancePersistentRequest: this.form.get(Controls.SpotInstancePersistentRequest).value,
+            ebsVolumeEncrypted: this.form.get(Controls.EBSVolumeEncrypted).value,
           },
         } as NodeCloudSpec,
       } as NodeSpec,

--- a/modules/web/src/app/node-data/extended/provider/aws/template.html
+++ b/modules/web/src/app/node-data/extended/provider/aws/template.html
@@ -58,4 +58,9 @@ limitations under the License.
                 [formControlName]="Controls.AssignPublicIP"
                 class="checkbox"
                 kmValueChangedIndicator>Assign Public IP</mat-checkbox>
+
+  <mat-checkbox [id]="Controls.EBSVolumeEncrypted"
+                [formControlName]="Controls.EBSVolumeEncrypted"
+                class="checkbox"
+                kmValueChangedIndicator>EBS Volume Encryption</mat-checkbox>
 </form>

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -1036,6 +1036,10 @@ limitations under the License.
                                    label="Assign Public IP"
                                    [value]="machineDeployment.spec.template.cloud?.aws?.assignPublicIP">
               </km-property-boolean>
+              <km-property-boolean *ngIf="machineDeployment.spec.template.cloud?.aws?.ebsVolumeEncrypted !== undefined"
+                                   label="EBS Volume Encryption"
+                                   [value]="machineDeployment.spec.template.cloud?.aws?.ebsVolumeEncrypted">
+              </km-property-boolean>
             </ng-container>
 
             <!-- Azure Node Options -->

--- a/modules/web/src/app/shared/entity/node.ts
+++ b/modules/web/src/app/shared/entity/node.ts
@@ -176,6 +176,7 @@ export class AWSNodeSpec {
   isSpotInstance?: boolean;
   spotInstanceMaxPrice?: string;
   spotInstancePersistentRequest?: boolean;
+  ebsVolumeEncrypted?: boolean;
 }
 
 export class AzureNodeSpec {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to configure EBS Volume Encryption for AWS provider:

**Create Cluster Wizard:**

![screenshot-localhost_8000-2023 07 31-18_34_21](https://github.com/kubermatic/dashboard/assets/13975988/856a378b-6930-472b-af05-2f3eb4918bb0)

**Cluster Summary:**

![screenshot-localhost_8000-2023 07 31-18_34_47](https://github.com/kubermatic/dashboard/assets/13975988/8483c4b5-2b8c-4fd3-9b19-5aabfaae3de8)

**Nodes List:**

![screenshot-localhost_8000-2023 07 31-18_35_27](https://github.com/kubermatic/dashboard/assets/13975988/9c804370-4a34-4895-9854-4e6270bdf401)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5357 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for encrypted root volumes in AWS.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
