### PR TITLE
Keep the show all projects toggel displayed when the user is admin

### DIFF
--- a/modules/web/src/app/project/style.scss
+++ b/modules/web/src/app/project/style.scss
@@ -141,6 +141,7 @@ $project-card-width: 330px;
 }
 
 .all-projects-toggle {
+  float: right;
   padding-right: 16px;
 }
 

--- a/modules/web/src/app/project/template.html
+++ b/modules/web/src/app/project/template.html
@@ -20,14 +20,7 @@ limitations under the License.
          fxLayoutAlign=" center">
       <km-search-field (queryChange)="onSearch($event)"></km-search-field>
       <div fxFlex></div>
-      <mat-slide-toggle *ngIf="isAdmin"
-                        class="all-projects-toggle"
-                        [disabled]="isProjectsLoading"
-                        labelPosition="before"
-                        [matTooltip]="isProjectsLoading ? 'Please wait while projects are loading' : null"
-                        [ngModel]="settings.displayAllProjectsForAdmin"
-                        (toggleChange)="changeProjectVisibility()">Show All Projects
-      </mat-slide-toggle>
+      <ng-container  *ngTemplateOutlet="allProjectToggle"></ng-container>
       <mat-button-toggle-group class="project-view-switch"
                                group="projectsView"
                                (change)="changeView()">
@@ -342,6 +335,7 @@ limitations under the License.
 </div>
 
 <ng-template #placeholder>
+  <ng-container  *ngTemplateOutlet="allProjectToggle"></ng-container>
   <div fxLayout="column"
        fxLayoutAlign="center center"
        class="placeholder">
@@ -376,4 +370,15 @@ limitations under the License.
     <i class="km-icon-mask km-icon-add"></i>
     <span>Add Project</span>
   </button>
+</ng-template>
+
+<ng-template #allProjectToggle>
+  <mat-slide-toggle *ngIf="isAdmin"
+                        class="all-projects-toggle"
+                        [disabled]="isProjectsLoading"
+                        labelPosition="before"
+                        [matTooltip]="isProjectsLoading ? 'Please wait while projects are loading' : null"
+                        [ngModel]="settings.displayAllProjectsForAdmin"
+                        (toggleChange)="changeProjectVisibility()">Show All Projects
+  </mat-slide-toggle>
 </ng-template>


### PR DESCRIPTION
**What this PR does / why we need it**:
the current case is that when user is admin and don't have any project he can't see other projects if the `show all project` toggle is unchecked and at the same time he can't see the toggle so he can't check it to see all projects,
in this PR we kkeep the toggle shown always if the user is admin.

![Screenshot from 2023-07-22 01-08-57](https://github.com/kubermatic/dashboard/assets/85109141/37b8306c-2880-4c44-b980-7991e8b26f85)

 
**Which issue(s) this PR fixes**:
Fixes #6039

**What type of PR is this?**
/kind feature


```release-note
NONE
```

```documentation
NONE
```
