### PR TITLE
Fix the redirect url for keycloak logout

### DIFF
--- a/modules/web/src/app/core/services/auth/service.ts
+++ b/modules/web/src/app/core/services/auth/service.ts
@@ -23,6 +23,7 @@ import {take, tap} from 'rxjs/operators';
 import {PreviousRouteService} from '../previous-route';
 import {TokenService} from '../token';
 import {UserService} from '../user';
+import {OIDCProviders} from '@app/shared/model/Config';
 
 @Injectable()
 export class Auth {
@@ -130,10 +131,18 @@ export class Auth {
     const config = this._appConfigService.getConfig();
     if (config.oidc_logout_url) {
       const logoutUrl = new URL(config.oidc_logout_url);
-      if (logoutUrl.searchParams.has('redirectUri')) {
-        logoutUrl.searchParams.set('redirectUri', this._redirectUri);
-      } else {
-        logoutUrl.searchParams.set('redirect_uri', this._redirectUri);
+      switch (config.oidc_provider?.toLowerCase()) {
+        case OIDCProviders.Keycloak:
+          logoutUrl.searchParams.set('post_logout_redirect_uri', this._redirectUri);
+          logoutUrl.searchParams.set('id_token_hint', this.getBearerToken());
+          break;
+        default:
+          if (logoutUrl.searchParams.has('redirectUri')) {
+              logoutUrl.searchParams.set('redirectUri', this._redirectUri);
+          } else {
+              logoutUrl.searchParams.set('redirect_uri', this._redirectUri);
+          }
+          break;
       }
       window.location.href = logoutUrl.toString();
     }

--- a/modules/web/src/app/project/template.html
+++ b/modules/web/src/app/project/template.html
@@ -20,7 +20,7 @@ limitations under the License.
          fxLayoutAlign=" center">
       <km-search-field (queryChange)="onSearch($event)"></km-search-field>
       <div fxFlex></div>
-      <ng-container  *ngTemplateOutlet="allProjectToggle"></ng-container>
+      <ng-container *ngTemplateOutlet="allProjectToggle"></ng-container>
       <mat-button-toggle-group class="project-view-switch"
                                group="projectsView"
                                (change)="changeView()">
@@ -335,7 +335,7 @@ limitations under the License.
 </div>
 
 <ng-template #placeholder>
-  <ng-container  *ngTemplateOutlet="allProjectToggle"></ng-container>
+  <ng-container *ngTemplateOutlet="allProjectToggle"></ng-container>
   <div fxLayout="column"
        fxLayoutAlign="center center"
        class="placeholder">
@@ -374,11 +374,11 @@ limitations under the License.
 
 <ng-template #allProjectToggle>
   <mat-slide-toggle *ngIf="isAdmin"
-                        class="all-projects-toggle"
-                        [disabled]="isProjectsLoading"
-                        labelPosition="before"
-                        [matTooltip]="isProjectsLoading ? 'Please wait while projects are loading' : null"
-                        [ngModel]="settings.displayAllProjectsForAdmin"
-                        (toggleChange)="changeProjectVisibility()">Show All Projects
+                    class="all-projects-toggle"
+                    [disabled]="isProjectsLoading"
+                    labelPosition="before"
+                    [matTooltip]="isProjectsLoading ? 'Please wait while projects are loading' : null"
+                    [ngModel]="settings.displayAllProjectsForAdmin"
+                    (toggleChange)="changeProjectVisibility()">Show All Projects
   </mat-slide-toggle>
 </ng-template>

--- a/modules/web/src/app/shared/model/Config.ts
+++ b/modules/web/src/app/shared/model/Config.ts
@@ -27,6 +27,7 @@ export interface Config {
   };
   google_analytics_code?: string;
   google_analytics_config?: object;
+  oidc_provider?: string;
   oidc_provider_url?: string;
   oidc_provider_scope?: string;
   oidc_provider_client_id?: string;
@@ -135,4 +136,8 @@ export class Backups implements Viewable {
   edit?: boolean;
   create?: boolean;
   delete?: boolean;
+}
+
+export enum OIDCProviders {
+  Keycloak = 'keycloak'
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Starting from Keycloak 18, [RP initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) was introduced in keycloak. `post_logout_redirect_uri` and `id_token_hint` parameters are required now for logging a user out. 

To support this special case, we are now adding a new configuration named `oidc_provider` which will allow us to manage OIDC provider specific configurations.

**Which issue(s) this PR fixes**:
Fixes #6127

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix support for keycloak OIDC logout. New field `oidc_provider` was introduced to support OIDC provider specific configurations. Configuring `oidc_provider` as `keycloak` will properly configure the logout workflow.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```