### PR TITLE
[release/v2.23] Fix the redirect URI for keycloak

### DIFF
--- a/modules/web/src/app/core/services/auth/service.ts
+++ b/modules/web/src/app/core/services/auth/service.ts
@@ -23,6 +23,7 @@ import {take, tap} from 'rxjs/operators';
 import {PreviousRouteService} from '../previous-route';
 import {TokenService} from '../token';
 import {UserService} from '../user';
+import {OIDCProviders} from '@app/shared/model/Config';
 
 @Injectable()
 export class Auth {
@@ -130,10 +131,18 @@ export class Auth {
     const config = this._appConfigService.getConfig();
     if (config.oidc_logout_url) {
       const logoutUrl = new URL(config.oidc_logout_url);
-      if (logoutUrl.searchParams.has('redirectUri')) {
-        logoutUrl.searchParams.set('redirectUri', this._redirectUri);
-      } else {
-        logoutUrl.searchParams.set('redirect_uri', this._redirectUri);
+      switch (config.oidc_provider?.toLowerCase()) {
+        case OIDCProviders.Keycloak:
+          logoutUrl.searchParams.set('post_logout_redirect_uri', this._redirectUri);
+          logoutUrl.searchParams.set('id_token_hint', this.getBearerToken());
+          break;
+        default:
+          if (logoutUrl.searchParams.has('redirectUri')) {
+            logoutUrl.searchParams.set('redirectUri', this._redirectUri);
+          } else {
+            logoutUrl.searchParams.set('redirect_uri', this._redirectUri);
+          }
+          break;
       }
       window.location.href = logoutUrl.toString();
     }

--- a/modules/web/src/app/shared/model/Config.ts
+++ b/modules/web/src/app/shared/model/Config.ts
@@ -27,6 +27,7 @@ export interface Config {
   };
   google_analytics_code?: string;
   google_analytics_config?: object;
+  oidc_provider?: string;
   oidc_provider_url?: string;
   oidc_provider_scope?: string;
   oidc_provider_client_id?: string;
@@ -135,4 +136,8 @@ export class Backups implements Viewable {
   edit?: boolean;
   create?: boolean;
   delete?: boolean;
+}
+
+export enum OIDCProviders {
+  Keycloak = 'keycloak',
 }


### PR DESCRIPTION
manual backporting to v2.23
xref #6144  #6127

```release-note
Fix support for keycloak OIDC logout. New field `oidc_provider` was introduced to support OIDC provider specific configurations. Configuring `oidc_provider` as `keycloak` will properly configure the logout workflow.
```