### PR TITLE
Skip fetching metrics if metric-server is not available

### DIFF
--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -717,6 +717,11 @@ func GetMetricsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGet
 	if err := client.List(ctx, nodeList); err != nil {
 		return nil, err
 	}
+
+	if len(nodeList.Items) == 0 {
+		return nil, utilerrors.New(http.StatusNotFound, "no nodes found")
+	}
+
 	availableResources := make(map[string]corev1.ResourceList)
 	for _, n := range nodeList.Items {
 		availableResources[n.Name] = n.Status.Allocatable

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -322,20 +322,15 @@ func ListNodesForCluster(ctx context.Context, userInfoGetter provider.UserInfoGe
 	// Go over all machines first
 	for i := range machineList.Items {
 		node := getNodeForMachine(&machineList.Items[i], nodeList.Items)
-		if node != nil {
-			matchedMachineNodes.Insert(string(node.UID))
-		}
-
-		// Do not list Machines that are controlled, i.e. by Machine Set.
-		if len(machineList.Items[i].ObjectMeta.OwnerReferences) != 0 {
+		if node == nil {
 			continue
 		}
 
+		matchedMachineNodes.Insert(string(node.UID))
 		outNode, err := outputMachine(&machineList.Items[i], node, hideInitialConditions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to output machine %s: %w", machineList.Items[i].Name, err)
 		}
-
 		nodesV1 = append(nodesV1, outNode)
 	}
 

--- a/modules/api/pkg/handler/v2/machine/machine_test.go
+++ b/modules/api/pkg/handler/v2/machine/machine_test.go
@@ -1165,66 +1165,7 @@ func TestListNodesForCluster(t *testing.T) {
 		},
 		// scenario 2
 		{
-			Name:            "scenario 2: list nodes that belong to the given cluster should skip controlled machines",
-			HTTPStatus:      http.StatusOK,
-			ClusterIDToSync: test.GenDefaultCluster().Name,
-			ProjectIDToSync: test.GenDefaultProject().Name,
-			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
-				test.GenTestSeed(),
-				test.GenDefaultCluster(),
-			),
-			ExistingAPIUser: test.GenDefaultAPIUser(),
-			ExistingNodes: []*corev1.Node{
-				{ObjectMeta: metav1.ObjectMeta{Name: "venus"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "mars"}},
-			},
-			ExistingMachines: []*clusterv1alpha1.Machine{
-				genTestMachine("venus", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50,"diskType":"standard"},"operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, []metav1.OwnerReference{{APIVersion: "", Kind: "", Name: "", UID: ""}}),
-				genTestMachine("mars", `{"cloudProvider":"aws","cloudProviderSpec":{"token":"dummy-token","region":"eu-central-1","availabilityZone":"eu-central-1a","vpcId":"vpc-819f62e9","subnetId":"subnet-2bff4f43","instanceType":"t2.micro","diskSize":50,"diskType":"standard"},"operatingSystem":"ubuntu", "operatingSystemSpec":{"distUpgradeOnBoot":false}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
-			},
-			ExpectedResponse: []apiv1.Node{
-				{
-					ObjectMeta: apiv1.ObjectMeta{
-						ID:   "mars",
-						Name: "mars",
-					},
-					Spec: apiv1.NodeSpec{
-						Cloud: apiv1.NodeCloudSpec{
-							AWS: &apiv1.AWSNodeSpec{
-								InstanceType:     "t2.micro",
-								VolumeSize:       50,
-								VolumeType:       "standard",
-								AvailabilityZone: "eu-central-1a",
-								SubnetID:         "subnet-2bff4f43",
-							},
-						},
-						OperatingSystem: apiv1.OperatingSystemSpec{
-							Ubuntu: &apiv1.UbuntuSpec{
-								DistUpgradeOnBoot: false,
-							},
-						},
-						SSHUserName: "ubuntu",
-						Versions: apiv1.NodeVersionInfo{
-							Kubelet: "v9.9.9",
-						},
-					},
-					Status: apiv1.NodeStatus{
-						MachineName: "mars",
-						Capacity: apiv1.NodeResources{
-							CPU:    "0",
-							Memory: "0",
-						},
-						Allocatable: apiv1.NodeResources{
-							CPU:    "0",
-							Memory: "0",
-						},
-					},
-				},
-			},
-		},
-		// scenario 3
-		{
-			Name:            "scenario 3: the admin John can list nodes that belong to the given Bob's cluster",
+			Name:            "scenario 2: the admin John can list nodes that belong to the given Bob's cluster",
 			HTTPStatus:      http.StatusOK,
 			ClusterIDToSync: test.GenDefaultCluster().Name,
 			ProjectIDToSync: test.GenDefaultProject().Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, we are fetching metrics as soon as the control plane components for the user cluster are up. This won't work since the metrics depend on the metric-server being up and available. Metric-server is not a control plane component and is installed on the user cluster in the form of a /pod. Hence, without having worker nodes available for that pod to be scheduled we end up getting bombarded with the following error after every 10 seconds because of polling.

```
failed to get API group resources: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
We don't need any release notes since this is only broken in main branch.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
