### PR TITLE
Fix filter for quota calculation

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/hetzner/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/hetzner/component.ts
@@ -14,19 +14,19 @@
 
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, forwardRef, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
-import {GlobalModule} from '@core/services/global/module';
 import {DynamicModule} from '@app/dynamic/module-registry';
-import _ from 'lodash';
-import {Observable} from 'rxjs';
-import {filter, takeUntil} from 'rxjs/operators';
 import {ClusterSpecService} from '@core/services/cluster-spec';
+import {GlobalModule} from '@core/services/global/module';
 import {NodeDataService} from '@core/services/node-data/service';
+import {QuotaCalculationService} from '@dynamic/enterprise/quotas/services/quota-calculation';
 import {HetznerNodeSpec, NodeCloudSpec, NodeSpec} from '@shared/entity/node';
 import {HetznerTypes, Type} from '@shared/entity/provider/hetzner';
+import {ResourceQuotaCalculationPayload} from '@shared/entity/quota';
 import {NodeData} from '@shared/model/NodeSpecChange';
 import {BaseFormValidator} from '@shared/validators/base-form.validator';
-import {QuotaCalculationService} from '@dynamic/enterprise/quotas/services/quota-calculation';
-import {ResourceQuotaCalculationPayload} from '@shared/entity/quota';
+import _ from 'lodash';
+import {Observable} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
 
 enum Controls {
   Type = 'type',
@@ -102,12 +102,11 @@ export class HetznerBasicNodeDataComponent extends BaseFormValidator implements 
 
     this.form
       .get(Controls.Type)
-      .valueChanges.pipe(filter(_ => this.isEnterpriseEdition))
-      .pipe(takeUntil(this._unsubscribe))
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => {
         this._nodeDataService.nodeData = this._getNodeData();
-        const payload = this._getQuotaCalculationPayload();
-        if (payload) {
+        if (this.isEnterpriseEdition) {
+          const payload = this._getQuotaCalculationPayload();
           this._quotaCalculationService.refreshQuotaCalculations(payload);
         }
       });

--- a/modules/web/src/app/node-data/basic/provider/nutanix/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/nutanix/component.ts
@@ -186,12 +186,13 @@ export class NutanixBasicNodeDataComponent extends BaseFormValidator implements 
       this.form.get(Controls.SubnetName).valueChanges,
       this.form.get(Controls.Categories).valueChanges
     )
-      .pipe(filter(_ => this.isEnterpriseEdition))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => {
         this._nodeDataService.nodeData = this._getNodeData();
-        const payload = this._getQuotaCalculationPayload();
-        this._quotaCalculationService.refreshQuotaCalculations(payload);
+        if (this.isEnterpriseEdition) {
+          const payload = this._getQuotaCalculationPayload();
+          this._quotaCalculationService.refreshQuotaCalculations(payload);
+        }
       });
 
     this.form

--- a/modules/web/src/app/node-data/basic/provider/vsphere/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/vsphere/component.ts
@@ -102,12 +102,13 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
       this.form.get(Controls.Template).valueChanges,
       this.form.get(Controls.DiskSizeGB).valueChanges
     )
-      .pipe(filter(_ => this.isEnterpriseEdition))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => {
         this._nodeDataService.nodeData = this._getNodeData();
-        const payload = this._getQuotaCalculationPayload();
-        this._quotaCalculationService.refreshQuotaCalculations(payload);
+        if (this.isEnterpriseEdition) {
+          const payload = this._getQuotaCalculationPayload();
+          this._quotaCalculationService.refreshQuotaCalculations(payload);
+        }
       });
 
     merge(this._clusterSpecService.datacenterChanges, of(this._clusterSpecService.datacenter))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug where a wrong filter for EE stopped the values being configured for node resources to be propagated from the forms to the persistence layer. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6165

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug, for Community Edition, where the values configured for vSphere, Hetzner, and Nutanix nodes were not being persisted.  
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
