### PR TITLE
Fix preset to cluster mapping for VMware Cloud Director

### DIFF
--- a/modules/api/pkg/provider/kubernetes/preset.go
+++ b/modules/api/pkg/provider/kubernetes/preset.go
@@ -480,6 +480,7 @@ func (m *PresetProvider) setVMwareCloudDirectorCredentials(preset *kubermaticv1.
 	cloud.VMwareCloudDirector.Organization = credentials.Organization
 	cloud.VMwareCloudDirector.VDC = credentials.VDC
 	cloud.VMwareCloudDirector.OVDCNetwork = credentials.OVDCNetwork
+	cloud.VMwareCloudDirector.APIToken = credentials.APIToken
 
 	return &cloud, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where the API Token from preset was not being sourced to the cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6195

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMware Cloud Director: fix an issue where the API Token from preset was not being sourced to the cluster
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
