### PR TITLE
[release/v2.23] Prepare v2.23.4 out-of-band patch release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.23.3
+KUBERMATIC_VERSION?=v2.23.4
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.23.3
+KUBERMATIC_VERSION?=v2.23.4
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -67,7 +67,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.6.2
-	k8c.io/kubermatic/v2 v2.23.2-0.20230820173313-bd13e1de9d95
+	k8c.io/kubermatic/v2 v2.23.4-0.20230921084125-218aec21ed48
 	k8c.io/operating-system-manager v1.3.2
 	k8c.io/reconciler v0.3.1
 	k8s.io/api v0.26.4
@@ -102,7 +102,7 @@ replace (
 
 replace (
 	github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.23.3-0.20230915082721-4a8e342d8697
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.23.4-0.20230921084125-218aec21ed48
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1367,8 +1367,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.6.2 h1:3oEvD90kENhYzvvmSrMNjUam2fq7UMMKVp/Py57xs6M=
 k8c.io/kubeone v1.6.2/go.mod h1:5U/6sUZAkAl7uvC+VIDIA0VBZMBbFI9QD1C90kxb4qA=
-k8c.io/kubermatic/v2 v2.23.3-0.20230915082721-4a8e342d8697 h1:Ss8EnuHECkYD+RG/gjErtDVGdJyMl9FPeLrWylOn78w=
-k8c.io/kubermatic/v2 v2.23.3-0.20230915082721-4a8e342d8697/go.mod h1:FKGDdbKXVsG9zj+XiaaNHHAnvxGDizAENXbCrxrTTWE=
+k8c.io/kubermatic/v2 v2.23.4-0.20230921084125-218aec21ed48 h1:uPWGM4rG7G3kkkRBEsC5QaIakxXAX0sBFxYbx2O17pc=
+k8c.io/kubermatic/v2 v2.23.4-0.20230921084125-218aec21ed48/go.mod h1:FKGDdbKXVsG9zj+XiaaNHHAnvxGDizAENXbCrxrTTWE=
 k8c.io/operating-system-manager v1.3.2 h1:DdScdSdUywzT/mVn3GMEShiKPxHjEIPn3OrlefvUu/I=
 k8c.io/operating-system-manager v1.3.2/go.mod h1:kKDzXLWrC5BLpDbgXQFRpTVa5Fjru2S3ylxX5hZMRKA=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.23.3
+KUBERMATIC_VERSION?=v2.23.4
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.23.3",
+  "version": "2.23.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.23.3",
+      "version": "2.23.4",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.23.3",
+  "version": "2.23.4",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",

--- a/modules/web/src/assets/config/changelog.json
+++ b/modules/web/src/assets/config/changelog.json
@@ -1,45 +1,13 @@
 {
-  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.23.md#2233",
+  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.23.md#v2234",
   "entries": [
     {
-      "category": "added",
-      "description": "Add support for Kubernetes 1.25.14, 1.26.9 and 1.27.6."
-    },
-    {
-      "category": "added",
-      "description": "Add Cilium 1.13.6 as supported CNI version. Older 1.13.x releases are now deprecated."
-    },
-    {
-      "category": "changed",
-      "description": "Set default Kubernetes version to 1.26.9."
-    },
-    {
-      "category": "changed",
-      "description": "Mark MLA Grafana dashboards as non-editable as they are managed by KKP."
+      "category": "fixed",
+      "description": "No longer show 1.14.1 as available Cilium version as it was never supported."
     },
     {
       "category": "fixed",
-      "description": "Add missing cluster-autoscaler release for user clusters using Kubernetes 1.27."
-    },
-    {
-      "category": "fixed",
-      "description": "MLA Grafana Kubernetes dashboards will no longer repeatedly ask to be saved."
-    },
-    {
-      "category": "fixed",
-      "description": "Allow expansion of side navigation on small screen sizes."
-    },
-    {
-      "category": "fixed",
-      "description": "Fix vSphere tags for initial machine deployments."
-    },
-    {
-      "category": "fixed",
-      "description": "Openstack: take TenantID into account while listing networks, security groups and subnet pools."
-    },
-    {
-      "category": "fixed",
-      "description": "VMware Cloud Director: fix an issue where the API Token from preset was not being sourced to the cluster."
+      "description": "If a vSphere user cluster uses a custom datastore, the seed's default datastore is no longer validated."
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
I [introduced](https://github.com/kubermatic/kubermatic/pull/12635) a [regression](https://github.com/kubermatic/kubermatic/issues/12662) in KKP v2.23.3 that made KKP offer Cilium 1.14.1 via the API and subsequently from the dashboard when creating a new cluster with Cilium. That version doesn't exist in KKP v2.23.

This PR bumps to https://github.com/kubermatic/kubermatic/commit/218aec21ed486418b079681e9755fd4c8052e3a8 to undo the damage and remove Cilium 1.14.1 from the list of supported versions. It also prepares an out-of-band patch release for it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
