### PR TITLE
Save the token to use in logout from keycloak

### DIFF
--- a/modules/web/src/app/core/components/user-panel/component.ts
+++ b/modules/web/src/app/core/components/user-panel/component.ts
@@ -74,10 +74,11 @@ export class UserPanelComponent implements OnInit, OnDestroy {
   }
 
   logout(): void {
+    const token = this._auth.getBearerToken();
     this._auth.logout().subscribe(_ => {
       this._settingsService.refreshCustomLinks();
       if (this._appConfigService.getConfig().oidc_logout_url) {
-        this._auth.oidcProviderLogout();
+        this._auth.oidcProviderLogout(token);
       } else {
         this._router.navigate(['']);
         this._document.defaultView.location.reload();

--- a/modules/web/src/app/core/services/auth/service.ts
+++ b/modules/web/src/app/core/services/auth/service.ts
@@ -127,14 +127,14 @@ export class Auth {
       .pipe(take(1));
   }
 
-  oidcProviderLogout(): void {
+  oidcProviderLogout(token: string): void {
     const config = this._appConfigService.getConfig();
     if (config.oidc_logout_url) {
       const logoutUrl = new URL(config.oidc_logout_url);
       switch (config.oidc_provider?.toLowerCase()) {
         case OIDCProviders.Keycloak:
           logoutUrl.searchParams.set('post_logout_redirect_uri', this._redirectUri);
-          logoutUrl.searchParams.set('id_token_hint', this.getBearerToken());
+          logoutUrl.searchParams.set('id_token_hint', token);
           break;
         default:
           if (logoutUrl.searchParams.has('redirectUri')) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix the empty `id_token_hint` when logout from keycloak.

**Which issue(s) this PR fixes**:
Fixes #6239 

**What type of PR is this?**
/kind bug

```release-note
fix the empty `id_token_hint` when logout from keycloak.
```

```documentation
NONE
```
