### PR TITLE
Set default value for cni plugin version 

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -27645,6 +27645,11 @@
       "description": "CNIVersions is a list of versions for a CNI Plugin",
       "type": "object",
       "properties": {
+        "cniDefaultVersion": {
+          "description": "CNIDefaultVersion represents the default CNI Plugin version",
+          "type": "string",
+          "x-go-name": "CNIDefaultVersion"
+        },
         "cniPluginType": {
           "description": "CNIPluginType represents the type of the CNI Plugin",
           "type": "string",

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1684,6 +1684,8 @@ type StorageClass struct {
 type CNIVersions struct {
 	// CNIPluginType represents the type of the CNI Plugin
 	CNIPluginType string `json:"cniPluginType"`
+	// CNIDefaultVersion represents the default CNI Plugin version
+	CNIDefaultVersion string `json:"cniDefaultVersion"`
 	// Versions represents the list of the CNI Plugin versions that are supported
 	Versions []string `json:"versions"`
 }

--- a/modules/api/pkg/handler/v2/cniversion/cniversion.go
+++ b/modules/api/pkg/handler/v2/cniversion/cniversion.go
@@ -53,8 +53,9 @@ func ListVersions() endpoint.Endpoint {
 		}
 
 		return apiv2.CNIVersions{
-			CNIPluginType: req.CNIPluginType,
-			Versions:      sets.List(versions),
+			CNIPluginType:     req.CNIPluginType,
+			Versions:          sets.List(versions),
+			CNIDefaultVersion: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginType(req.CNIPluginType)),
 		}, nil
 	}
 }

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/c_n_i_versions.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/c_n_i_versions.go
@@ -17,6 +17,9 @@ import (
 // swagger:model CNIVersions
 type CNIVersions struct {
 
+	// CNIDefaultVersion represents the default CNI Plugin version
+	CNIDefaultVersion string `json:"cniDefaultVersion,omitempty"`
+
 	// CNIPluginType represents the type of the CNI Plugin
 	CNIPluginType string `json:"cniPluginType,omitempty"`
 

--- a/modules/web/src/app/shared/entity/cluster.ts
+++ b/modules/web/src/app/shared/entity/cluster.ts
@@ -397,6 +397,7 @@ export class NetworkRanges {
 
 export class CNIPluginVersions {
   cniPluginType: string;
+  cniDefaultVersion: string;
   versions: string[];
 }
 

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -278,7 +278,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         this._updateAvailableProxyModes();
         this.form.get(Controls.CNIPluginVersion).setValue('');
         this.cniPluginVersions = cniVersions.versions.sort((a, b) => compare(coerce(a), coerce(b)));
-        this._setDefaultCNIVersion();
+        this._setDefaultCNIVersion(cniVersions.cniDefaultVersion);
       });
 
     this.control(Controls.Konnectivity)
@@ -639,7 +639,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       .pipe(take(1))
       .subscribe(versions => {
         this.cniPluginVersions = versions.versions.sort((a, b) => compare(coerce(a), coerce(b)));
-        this._setDefaultCNIVersion();
+        this._setDefaultCNIVersion(versions.cniDefaultVersion);
       });
   }
 
@@ -701,7 +701,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     }
   }
 
-  private _setDefaultCNIVersion(): void {
+  private _setDefaultCNIVersion(cniDefaultVersion: string): void {
     if (this.cniPluginVersions.length > 0 && !this.form.get(Controls.CNIPluginVersion).value) {
       // Dual-stack not allowed on Canal CNI version lower than 3.22.
       if (this.controlValue(Controls.CNIPlugin) === CNIPlugin.Canal && this.isDualStackIPFamilySelected()) {
@@ -709,8 +709,11 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           gte(coerce(v), this._canalDualStackMinimumSupportedVersion)
         );
       }
-
-      this.form.get(Controls.CNIPluginVersion).setValue(this.cniPluginVersions[this.cniPluginVersions.length - 1]);
+      if (this.cniPluginVersions.includes(cniDefaultVersion)) {
+        this.form.get(Controls.CNIPluginVersion).setValue(cniDefaultVersion);
+      } else {
+        this.form.get(Controls.CNIPluginVersion).setValue(this.cniPluginVersions[this.cniPluginVersions.length - 1]);
+      }
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
use `cni.GetDefaultCNIPluginVersion` to get the default value for cni Plugin version .

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6233 

**What type of PR is this?**
/kind bug


```release-note
NONE
```

```documentation
NONE
```
