### PR TITLE
Add OSP to the MD patch object

### DIFF
--- a/modules/web/src/app/core/services/node.ts
+++ b/modules/web/src/app/core/services/node.ts
@@ -59,6 +59,11 @@ export class NodeService {
         maxReplicas: data.nodeData.maxReplicas,
       },
     };
+    if (data.nodeData.operatingSystemProfile) {
+      patch.annotations = {
+        [OPERATING_SYSTEM_PROFILE_ANNOTATION]: data.nodeData.operatingSystemProfile,
+      };
+    }
 
     // As we are using merge patch to send whole spec we need to ensure that previous values will be unset
     // and replaced by the values from patch. That's why we need to set undefined fields to null.

--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -282,7 +282,10 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
 
     this._settingsService.adminSettings.pipe(take(1)).subscribe(settings => {
       this.allowedOperatingSystems = settings?.allowedOperatingSystems && settings.allowedOperatingSystems;
-      this.form.get(Controls.OperatingSystem).setValue(this._getDefaultOS());
+      const defaultOS = this._getDefaultOS();
+      if (defaultOS !== this.form.get(Controls.OperatingSystem).value) {
+        this.form.get(Controls.OperatingSystem).setValue(defaultOS);
+      }
 
       const autoUpdatesEnabled = settings.machineDeploymentOptions.autoUpdatesEnabled;
       const replicas =

--- a/modules/web/src/app/shared/entity/machine-deployment.ts
+++ b/modules/web/src/app/shared/entity/machine-deployment.ts
@@ -43,6 +43,7 @@ export class MachineDeploymentStatus {
 }
 
 export class MachineDeploymentPatch {
+  annotations?: object;
   spec: MachineDeploymentSpecPatch;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add the `'k8c.io/operating-system-profile'` annotation to the patch object for editing a machine deployment .

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6255

**What type of PR is this?**
/kind bug


```release-note
Add operating system profile to the machine deployment patch object.
```

```documentation
NONE
```
