### PR TITLE
[release/v2.22] Add OSP to the MD patch object

### DIFF
--- a/modules/web/src/app/core/services/node.ts
+++ b/modules/web/src/app/core/services/node.ts
@@ -59,6 +59,12 @@ export class NodeService {
       },
     };
 
+    if (data.nodeData.operatingSystemProfile) {
+      patch.annotations = {
+        [OPERATING_SYSTEM_PROFILE_ANNOTATION]: data.nodeData.operatingSystemProfile,
+      };
+    }
+
     // As we are using merge patch to send whole spec we need to ensure that previous values will be unset
     // and replaced by the values from patch. That's why we need to set undefined fields to null.
     // It is not part of API service as it is not required in all cases (i.e. replicas count change).

--- a/modules/web/src/app/shared/entity/machine-deployment.ts
+++ b/modules/web/src/app/shared/entity/machine-deployment.ts
@@ -43,6 +43,7 @@ export class MachineDeploymentStatus {
 }
 
 export class MachineDeploymentPatch {
+  annotations?: object;
   spec: MachineDeploymentSpecPatch;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of #6255

```release-note
Add operating system profile to the machine deployment patch object.
```
