### PR TITLE
Spelling-fixes

### DIFF
--- a/docs/proposals/testing.md
+++ b/docs/proposals/testing.md
@@ -1,4 +1,4 @@
-# Title of the Poposal: e.g. **Angular Testing**
+# Title of the Proposal: e.g. **Angular Testing**
 
 **Author**: Eugenia Stempel (@j3ank)
 

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2007,11 +2007,11 @@ type KubevirtNodeSpec struct {
 	// Instancetype provide a way to define a set of resource, performance and other runtime characteristics,
 	// allowing users to reuse these definitions across multiple VirtualMachines.
 	// Anything provided within an instancetype cannot be overridden within the VirtualMachine.
-	// Type is very simple, re-use directly KubeVirt type.
+	// Type is very simple, reuse directly KubeVirt type.
 	Instancetype *kubevirtv1.InstancetypeMatcher `json:"instancetype"`
 	// Preference are like Instancetype defining runtime characteristics. But unlike Instancetypes,
 	// Preferences only represent the preferred values and as such can be overridden by values in the VirtualMachine.
-	// Type is very simple, re-use directly KubeVirt type.
+	// Type is very simple, reuse directly KubeVirt type.
 	Preference *kubevirtv1.PreferenceMatcher `json:"preference"`
 	// CPUs states how many cpus the kubevirt node will have.
 	// required: true

--- a/modules/api/pkg/handler/common/kubeconfig.go
+++ b/modules/api/pkg/handler/common/kubeconfig.go
@@ -205,7 +205,7 @@ func GetClusterSAKubeconfigEndpoint(ctx context.Context, userInfoGetter provider
 // getServiceAccountToken returns the token associated to the k8s service account named serviceAccountID in serviceAccountNamespace.
 // An error is returned for the following cases:
 //   - service account does not exist
-//   - service account does not have token associated. (ie no secret annoated with service account's name and uid)
+//   - service account does not have token associated. (ie no secret annotated with service account's name and uid)
 //   - secret that stores token does not have key "token"
 func getServiceAccountToken(ctx context.Context, client ctrlruntimeclient.Client, serviceAccountNamespace string, serviceAccountName string) (string, error) {
 	serviceAccount := &corev1.ServiceAccount{}

--- a/modules/api/pkg/handler/v2/cluster/kubeconfig_test.go
+++ b/modules/api/pkg/handler/v2/cluster/kubeconfig_test.go
@@ -242,7 +242,7 @@ func TestGetClusterSAKubeconfig(t *testing.T) {
 			ExpectedResponseString: genToken("cluster-foo", "sa-test", "fake-sa-token"),
 		},
 		{
-			Name:                    "scenario 2: error is returned if service account has no secret (may happen in k8s >= 1.24 if secret is not annoated)",
+			Name:                    "scenario 2: error is returned if service account has no secret (may happen in k8s >= 1.24 if secret is not annotated)",
 			HTTPStatus:              http.StatusInternalServerError,
 			ProjectToGet:            "foo-ID",
 			ClusterToGet:            "cluster-foo",

--- a/modules/api/pkg/handler/v2/constraint/constraint.go
+++ b/modules/api/pkg/handler/v2/constraint/constraint.go
@@ -92,7 +92,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			apiConstraintMap[genConstraintKey(ct.Spec.ConstraintType, ct.Name)] = apiConstraint
 		}
 
-		// List all diffrerent gatekeeper constraints and get status
+		// List all different gatekeeper constraints and get status
 		for kind := range cKinds {
 			list := &unstructured.UnstructuredList{}
 			list.SetGroupVersionKind(schema.GroupVersionKind{

--- a/modules/api/pkg/provider/cloud/aws/client_test.go
+++ b/modules/api/pkg/provider/cloud/aws/client_test.go
@@ -57,7 +57,7 @@ func TestIsNotFound(t *testing.T) {
 
 	for _, err := range errs {
 		if !isNotFound(err) {
-			t.Errorf("%v should have been recoginized as a notFound error.", err)
+			t.Errorf("%v should have been recognized as a notFound error.", err)
 		}
 	}
 }

--- a/modules/api/pkg/test/e2e/utils/oidc.go
+++ b/modules/api/pkg/test/e2e/utils/oidc.go
@@ -119,7 +119,7 @@ func RetrieveAdminMasterToken(ctx context.Context) (string, error) {
 }
 
 func retrieveToken(ctx context.Context, token *string, login, password string, connector dex.ConnectorType) (string, error) {
-	// re-use the previous token
+	// reuse the previous token
 	if token != nil && *token != "" {
 		return *token, nil
 	}

--- a/modules/web/version.js
+++ b/modules/web/version.js
@@ -32,7 +32,7 @@ const gitInfo = gitDescribe.gitDescribeSync({
 // Append edition information
 gitInfo.edition = getEditionDisplayName();
 
-// Re-use the version logic from our Makefile
+// Reuse the version logic from our Makefile
 gitInfo.humanReadable = execSync("make version --no-print-directory").toString().trim();
 
 // Append date information


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing spelling issues in the codebase to satisfy `pre-dashboard-common-verify` CI job.

/kind chore

```release-note
NONE
```

```documentation
NONE
```
