### PR TITLE
Add functionality to configure `basePath` in preset and cluster for vSphere

### DIFF
--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/component.ts
@@ -27,6 +27,7 @@ export enum Controls {
   Datastore = 'datastore',
   DatastoreCluster = 'datastoreCluster',
   ResourcePool = 'resourcePool',
+  BasePath = 'basePath',
 }
 
 @Component({
@@ -65,6 +66,7 @@ export class VSphereSettingsComponent extends BaseFormValidator implements OnIni
       [Controls.Datastore]: this._builder.control(null),
       [Controls.DatastoreCluster]: this._builder.control(null),
       [Controls.ResourcePool]: this._builder.control(null),
+      [Controls.BasePath]: this._builder.control(null),
     });
 
     this.form.valueChanges
@@ -96,6 +98,7 @@ export class VSphereSettingsComponent extends BaseFormValidator implements OnIni
       datastore: this.form.get(Controls.Datastore).value,
       datastoreCluster: this.form.get(Controls.DatastoreCluster).value,
       resourcePool: this.form.get(Controls.ResourcePool).value,
+      basePath: this.form.get(Controls.BasePath).value,
     } as VSpherePresetSpec;
   }
 }

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
@@ -82,4 +82,17 @@ limitations under the License.
            autocomplete="off"
            kmValueChangedIndicator />
   </mat-form-field>
+
+  <mat-form-field>
+    <mat-label>Base Folder Path</mat-label>
+    <input matInput
+           [formControlName]="Controls.BasePath"
+           [name]="Controls.BasePath"
+           type="text"
+           autocomplete="off"
+           kmValueChangedIndicator />
+    <mat-hint>
+      Base folder path configures a vCenter folder path where KKP will create an individual cluster folder.
+    </mat-hint>
+  </mat-form-field>
 </form>

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -487,6 +487,10 @@ limitations under the License.
               <div key>Folder</div>
               <div value>{{cluster.spec.cloud?.vsphere.folder}}</div>
             </km-property>
+            <km-property *ngIf="cluster.spec.cloud?.vsphere.basePath">
+              <div key>Base Folder Path</div>
+              <div value>{{cluster.spec.cloud?.vsphere.basePath}}</div>
+            </km-property>
             <km-property *ngIf="cluster.spec.cloud?.vsphere.datastore">
               <div key>Datastore</div>
               <div value>{{cluster.spec.cloud?.vsphere.datastore}}</div>

--- a/modules/web/src/app/shared/entity/cluster.ts
+++ b/modules/web/src/app/shared/entity/cluster.ts
@@ -287,6 +287,7 @@ export class VSphereCloudSpec {
   vmNetName?: string;
   networks?: string[];
   folder?: string;
+  basePath?: string;
   infraManagementUser: VSphereInfraManagementUser;
   datastore?: string;
   datastoreCluster?: string;

--- a/modules/web/src/app/shared/entity/preset.ts
+++ b/modules/web/src/app/shared/entity/preset.ts
@@ -213,6 +213,7 @@ export class VSpherePresetSpec extends PresetProviderSpec {
   datastore?: string;
   datastoreCluster?: string;
   resourcePool?: string;
+  basePath?: string;
 }
 
 export class VMwareCloudDirectorPresetSpec extends PresetProviderSpec {

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
@@ -44,12 +44,26 @@ limitations under the License.
     <div *option="let folder">{{folder.path}}</div>
   </km-combobox>
 
+  <km-combobox #baseFolderPathCombobox
+               [grouped]="false"
+               [isDisabled]="isPresetSelected"
+               [options]="folders"
+               [formControlName]="Controls.BaseFolderPath"
+               [hint]="getHint(Controls.BaseFolderPath)"
+               (changed)="onBaseFolderPathChange($event)"
+               [label]="folderLabel === FolderState.Ready ? 'Base Folder Path' : folderLabel"
+               inputLabel="Select base folder path..."
+               filterBy="path">
+    <div *option="let folder">{{folder.path}}</div>
+  </km-combobox>
+
   <km-autocomplete label="Datastore"
                    [formControlName]="Controls.Datastore"
                    [isLoading]="isLoadingDatastores"
                    [options]="datastores">
     <ng-container hint>
-      Datastore to be used for the virtual machines. It is mutually exclusive with Datastore Cluster field.
+      Datastore to be used for storing virtual machines and as a default for dynamic volume provisioning.
+      It is mutually exclusive with Datastore Cluster field.
       <span *ngIf="!hasRequiredCredentials()">&nbsp;Enter your credentials to load autocompletions.</span>
     </ng-container>
   </km-autocomplete>
@@ -61,7 +75,7 @@ limitations under the License.
            [name]="Controls.DatastoreCluster"
            type="text"
            autocomplete="off" />
-    <mat-hint>Datastore to be used for the virtual machines. It is mutually exclusive with Datastore field.</mat-hint>
+    <mat-hint>DatastoreCluster to be used for storing virtual machines. It is mutually exclusive with Datastore field.</mat-hint>
   </mat-form-field>
 
   <mat-form-field fxFlex>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add functionality to configure `basePath` in preset and cluster for vSphere.

**Add Preset Dialog:**

![screenshot-localhost_8000-2023 10 13-17_16_15](https://github.com/kubermatic/dashboard/assets/13975988/b476bc99-eaf0-4b09-a186-8b2968f6117f)

**Create Cluster Wizard:**

![screenshot-localhost_8000-2023 10 13-17_17_55](https://github.com/kubermatic/dashboard/assets/13975988/b67e3c17-e0f3-4070-b60b-690849d63661)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/12632

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add functionality to configure `basePath` in preset and cluster for vSphere.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
