### PR TITLE
Replace base folder path dropdown with an input field

### DIFF
--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
@@ -83,7 +83,7 @@ limitations under the License.
            kmValueChangedIndicator />
   </mat-form-field>
 
-  <mat-form-field>
+  <mat-form-field class="km-long-subscript">
     <mat-label>Base Folder Path</mat-label>
     <input matInput
            [formControlName]="Controls.BasePath"
@@ -92,7 +92,11 @@ limitations under the License.
            autocomplete="off"
            kmValueChangedIndicator />
     <mat-hint>
-      Base folder path configures a vCenter folder path where KKP will create an individual cluster folder.
+      Base folder path configures a vCenter folder path where KKP will create an
+      individual cluster folder. If the value is a relative path, it’s appended
+      to root path (results in <code>/&lt;root path&gt;/&lt;base path&gt;/&lt;cluster
+      folder to be created&gt;</code>). If it’s an absolute path it ignores the root
+      path (<code>/&lt;base path&gt;/&lt;cluster folder to be created&gt;</code>).
     </mat-hint>
   </mat-form-field>
 </form>

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
@@ -93,8 +93,6 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
 
   @ViewChild('folderCombobox')
   private readonly _folderCombobox: FilteredComboboxComponent;
-  @ViewChild('baseFolderPathCombobox')
-  private readonly _baseFolderPathCombobox: FilteredComboboxComponent;
   @ViewChild('networkCombobox')
   private readonly _networkCombobox: FilteredComboboxComponent;
   @ViewChild('tagCategoryComboBox')
@@ -193,15 +191,13 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
       .get(Controls.BaseFolderPath)
       .valueChanges.pipe(filter(_ => !this._presets.preset))
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe((val: {select: string}) => this._enable(!val.select, Controls.Folder));
+      .subscribe((value: string) => this._enable(!value, Controls.Folder));
 
-    this.form
-      .get(Controls.DatastoreCluster)
-      .valueChanges.pipe(filter(_ => !this._presets.preset))
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(val => this._enable(!val, Controls.Datastore));
-
-    merge(this.form.get(Controls.DatastoreCluster).valueChanges, this.form.get(Controls.ResourcePool).valueChanges)
+    merge(
+      this.form.get(Controls.DatastoreCluster).valueChanges,
+      this.form.get(Controls.ResourcePool).valueChanges,
+      this.form.get(Controls.BaseFolderPath).valueChanges
+    )
       .pipe(distinctUntilChanged(), takeUntil(this._unsubscribe))
       .subscribe(_ => (this._clusterSpecService.cluster = this._getCluster()));
 
@@ -246,10 +242,6 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
     this._clusterSpecService.cluster.spec.cloud.vsphere.folder = folder;
   }
 
-  onBaseFolderPathChange(value: string): void {
-    this._clusterSpecService.cluster.spec.cloud.vsphere.basePath = value;
-  }
-
   onTagCategoryChange(tagCategory: string): void {
     this.selectedTagCategory = tagCategory;
     if (tagCategory) {
@@ -284,8 +276,6 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
     switch (control) {
       case Controls.Folder:
         return 'Folder is used to group the provisioned virtual machines. It is mutually exclusive with Base Folder Path field.';
-      case Controls.BaseFolderPath:
-        return 'Base folder path configures a vCenter folder path where KKP will create an individual cluster folder.';
     }
 
     return '';
@@ -428,7 +418,6 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
     this.folders = [];
     this.folderLabel = FolderState.Empty;
     this._folderCombobox.reset();
-    this._baseFolderPathCombobox.reset();
     this._cdr.detectChanges();
   }
 
@@ -488,6 +477,7 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
           vsphere: {
             datastoreCluster: this.form.get(Controls.DatastoreCluster).value,
             resourcePool: this.form.get(Controls.ResourcePool).value,
+            basePath: this.form.get(Controls.BaseFolderPath).value,
           } as VSphereCloudSpec,
         } as CloudSpec,
       } as ClusterSpec,

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
@@ -44,18 +44,22 @@ limitations under the License.
     <div *option="let folder">{{folder.path}}</div>
   </km-combobox>
 
-  <km-combobox #baseFolderPathCombobox
-               [grouped]="false"
-               [isDisabled]="isPresetSelected"
-               [options]="folders"
-               [formControlName]="Controls.BaseFolderPath"
-               [hint]="getHint(Controls.BaseFolderPath)"
-               (changed)="onBaseFolderPathChange($event)"
-               [label]="folderLabel === FolderState.Ready ? 'Base Folder Path' : folderLabel"
-               inputLabel="Select base folder path..."
-               filterBy="path">
-    <div *option="let folder">{{folder.path}}</div>
-  </km-combobox>
+  <mat-form-field fxFlex
+                  class="km-long-subscript">
+    <mat-label>Base Folder Path</mat-label>
+    <input matInput
+           [formControlName]="Controls.BaseFolderPath"
+           [name]="Controls.BaseFolderPath"
+           type="text"
+           autocomplete="off" />
+    <mat-hint>
+      Base folder path configures a vCenter folder path where KKP will create an
+      individual cluster folder. If the value is a relative path, it’s appended
+      to root path (results in <code>/&lt;root path&gt;/&lt;base path&gt;/&lt;cluster
+      folder to be created&gt;</code>). If it’s an absolute path it ignores the root
+      path (<code>/&lt;base path&gt;/&lt;cluster folder to be created&gt;</code>).
+    </mat-hint>
+  </mat-form-field>
 
   <km-autocomplete label="Datastore"
                    [formControlName]="Controls.Datastore"


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace base folder path dropdown with an input field for vSphere. Also update field description in both preset dialog and cluster wizard.

**Preset Dialog:**

![screenshot-localhost_8000-2023 10 16-14_31_25](https://github.com/kubermatic/dashboard/assets/13975988/df1f6ad5-e720-4f70-bb64-de63e398e96f)

**Create Cluster Wizard:**

![screenshot-localhost_8000-2023 10 16-14_43_58](https://github.com/kubermatic/dashboard/assets/13975988/2ebfd735-5431-4adf-9d71-76f2979def5a)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/12632

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
