### PR TITLE
Update web-terminal image to kubectl 1.27, Helm 3.12.3 and curl 8.4.0

### DIFF
--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -12,21 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
-# Source: https://dl.k8s.io/release/stable-1.26.txt
-ENV KUBECTL_VERSION=v1.26.5
+# Source: https://dl.k8s.io/release/stable-1.27.txt
+ENV KUBECTL_VERSION=v1.27.6
 
 # Source: https://github.com/helm/helm/releases
-ENV HELM_VERSION=v3.11.3
+ENV HELM_VERSION=v3.12.3
 
 ARG ARCH=amd64
 
+# ensure that we install a curl version that fixes CVE-2023-38545 and CVE-2023-38546.
 RUN apk add --no-cache -U \
   bash \
   ca-certificates \
-  curl \
+   'curl>=8.4.0-r0' \
   git \
   jq \
   make \

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 source hack/lib.sh
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.6.1
+VERSION=0.7.0
 SUFFIX=""
 ARCHITECTURES=${ARCHITECTURES:-amd64 arm64}
 IMAGE="${REPOSITORY}:${VERSION}${SUFFIX}"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -109,7 +109,7 @@ is_containerized() {
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.2.0}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.3.1}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
   local gomodcache="${CONTAINERIZE_GOMODCACHE:-/tmp/.gomodcache}"
   local skip="${NO_CONTAINERIZE:-}"


### PR DESCRIPTION
**What this PR does / why we need it**:
The web-terminal image needs an update to match what KKP 2.24 will support. Therefore it's updated to latest kubectl for 1.27, Helm 3.12 (matching the version in kubermatic/kubermatic) and curl 8.4.0.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update web-terminal image to kubectl 1.27, Helm 3.12.3 and curl 8.4.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
