### PR TITLE
[release/v2.23] Update web-terminal image to kubectl 1.26.9 and curl 8.4.0

### DIFF
--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -16,17 +16,18 @@ FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 # Source: https://dl.k8s.io/release/stable-1.26.txt
-ENV KUBECTL_VERSION=v1.26.5
+ENV KUBECTL_VERSION=v1.26.9
 
 # Source: https://github.com/helm/helm/releases
 ENV HELM_VERSION=v3.11.3
 
 ARG ARCH=amd64
 
+# ensure that we install a curl version that fixes CVE-2023-38545 and CVE-2023-38546.
 RUN apk add --no-cache -U \
   bash \
   ca-certificates \
-  curl \
+  'curl>=8.4.0-r0' \
   git \
   jq \
   make \

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 source hack/lib.sh
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.6.1
+VERSION=0.6.2
 SUFFIX=""
 ARCHITECTURES=${ARCHITECTURES:-amd64 arm64}
 IMAGE="${REPOSITORY}:${VERSION}${SUFFIX}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Sort of a manual cherry-pick to #6283, this PR updates the web-terminal image to kubectl 1.26.9 and curl 8.4.0.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update web-terminal image to kubectl 1.26.9 and curl 8.4.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
