### PR TITLE
[release/v2.23] Update to `quay.io/kubermatic/web-terminal:0.6.2`

### DIFF
--- a/modules/api/pkg/handler/websocket/terminal.go
+++ b/modules/api/pkg/handler/websocket/terminal.go
@@ -65,7 +65,7 @@ const (
 	pingMessage                       = "PING"
 	pongMessage                       = "PONG"
 
-	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.6.0"
+	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.6.2"
 	webTerminalContainerKubeconfigPath = "/etc/kubernetes/kubeconfig/kubeconfig"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up PR to #6284, bumping the image version to `0.6.2` after @xrstf has built them. Apparently we never released 0.6.1 although it was bumped at some point, but alas.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
