### PR TITLE
Propagate KubeLB cluster status to dashboard

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -27877,6 +27877,9 @@
         "gatekeeperController": {
           "$ref": "#/definitions/HealthStatus"
         },
+        "kubelb": {
+          "$ref": "#/definitions/HealthStatus"
+        },
         "kubernetesDashboard": {
           "$ref": "#/definitions/HealthStatus"
         },

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -1365,6 +1365,7 @@ type ClusterHealth struct {
 	MLAGateway                   *kubermaticv1.HealthStatus `json:"mlaGateway,omitempty"`
 	OperatingSystemManager       *kubermaticv1.HealthStatus `json:"operatingSystemManager,omitempty"`
 	KubernetesDashboard          *kubermaticv1.HealthStatus `json:"kubernetesDashboard,omitempty"`
+	KubeLB                       *kubermaticv1.HealthStatus `json:"kubelb,omitempty"`
 }
 
 // AccessibleAddons represents an array of addons that can be configured in the user clusters.

--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -697,6 +697,7 @@ func HealthEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter,
 		MLAGateway:                   existingCluster.Status.ExtendedHealth.MLAGateway,
 		OperatingSystemManager:       existingCluster.Status.ExtendedHealth.OperatingSystemManager,
 		KubernetesDashboard:          existingCluster.Status.ExtendedHealth.KubernetesDashboard,
+		KubeLB:                       existingCluster.Status.ExtendedHealth.KubeLB,
 	}, nil
 }
 

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/cluster_health.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/cluster_health.go
@@ -42,6 +42,9 @@ type ClusterHealth struct {
 	// gatekeeper controller
 	GatekeeperController HealthStatus `json:"gatekeeperController,omitempty"`
 
+	// kubelb
+	Kubelb HealthStatus `json:"kubelb,omitempty"`
+
 	// kubernetes dashboard
 	KubernetesDashboard HealthStatus `json:"kubernetesDashboard,omitempty"`
 
@@ -100,6 +103,10 @@ func (m *ClusterHealth) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateGatekeeperController(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateKubelb(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -270,6 +277,23 @@ func (m *ClusterHealth) validateGatekeeperController(formats strfmt.Registry) er
 			return ve.ValidateName("gatekeeperController")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("gatekeeperController")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *ClusterHealth) validateKubelb(formats strfmt.Registry) error {
+	if swag.IsZero(m.Kubelb) { // not required
+		return nil
+	}
+
+	if err := m.Kubelb.Validate(formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("kubelb")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("kubelb")
 		}
 		return err
 	}
@@ -449,6 +473,10 @@ func (m *ClusterHealth) ContextValidate(ctx context.Context, formats strfmt.Regi
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateKubelb(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateKubernetesDashboard(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -592,6 +620,20 @@ func (m *ClusterHealth) contextValidateGatekeeperController(ctx context.Context,
 			return ve.ValidateName("gatekeeperController")
 		} else if ce, ok := err.(*errors.CompositeError); ok {
 			return ce.ValidateName("gatekeeperController")
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (m *ClusterHealth) contextValidateKubelb(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := m.Kubelb.ContextValidate(ctx, formats); err != nil {
+		if ve, ok := err.(*errors.Validation); ok {
+			return ve.ValidateName("kubelb")
+		} else if ce, ok := err.(*errors.CompositeError); ok {
+			return ce.ValidateName("kubelb")
 		}
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Followup to https://github.com/kubermatic/dashboard/pull/6256, the kubelb status is not displayed on the dashboard, I think it might be due to a missing translation from the API.
```
$ k get cluster kdph8trwp7 -o json | jq '.status.extendedHealth.kubelb'
"HealthStatusUp"
```
![kubelb no status](https://github.com/kubermatic/dashboard/assets/1529535/6a5dd12d-8855-4e0a-9380-ee19c4d01b67)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
see also: https://github.com/kubermatic/kubermatic/issues/12676

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
I am not sure how to test this locally as the instructions seem to be out of date https://github.com/kubermatic/dashboard/blob/v2.23.4/Development.md

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
