### PR TITLE
Fix issue caused by invalid value of allowed IP ranges for NodePorts

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -489,7 +489,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         clusterSpec?.apiServerAllowedIPRanges?.cidrBlocks ?? null
       ),
       [Controls.NodePortsAllowedIPRanges]: this._builder.control(
-        this.isAllowedIPRangeSupported() ? this._getExtraCloudSpecOptions().nodePortsAllowedIPRanges : ''
+        this.isAllowedIPRangeSupported() ? this._getExtraCloudSpecOptions().nodePortsAllowedIPRanges?.cidrBlocks : ''
       ),
       [Controls.IPv4PodsCIDR]: this._builder.control(NetworkRanges.ipv4CIDR(clusterSpec?.clusterNetwork?.pods) ?? '', [
         IPV4_CIDR_PATTERN_VALIDATOR,
@@ -566,7 +566,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           [Controls.APIServerAllowedIPRanges]:
             clusterSpec?.apiServerAllowedIPRanges?.cidrBlocks ?? this.controlValue(Controls.APIServerAllowedIPRanges),
           [Controls.NodePortsAllowedIPRanges]: this.isAllowedIPRangeSupported()
-            ? this._getExtraCloudSpecOptions().nodePortsAllowedIPRanges ??
+            ? this._getExtraCloudSpecOptions().nodePortsAllowedIPRanges?.cidrBlocks ??
               this.controlValue(Controls.NodePortsAllowedIPRanges)
             : this.controlValue(Controls.NodePortsAllowedIPRanges),
           [Controls.IPv4PodsCIDR]:


### PR DESCRIPTION
**What this PR does / why we need it**:
There was error thrown during edit/customize cluster template due to invalid value of Allowed IP Ranges for NodesPorts. This has been fixed by reading value from `cidrBlocks` property.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
