### PR TITLE
Fix for determining available CNI version upgrades

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/cni-version/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/cni-version/component.ts
@@ -41,13 +41,14 @@ export class CNIVersionComponent implements OnInit {
   }
 
   private _checkForCNIVersionUpgrades(): void {
+    this.versions = [];
     this.cniVersions.forEach(version => {
       const isUpgrade = lt(coerce(this.cluster.spec.cniPlugin.version), coerce(version));
-      this.upgradeAvailable = this.upgradeAvailable ? true : isUpgrade;
       if (isUpgrade && !this.versions.includes(version)) {
         this.versions.push(version);
       }
     });
+    this.upgradeAvailable = this.versions.length > 0;
   }
 
   private _isEnabled(): boolean {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where available version upgrades for CNI plugins were not being properly deduced.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug where available version upgrades for CNI plugins were not being properly deduced
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
