### PR TITLE
Set default OS value only when it's different from selected OS value

### DIFF
--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -215,9 +215,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     this._init();
     this._nodeDataService.nodeData = this._getNodeData();
 
-    this._clusterSpecService.providerChanges
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(_ => this.form.get(Controls.OperatingSystem).setValue(this._getDefaultOS()));
+    this._clusterSpecService.providerChanges.pipe(takeUntil(this._unsubscribe)).subscribe(_ => this._setDefaultOS());
 
     this._clusterSpecService.providerChanges
       .pipe(filter(_ => !this.isCusterTemplateEditMode))
@@ -247,7 +245,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
       .pipe(takeUntil(this._unsubscribe))
       .pipe(tap(dc => (this._datacenterSpec = dc)))
       .pipe(tap(() => this._loadOperatingSystemProfiles()))
-      .subscribe(_ => this.form.get(Controls.OperatingSystem).setValue(this._getDefaultOS()));
+      .subscribe(_ => this._setDefaultOS());
 
     merge(
       this.form.get(Controls.Name).valueChanges,
@@ -282,10 +280,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
 
     this._settingsService.adminSettings.pipe(take(1)).subscribe(settings => {
       this.allowedOperatingSystems = settings?.allowedOperatingSystems && settings.allowedOperatingSystems;
-      const defaultOS = this._getDefaultOS();
-      if (defaultOS !== this.form.get(Controls.OperatingSystem).value) {
-        this.form.get(Controls.OperatingSystem).setValue(defaultOS);
-      }
+      this._setDefaultOS();
 
       const autoUpdatesEnabled = settings.machineDeploymentOptions.autoUpdatesEnabled;
       const replicas =
@@ -421,6 +416,13 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     this.form.get(Controls.DisableAutoUpdate).setValue(!!disableAutoUpdate);
 
     this._cdr.detectChanges();
+  }
+
+  private _setDefaultOS() {
+    const defaultOS = this._getDefaultOS();
+    if (defaultOS !== this.form.get(Controls.OperatingSystem).value) {
+      this.form.get(Controls.OperatingSystem).setValue(defaultOS);
+    }
   }
 
   private _loadOperatingSystemProfiles() {


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an issue where a custom OSP value was not selected when editing/customizing cluster template. This has been fixed by avoiding unnecessary trigger of `valueChanges` event.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6316 
Close #6309 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue where a custom OSP value was not selected when editing/customizing cluster template.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
