### PR TITLE
Set Floating IP Pools label to empty if there are no pools available

### DIFF
--- a/modules/web/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
@@ -159,11 +159,10 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .pipe(take(1))
       .subscribe((floatingIPPools: OpenstackFloatingIPPool[]) => {
         this.floatingIPPools = floatingIPPools;
-
-        if (!_.isEmpty(this.floatingIPPools)) {
-          this.floatingIPPoolsLabel = FloatingIPPoolState.Ready;
-          this._cdr.detectChanges();
-        }
+        this.floatingIPPoolsLabel = !_.isEmpty(this.floatingIPPools)
+          ? FloatingIPPoolState.Ready
+          : FloatingIPPoolState.Empty;
+        this._cdr.detectChanges();
       });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where label of Floating IP Pools (in Openstack provider settings step) would keep displaying `Loading...` when there were no pools available.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
