### PR TITLE
fix listing events for external clusters

### DIFF
--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -655,7 +655,7 @@ func GetClusterEventsEndpoint(ctx context.Context, userInfoGetter provider.UserI
 		eventTypeAPI = corev1.EventTypeNormal
 	}
 
-	events, err := common.GetEvents(ctx, client, cluster, "")
+	events, err := common.GetEvents(ctx, client, cluster, metav1.NamespaceAll)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}

--- a/modules/api/pkg/handler/v2/external_cluster/external_cluster.go
+++ b/modules/api/pkg/handler/v2/external_cluster/external_cluster.go
@@ -925,7 +925,7 @@ func ListEventsEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider 
 				events = append(events, nodeEvents...)
 			}
 		}
-		kubermaticEvents, err := common.GetEvents(ctx, privilegedClusterProvider.GetMasterClient(), cluster, metav1.NamespaceDefault)
+		kubermaticEvents, err := common.GetEvents(ctx, privilegedClusterProvider.GetMasterClient(), cluster, metav1.NamespaceAll)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Since controller-runtime introduced the new caching config, we had to explicitly enable caches per namespace. Looking at our dev system, I spotted

> {"level":"error","time":"2023-10-26T06:36:58.837Z","caller":"handler/routing.go:153","msg":"unable to list: default because of unknown namespace for the cache","request":"/api/v2/projects/wt8bxznl97/kubernetes/clusters/2g6zd8vwkw/events"}

Looking deeper, it seemed that we accidentally specified a namespace when ExternalClusters are not namespaced.

Fixes #6331

We can backport this, even though the error should only surface with controller-runtime 0.16, i.e. KKP 2.24.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix listing events for external clusters
```

**Documentation**:
```documentation
NONE
```
