### PR TITLE
Fix GKE Credentials validation

### DIFF
--- a/modules/web/src/app/cluster/details/external-cluster/template.html
+++ b/modules/web/src/app/cluster/details/external-cluster/template.html
@@ -117,10 +117,6 @@ limitations under the License.
             <div value>{{cluster?.cloud?.aks?.resourceGroup}}</div>
           </km-property>
           <km-property>
-            <div key>Cluster Version</div>
-            <div value>{{cluster?.spec?.aksclusterSpec?.kubernetesVersion}}</div>
-          </km-property>
-          <km-property>
             <div key>Provisioning State</div>
             <div value>{{cluster?.status?.aks?.provisioningState}}</div>
           </km-property>
@@ -153,10 +149,6 @@ limitations under the License.
           <km-property>
             <div key>Region</div>
             <div value>{{cluster?.cloud?.eks?.region}}</div>
-          </km-property>
-          <km-property>
-            <div key>Cluster Version</div>
-            <div value>{{cluster?.spec?.eksclusterSpec?.version}}</div>
           </km-property>
           <km-property>
             <div key>VpcId</div>
@@ -199,10 +191,6 @@ limitations under the License.
           <km-property>
             <div key>Zone</div>
             <div value>{{cluster?.cloud?.gke?.zone}}</div>
-          </km-property>
-          <km-property>
-            <div key>Cluster Version</div>
-            <div value>{{cluster?.spec?.gkeclusterSpec?.initialClusterVersion}}</div>
           </km-property>
           <km-property>
             <div key>Cluster Ipv4 CIDR</div>

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
@@ -95,7 +95,7 @@ limitations under the License.
       Base folder path configures a vCenter folder path where KKP will create an
       individual cluster folder. If the value is a relative path, it’s appended
       to root path (results in <code>/&lt;root path&gt;/&lt;base path&gt;/&lt;cluster
-      folder to be created&gt;</code>). If it’s an absolute path it ignores the root
+        folder to be created&gt;</code>). If it’s an absolute path it ignores the root
       path (<code>/&lt;base path&gt;/&lt;cluster folder to be created&gt;</code>).
     </mat-hint>
   </mat-form-field>

--- a/modules/web/src/app/shared/components/external-cluster-credentials/provider/gke/component.ts
+++ b/modules/web/src/app/shared/components/external-cluster-credentials/provider/gke/component.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Component, OnDestroy, OnInit} from '@angular/core';
-import {AbstractControl, FormBuilder, FormGroup, ValidationErrors, Validators} from '@angular/forms';
+import {FormBuilder, FormGroup, ValidationErrors, Validators} from '@angular/forms';
 import {ExternalClusterService} from '@core/services/external-cluster';
 import {Observable, of, Subject} from 'rxjs';
 import {catchError, take, takeUntil} from 'rxjs/operators';
@@ -66,8 +66,8 @@ export class GKECredentialsComponent implements OnInit, OnDestroy {
     this._unsubscribe.complete();
   }
 
-  private _serviceAccountValidator(control: AbstractControl): Observable<ValidationErrors | null> {
-    const serviceAccount = control.value.toString();
+  private _serviceAccountValidator(): Observable<ValidationErrors | null> {
+    const serviceAccount = this._serviceAccountValue;
     if (!serviceAccount) {
       return of(null);
     }

--- a/modules/web/src/app/shared/components/external-cluster-credentials/provider/gke/template.html
+++ b/modules/web/src/app/shared/components/external-cluster-credentials/provider/gke/template.html
@@ -25,13 +25,10 @@ limitations under the License.
               [name]="Controls.ServiceAccount"
               autocomplete="off"></textarea>
     <mat-hint *ngIf="form.get(Controls.ServiceAccount).pending">Validating...</mat-hint>
-    <mat-hint *ngIf="!form.get(Controls.ServiceAccount).pending">
-      Enter base64 encoded value for Service Account
-    </mat-hint>
     <mat-error *ngIf="form.get(Controls.ServiceAccount).hasError('required')">
       <strong>Required</strong>
     </mat-error>
-    <mat-error *ngIf="form.get(Controls.ServiceAccount).hasError('invalidServiceAccount')">
+    <mat-error *ngIf="form.get(Controls.ServiceAccount).hasError('invalidCredentials')">
       Service account is <strong>invalid</strong>.
     </mat-error>
   </mat-form-field>

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
@@ -56,7 +56,7 @@ limitations under the License.
       Base folder path configures a vCenter folder path where KKP will create an
       individual cluster folder. If the value is a relative path, it’s appended
       to root path (results in <code>/&lt;root path&gt;/&lt;base path&gt;/&lt;cluster
-      folder to be created&gt;</code>). If it’s an absolute path it ignores the root
+        folder to be created&gt;</code>). If it’s an absolute path it ignores the root
       path (<code>/&lt;base path&gt;/&lt;cluster folder to be created&gt;</code>).
     </mat-hint>
   </mat-form-field>


### PR DESCRIPTION
**What this PR does / why we need it**:
* send the encode value of service Account instead of the string value

* remove the `cluster version`  property from the external cluster detail since it's control plan version already show the version 

![image](https://github.com/kubermatic/dashboard/assets/85109141/65ca5d0a-d79b-4ced-b29f-9778913bfde6)

**Which issue(s) this PR fixes**:
Fixes #6333

**What type of PR is this?**
/kind bug


```release-note
NONE
```

```documentation
NONE
```
