### PR TITLE
Add disableDeletion method in EKS 

### DIFF
--- a/modules/web/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/component.ts
+++ b/modules/web/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/component.ts
@@ -107,4 +107,12 @@ export class ExternalClusterDeleteConfirmationComponent implements OnInit, OnDes
     this._notificationService.success(`Deleting the ${this.cluster.name} cluster`);
     this._clusterService.refreshExternalClusters();
   }
+
+  disableDeletion(): boolean {
+    return (
+      this.inputName !== this.cluster.name ||
+      this.isLoadingMachineDeployments ||
+      (this.machineDeployments.length && this.clusterProvider === ExternalClusterProvider.EKS)
+    );
+  }
 }

--- a/modules/web/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
+++ b/modules/web/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/template.html
@@ -50,7 +50,7 @@ limitations under the License.
   <km-button id="km-delete-external-cluster-dialog-delete-btn"
              icon="km-icon-delete"
              label="Delete Cluster"
-             [disabled]="inputName !== cluster.name || isLoadingMachineDeployments"
+             [disabled]="disableDeletion()"
              [matTooltip]="isLoadingMachineDeployments ? 'Loading Machine Deployments': null"
              [observable]="getObservable()"
              (next)="onNext()">


### PR DESCRIPTION
**What this PR does / why we need it**:
disable the deletion button on the delete external cluster dialog for EKS in case there is any nodegroup 

**Which issue(s) this PR fixes**:
Fixes #6335 

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
