### PR TITLE
Remove the disable method for vmsizes

### DIFF
--- a/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
+++ b/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/aks/component.ts
@@ -269,7 +269,6 @@ export class AKSClusterSettingsComponent
       this.control(Controls.NodeResourceGroup).clearValidators();
 
       this.vmSizeLabel = VMSizeState.Loading;
-      this.control(Controls.VmSize).disable();
       this._getAKSVmSizesForMachineDeployment(this.cluster.cloud.aks.location).subscribe((vmSizes: AKSVMSize[]) => {
         this.vmSizes = vmSizes;
         const defaultValue = this.vmSizes.find((vmSize: AKSVMSize) => vmSize.name === this.DEFAULT_VMSIZE);
@@ -277,7 +276,6 @@ export class AKSClusterSettingsComponent
           this.control(Controls.VmSize).setValue(defaultValue.name);
         }
         this.vmSizeLabel = this.vmSizes?.length ? VMSizeState.Ready : VMSizeState.Empty;
-        this.control(Controls.VmSize).enable();
       });
 
       this.nodePoolVersionsForMDLabel = NodePoolVersionState.Loading;


### PR DESCRIPTION
**What this PR does / why we need it**:
remove the disable method for the vmsizes form control when fetching VMs

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6347 

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
