### PR TITLE
Enforce Konnectivity value because OpenVPN support is deprecated

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.spec.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.spec.ts
@@ -34,7 +34,7 @@ import {ClusterService} from '@core/services/cluster';
 import {DatacenterService} from '@core/services/datacenter';
 import {UserService} from '@core/services/user';
 import {SettingsService} from '@core/services/settings';
-import {ClusterSpec, CNIPlugin, ProviderSettingsPatch, ProxyMode} from '@shared/entity/cluster';
+import {ClusterSpec, CNIPlugin, ProviderSettingsPatch} from '@shared/entity/cluster';
 import {SharedModule} from '@shared/module';
 import {Subject} from 'rxjs';
 import {AlibabaProviderSettingsComponent} from '../edit-provider-settings/alibaba-provider-settings/component';
@@ -154,12 +154,12 @@ describe('EditClusterComponent', () => {
       spec = component.cluster.spec;
     });
 
-    it('should be disabled when cluster uses Cilium CNI and ebpf proxy mode', () => {
+    it('should be disabled when initial Konnectivity value is true', () => {
       setClusterAndRunNgOnInit({
         ...spec,
         clusterNetwork: {
           ...spec.clusterNetwork,
-          proxyMode: ProxyMode.ebpf,
+          konnectivityEnabled: true,
         },
         cniPlugin: {
           ...spec.cniPlugin,
@@ -170,56 +170,16 @@ describe('EditClusterComponent', () => {
       expect(component.form.get(component.Controls.Konnectivity).disabled).toBeTruthy();
     });
 
-    it('should not be disabled when cluster uses Cilium CNI and ipvs proxy mode', () => {
+    it('should not be disabled when initial Konnectivity value is false', () => {
       setClusterAndRunNgOnInit({
         ...spec,
         clusterNetwork: {
           ...spec.clusterNetwork,
-          proxyMode: ProxyMode.ipvs,
+          konnectivityEnabled: false,
         },
         cniPlugin: {
           ...spec.cniPlugin,
           type: CNIPlugin.Cilium,
-        },
-      });
-
-      expect(component.form.get(component.Controls.Konnectivity).disabled).toBeFalsy();
-    });
-
-    it('should not be disabled when cluster uses Cilium CNI and iptables proxy mode', () => {
-      setClusterAndRunNgOnInit({
-        ...spec,
-        clusterNetwork: {
-          ...spec.clusterNetwork,
-          proxyMode: ProxyMode.iptables,
-        },
-        cniPlugin: {
-          ...spec.cniPlugin,
-          type: CNIPlugin.Cilium,
-        },
-      });
-
-      expect(component.form.get(component.Controls.Konnectivity).disabled).toBeFalsy();
-    });
-
-    it('should not be disabled when cluster uses Canal CNI', () => {
-      setClusterAndRunNgOnInit({
-        ...spec,
-        cniPlugin: {
-          ...spec.cniPlugin,
-          type: CNIPlugin.Canal,
-        },
-      });
-
-      expect(component.form.get(component.Controls.Konnectivity).disabled).toBeFalsy();
-    });
-
-    it('should not be disabled when cluster does not use any CNI', () => {
-      setClusterAndRunNgOnInit({
-        ...spec,
-        cniPlugin: {
-          ...spec.cniPlugin,
-          type: CNIPlugin.None,
         },
       });
 

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -22,7 +22,6 @@ import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {
   AuditPolicyPreset,
-  CNIPlugin,
   Cluster,
   ClusterPatch,
   ClusterSpecPatch,
@@ -31,7 +30,6 @@ import {
   ExposeStrategy,
   NetworkRanges,
   ProviderSettingsPatch,
-  ProxyMode,
 } from '@shared/entity/cluster';
 import {ResourceType} from '@shared/entity/common';
 import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
@@ -146,9 +144,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       ),
       [Controls.Konnectivity]: new FormControl({
         value: !!this.cluster.spec.clusterNetwork?.konnectivityEnabled,
-        disabled:
-          this.cluster.spec.clusterNetwork?.proxyMode === ProxyMode.ebpf &&
-          this.cluster.spec.cniPlugin?.type === CNIPlugin.Cilium,
+        disabled: !!this.cluster.spec.clusterNetwork?.konnectivityEnabled,
       }),
       [Controls.MLALogging]: new FormControl(!!this.cluster.spec.mla && this.cluster.spec.mla.loggingEnabled),
       [Controls.MLAMonitoring]: new FormControl(!!this.cluster.spec.mla && this.cluster.spec.mla.monitoringEnabled),

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -137,6 +137,9 @@ limitations under the License.
                     [class.km-text-muted]="form.get(Controls.Konnectivity).disabled"
                     kmValueChangedIndicator>
         Konnectivity
+        <i *ngIf="!!form.get(Controls.Konnectivity).value && form.get(Controls.Konnectivity).disabled"
+           class="km-icon-info km-pointer"
+           matTooltip="OpenVPN support is deprecated, hence Konnectivity can no longer be disabled."></i>
       </mat-checkbox>
 
       <div fxLayoutAlign=" center">

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -287,21 +287,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         this._updateAvailableProxyModes();
       });
 
-    combineLatest([this.control(Controls.ProxyMode).valueChanges, this.control(Controls.CNIPlugin).valueChanges])
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(([proxyMode, cniPlugin]) => {
-        const konnectivityControl = this.control(Controls.Konnectivity);
-
-        if (proxyMode === ProxyMode.ebpf && cniPlugin === CNIPlugin.Cilium) {
-          if (!konnectivityControl.value) {
-            konnectivityControl.setValue(true);
-          }
-          konnectivityControl.disable();
-        } else if (konnectivityControl.disabled) {
-          konnectivityControl.enable();
-        }
-      });
-
     merge(this.control(Controls.IPFamily).valueChanges, this.control(Controls.NodePortsAllowedIPRanges).valueChanges)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => {
@@ -508,6 +493,8 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         [IPV6_CIDR_PATTERN_VALIDATOR, this._dualStackRequiredIfValidator(Controls.IPv4ServicesCIDR)]
       ),
     });
+
+    this.control(Controls.Konnectivity).disable();
   }
 
   private _loadClusterDefaults(): void {

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -252,6 +252,9 @@ limitations under the License.
             <mat-checkbox [formControlName]="Controls.Konnectivity"
                           [class.km-text-muted]="control(Controls.Konnectivity).disabled">
               Konnectivity
+              <i *ngIf="!!control(Controls.Konnectivity).value && control(Controls.Konnectivity).disabled"
+                 class="km-icon-info km-pointer"
+                 matTooltip="OpenVPN support is deprecated, hence Konnectivity can no longer be disabled."></i>
             </mat-checkbox>
           </div>
         </km-expansion-panel>


### PR DESCRIPTION
**What this PR does / why we need it**:
Since OpenVPN support is now deprecated, Konnectivity is enabled and enforced by default.
Ref: https://github.com/kubermatic/kubermatic/pull/12691

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enforce Konnectivity value because OpenVPN support is now deprecated.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
