### PR TITLE
Prevent `clusterDefaultNodeSelector` label from being added on opening of edit cluster dialog

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -82,7 +82,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   admissionPlugin = AdmissionPlugin;
   form: FormGroup;
   labels: Record<string, string>;
-  initialClusterDefaultNodeSelectorKey: string;
   podNodeSelectorAdmissionPluginConfig: Record<string, string>;
   eventRateLimitConfig: EventRateLimitConfig;
   admissionPlugins: string[] = [];
@@ -208,7 +207,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         const selectedPlugins = this.form.get(Controls.AdmissionPlugins).value;
         if (
-          !selectedPlugins.includes(AdmissionPlugin.PodSecurityPolicy) &&
+          !selectedPlugins.includes(AdmissionPlugin.PodNodeSelector) &&
           !_.isEmpty(this.podNodeSelectorAdmissionPluginConfig)
         ) {
           this.form.get(Controls.PodNodeSelectorAdmissionPluginConfig).reset();
@@ -219,8 +218,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     const [initialClusterDefaultNodeSelectorKey] =
       this.podNodeSelectorAdmissionPluginConfig?.[this.CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE]?.split('=') ?? [];
 
-    if (initialClusterDefaultNodeSelectorKey) {
-      this.initialClusterDefaultNodeSelectorKey = initialClusterDefaultNodeSelectorKey;
+    if (initialClusterDefaultNodeSelectorKey && this.labels?.[initialClusterDefaultNodeSelectorKey]) {
       this._handleClusterDefaultNodeSelector(this.podNodeSelectorAdmissionPluginConfig);
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent `clusterDefaultNodeSelector` label from being added on opening of edit cluster dialog if those labels are not present in cluster object.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #5979 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue where `clusterDefaultNodeSelector` label was being added back on opening of edit cluster dialog.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
