### PR TITLE
Set `eventRateLimitConfig` to `null` instead of calling `delete` on service getter method

### DIFF
--- a/modules/web/src/app/shared/components/event-rate-limit/component.ts
+++ b/modules/web/src/app/shared/components/event-rate-limit/component.ts
@@ -92,7 +92,7 @@ export class EventRateLimitComponent extends BaseFormValidator implements OnInit
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();
-    delete this._clusterSpecService.eventRateLimitConfig;
+    this._clusterSpecService.eventRateLimitConfig = null;
   }
 
   writeValue(eventRateLimitConfig: EventRateLimitConfig) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Set `eventRateLimitConfig` to `null` instead of deleting service getter method. This fixes an issue where unselecting `Event Rate Limit` option from Admission Plugins doesn't remove `eventRateLimitConfig` from the cluster spec object.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
