### PR TITLE
Don't return error in case one of a seed down

### DIFF
--- a/modules/api/pkg/handler/middleware/middleware.go
+++ b/modules/api/pkg/handler/middleware/middleware.go
@@ -348,6 +348,11 @@ func getAddonProvider(ctx context.Context, clusterProviderGetter provider.Cluste
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				return nil, utilerrors.NewNotFound("cluster-provider", clusterID)
@@ -429,6 +434,11 @@ func GetClusterProvider(ctx context.Context, request interface{}, seedsGetter pr
 
 func getClusterProviderByClusterID(ctx context.Context, seeds map[string]*kubermaticv1.Seed, clusterProviderGetter provider.ClusterProviderGetter, clusterID string) (provider.ClusterProvider, context.Context, error) {
 	for _, seed := range seeds {
+		if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+			log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+			continue
+		}
+
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
 			// if one or more Seeds are bad, continue with the request, log that a Seed is in error
@@ -509,6 +519,11 @@ func getConstraintProvider(ctx context.Context, clusterProviderGetter provider.C
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				return nil, utilerrors.NewNotFound("cluster-provider", clusterID)
@@ -568,6 +583,11 @@ func getAlertmanagerProvider(ctx context.Context, clusterProviderGetter provider
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
@@ -627,6 +647,11 @@ func getRuleGroupProvider(ctx context.Context, clusterProviderGetter provider.Cl
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				// if one or more Seeds are bad, continue with the request, log that a Seed is in error
@@ -688,6 +713,11 @@ func getEtcdBackupConfigProvider(ctx context.Context, clusterProviderGetter prov
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
@@ -747,6 +777,11 @@ func getEtcdRestoreProvider(ctx context.Context, clusterProviderGetter provider.
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
@@ -892,6 +927,11 @@ func getPrivilegedMLAAdminSettingProvider(ctx context.Context, clusterProviderGe
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
@@ -961,6 +1001,11 @@ func getPrivilegedOperatingSystemProfileProvider(ctx context.Context, clusterPro
 
 	if clusterID != "" {
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
@@ -1014,6 +1059,11 @@ func getOIDCIssuerVerifier(
 
 	var seedName string
 	for _, seed := range seeds {
+		if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+			log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+			continue
+		}
+
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
 			return nil, utilerrors.NewNotFound("cluster-provider", clusterID)

--- a/modules/api/pkg/handler/middleware/middleware.go
+++ b/modules/api/pkg/handler/middleware/middleware.go
@@ -435,7 +435,7 @@ func GetClusterProvider(ctx context.Context, request interface{}, seedsGetter pr
 func getClusterProviderByClusterID(ctx context.Context, seeds map[string]*kubermaticv1.Seed, clusterProviderGetter provider.ClusterProviderGetter, clusterID string) (provider.ClusterProvider, context.Context, error) {
 	for _, seed := range seeds {
 		if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
-			log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+			log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seed.Name)
 			continue
 		}
 

--- a/modules/api/pkg/handler/v1/cluster/cluster.go
+++ b/modules/api/pkg/handler/v1/cluster/cluster.go
@@ -119,7 +119,12 @@ func ListAllEndpoint(
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		for _, seed := range seeds {
+		for seedName, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				kubermaticlog.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			// if a Seed is bad, do not forward that error to the user, but only log
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {

--- a/modules/api/pkg/handler/v1/project/project.go
+++ b/modules/api/pkg/handler/v1/project/project.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-kit/kit/endpoint"
 
@@ -39,6 +40,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // CreateEndpoint defines an HTTP endpoint that creates a new project in the system.
@@ -619,17 +621,29 @@ func getNumberOfClustersForProject(ctx context.Context, clusterProviderGetter pr
 	}
 
 	for seedName, seed := range seeds {
+		if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+			log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+			continue
+		}
+
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
 			// if one or more Seeds are bad, continue with the request, log that a Seed is in error
 			log.Logger.Warnw("error getting cluster provider", "seed", seedName, "error", err)
 			continue
 		}
-		clusters, err := clusterProvider.List(ctx, project, nil)
-		if err != nil {
-			log.Logger.Warnw("error getting clusters", "seed", seedName, "error", err)
-		} else {
-			clustersNumber += len(clusters.Items)
+
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			clusters, err := clusterProvider.List(ctx, project, nil)
+			if err != nil {
+				log.Logger.Warnw("error getting clusters", "seed", seedName, "error", err)
+				return false, nil
+			} else {
+				clustersNumber += len(clusters.Items)
+			}
+			return true, nil
+		}); err != nil {
+			log.Logger.Warnw("timed out waiting to retrieve clusters", "seed", seedName, "error", err)
 		}
 	}
 
@@ -644,22 +658,33 @@ func getNumberOfClusters(ctx context.Context, clusterProviderGetter provider.Clu
 	}
 
 	for seedName, seed := range seeds {
+		if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+			log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+			continue
+		}
+
 		clusterProvider, err := clusterProviderGetter(seed)
 		if err != nil {
 			// if one or more Seeds are bad, continue with the request, log that a Seed is in error
 			log.Logger.Warnw("error getting cluster provider", "seed", seedName, "error", err)
 			continue
 		}
-		clusters, err := clusterProvider.ListAll(ctx, nil)
-		if err != nil {
-			log.Logger.Warnw("error getting clusters", "seed", seedName, "error", err)
-		} else {
-			for _, cluster := range clusters.Items {
-				projectName, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
-				if ok {
-					clustersNumber[projectName]++
+		if err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+			clusters, err := clusterProvider.ListAll(ctx, nil)
+			if err != nil {
+				log.Logger.Warnw("error getting clusters", "seed", seedName, "error", err)
+				return false, nil
+			} else {
+				for _, cluster := range clusters.Items {
+					projectName, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
+					if ok {
+						clustersNumber[projectName]++
+					}
 				}
 			}
+			return true, nil
+		}); err != nil {
+			log.Logger.Warnw("timed out waiting to retrieve clusters", "seed", seedName, "error", err)
 		}
 	}
 

--- a/modules/api/pkg/handler/v1/project/project.go
+++ b/modules/api/pkg/handler/v1/project/project.go
@@ -627,9 +627,10 @@ func getNumberOfClustersForProject(ctx context.Context, clusterProviderGetter pr
 		}
 		clusters, err := clusterProvider.List(ctx, project, nil)
 		if err != nil {
-			return clustersNumber, err
+			log.Logger.Warnw("error getting clusters", "seed", seedName, "error", err)
+		} else {
+			clustersNumber += len(clusters.Items)
 		}
-		clustersNumber += len(clusters.Items)
 	}
 
 	return clustersNumber, nil
@@ -651,12 +652,13 @@ func getNumberOfClusters(ctx context.Context, clusterProviderGetter provider.Clu
 		}
 		clusters, err := clusterProvider.ListAll(ctx, nil)
 		if err != nil {
-			return clustersNumber, err
-		}
-		for _, cluster := range clusters.Items {
-			projectName, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
-			if ok {
-				clustersNumber[projectName]++
+			log.Logger.Warnw("error getting clusters", "seed", seedName, "error", err)
+		} else {
+			for _, cluster := range clusters.Items {
+				projectName, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
+				if ok {
+					clustersNumber[projectName]++
+				}
 			}
 		}
 	}

--- a/modules/api/pkg/handler/v2/cluster/cluster.go
+++ b/modules/api/pkg/handler/v2/cluster/cluster.go
@@ -93,6 +93,12 @@ func ListEndpoint(
 
 		brokenSeeds := []string{}
 		for _, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				kubermaticlog.Logger.Warnf("skipping seed %s as it is in an invalid phase", seed.Name)
+				brokenSeeds = append(brokenSeeds, seed.Name)
+				continue
+			}
+
 			// if a Seed is bad, log error and put seed's name on the list of broken seeds.
 			seedClusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {

--- a/modules/api/pkg/handler/v2/cluster/cluster.go
+++ b/modules/api/pkg/handler/v2/cluster/cluster.go
@@ -97,7 +97,6 @@ func ListEndpoint(
 			seedClusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				kubermaticlog.Logger.Errorw("failed to create cluster provider", "seed", seed.Name, zap.Error(err))
-				brokenSeeds = append(brokenSeeds, seed.Name)
 				continue
 			}
 			seedClusters, err := handlercommon.GetClusters(
@@ -112,9 +111,11 @@ func ListEndpoint(
 				req.ShowDeploymentMachineCount,
 			)
 			if err != nil {
-				return nil, common.KubernetesErrorToHTTPError(err)
+				kubermaticlog.Logger.Errorw("failed to get clusters from seed ", "seed", seed.Name, zap.Error(err))
+				brokenSeeds = append(brokenSeeds, seed.Name)
+			} else {
+				allClusters = append(allClusters, seedClusters...)
 			}
-			allClusters = append(allClusters, seedClusters...)
 		}
 
 		clusterList := make(apiv1.ClusterList, len(allClusters))

--- a/modules/api/pkg/handler/v2/preset/preset.go
+++ b/modules/api/pkg/handler/v2/preset/preset.go
@@ -860,6 +860,11 @@ func GetPresetStats(presetProvider provider.PresetProvider, userInfoGetter provi
 		}
 
 		for seedName, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			clusterProvider, err := clusterProviderGetter(seed)
 			if err != nil {
 				// if one or more Seeds are bad, continue with the request, log that a Seed is in error

--- a/modules/api/pkg/handler/v2/seedoverview/seedoverview.go
+++ b/modules/api/pkg/handler/v2/seedoverview/seedoverview.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	"k8c.io/dashboard/v2/pkg/handler/v1/dc"
 	"k8c.io/dashboard/v2/pkg/provider"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
@@ -82,53 +83,55 @@ func GetSeedOverview(userInfoGetter provider.UserInfoGetter, seedsGetter provide
 			return nil, utilerrors.NewNotFound("Seed", req.SeedName)
 		}
 
-		// Creating a map of datacenters by provider based on the Seed object.
-		for datacenterName, datacenter := range seed.Spec.Datacenters {
-			spec, err := dc.ConvertInternalDCToExternalSpec(datacenter.DeepCopy(), seed.Name)
-			if err != nil {
-				log.Logger.Errorf("api spec error in dc %q: %v", datacenterName, err)
-				continue
-			}
-
-			providerType, err := dc.GetProviderName(spec)
-			if err != nil {
-				log.Logger.Error(err)
-				continue
-			}
-
-			if provider, ok := datacentersByProvider[string(providerType)]; ok {
-				provider[datacenterName] = 0
-			} else {
-				// Creating a map of clusters by datacenter for each previously found provider type.
-				// For now cluster number is initialised with 0, proper calculation takes place later on.
-				datacentersByProvider[string(providerType)] = apiv2.ClustersByDatacenter{datacenterName: 0}
-			}
-		}
-
-		clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
-		clusterList, err := clusterProvider.ListAll(ctx, nil)
-		if err != nil {
-			return nil, common.KubernetesErrorToHTTPError(err)
-		}
-
-		for _, cluster := range clusterList.Items {
-			providerName := cluster.Spec.Cloud.ProviderName
-			datacenterName := cluster.Spec.Cloud.DatacenterName
-
-			if datacenters, ok := datacentersByProvider[providerName]; ok {
-				if clustersByDatacenter, ok := datacenters[datacenterName]; ok {
-					datacenters[datacenterName] = clustersByDatacenter + 1
-				} else {
-					// This code should execute only when a datacenter is removed
-					// but some of its clusters are still running.
-					datacenters[datacenterName] = 1
+		if seed.Status.Phase != kubermaticv1.SeedInvalidPhase {
+			// Creating a map of datacenters by provider based on the Seed object.
+			for datacenterName, datacenter := range seed.Spec.Datacenters {
+				spec, err := dc.ConvertInternalDCToExternalSpec(datacenter.DeepCopy(), seed.Name)
+				if err != nil {
+					log.Logger.Errorf("api spec error in dc %q: %v", datacenterName, err)
+					continue
 				}
-			} else {
-				// This code should execute only when all datacenters of a provider type are removed
-				// but some of their clusters are still running.
-				clustersByDatacenter := make(apiv2.ClustersByDatacenter)
-				clustersByDatacenter[datacenterName] = 1
-				datacentersByProvider[providerName] = clustersByDatacenter
+
+				providerType, err := dc.GetProviderName(spec)
+				if err != nil {
+					log.Logger.Error(err)
+					continue
+				}
+
+				if provider, ok := datacentersByProvider[string(providerType)]; ok {
+					provider[datacenterName] = 0
+				} else {
+					// Creating a map of clusters by datacenter for each previously found provider type.
+					// For now cluster number is initialised with 0, proper calculation takes place later on.
+					datacentersByProvider[string(providerType)] = apiv2.ClustersByDatacenter{datacenterName: 0}
+				}
+			}
+
+			clusterProvider := ctx.Value(middleware.ClusterProviderContextKey).(provider.ClusterProvider)
+			clusterList, err := clusterProvider.ListAll(ctx, nil)
+			if err != nil {
+				return nil, common.KubernetesErrorToHTTPError(err)
+			}
+
+			for _, cluster := range clusterList.Items {
+				providerName := cluster.Spec.Cloud.ProviderName
+				datacenterName := cluster.Spec.Cloud.DatacenterName
+
+				if datacenters, ok := datacentersByProvider[providerName]; ok {
+					if clustersByDatacenter, ok := datacenters[datacenterName]; ok {
+						datacenters[datacenterName] = clustersByDatacenter + 1
+					} else {
+						// This code should execute only when a datacenter is removed
+						// but some of its clusters are still running.
+						datacenters[datacenterName] = 1
+					}
+				} else {
+					// This code should execute only when all datacenters of a provider type are removed
+					// but some of their clusters are still running.
+					clustersByDatacenter := make(apiv2.ClustersByDatacenter)
+					clustersByDatacenter[datacenterName] = 1
+					datacentersByProvider[providerName] = clustersByDatacenter
+				}
 			}
 		}
 

--- a/modules/api/pkg/provider/kubernetes/etcdbackupconfig.go
+++ b/modules/api/pkg/provider/kubernetes/etcdbackupconfig.go
@@ -181,6 +181,11 @@ func EtcdBackupConfigProjectProviderFactory(mapper meta.RESTMapper, seedKubeconf
 		createSeedImpersonationClients := make(map[string]ImpersonationClient)
 
 		for seedName, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			cfg, err := seedKubeconfigGetter(seed)
 			if err != nil {
 				// if one or more Seeds are bad, continue with the request, log that a Seed is in error

--- a/modules/api/pkg/provider/kubernetes/etcdrestore.go
+++ b/modules/api/pkg/provider/kubernetes/etcdrestore.go
@@ -166,6 +166,11 @@ func EtcdRestoreProjectProviderFactory(mapper meta.RESTMapper, seedKubeconfigGet
 		createSeedImpersonationClients := make(map[string]ImpersonationClient)
 
 		for seedName, seed := range seeds {
+			if seed.Status.Phase == kubermaticv1.SeedInvalidPhase {
+				log.Logger.Warnf("skipping seed %s as it is in an invalid phase", seedName)
+				continue
+			}
+
 			cfg, err := seedKubeconfigGetter(seed)
 			if err != nil {
 				// if one or more Seeds are bad, continue with the request, log that a Seed is in error

--- a/modules/web/src/app/core/services/cluster.ts
+++ b/modules/web/src/app/core/services/cluster.ts
@@ -344,7 +344,7 @@ export class ClusterService {
 
   restores(projectID: string): Observable<EtcdRestore[]> {
     const url = `${this._newRestRoot}/projects/${projectID}/etcdrestores`;
-    return this._http.get<EtcdRestore[]>(url);
+    return this._http.get<EtcdRestore[]>(url).pipe(catchError(() => of<EtcdRestore[]>([])));
   }
 
   getMasterVersions(provider: NodeProvider): Observable<MasterVersion[]> {


### PR DESCRIPTION
**What this PR does / why we need it**:
in case of error come when fetching clusters from seed don't return the error and keep fetching clusters from other seeds 

![image](https://github.com/kubermatic/dashboard/assets/85109141/6a08d8dd-6efb-40cc-8a7f-8d334c25a7ef)


**Which issue(s) this PR fixes**:
Fixes #6056

**What type of PR is this?**
/kind bug

```release-note
Fix issue with managing clusters if some seeds are down. 
```

```documentation
NONE
```
