### PR TITLE
Bump `k8c.io/kubermatic/v2` and add changelog entry for partial cluster  list

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -11340,13 +11340,6 @@
         "parameters": [
           {
             "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -11358,6 +11351,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {
@@ -11874,11 +11874,6 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatacenterName",
-            "in": "header"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -11890,6 +11885,11 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "DatacenterName",
+            "in": "header"
           }
         ],
         "responses": {
@@ -37713,7 +37713,7 @@
       "type": "object",
       "properties": {
         "basePath": {
-          "description": "BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.\nIf it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,\nthe BasePath part will be appended to the RootPath to construct the full path.",
+          "description": "BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.\nIf it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,\nthe BasePath part will be appended to the RootPath to construct the full path. For both cases,\nthe full folder structure needs to exist. KKP will only try to create the cluster folder.",
           "type": "string",
           "x-go-name": "BasePath"
         },
@@ -37773,7 +37773,7 @@
       "title": "VSphereCloudSpec specifies access data to VSphere cloud.",
       "properties": {
         "basePath": {
-          "description": "Optional: BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.\nIf it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,\nthe BasePath part will be appended to the RootPath (if set) to construct the full path.\n+optional",
+          "description": "Optional: BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.\nIf it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,\nthe BasePath part will be appended to the RootPath to construct the full path. For both cases,\nthe full folder structure needs to exist. KKP will only try to create the cluster folder.\n+optional",
           "type": "string",
           "x-go-name": "BasePath"
         },

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -67,7 +67,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.0
-	k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231106121421-050a23105428
+	k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231113140027-c1efb1b1b6f4
 	k8c.io/operating-system-manager v1.3.2
 	k8c.io/reconciler v0.4.0
 	k8s.io/api v0.28.2
@@ -102,7 +102,7 @@ replace (
 
 replace (
 	github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231106121421-050a23105428
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231113140027-c1efb1b1b6f4
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1419,8 +1419,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.0 h1:HDUHcGZWw8v2cN1KWmeUfXVquppqlQLmDgMZdWfg1hA=
 k8c.io/kubeone v1.7.0/go.mod h1:v/rybawEit3+HXPOtHyFyww0laqGzcxL0EJmdiJqQNo=
-k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231106121421-050a23105428 h1:55L6apxKfF+zBK1turMD07DDR6zNUy5GcUf68bXqmNI=
-k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231106121421-050a23105428/go.mod h1:cnNxWd3kGOuyPM4ukhV6e/siLPSYSvDWqcQ6gpKQOU0=
+k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231113140027-c1efb1b1b6f4 h1:6C0+gV9E5jAWtC4bMFh3/kfxCtb/eOqFqkfHB0+Rm3g=
+k8c.io/kubermatic/v2 v2.24.0-beta.1.0.20231113140027-c1efb1b1b6f4/go.mod h1:cnNxWd3kGOuyPM4ukhV6e/siLPSYSvDWqcQ6gpKQOU0=
 k8c.io/operating-system-manager v1.3.2 h1:DdScdSdUywzT/mVn3GMEShiKPxHjEIPn3OrlefvUu/I=
 k8c.io/operating-system-manager v1.3.2/go.mod h1:kKDzXLWrC5BLpDbgXQFRpTVa5Fjru2S3ylxX5hZMRKA=
 k8c.io/reconciler v0.4.0 h1:movw1R8Q0/JC8S+d6eq9si5PvLFbX3A0x8yaDlxuFn4=

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/v_sphere.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/v_sphere.go
@@ -19,7 +19,8 @@ type VSphere struct {
 
 	// BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.
 	// If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,
-	// the BasePath part will be appended to the RootPath to construct the full path.
+	// the BasePath part will be appended to the RootPath to construct the full path. For both cases,
+	// the full folder structure needs to exist. KKP will only try to create the cluster folder.
 	BasePath string `json:"basePath,omitempty"`
 
 	// If datacenter is set, this preset is only applicable to the

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/v_sphere_cloud_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/v_sphere_cloud_spec.go
@@ -20,7 +20,8 @@ type VSphereCloudSpec struct {
 
 	// Optional: BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.
 	// If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,
-	// the BasePath part will be appended to the RootPath (if set) to construct the full path.
+	// the BasePath part will be appended to the RootPath to construct the full path. For both cases,
+	// the full folder structure needs to exist. KKP will only try to create the cluster folder.
 	// +optional
 	BasePath string `json:"basePath,omitempty"`
 

--- a/modules/web/src/assets/config/changelog.json
+++ b/modules/web/src/assets/config/changelog.json
@@ -87,6 +87,10 @@
     },
     {
       "category": "changed",
+      "description": "Show warning when Seed is unavailable and list remaining clusters."
+    },
+    {
+      "category": "changed",
       "description": "Create a NetworkPolicy for user cluster kube-apiserver to access the Seed Kubernetes API."
     },
     {


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the `k8c.io/kubermatic/v2` dependency and adds a changelog entry for partial cluster listing, added in #6374.

This is the last PR planned for 2.24.0-rc.0.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
