### PR TITLE
Added flatcar for VMWare Cloud Director to the UI

### DIFF
--- a/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile.go
+++ b/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile.go
@@ -54,7 +54,7 @@ var defaultOperatingSystemProfiles = []apiv2.OperatingSystemProfile{
 	{
 		Name:                    "osp-flatcar",
 		OperatingSystem:         "flatcar",
-		SupportedCloudProviders: []string{"aws", "azure", "equinixmetal", "kubevirt", "openstack", "vsphere"},
+		SupportedCloudProviders: []string{"aws", "azure", "equinixmetal", "kubevirt", "openstack", "vsphere", "vmware-cloud-director"},
 	},
 	{
 		Name:                    "osp-rhel",

--- a/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
+++ b/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
@@ -77,7 +77,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-flatcar",
 					OperatingSystem:         "flatcar",
-					SupportedCloudProviders: []string{"aws", "azure", "equinixmetal", "kubevirt", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"aws", "azure", "equinixmetal", "kubevirt", "openstack", "vsphere", "vmware-cloud-director"},
 				},
 				{
 					Name:                    "osp-rhel",
@@ -115,7 +115,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-flatcar",
 					OperatingSystem:         "flatcar",
-					SupportedCloudProviders: []string{"aws", "azure", "equinixmetal", "kubevirt", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"aws", "azure", "equinixmetal", "kubevirt", "openstack", "vsphere", "vmware-cloud-director"},
 				},
 				{
 					Name:                    "osp-rhel",

--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -344,7 +344,8 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
           NodeProvider.EQUINIX,
           NodeProvider.KUBEVIRT,
           NodeProvider.OPENSTACK,
-          NodeProvider.VSPHERE
+          NodeProvider.VSPHERE,
+          NodeProvider.VMWARECLOUDDIRECTOR
         );
       case OperatingSystem.Ubuntu:
         return !this.isProvider(NodeProvider.ANEXIA);


### PR DESCRIPTION
**What this PR does / why we need it**:
As followup to https://github.com/kubermatic/operating-system-manager/pull/330 this PR makes flatcar selectable with VMWare Cloud director and also sets the default osp

**Which issue(s) this PR fixes**:
Addresses the UI Part for https://github.com/kubermatic/kubermatic/issues/12576 

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
VMware-cloud-director: Added Flatcar as supported os
```

**Documentation**:
```documentation
NONE
```
