### PR TITLE
Use JoinPath to construct vSphere url

### DIFF
--- a/modules/api/pkg/provider/cloud/vsphere/provider.go
+++ b/modules/api/pkg/provider/cloud/vsphere/provider.go
@@ -137,10 +137,12 @@ func newRESTSession(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere,
 }
 
 func createVim25Client(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere, caBundle *x509.CertPool) (*vim25.Client, error) {
-	u, err := url.Parse(fmt.Sprintf("%s/sdk", dc.Endpoint))
+	endpoint, err := url.Parse(dc.Endpoint)
 	if err != nil {
 		return nil, err
 	}
+
+	u := endpoint.JoinPath("/sdk")
 
 	// creating the govmoni Client in roundabout way because we need to set the proper CA bundle: reference https://github.com/vmware/govmomi/issues/1200
 	soapClient := soap.NewClient(u, dc.AllowInsecure)


### PR DESCRIPTION
**What this PR does / why we need it**:
Companion PR to https://github.com/kubermatic/kubermatic/pull/12861, fixing the way the vSphere client is generated as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
No longer fail constructing vSphere endpoint when a `/` suffix is present in the datacenter configuration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
