### PR TITLE
Use default font to fix cursor position issue in monaco editor

### DIFF
--- a/modules/web/src/app/shared/components/editor/component.ts
+++ b/modules/web/src/app/shared/components/editor/component.ts
@@ -50,8 +50,7 @@ export class EditorComponent implements OnInit, OnDestroy {
    */
   options: any = {
     contextmenu: false,
-    fontFamily: 'Inconsolata, monospace',
-    fontSize: 14,
+    fontSize: 12,
     lineNumbersMinChars: 4,
     minimap: {enabled: false},
     scrollbar: {vertical: 'hidden'},


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an issue with cursor position inside Monaco Editor which was caused by inconsistent rendered size of `Inconsolata` font. This PR removes the usage of `Inconsolata` font for Monaco editor and uses the default font with some reduced font size.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6412 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix issue with cursor position inside YAML editor.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
