### PR TITLE
Prune `id` value from applications in request payload when editing cluster template

### DIFF
--- a/modules/web/src/app/wizard/step/applications/component.ts
+++ b/modules/web/src/app/wizard/step/applications/component.ts
@@ -68,6 +68,7 @@ export class ApplicationsStepComponent extends StepBase implements OnInit, OnDes
         }
         return application;
       }) || [];
+    this._onApplicationsChanged();
   }
 
   onApplicationAdded(application: Application): void {


### PR DESCRIPTION
**What this PR does / why we need it**:
Missed this change in https://github.com/kubermatic/dashboard/pull/6415. `id` value was still attached in the request payload when editing cluster template.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
