### PR TITLE
Fix operating system profile filter for GCP

### DIFF
--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -585,14 +585,18 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
   }
 
   private getSupportedOperatingSystemProfiles(): string[] {
+    let cloudProvider = this.provider.toString();
+    if (this.provider === NodeProvider.EQUINIX) {
+      // Packet was renamed to EquinixMetal for the machines.
+      cloudProvider = 'equinixmetal';
+    } else if (this.provider === NodeProvider.GCP) {
+      // For machines, GCP needs to be replaced with gce.
+      cloudProvider = 'gce';
+    }
+
     return this.operatingSystemProfiles
       .filter(osp => osp.operatingSystem === this.form.get(Controls.OperatingSystem).value?.toLowerCase())
-      .filter(
-        // Packet was renamed to EquinixMetal for the machines.
-        osp =>
-          osp.supportedCloudProviders.indexOf(this.provider === NodeProvider.EQUINIX ? 'equinixmetal' : this.provider) >
-          -1
-      )
+      .filter(osp => osp.supportedCloudProviders.indexOf(cloudProvider) > -1)
       .map(osp => osp.name);
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In KKP we have support for GCP i.e. Google Cloud Platform. Similarly, machine-controller also supports creating machines on Google Cloud using the Google Compute Engine. Hence the drift in the name; GCP and GCE for KKP and machines respectively.

This PR fixes an issue where Operating System Profiles for GCP were not being listed properly because of this drift.
 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where Operating System Profiles were not being listed for GCP
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
