### PR TITLE
Update k8c.io/kubermatic/v2 dependency to `223a5c1`

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -11382,6 +11382,13 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -11393,13 +11400,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
           }
         ],
         "responses": {
@@ -11916,6 +11916,11 @@
         "parameters": [
           {
             "type": "string",
+            "name": "DatacenterName",
+            "in": "header"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -11927,11 +11932,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "name": "DatacenterName",
-            "in": "header"
           }
         ],
         "responses": {

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -69,7 +69,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.0
-	k8c.io/kubermatic/v2 v2.24.1-0.20240116091326-dbc07007022e
+	k8c.io/kubermatic/v2 v2.24.1-0.20240119123730-223a5c1053d1
 	k8c.io/operating-system-manager v1.4.1-0.20231210203405-28d391f034d8
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.28.4
@@ -104,7 +104,7 @@ replace (
 
 replace (
 	github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.24.1-0.20240116091326-dbc07007022e
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.24.1-0.20240119123730-223a5c1053d1
 )
 
 require github.com/vmware-tanzu/velero v1.12.1

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1451,8 +1451,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.0 h1:HDUHcGZWw8v2cN1KWmeUfXVquppqlQLmDgMZdWfg1hA=
 k8c.io/kubeone v1.7.0/go.mod h1:v/rybawEit3+HXPOtHyFyww0laqGzcxL0EJmdiJqQNo=
-k8c.io/kubermatic/v2 v2.24.1-0.20240116091326-dbc07007022e h1:JPUL9mfAQuJ7X6evXEsBaCFLLJc88ZZj8YB6ofwRKpE=
-k8c.io/kubermatic/v2 v2.24.1-0.20240116091326-dbc07007022e/go.mod h1:ZRc/r2UTueVWAtcFvtX8j3ZzA5T2DTmRVJ+YT8Rg0hM=
+k8c.io/kubermatic/v2 v2.24.1-0.20240119123730-223a5c1053d1 h1:wjQLif0UCL4as6jfXBJIG5NERSrNXuDTCa6hJOUt6H4=
+k8c.io/kubermatic/v2 v2.24.1-0.20240119123730-223a5c1053d1/go.mod h1:ZRc/r2UTueVWAtcFvtX8j3ZzA5T2DTmRVJ+YT8Rg0hM=
 k8c.io/operating-system-manager v1.4.1-0.20231210203405-28d391f034d8 h1:d5S2/7BQP2EJBTY1Fxl7IcXC0YhSH8iBqsfuWjpMX5A=
 k8c.io/operating-system-manager v1.4.1-0.20231210203405-28d391f034d8/go.mod h1:d/efJngp0rd2xx23JnOQhfAWBtY9nl2fp4QBrCIv2DA=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=

--- a/modules/api/pkg/handler/v2/cluster_default/cluster_default_test.go
+++ b/modules/api/pkg/handler/v2/cluster_default/cluster_default_test.go
@@ -50,7 +50,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","aws":{}},"version":"v1.27.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","aws":{}},"version":"v1.28.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 		{
 			Name:     "Default cluster for Azure",
@@ -61,7 +61,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","azure":{"assignAvailabilitySet":null}},"version":"v1.27.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","azure":{"assignAvailabilitySet":null}},"version":"v1.28.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 		{
 			Name:     "Default cluster for vSphere",
@@ -72,7 +72,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","vsphere":{}},"version":"v1.27.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","vsphere":{}},"version":"v1.28.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 		{
 			Name:     "Default cluster for GCP",
@@ -83,7 +83,7 @@ func TestGetEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser:        test.GenDefaultAPIUser(),
 			ExpectedHTTPStatusCode: http.StatusOK,
-			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","gcp":{}},"version":"v1.27.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
+			ExpectedResponse:       `{"name":"","creationTimestamp":"0001-01-01T00:00:00Z","type":"kubernetes","spec":{"cloud":{"dc":"fake-dc","gcp":{}},"version":"v1.28.6","oidc":{},"enableUserSSHKeyAgent":true,"enableOperatingSystemManager":true,"kubernetesDashboard":{"enabled":true},"containerRuntime":"containerd","clusterNetwork":{"ipFamily":"IPv4","services":{"cidrBlocks":["10.240.16.0/20","fd02::/120"]},"pods":{"cidrBlocks":["172.25.0.0/16","fd01::/48"]},"nodeCidrMaskSizeIPv4":24,"nodeCidrMaskSizeIPv6":64,"dnsDomain":"cluster.local","proxyMode":"ipvs","ipvs":{"strictArp":true},"nodeLocalDNSCacheEnabled":true},"cniPlugin":{"type":"cilium","version":"1.14.3"},"exposeStrategy":"NodePort"},"status":{"version":"","url":"","externalCCMMigration":""}}`,
 		},
 	}
 

--- a/modules/api/pkg/handler/v2/external_cluster/external_cluster_test.go
+++ b/modules/api/pkg/handler/v2/external_cluster/external_cluster_test.go
@@ -306,7 +306,7 @@ func TestListClusters(t *testing.T) {
 						ID:   "clusterAbcID",
 					},
 					Spec: apiv1.ClusterSpec{
-						Version: "v1.27.6",
+						Version: "v1.28.6",
 					},
 					Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: test.GenDefaultProject().Name},
 				},
@@ -316,7 +316,7 @@ func TestListClusters(t *testing.T) {
 						ID:   "clusterDefID",
 					},
 					Spec: apiv1.ClusterSpec{
-						Version: "v1.27.6",
+						Version: "v1.28.6",
 					},
 					Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: test.GenDefaultProject().Name},
 				},
@@ -339,7 +339,7 @@ func TestListClusters(t *testing.T) {
 						ID:   "clusterAbcID",
 					},
 					Spec: apiv1.ClusterSpec{
-						Version: "v1.27.6",
+						Version: "v1.28.6",
 					},
 					Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: test.GenDefaultProject().Name},
 				},
@@ -349,7 +349,7 @@ func TestListClusters(t *testing.T) {
 						ID:   "clusterDefID",
 					},
 					Spec: apiv1.ClusterSpec{
-						Version: "v1.27.6",
+						Version: "v1.28.6",
 					},
 					Labels: map[string]string{kubermaticv1.ProjectIDLabelKey: test.GenDefaultProject().Name},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubernetes 1.29 support has been merged into k8c.io/kubermatic, this updates the dependency. In addition, we are building the dashboard with Go 1.21, so this updates the `go.mod` file accordingly.

cc @xrstf for awareness.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
