### PR TITLE
Add new option for default volumes file system 

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/style.scss
@@ -26,3 +26,11 @@
 .schedule-field {
   margin-bottom: 15px;
 }
+
+.default-volumes {
+  margin-top: 15px;
+
+  i {
+    margin: 3px 0 0 5px;
+  }
+}

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
@@ -32,23 +32,10 @@ END OF TERMS AND CONDITIONS
         <mat-hint>The name of the created cluster {{type.toLowerCase()}}.</mat-hint>
       </mat-form-field>
       <mat-form-field>
-        <mat-label>{{destinationsLabel}}</mat-label>
-        <mat-select [formControlName]="Controls.Destination"
-                    disableOptionCentering
-                    required>
-          <mat-option *ngFor="let destination of destinations"
-                      [value]="destination">{{destination}}</mat-option>
-        </mat-select>
-        <mat-hint *ngIf="isAdmin && !hasDestinations()">
-          <a class="km-pointer"
-             href="/settings/backupdestinations"
-             fxLayoutAlign=" center"
-             target="_blank">Configure a destination for this seed <i class="km-icon-external-link"></i>.</a>
-        </mat-hint>
-        <mat-hint *ngIf="!isAdmin && !hasDestinations()">Contact your Administrator to configure a destination.
-        </mat-hint>
-        <mat-hint *ngIf="hasDestinations()">The list of existing destinations for the selected cluster seed.
-        </mat-hint>
+        <mat-label>Backup Storage Location</mat-label>
+        <input [formControlName]="Controls.Destination"
+               matInput
+               required>
       </mat-form-field>
       <mat-form-field>
         <mat-label>{{namespacesLabel}}</mat-label>
@@ -86,6 +73,14 @@ END OF TERMS AND CONDITIONS
         <mat-hint>Enter time in the format HHhMMmSSs (e.g., 24h10m10s), The amount of time before this backup is eligible for garbage collection. If not specified,
           a default value of 30 days will be used.</mat-hint>
       </mat-form-field>
+
+      <mat-checkbox class="default-volumes"
+                    [formControlName]="Controls.DefaultVolumesToFsBackup">
+        Default Volumes
+        <i class="km-icon-info km-pointer"
+           matTooltip="Whether pod volume file system backup should be used for all volumes by default."></i>
+      </mat-checkbox>
+
       <div class="labels">
         <km-label-form title="Labels"
                        [labels]="labels"

--- a/modules/web/src/app/shared/entity/backup.ts
+++ b/modules/web/src/app/shared/entity/backup.ts
@@ -139,7 +139,7 @@ export enum BackupType {
 }
 
 // this variable is temporary, it will be removed after adding the storageLocation implementation
-export const StorageLocationTempName = 'default';
+export const StorageLocationTempName = 'default-cluster-backup-bsl';
 
 export class ClusterBackup {
   name: string;
@@ -150,6 +150,7 @@ export class ClusterBackup {
 export class ClusterBackupSpec {
   includedNamespaces?: string[] | string;
   storageLocation: string;
+  defaultVolumesToFsBackup: boolean;
   clusterid: string;
   ttl?: string;
   schedule?: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
add new field in the add backup/schedule to chose whether pod volume file system backup should be used for all volumes by default.
also for changing the default value of BSL and removing the destinations.
In an upcoming PR, the list of BSL will be added.

![image](https://github.com/kubermatic/dashboard/assets/85109141/e6972a7b-15e7-4d8f-951f-1c6a489f1f16)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

```release-note
NONE
```

```documentation
NONE
```
