### PR TITLE
Set LoadBalancerSKU from Azure preset

### DIFF
--- a/modules/api/pkg/provider/kubernetes/preset.go
+++ b/modules/api/pkg/provider/kubernetes/preset.go
@@ -357,6 +357,7 @@ func (m *PresetProvider) setAzureCredentials(preset *kubermaticv1.Preset, cloud 
 	cloud.Azure.SecurityGroup = credentials.SecurityGroup
 	cloud.Azure.SubnetName = credentials.SubnetName
 	cloud.Azure.VNetName = credentials.VNetName
+	cloud.Azure.LoadBalancerSKU = credentials.LoadBalancerSKU
 
 	return &cloud, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Looks like the preset-to-spec logic never set the load balancer SKU. I'm surprised to see this, but there are no other references to those fields in the dashboard code.

This PR sets the field from the preset. If it's empty, there is still defaulting code in KKP that will put `basic` as value.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/13063

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set LoadBalancerSKU on Azure clusters if the field is set in the preset
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
