### PR TITLE
bump to latest KKP 2.23 commit

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -67,7 +67,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.6.2
-	k8c.io/kubermatic/v2 v2.23.10-0.20240119155130-3b260b451468
+	k8c.io/kubermatic/v2 v2.23.11-0.20240206183359-fd451a1c566b
 	k8c.io/operating-system-manager v1.3.3
 	k8c.io/reconciler v0.3.1
 	k8s.io/api v0.26.4
@@ -102,7 +102,7 @@ replace (
 
 replace (
 	github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.23.10-0.20240119155130-3b260b451468
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.23.11-0.20240206183359-fd451a1c566b
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1367,8 +1367,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.6.2 h1:3oEvD90kENhYzvvmSrMNjUam2fq7UMMKVp/Py57xs6M=
 k8c.io/kubeone v1.6.2/go.mod h1:5U/6sUZAkAl7uvC+VIDIA0VBZMBbFI9QD1C90kxb4qA=
-k8c.io/kubermatic/v2 v2.23.10-0.20240119155130-3b260b451468 h1:UxT/WTceuxWkJWnZzvoD0sBsdOmfALgn2t6OQvy5Kgo=
-k8c.io/kubermatic/v2 v2.23.10-0.20240119155130-3b260b451468/go.mod h1:7th2Sx1gX7nQdMVJFuXSo/fzaIMc11TMg2C7U3slGyc=
+k8c.io/kubermatic/v2 v2.23.11-0.20240206183359-fd451a1c566b h1:JLhjcFBXLwoh9TZ9NuhVqg/23cbft/qfWjUiWO6kStA=
+k8c.io/kubermatic/v2 v2.23.11-0.20240206183359-fd451a1c566b/go.mod h1:7th2Sx1gX7nQdMVJFuXSo/fzaIMc11TMg2C7U3slGyc=
 k8c.io/operating-system-manager v1.3.3 h1:8E58WGz+67+dDYuvAZu0QRRkslkWa4vMrbseQeRWceA=
 k8c.io/operating-system-manager v1.3.3/go.mod h1:kKDzXLWrC5BLpDbgXQFRpTVa5Fjru2S3ylxX5hZMRKA=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=


### PR DESCRIPTION
**What this PR does / why we need it**:
After I cleaned out non-versioned container images, we need to bump the dashboard to one KKP commit that does have images available again.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
