### PR TITLE
Drop additional configuration for web-terminal pod

### DIFF
--- a/modules/api/pkg/handler/websocket/terminal.go
+++ b/modules/api/pkg/handler/websocket/terminal.go
@@ -553,15 +553,6 @@ func genWebTerminalPod(userAppName, userEmailID string) *corev1.Pod {
 		},
 	}
 
-	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsUser:  resources.Int64(12345),
-		RunAsGroup: resources.Int64(23456),
-		FSGroup:    resources.Int64(2000),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-
 	return pod
 }
 
@@ -639,14 +630,6 @@ func genWebTerminalCleanupJob(userAppName, userEmailID string) *batchv1.Job {
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyOnFailure,
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsUser:  resources.Int64(1000),
-						RunAsGroup: resources.Int64(3000),
-						FSGroup:    resources.Int64(2000),
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
The security context is redundant in this case. It's used to configure the group and user for the web-terminal. Although we now already configure this in the container image https://github.com/kubermatic/dashboard/blob/main/hack/images/web-terminal/Dockerfile#L31-L40

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
