### PR TITLE
Fix select BSL on cluster creation

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -18,6 +18,7 @@ import {MatDialogRef} from '@angular/material/dialog';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {ProjectService} from '@app/core/services/project';
 import {DynamicModule} from '@app/dynamic/module-registry';
+import {BackupStorageLocation} from '@app/shared/entity/backup';
 import {BSLListState} from '@app/wizard/step/cluster/component';
 import {ClusterService} from '@core/services/cluster';
 import {DatacenterService} from '@core/services/datacenter';
@@ -100,7 +101,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   isKubeLBEnforced = false;
   isKubeLBEnabled = false;
   isCSIDriverDisabled = false;
-  backupStorageLocationsList: string[];
+  backupStorageLocationsList: BackupStorageLocation[];
   backupStorageLocationLabel: BSLListState = BSLListState.Ready;
   readonly isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   readonly CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE = CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE;
@@ -372,7 +373,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .listBackupStorageLocation(projectID)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(cbslList => {
-        this.backupStorageLocationsList = cbslList.map(cbsl => cbsl.name);
+        this.backupStorageLocationsList = cbslList;
         this.backupStorageLocationLabel = cbslList.length ? BSLListState.Ready : BSLListState.Empty;
       });
   }

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -244,7 +244,7 @@ limitations under the License.
         <mat-select [formControlName]="Controls.BackupStorageLocation"
                     disableOptionCentering>
           <mat-option *ngFor="let bsl of backupStorageLocationsList"
-                      [value]="bsl">{{bsl}}
+                      [value]="bsl.name">{{bsl.displayName}}
           </mat-option>
         </mat-select>
         <mat-error *ngIf="form.get(Controls.BackupStorageLocation).hasError('required')">

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/delete-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/delete-dialog/template.html
@@ -30,7 +30,7 @@ END OF TERMS AND CONDITIONS
          class="km-copy">{{getcbContent()}}</b>
       {{type}} permanently?
     </p>
-    <p *ngIf="(backups?.length > 1) && !!bslName">
+    <p *ngIf="(backups?.length > 1)">
       Type
       <b ngxClipboard
          [cbContent]="getcbContent()"

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -450,7 +450,7 @@ limitations under the License.
               <mat-select [formControlName]="Controls.BackupStorageLocation"
                           disableOptionCentering>
                 <mat-option *ngFor="let bsl of backupStorageLocationsList"
-                            [value]="bsl">{{bsl}}
+                            [value]="bsl.name">{{bsl.displayName}}
                 </mat-option>
               </mat-select>
               <mat-error *ngIf="form.get(Controls.BackupStorageLocation).hasError('required')">


### PR DESCRIPTION
**What this PR does / why we need it**:
fix an issue with choosing BSL in the cluster creation wizard and show the `displayName` for the user instead of the `name`

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
