### PR TITLE
Exclude machine controller health check when edge provider is used

### DIFF
--- a/modules/api/pkg/provider/kubernetes/cluster.go
+++ b/modules/api/pkg/provider/kubernetes/cluster.go
@@ -282,6 +282,8 @@ func (p *ClusterProvider) Get(ctx context.Context, userInfo *provider.UserInfo, 
 	}
 	if options.CheckInitStatus {
 		healthCheck := cluster.Status.ExtendedHealth
+		// If the edge provider is used, machine controller is not deployed as part of the cluster control plane which means
+		// the health checks for machine controller is not needed thus we skip it.
 		if cluster.Spec.Cloud.ProviderName == string(kubermaticv1.EdgeCloudProvider) {
 			if !healthCheck.ControlPlaneHealthy() ||
 				healthCheck.CloudProviderInfrastructure != kubermaticv1.HealthStatusUp ||
@@ -480,6 +482,8 @@ func (p *ClusterProvider) GetUnsecured(ctx context.Context, project *kubermaticv
 	if cluster.Labels[kubermaticv1.ProjectIDLabelKey] == project.Name {
 		if options.CheckInitStatus {
 			healthCheck := cluster.Status.ExtendedHealth
+			// If the edge provider is used, machine controller is not deployed as part of the cluster control plane which means
+			// the health checks for machine controller is not needed thus we skip it.
 			if cluster.Spec.Cloud.ProviderName == string(kubermaticv1.EdgeCloudProvider) {
 				if !healthCheck.ControlPlaneHealthy() ||
 					healthCheck.CloudProviderInfrastructure != kubermaticv1.HealthStatusUp ||


### PR DESCRIPTION
**What this PR does / why we need it**:
Machine controller health check must be excluded when the edge cloud provider is used. This PR guarantees that no check for machine controller is present when the edge provider used. Another PR will be open in KKP to mitigate that abstract machine controller health check over there.  
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
