### PR TITLE
Hide cluster backup feature for user cluster

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -16,7 +16,6 @@ import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {MatDialogRef} from '@angular/material/dialog';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
-import {ProjectService} from '@app/core/services/project';
 import {DynamicModule} from '@app/dynamic/module-registry';
 import {BackupStorageLocation} from '@app/shared/entity/backup';
 import {BSLListState} from '@app/wizard/step/cluster/component';
@@ -119,6 +118,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     return this._settings.enableDashboard;
   }
 
+  get isclusterBackupEnabled(): boolean {
+    return this._settings.enableClusterBackups;
+  }
+
   constructor(
     private readonly _builder: FormBuilder,
     private readonly _clusterService: ClusterService,
@@ -126,7 +129,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     private readonly _matDialogRef: MatDialogRef<EditClusterComponent>,
     private readonly _notificationService: NotificationService,
     private readonly _settingsService: SettingsService,
-    private readonly _projectService: ProjectService,
     private readonly _clusterBackupService: ClusterBackupService
   ) {}
 
@@ -177,6 +179,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         this._builder.control(this.cluster.spec?.backupConfig?.backupStorageLocation?.name, Validators.required)
       );
     }
+    this._getCBSL(this.projectID);
 
     this.form
       .get(Controls.ClusterBackup)
@@ -227,10 +230,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .getAdmissionPlugins(this.cluster.spec.version)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(plugins => (this.admissionPlugins = plugins));
-
-    this._projectService.selectedProject
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(project => this._getCBSL(project.id));
 
     this.checkForLegacyAdmissionPlugins();
 

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -227,7 +227,9 @@ limitations under the License.
            [matTooltip]="isCSIDriverDisabled ? 'CSI Driver is disabled by your admin in the chosen datacenter.' : 'Disable default CSI storage driver, if available.'"></i>
       </mat-checkbox>
 
-      <mat-checkbox [formControlName]="Controls.ClusterBackup">
+      <mat-checkbox [formControlName]="Controls.ClusterBackup"
+                    *ngIf="isclusterBackupEnabled"
+                    kmValueChangedIndicator>
         Cluster Backup
         <i class="km-icon-info km-pointer"
            matTooltip="Enable create backups from this cluster"></i>
@@ -238,11 +240,12 @@ limitations under the License.
         </mat-chip>
       </mat-checkbox>
 
-      <mat-form-field *ngIf="!!form.get(Controls.ClusterBackup).value"
+      <mat-form-field *ngIf="!!form.get(Controls.ClusterBackup).value && isclusterBackupEnabled"
                       class="bsl-field">
-        <mat-label>{{backupStorageLocationLabel}}"</mat-label>
+        <mat-label>{{backupStorageLocationLabel}}</mat-label>
         <mat-select [formControlName]="Controls.BackupStorageLocation"
-                    disableOptionCentering>
+                    disableOptionCentering
+                    kmValueChangedIndicator>
           <mat-option *ngFor="let bsl of backupStorageLocationsList"
                       [value]="bsl.name">{{bsl.displayName}}
           </mat-option>

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -81,7 +81,7 @@ import {BackupStorageLocation} from '@app/shared/entity/backup';
 export enum BSLListState {
   Ready = 'Backup Storage Location',
   Loading = 'Loading...',
-  Empty = 'No Backups Available',
+  Empty = 'No Backup Storage Locations Available',
 }
 
 enum Controls {
@@ -185,6 +185,10 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
   get isKubernetesDashboardEnabled(): boolean {
     return this._settings.enableDashboard;
+  }
+
+  get isclusterBackupEnabled(): boolean {
+    return this._settings.enableClusterBackups;
   }
 
   constructor(

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -393,7 +393,8 @@ limitations under the License.
                  matTooltip="Audit Logging is enforced by your admin in the chosen datacenter."></i>
             </div>
 
-            <mat-checkbox [formControlName]="Controls.ClusterBackup">
+            <mat-checkbox [formControlName]="Controls.ClusterBackup"
+                          *ngIf="isclusterBackupEnabled">
               Cluster Backup
               <i class="km-icon-info km-pointer"
                  matTooltip="Enable create backups from this cluster"></i>
@@ -402,7 +403,7 @@ limitations under the License.
               </mat-chip>
             </mat-checkbox>
 
-            <mat-form-field *ngIf="!!controlValue(Controls.ClusterBackup)">
+            <mat-form-field *ngIf="!!controlValue(Controls.ClusterBackup) && isclusterBackupEnabled">
               <mat-label>{{backupStorageLocationLabel}}</mat-label>
               <mat-select [formControlName]="Controls.BackupStorageLocation"
                           disableOptionCentering>


### PR DESCRIPTION
**What this PR does / why we need it**:
Hide cluster backup feature in cluster creation and in edit cluster if the feature is disabled from the admin.

**What type of PR is this?**
/kind bug

```release-note
NONE
```
```documentation
NONE
```
