### PR TITLE
Add valuesBlock and defaultValuesBlock and their conversion

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -27490,6 +27490,11 @@
         },
         "values": {
           "$ref": "#/definitions/RawExtension"
+        },
+        "valuesBlock": {
+          "description": "ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.",
+          "type": "string",
+          "x-go-name": "ValuesBlock"
         }
       },
       "x-go-package": "k8c.io/dashboard/v2/pkg/api/v2"

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1908,10 +1908,14 @@ type ApplicationInstallationSpec struct {
 	// DeployOptions holds the settings specific to the templating method used to deploy the application.
 	DeployOptions *appskubermaticv1.DeployOptions `json:"deployOptions,omitempty"`
 
-	// Values describe overrides for manifest-rendering. It's a free yaml field.
+	// Values specify values overrides that are passed to helm templating. Comments are not preserved.
 	// +kubebuilder:pruning:PreserveUnknownFields
+	// Deprecated: Use ValuesBlock instead.
 	Values runtime.RawExtension `json:"values,omitempty"`
 	// As kubebuilder does not support interface{} as a type, deferring json decoding, seems to be our best option (see https://github.com/kubernetes-sigs/controller-tools/issues/294#issuecomment-518379253)
+
+	// ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
+	ValuesBlock string `json:"valuesBlock,omitempty"`
 }
 
 // ApplicationInstallationStatus is the object representing the status of an Application.

--- a/modules/api/pkg/handler/test/helper.go
+++ b/modules/api/pkg/handler/test/helper.go
@@ -2252,6 +2252,18 @@ func GenApiApplicationInstallation(name, clusterName, targetnamespace string) *a
 	}
 }
 
+func GenApiApplicationInstallationWithValues(name, clusterName, targetnamespace string) *apiv2.ApplicationInstallation {
+	ai := GenApiApplicationInstallation(name, clusterName, targetnamespace)
+	ai.Spec.Values = runtime.RawExtension{Raw: []byte(`{"key": "value"}`)}
+	return ai
+}
+
+func GenApiApplicationInstallationWithValuesBlock(name, clusterName, targetnamespace string) *apiv2.ApplicationInstallation {
+	ai := GenApiApplicationInstallation(name, clusterName, targetnamespace)
+	ai.Spec.ValuesBlock = "key: value\n"
+	return ai
+}
+
 func GenApplicationDefinition(name string) *appskubermaticv1.ApplicationDefinition {
 	return &appskubermaticv1.ApplicationDefinition{
 		ObjectMeta: metav1.ObjectMeta{

--- a/modules/api/pkg/handler/test/helper.go
+++ b/modules/api/pkg/handler/test/helper.go
@@ -2336,6 +2336,17 @@ func GenApiApplicationDefinition(name string) apiv2.ApplicationDefinition {
 	}
 }
 
+func GenApiApplicationDefinitionWithDefaultValues(name string) apiv2.ApplicationDefinition {
+	ad := GenApiApplicationDefinition(name)
+	ad.Spec.DefaultValues = &runtime.RawExtension{Raw: []byte(`{"key": "value"}`)}
+	return ad
+}
+
+func GenApiApplicationDefinitionWithDefaultValuesBlock(name string) apiv2.ApplicationDefinition {
+	ad := GenApiApplicationDefinition(name)
+	ad.Spec.DefaultValuesBlock = "key: value"
+	return ad
+}
 func GenApiApplicationDefinitionListItem(name string) apiv2.ApplicationDefinitionListItem {
 	return apiv2.ApplicationDefinitionListItem{
 		Name: name,

--- a/modules/api/pkg/handler/v2/application_definition/application_definition.go
+++ b/modules/api/pkg/handler/v2/application_definition/application_definition.go
@@ -26,7 +26,11 @@ import (
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	"k8c.io/dashboard/v2/pkg/provider"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 )
 
 func ListApplicationDefinitions(applicationDefinitionProvider provider.ApplicationDefinitionProvider) endpoint.Endpoint {
@@ -76,7 +80,15 @@ func CreateApplicationDefinition(userInfoGetter provider.UserInfoGetter, applica
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
 
-		appdef, err := applicationDefinitionProvider.CreateUnsecured(ctx, convertAPItoInternalApplicationDefinitionBody(&req.Body))
+		inApp := convertAPItoInternalApplicationDefinitionBody(&req.Body)
+
+		// if the defaultValues field is set, convert all of its defaultValues into the defaultValuesBlock field.
+		// we do this as defaultValues is a deprecated field
+		if err := migrateDefaultValuesToDefaultValuesBlock(&inApp.Spec); err != nil {
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to convert defaultValues into defaultValuesBlock field: %v", err))
+		}
+
+		appdef, err := applicationDefinitionProvider.CreateUnsecured(ctx, inApp)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
@@ -106,6 +118,12 @@ func UpdateApplicationDefinition(userInfoGetter provider.UserInfoGetter, applica
 
 		reqAppDef := convertAPItoInternalApplicationDefinitionBody(&req.Body)
 		curAppDef.Spec = reqAppDef.Spec
+
+		// if the defaultValues field is set, convert all of its defaultValues into the defaultValuesBlock field.
+		// we do this as defaultValues is a deprecated field
+		if err := migrateDefaultValuesToDefaultValuesBlock(&curAppDef.Spec); err != nil {
+			return nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("failed to convert defaultValues into defaultValuesBlock field: %v", err))
+		}
 
 		resAppDef, err := applicationDefinitionProvider.UpdateUnsecured(ctx, curAppDef)
 		if err != nil {
@@ -138,4 +156,16 @@ func DeleteApplicationDefinition(userInfoGetter provider.UserInfoGetter, applica
 
 		return nil, nil
 	}
+}
+
+func migrateDefaultValuesToDefaultValuesBlock(ads *appskubermaticv1.ApplicationDefinitionSpec) error {
+	if len(ads.DefaultValues.Raw) > 0 {
+		y, err := yaml.JSONToYAML(ads.DefaultValues.Raw)
+		if err != nil {
+			return err
+		}
+		ads.DefaultValuesBlock = string(y)
+		ads.DefaultValues = &runtime.RawExtension{}
+	}
+	return nil
 }

--- a/modules/api/pkg/handler/v2/application_definition/application_definition.go
+++ b/modules/api/pkg/handler/v2/application_definition/application_definition.go
@@ -159,7 +159,7 @@ func DeleteApplicationDefinition(userInfoGetter provider.UserInfoGetter, applica
 }
 
 func migrateDefaultValuesToDefaultValuesBlock(ads *appskubermaticv1.ApplicationDefinitionSpec) error {
-	if len(ads.DefaultValues.Raw) > 0 {
+	if ads.DefaultValues != nil && len(ads.DefaultValues.Raw) > 0 {
 		y, err := yaml.JSONToYAML(ads.DefaultValues.Raw)
 		if err != nil {
 			return err

--- a/modules/api/pkg/handler/v2/application_definition/application_definition_test.go
+++ b/modules/api/pkg/handler/v2/application_definition/application_definition_test.go
@@ -188,6 +188,14 @@ func TestCreateApplicationDefinition(t *testing.T) {
 			ExpectedHTTPStatusCode: http.StatusCreated,
 		},
 		{
+			Name:                   "defaultValues are converted to defaultValuesBlock",
+			ApplicationDefinition:  test.GenApiApplicationDefinitionWithDefaultValues(appname),
+			ExistingAPIUser:        test.GenDefaultAdminAPIUser(),
+			ExistingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true)},
+			ExpectedResponse:       test.GenApiApplicationDefinitionWithDefaultValuesBlock(appname),
+			ExpectedHTTPStatusCode: http.StatusCreated,
+		},
+		{
 			Name:                   "user cannot create an applicationdefinition",
 			ApplicationDefinition:  test.GenApiApplicationDefinition(appname),
 			ExistingAPIUser:        test.GenAPIUser("John", "john@acme.com"),
@@ -292,6 +300,14 @@ func TestUpdateApplicationDefinitions(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			Name:                   "defaultValues are converted to defaultValuesBlock",
+			ApplicationDefinition:  test.GenApiApplicationDefinitionWithDefaultValuesBlock(appname),
+			ExistingAPIUser:        test.GenDefaultAdminAPIUser(),
+			ExistingKubermaticObjs: []ctrlruntimeclient.Object{genUser("Bob", "bob@acme.com", true), test.GenApplicationDefinition(appname)},
+			ExpectedHTTPStatusCode: http.StatusOK,
+			ExpectedResponse:       test.GenApiApplicationDefinitionWithDefaultValuesBlock(appname),
 		},
 		{
 			Name:                   "user cannot update an applicationdefinition",

--- a/modules/api/pkg/handler/v2/application_definition/conversion.go
+++ b/modules/api/pkg/handler/v2/application_definition/conversion.go
@@ -60,14 +60,15 @@ func convertAPItoInternalApplicationDefinitionBody(appDef *apiv2.ApplicationDefi
 			Labels: appDef.Labels,
 		},
 		Spec: appskubermaticv1.ApplicationDefinitionSpec{
-			Description:      appDef.Spec.Description,
-			Method:           appDef.Spec.Method,
-			DefaultValues:    appDef.Spec.DefaultValues,
-			Versions:         appDef.Spec.Versions,
-			DocumentationURL: appDef.Spec.DocumentationURL,
-			SourceURL:        appDef.Spec.SourceURL,
-			Logo:             appDef.Spec.Logo,
-			LogoFormat:       appDef.Spec.LogoFormat,
+			Description:        appDef.Spec.Description,
+			Method:             appDef.Spec.Method,
+			DefaultValues:      appDef.Spec.DefaultValues,
+			DefaultValuesBlock: appDef.Spec.DefaultValuesBlock,
+			Versions:           appDef.Spec.Versions,
+			DocumentationURL:   appDef.Spec.DocumentationURL,
+			SourceURL:          appDef.Spec.SourceURL,
+			Logo:               appDef.Spec.Logo,
+			LogoFormat:         appDef.Spec.LogoFormat,
 		},
 	}
 }

--- a/modules/api/pkg/handler/v2/application_installation/application_installation_test.go
+++ b/modules/api/pkg/handler/v2/application_installation/application_installation_test.go
@@ -205,6 +205,24 @@ func TestCreateApplicationInstallation(t *testing.T) {
 				Status: &apiv2.ApplicationInstallationStatus{},
 			},
 		},
+		{
+			Name:      "values are converted to valuesBlock",
+			ProjectID: test.GenDefaultProject().Name,
+			ClusterID: test.GenDefaultCluster().Name,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			ExistingAPIUser:         test.GenDefaultAPIUser(),
+			ApplicationInstallation: test.GenApiApplicationInstallationWithValues("app1", test.GenDefaultCluster().Name, app1TargetNamespace),
+			ExpectedHTTPStatusCode:  http.StatusCreated,
+			ExpectedNamespaces:      []string{app1TargetNamespace},
+			ExpectedResponse: func() *apiv2.ApplicationInstallation {
+				ai := test.GenApiApplicationInstallationWithValuesBlock("app1", test.GenDefaultCluster().Name, app1TargetNamespace)
+				ai.ID = ""
+				return ai
+			}(),
+		},
 	}
 
 	for _, tc := range testcases {
@@ -500,7 +518,7 @@ func TestUpdateApplicationInstallation(t *testing.T) {
 						Name:    "sample-app",
 						Version: "1.0.0",
 					},
-					Values: *test.CreateRawVariables(t, map[string]interface{}{"key": "val"}),
+					ValuesBlock: "key: val\n", // we expect ValuesBlock to be filled since Values are being converted
 				},
 				Status: &apiv2.ApplicationInstallationStatus{},
 			},

--- a/modules/api/pkg/handler/v2/application_installation/conversion.go
+++ b/modules/api/pkg/handler/v2/application_installation/conversion.go
@@ -48,6 +48,7 @@ func convertInternalToAPIApplicationInstallation(in *appskubermaticv1.Applicatio
 			ReconciliationInterval: in.Spec.ReconciliationInterval,
 			DeployOptions:          in.Spec.DeployOptions,
 			Values:                 in.Spec.Values,
+			ValuesBlock:            in.Spec.ValuesBlock,
 		},
 		Status: &apiv2.ApplicationInstallationStatus{
 			ApplicationVersion: in.Status.ApplicationVersion,
@@ -119,6 +120,7 @@ func convertAPItoInternalApplicationInstallationBody(app *apiv2.ApplicationInsta
 			ReconciliationInterval: app.Spec.ReconciliationInterval,
 			DeployOptions:          app.Spec.DeployOptions,
 			Values:                 app.Spec.Values,
+			ValuesBlock:            app.Spec.ValuesBlock,
 		},
 	}
 }

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/application_installation_spec.go
@@ -18,6 +18,9 @@ import (
 // swagger:model ApplicationInstallationSpec
 type ApplicationInstallationSpec struct {
 
+	// ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
+	ValuesBlock string `json:"valuesBlock,omitempty"`
+
 	// application ref
 	ApplicationRef *ApplicationRef `json:"applicationRef,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds makes the new fields valuesBlock and defaultValuesBlock of AppInstalls and AppDefs available in the api. In addition on POST & PUT requests for AppInstalls/AppDefs the values/defaultValues fields are being converted to their valuesBlock/defaultValuesBlock equivalent.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12941

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
valuesBlock and defaultValuesBlock fields are now available via the api
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
