### PR TITLE
Fix handling of cloud credentials for vSphere when editting provider

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/template.html
@@ -41,23 +41,38 @@ limitations under the License.
     </mat-error>
   </mat-form-field>
 
-  <mat-form-field fxFlex>
-    <mat-label>VSphere Cloud Provider Username</mat-label>
-    <input matInput
-           [formControlName]="Control.InfraManagementUsername"
-           type="text"
-           autocomplete="off"
-           required
-           kmValueChangedIndicator />
-  </mat-form-field>
+  <mat-checkbox [formControlName]="Control.UseCustomCloudCredentials"
+                [name]="Control.UseCustomCloudCredentials">
+    <div fxLayoutAlign=" center"
+         fxLayoutGap="5px">
+      <span>Use dedicated credentials to provision vSphere resources</span>
+      <i class="km-icon-info km-pointer"
+         matTooltip="These credentials will be used for managing resources like tags, folders, networks etc. For cloud provider functionality i.e. external CCM and CSI drivers, the credentials specified above will be used."></i>
+    </div>
+  </mat-checkbox>
 
-  <mat-form-field fxFlex>
-    <mat-label>VSphere Cloud Provider Password</mat-label>
-    <input matInput
-           [formControlName]="Control.InfraManagementPassword"
-           kmInputPassword
-           autocomplete="off"
-           required
-           kmValueChangedIndicator />
-  </mat-form-field>
+  <mat-card-header class="km-no-padding"
+                   *ngIf="useCustomCloudCredentials">
+    <mat-card-title>Credentials for provisioning vSphere resources</mat-card-title>
+  </mat-card-header>
+
+  <ng-container *ngIf="useCustomCloudCredentials">
+    <mat-form-field fxFlex>
+      <mat-label>VSphere Cloud Provider Username</mat-label>
+      <input matInput
+             [formControlName]="Control.InfraManagementUsername"
+             type="text"
+             autocomplete="off"
+             kmValueChangedIndicator />
+    </mat-form-field>
+
+    <mat-form-field fxFlex>
+      <mat-label>VSphere Cloud Provider Password</mat-label>
+      <input matInput
+             [formControlName]="Control.InfraManagementPassword"
+             kmInputPassword
+             autocomplete="off"
+             kmValueChangedIndicator />
+    </mat-form-field>
+  </ng-container>
 </form>


### PR DESCRIPTION
**What this PR does / why we need it**:
Infra management credentials should not be "required" as they are optional credentials. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6550

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vSphere: fix a bug where dedicated credentials were incorrectly being required as mandatory input when editing provider settings for a cluster
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
