### PR TITLE
Set replicas to 1 when edge provider is used

### DIFF
--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	semverlib "github.com/Masterminds/semver/v3"
-	"github.com/aws/smithy-go/ptr"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
@@ -40,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -155,7 +155,7 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	}
 
 	if string(config.CloudProvider) == string(kubermaticv1.EdgeCloudProvider) {
-		md.Spec.Replicas = ptr.Int32(1)
+		md.Spec.Replicas = ptr.To(int32(1))
 
 		md.Status = clusterv1alpha1.MachineDeploymentStatus{
 			ObservedGeneration: 1,

--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	semverlib "github.com/Masterminds/semver/v3"
+	"github.com/aws/smithy-go/ptr"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
@@ -151,6 +152,10 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	config, err := getProviderConfig(c, nd, dc, keys)
 	if err != nil {
 		return nil, err
+	}
+
+	if string(config.CloudProvider) == string(kubermaticv1.EdgeCloudProvider) {
+		md.Spec.Replicas = ptr.Int32(0)
 	}
 
 	err = getProviderOS(config, nd)

--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -155,7 +155,15 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	}
 
 	if string(config.CloudProvider) == string(kubermaticv1.EdgeCloudProvider) {
-		md.Spec.Replicas = ptr.Int32(0)
+		md.Spec.Replicas = ptr.Int32(1)
+
+		md.Status = clusterv1alpha1.MachineDeploymentStatus{
+			ObservedGeneration: 1,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			ReadyReplicas:      1,
+			AvailableReplicas:  1,
+		}
 	}
 
 	err = getProviderOS(config, nd)


### PR DESCRIPTION
**What this PR does / why we need it**:
The edge provider is not supported by machine controller by design since it doesn't play any role in the node lifecycle. Thus the replica should be set to 1 and the status should be also updated.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
