### PR TITLE
update to Go 1.22.1

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
           command:
             - "./hack/ci/run-api-e2e.sh"
           env:
@@ -60,7 +60,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-5
           command:
             - make
           args:
@@ -81,7 +81,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-5
           command:
             - make
             - api-lint
@@ -101,7 +101,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-5
           command:
             - make
             - api-verify

--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
           command:
             - ./hack/ci/verify.sh
           resources:

--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -43,7 +43,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.6.2
+        - image: quay.io/kubermatic/chrome-headless:v1.6.4
           imagePullPolicy: Always
           command:
             - make
@@ -98,7 +98,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.6.2
+        - image: quay.io/kubermatic/chrome-headless:v1.6.4
           imagePullPolicy: Always
           command:
             - make
@@ -133,7 +133,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.6.2
+        - image: quay.io/kubermatic/chrome-headless:v1.6.4
           imagePullPolicy: Always
           command:
             - make
@@ -161,7 +161,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.6.2
+        - image: quay.io/kubermatic/chrome-headless:v1.6.4
           imagePullPolicy: Always
           command:
             - make
@@ -189,7 +189,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.6.2
+        - image: quay.io/kubermatic/chrome-headless:v1.6.4
           command:
             - make
             - web-test-headless
@@ -215,7 +215,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
           command:
             - make
             - web-check-dependencies
@@ -231,7 +231,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-5
           command:
             - make
             - web-lint
@@ -251,7 +251,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
           command:
             - make
             - web-check

--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -44,7 +44,7 @@ RUN apk add --no-cache -U \
   bash \
   bash-completion \
   ca-certificates \
-   'curl>=8.4.0-r0' \
+  'curl>=8.4.0-r0' \
   fzf-bash-plugin \
   git \
   jq \

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-2 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-5 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/modules/api/hack/gen-api-client.sh
+++ b/modules/api/hack/gen-api-client.sh
@@ -24,7 +24,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=golang:1.22.0 containerize ./modules/api/hack/gen-api-client.sh
+CONTAINERIZE_IMAGE=golang:1.22.1 containerize ./modules/api/hack/gen-api-client.sh
 
 cd $API/cmd/kubermatic-api/
 SWAGGER_FILE="swagger.json"

--- a/modules/api/hack/update-swagger.sh
+++ b/modules/api/hack/update-swagger.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-2 containerize ./$API/hack/update-swagger.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-5 containerize ./$API/hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd $API/cmd/kubermatic-api/

--- a/modules/api/hack/verify-licenses.sh
+++ b/modules/api/hack/verify-licenses.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-2 containerize ./$API/hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-5 containerize ./$API/hack/verify-licenses.sh
 
 cd $API
 go mod vendor

--- a/modules/web/containers/chrome-headless/Dockerfile
+++ b/modules/web/containers/chrome-headless/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+FROM quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
 
 LABEL maintainer="support@kubermatic.com"
 

--- a/modules/web/containers/chrome-headless/release.sh
+++ b/modules/web/containers/chrome-headless/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v1.6.3
+TAG=v1.6.4
 
 set -euo pipefail
 

--- a/modules/web/containers/custom-dashboard/Dockerfile
+++ b/modules/web/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.22-node-18-kind-0.21-2
+FROM quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps KKP to Go 1.22.1, which comes with some important fixes: https://groups.google.com/g/golang-announce/c/Fm51GRLNRvM/m/F5bwBlXMAQAJ

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update to Go 1.22.1
```

**Documentation**:
```documentation
NONE
```
