### PR TITLE
bump to future KKP 2.25.0-beta.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.0-beta.2
+KUBERMATIC_VERSION?=v2.25.0-beta.3
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.0-beta.2
+KUBERMATIC_VERSION?=v2.25.0-beta.3
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,7 +70,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.2
-	k8c.io/kubermatic/v2 v2.25.0-beta.1.0.20240229065858-93a0c895930d
+	k8c.io/kubermatic/v2 v2.25.0-beta.2.0.20240307093143-78167a41ac15
 	k8c.io/operating-system-manager v1.4.1-0.20231210203405-28d391f034d8
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.29.1
@@ -106,7 +106,7 @@ replace (
 replace (
 	github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
 	github.com/google/cel-go => github.com/google/cel-go v0.17.7
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.25.0-beta.1.0.20240229065858-93a0c895930d
+	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.25.0-beta.2.0.20240307093143-78167a41ac15
 )
 
 require (

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -2378,8 +2378,8 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.25.0-beta.1.0.20240229065858-93a0c895930d h1:ThBSr6CVGNOJHRsA+ZF4keTWsIEmwqsCP0KLDwMChjk=
-k8c.io/kubermatic/v2 v2.25.0-beta.1.0.20240229065858-93a0c895930d/go.mod h1:IbTYYwdIT5KxmQEfOpd34Zu+MLHXrc61Sajm5jBob9M=
+k8c.io/kubermatic/v2 v2.25.0-beta.2.0.20240307093143-78167a41ac15 h1:n4IJl2Cog14nerSFkiQZc9zLtK/l3fuZj97eStDm9W0=
+k8c.io/kubermatic/v2 v2.25.0-beta.2.0.20240307093143-78167a41ac15/go.mod h1:IbTYYwdIT5KxmQEfOpd34Zu+MLHXrc61Sajm5jBob9M=
 k8c.io/operating-system-manager v1.4.1-0.20231210203405-28d391f034d8 h1:d5S2/7BQP2EJBTY1Fxl7IcXC0YhSH8iBqsfuWjpMX5A=
 k8c.io/operating-system-manager v1.4.1-0.20231210203405-28d391f034d8/go.mod h1:d/efJngp0rd2xx23JnOQhfAWBtY9nl2fp4QBrCIv2DA=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.0-beta.2
+KUBERMATIC_VERSION?=v2.25.0-beta.3
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.25.0-beta.2",
+  "version": "2.25.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.25.0-beta.2",
+      "version": "2.25.0-beta.3",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.25.0-beta.2",
+  "version": "2.25.0-beta.3",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps KKP to the version I'm going to tag as beta.3 after this PR got merged.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Bump KKP for v2.25.0-beta.3
```

**Documentation**:
```documentation
NONE
```
