### PR TITLE
add valuesblock to api type used by cluster generation

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -27559,9 +27559,14 @@
           "$ref": "#/definitions/NamespaceSpec"
         },
         "values": {
-          "description": "Values describe overrides for manifest-rendering",
+          "description": "Values specify values overrides that are passed to helm templating. Comments are not preserved.\nDeprecated: Use ValuesBlock instead.",
           "type": "object",
           "x-go-name": "Values"
+        },
+        "valuesBlock": {
+          "description": "ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.",
+          "type": "string",
+          "x-go-name": "ValuesBlock"
         }
       },
       "x-go-package": "k8c.io/dashboard/v2/pkg/api/v1"

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -2650,8 +2650,12 @@ type ApplicationSpec struct {
 	// ApplicationRef is a reference to identify which Application should be deployed
 	ApplicationRef ApplicationRef `json:"applicationRef"`
 
-	// Values describe overrides for manifest-rendering
+	// Values specify values overrides that are passed to helm templating. Comments are not preserved.
+	// Deprecated: Use ValuesBlock instead.
 	Values json.RawMessage `json:"values,omitempty"`
+
+	// ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
+	ValuesBlock string `json:"valuesBlock,omitempty"`
 }
 
 // NamespaceSpec describe the desired state of the namespace where application will be created.

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/application_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/application_spec.go
@@ -18,8 +18,12 @@ import (
 // swagger:model ApplicationSpec
 type ApplicationSpec struct {
 
-	// Values describe overrides for manifest-rendering
+	// Values specify values overrides that are passed to helm templating. Comments are not preserved.
+	// Deprecated: Use ValuesBlock instead.
 	Values interface{} `json:"values,omitempty"`
+
+	// ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
+	ValuesBlock string `json:"valuesBlock,omitempty"`
 
 	// application ref
 	ApplicationRef *ApplicationRef `json:"applicationRef,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where the valuesBlock field did not get rendered in the clusters' `kubermatic.io/initial-application-installations-request` annotation.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
