### PR TITLE
Enable web terminal button when at least one MD replica is ready

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/component.ts
@@ -61,7 +61,6 @@ import {
   HealthStatus,
   StatusMassage,
   getClusterHealthStatus,
-  getMachineDeploymentHealthStatus,
   isClusterAPIRunning,
   isClusterRunning,
   isOPARunning,
@@ -626,7 +625,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     if (this.machineDeployments?.length) {
       return (
         this.machineDeployments.some(
-          (md: MachineDeployment) => getMachineDeploymentHealthStatus(md)?.message === StatusMassage.Running
+          (md: MachineDeployment) => !md.deletionTimestamp && md.status.availableReplicas > 0
         ) && !this.isDeletingState
       );
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable web terminal button when at least one MD replica is ready.

![screenshot-localhost_8000-2024 03 08-20_52_16](https://github.com/kubermatic/dashboard/assets/13975988/81f162f1-5ede-46d9-9d2c-55b5539ed7b4)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6601 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable web terminal button when at least one MD replica is ready.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
