### PR TITLE
Revert the machine deployment status

### DIFF
--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -117,10 +117,6 @@ func CreateMachineDeployment(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, fmt.Errorf("failed to create machine deployment: %w", err)
 	}
 
-	if err := client.Status().Patch(ctx, md, ctrlruntimeclient.Merge); err != nil {
-		return nil, fmt.Errorf("failed to update machine deployment status: %w", err)
-	}
-
 	return OutputMachineDeployment(md)
 }
 
@@ -565,10 +561,6 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 	machineDeployment.Spec.Template.Spec = patchedMachineDeployment.Spec.Template.Spec
 	machineDeployment.Spec.Replicas = patchedMachineDeployment.Spec.Replicas
 	machineDeployment.Spec.Paused = patchedMachineDeployment.Spec.Paused
-
-	if err := client.Status().Patch(ctx, machineDeployment, ctrlruntimeclient.Merge); err != nil {
-		return nil, fmt.Errorf("failed to update machine deployment status: %w", err)
-	}
 
 	if err := client.Update(ctx, machineDeployment); err != nil {
 		return nil, fmt.Errorf("failed to update machine deployment: %w", err)

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -117,6 +117,10 @@ func CreateMachineDeployment(ctx context.Context, userInfoGetter provider.UserIn
 		return nil, fmt.Errorf("failed to create machine deployment: %w", err)
 	}
 
+	if err := client.Status().Patch(ctx, md, ctrlruntimeclient.Merge); err != nil {
+		return nil, fmt.Errorf("failed to update machine deployment status: %w", err)
+	}
+
 	return OutputMachineDeployment(md)
 }
 
@@ -561,6 +565,10 @@ func PatchMachineDeployment(ctx context.Context, userInfoGetter provider.UserInf
 	machineDeployment.Spec.Template.Spec = patchedMachineDeployment.Spec.Template.Spec
 	machineDeployment.Spec.Replicas = patchedMachineDeployment.Spec.Replicas
 	machineDeployment.Spec.Paused = patchedMachineDeployment.Spec.Paused
+
+	if err := client.Status().Patch(ctx, machineDeployment, ctrlruntimeclient.Merge); err != nil {
+		return nil, fmt.Errorf("failed to update machine deployment status: %w", err)
+	}
 
 	if err := client.Update(ctx, machineDeployment); err != nil {
 		return nil, fmt.Errorf("failed to update machine deployment: %w", err)

--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -160,18 +159,6 @@ func Deployment(ctx context.Context, c *kubermaticv1.Cluster, nd *apiv1.NodeDepl
 	config, err := getProviderConfig(c, nd, dc, keys)
 	if err != nil {
 		return nil, err
-	}
-
-	if string(config.CloudProvider) == string(kubermaticv1.EdgeCloudProvider) {
-		md.Spec.Replicas = ptr.To(int32(1))
-
-		md.Status = clusterv1alpha1.MachineDeploymentStatus{
-			ObservedGeneration: 1,
-			Replicas:           1,
-			UpdatedReplicas:    1,
-			ReadyReplicas:      1,
-			AvailableReplicas:  1,
-		}
 	}
 
 	err = getProviderOS(config, nd)


### PR DESCRIPTION
**What this PR does / why we need it**:
For the edge provider, the machine deployment replicas should be ignored as it plays no role at all. This PR remove the update of the machine deployment status replicas.  
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
