### PR TITLE
Hide the update available icon when there is no updates

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/machine-deployment-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/machine-deployment-list/template.html
@@ -38,7 +38,8 @@ limitations under the License.
       </mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <div *ngIf="!!cluster.spec.cloud.edge" class="kubeadm-manual">
+      <div *ngIf="!!cluster.spec.cloud.edge"
+           class="kubeadm-manual">
         To interact with cluster pods (reading logs, exec into containers, etc…), cluster CSRs must be approved manually per worker node:
         <div class="km-code-block km-copy"
              fxLayoutAlign=" center"

--- a/modules/web/src/app/cluster/details/shared/version-change-dialog/component.ts
+++ b/modules/web/src/app/cluster/details/shared/version-change-dialog/component.ts
@@ -17,7 +17,6 @@ import {MatDialogRef} from '@angular/material/dialog';
 import {GoogleAnalyticsService} from '@app/google-analytics.service';
 import {ClusterService} from '@core/services/cluster';
 import {MachineDeploymentService} from '@core/services/machine-deployment';
-import {EndOfLifeService} from '@core/services/eol';
 import {NotificationService} from '@core/services/notification';
 import {ProjectService} from '@core/services/project';
 import {Cluster, ClusterPatch, END_OF_POD_SECURITY_POLICY_SUPPORT_VERSION} from '@shared/entity/cluster';
@@ -37,6 +36,7 @@ export class VersionChangeDialogComponent implements OnInit, OnDestroy {
   @Input() versions: string[] = [];
   @Input() hasVersionOptions = true;
   @Input() isClusterExternal = false;
+  @Input() hasAvailableUpdates = false;
 
   private readonly _PSPAdmissionPlugin = 'PodSecurityPolicy';
 
@@ -67,13 +67,12 @@ export class VersionChangeDialogComponent implements OnInit, OnDestroy {
     private readonly _machineDeploymentService: MachineDeploymentService,
     private readonly _dialogRef: MatDialogRef<VersionChangeDialogComponent>,
     private readonly _notificationService: NotificationService,
-    private readonly _eolService: EndOfLifeService,
     private readonly _googleAnalyticsService: GoogleAnalyticsService
   ) {}
 
   ngOnInit(): void {
     if (this.versions.length > 0) {
-      this.selectedVersion = this.versions[this.versions.length - 1];
+      this.selectedVersion = this.versions[0];
     }
 
     this._projectService.selectedProject
@@ -155,12 +154,5 @@ export class VersionChangeDialogComponent implements OnInit, OnDestroy {
           `Updating the machine deployments version to the ${this.selectedVersion} for the ${this.cluster.name} cluster`
         );
       });
-  }
-
-  isClusterDeprecated(): boolean {
-    return (
-      this._eolService.cluster.isAfter(this.cluster.spec.version) ||
-      this._eolService.cluster.isBefore(this.cluster.spec.version)
-    );
   }
 }

--- a/modules/web/src/app/cluster/details/shared/version-change-dialog/template.html
+++ b/modules/web/src/app/cluster/details/shared/version-change-dialog/template.html
@@ -17,7 +17,7 @@ limitations under the License.
   <div fxLayout="row inline"
        fxLayoutAlign=" center">
     <span>Change Control Plane Version</span>
-    <div *ngIf="!isClusterDeprecated() && hasVersionOptions"
+    <div *ngIf="hasAvailableUpdates && hasVersionOptions"
          class="km-update-available-badge">
       <i class="km-icon-update-available-arrow"></i>
       <span>Update Available</span>

--- a/modules/web/src/app/cluster/details/shared/version-picker/component.ts
+++ b/modules/web/src/app/cluster/details/shared/version-picker/component.ts
@@ -100,8 +100,9 @@ export class VersionPickerComponent implements OnInit, OnChanges {
       const modal = this._matDialog.open(VersionChangeDialogComponent);
       modal.componentInstance.cluster = this.cluster;
       modal.componentInstance.isClusterExternal = this.isClusterExternal;
-      modal.componentInstance.versions = this.versionsList;
+      modal.componentInstance.versions = this.versionsList.reverse();
       modal.componentInstance.hasVersionOptions = this.hasUpgradeOptions;
+      modal.componentInstance.hasAvailableUpdates = this.hasAvailableUpdates();
       modal
         .afterClosed()
         .pipe(take(1))

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -781,7 +781,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   private _setDefaultVersion(versions: MasterVersion[]): void {
-    this.masterVersions = versions;
+    this.masterVersions = versions.reverse();
 
     if (this._clusterSpecService.cluster.spec.version) {
       this.control(Controls.Version).setValue(this._clusterSpecService.cluster.spec.version);


### PR DESCRIPTION
**What this PR does / why we need it**:
In cluster version change dialog, sort the versions list in descending order and hide the update available icon when there is no updates.

![image](https://github.com/kubermatic/dashboard/assets/85109141/617e9a0a-152e-488c-b668-3c6063927fd8)

**Which issue(s) this PR fixes**:
Fixes #6524 

**What type of PR is this?**
/kind design


```release-note
NONE
```

```documentation
NONE
```
