### PR TITLE
[release/v2.24] bump for 2.24.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.24.4
+KUBERMATIC_VERSION?=v2.24.5
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.24.4
+KUBERMATIC_VERSION?=v2.24.5
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -67,7 +67,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.0
-	k8c.io/kubermatic/v2 v2.24.4-0.20240226075556-2f688feae54f
+	k8c.io/kubermatic/v2 v2.24.5-0.20240321103009-9653c6d3142b
 	k8c.io/operating-system-manager v1.4.1
 	k8c.io/reconciler v0.4.0
 	k8s.io/api v0.28.2
@@ -100,10 +100,7 @@ replace (
 	k8s.io/metrics => k8s.io/metrics v0.28.2
 )
 
-replace (
-	github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.24.4-0.20240226075556-2f688feae54f
-)
+replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
 
 require (
 	cloud.google.com/go/compute v1.23.0 // indirect

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1425,8 +1425,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.0 h1:HDUHcGZWw8v2cN1KWmeUfXVquppqlQLmDgMZdWfg1hA=
 k8c.io/kubeone v1.7.0/go.mod h1:v/rybawEit3+HXPOtHyFyww0laqGzcxL0EJmdiJqQNo=
-k8c.io/kubermatic/v2 v2.24.4-0.20240226075556-2f688feae54f h1:B7sgj7nuEIlbvOlzg2wUYq0YsAbppgM/42rOfLubLE0=
-k8c.io/kubermatic/v2 v2.24.4-0.20240226075556-2f688feae54f/go.mod h1:PUzG0zBBA4BArWSonWFAJLyhGsEJdeK9KtbXT2kADTI=
+k8c.io/kubermatic/v2 v2.24.5-0.20240321103009-9653c6d3142b h1:bRB+utUOYjrUM69+DgDnMFbJxIBOGpOgG+/7JRhdkE8=
+k8c.io/kubermatic/v2 v2.24.5-0.20240321103009-9653c6d3142b/go.mod h1:PUzG0zBBA4BArWSonWFAJLyhGsEJdeK9KtbXT2kADTI=
 k8c.io/operating-system-manager v1.4.1 h1:hUL6YA1h2i0IpiobohsQuIbsz7vDRNsKGEZuO/loPpo=
 k8c.io/operating-system-manager v1.4.1/go.mod h1:4buJRqOn406AYiQ7FGs4tXaySgb6Ro6Hffp6gu6FHY8=
 k8c.io/reconciler v0.4.0 h1:movw1R8Q0/JC8S+d6eq9si5PvLFbX3A0x8yaDlxuFn4=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.24.4
+KUBERMATIC_VERSION?=v2.24.5
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.24.4",
+  "version": "2.24.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.24.2",
+      "version": "2.24.5",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.24.4",
+  "version": "2.24.5",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the KKP dependency to the latest 2.24 revision.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
