### PR TITLE
[release/v2.23] bump for 2.23.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.23.11
+KUBERMATIC_VERSION?=v2.23.12
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.23.11
+KUBERMATIC_VERSION?=v2.23.12
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -67,7 +67,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.6.2
-	k8c.io/kubermatic/v2 v2.23.11-0.20240215191743-318262868e91
+	k8c.io/kubermatic/v2 v2.23.12-0.20240308125543-beee0fc940e5
 	k8c.io/operating-system-manager v1.3.4
 	k8c.io/reconciler v0.3.1
 	k8s.io/api v0.26.4
@@ -100,10 +100,7 @@ replace (
 	k8s.io/metrics => k8s.io/metrics v0.26.2
 )
 
-replace (
-	github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
-	k8c.io/kubermatic/v2 => k8c.io/kubermatic/v2 v2.23.11-0.20240215191743-318262868e91
-)
+replace github.com/ajeddeloh/go-json => github.com/coreos/go-json v0.0.0-20220810161552-7cce03887f34
 
 require (
 	cloud.google.com/go/compute v1.18.0 // indirect

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1367,8 +1367,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.6.2 h1:3oEvD90kENhYzvvmSrMNjUam2fq7UMMKVp/Py57xs6M=
 k8c.io/kubeone v1.6.2/go.mod h1:5U/6sUZAkAl7uvC+VIDIA0VBZMBbFI9QD1C90kxb4qA=
-k8c.io/kubermatic/v2 v2.23.11-0.20240215191743-318262868e91 h1:UFlagoxtUZqMR4CPGktnP/kJDIJJaVqrt1MEoGgdAi4=
-k8c.io/kubermatic/v2 v2.23.11-0.20240215191743-318262868e91/go.mod h1:1db/9/QzRMKLiNZ//cSP5oPx3Cbs4kfY/hCSRhGFWLI=
+k8c.io/kubermatic/v2 v2.23.12-0.20240308125543-beee0fc940e5 h1:LJLmjTG932hPp8Hlvcoa5VxEnTg1z39DH6uVaSra1sE=
+k8c.io/kubermatic/v2 v2.23.12-0.20240308125543-beee0fc940e5/go.mod h1:1db/9/QzRMKLiNZ//cSP5oPx3Cbs4kfY/hCSRhGFWLI=
 k8c.io/operating-system-manager v1.3.4 h1:wNGCXZ+UyaLDJNprBv9P2RSNeO8ecsk54kbJD7vxET8=
 k8c.io/operating-system-manager v1.3.4/go.mod h1:kKDzXLWrC5BLpDbgXQFRpTVa5Fjru2S3ylxX5hZMRKA=
 k8c.io/reconciler v0.3.1 h1:fZ8gFvrDxjsJ6jdKogZVX9Er980EDUYnVPuOna32d0k=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.23.11
+KUBERMATIC_VERSION?=v2.23.12
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.23.11",
+  "version": "2.23.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.23.10",
+      "version": "2.23.12",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.23.11",
+  "version": "2.23.12",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the KKP dependency to the latest 2.23 revision.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
