### PR TITLE
migrate mat-radio component to v15

### DIFF
--- a/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/style.scss
+++ b/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/style.scss
@@ -26,13 +26,6 @@ label {
   }
 }
 
-// TODO(mdc-migration): The following rule targets internal classes of radio that may no longer apply for the MDC version. */
-mat-radio-group {
-  mat-hint {
-    bottom: 8px;
-    font-size: variables.$font-size-caption;
-    left: 15px;
-    position: relative;
-    width: 90%;
-  }
+.km-radio-button-title{
+  margin-bottom: 5px;
 }

--- a/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
+++ b/modules/web/src/app/external-cluster-wizard/steps/external-cluster/provider/gke/template.html
@@ -78,16 +78,16 @@ limitations under the License.
         <mat-radio-button [value]="KubernetesVersionMode.StaticVersion"
                           class="km-radio-button">
           <div class="km-radio-button-title">Static Version</div>
+          <div class="km-radio-button-description">Manually manage the version upgrades,
+            GKE will only upgrade the control plane and nodes
+            if it's necessary to maintain security and compatibility.
+          </div>
         </mat-radio-button>
-        <mat-hint>Manually manage the version upgrades,
-          GKE will only upgrade the control plane and nodes
-          if it's necessary to maintain security and compatibility.
-        </mat-hint>
         <mat-radio-button [value]="KubernetesVersionMode.ReleaseChannel"
                           class="km-radio-button">
           <div class="km-radio-button-title">Release Channel</div>
+          <div class="km-radio-button-description">Let GKE automatically manage the cluster's control plane version.</div>
         </mat-radio-button>
-        <mat-hint>Let GKE automatically manage the cluster's control plane version.</mat-hint>
 
         <km-select *ngIf="form.get(Controls.KubernetesVersionMode).value === KubernetesVersionMode.ReleaseChannel"
                    label="Release Channel"

--- a/modules/web/src/app/shared/directives/value-changed-indicator.ts
+++ b/modules/web/src/app/shared/directives/value-changed-indicator.ts
@@ -53,7 +53,7 @@ export class ValueChangedIndicatorDirective implements OnInit {
       this._initialValue = this._control.control.value === null ? false : this._control.control.value;
     }
 
-    if (classList.includes('mat-radio-group')) {
+    if (classList.includes('mat-mdc-radio-group')) {
       element.classList.toggle('radio-group-column', element.style.flexDirection === 'column');
     }
 

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -584,14 +584,6 @@ km-dashboard {
   }
 }
 
-.km-radio-group {
-  // TODO(mdc-migration): The following rule targets internal classes of radio that may no longer apply for the MDC version. */
-  .mat-radio-container {
-    align-self: flex-start;
-    margin-top: 2px;
-  }
-}
-
 .km-radio-group-label {
   font-weight: 500;
   padding: 12px 0;
@@ -599,6 +591,10 @@ km-dashboard {
 
 .km-radio-button {
   padding-bottom: 15px;
+}
+
+.mdc-radio {
+  padding: 0 5px 0 0 !important;
 }
 
 .km-radio-button-title {
@@ -781,19 +777,19 @@ km-cni-version {
   }
 
   &.radio-group-column {
-    // TODO(mdc-migration): The following rule targets internal classes of radio that may no longer apply for the MDC version. */
     .mat-mdc-radio-checked {
-      position: relative;
+      .mdc-radio{
+        position: relative;
 
-      &::after {
-        border-bottom-left-radius: variables.$border-radius;
-        border-top-left-radius: variables.$border-radius;
-        content: '';
-        height: 33%;
-        left: -12px;
-        position: absolute;
-        top: 2px;
-        width: 5px;
+        &::after {
+          border-bottom-left-radius: variables.$border-radius;
+          border-top-left-radius: variables.$border-radius;
+          content: '';
+          height: 100%;
+          left: -12px;
+          position: absolute;
+          width: 5px;
+        }
       }
     }
   }

--- a/modules/web/src/assets/css/global/_theme.scss
+++ b/modules/web/src/assets/css/global/_theme.scss
@@ -355,9 +355,8 @@
     }
   }
 
-  .radio-group-column {
-    // TODO(mdc-migration): The following rule targets internal classes of radio that may no longer apply for the MDC version. */
-    .mat-mdc-radio-checked::after {
+  .mat-mdc-radio-checked {
+    .mdc-radio::after {
       background-color: map.get($colors, primary);
     }
   }

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -797,12 +797,6 @@ mat-tooltip-component .mat-mdc-tooltip {
   }
 }
 
-// Radio button.
-// TODO(mdc-migration): The following rule targets internal classes of radio that may no longer apply for the MDC version.*/
-.mdc-label {
-  flex: 1 1 auto;
-}
-
 .mat-mdc-optgroup .mat-mdc-option:not(.mat-mdc-option-multiple) {
   padding-left: 16px !important;
 }

--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -318,20 +318,12 @@
 
   .mat-mdc-radio-button {
     &.mat-accent {
-      // TODO(mdc-migration): The following rule targets internal classes of radio that may no longer apply for the MDC version. */
-      .mat-radio-ripple {
-        .mat-ripple-element {
-          background-color: map.get($colors, primary);
-        }
-      }
-
-      .mdc-radio__inner-circle {
-        background-color: map.get($colors, primary);
-      }
-
-      &.mat-mdc-radio-checked .mdc-radio__outer-circle {
-        border-color: map.get($colors, primary);
-      }
+      --mdc-radio-selected-icon-color: #{map.get($colors, primary)};
+      --mat-radio-checked-ripple-color: none;
+      --mdc-radio-selected-pressed-icon-color: var(--mdc-radio-selected-icon-color);
+      --mdc-radio-selected-hover-icon-color: var(--mdc-radio-selected-icon-color);
+      --mdc-radio-selected-focus-icon-color: var(--mdc-radio-selected-icon-color);
+      --mdc-radio-unselected-icon-color:#{map.get($colors, text-secondary)};
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
migrates Angular Material Radio components from legacy to v15.
**Which issue(s) this PR fixes**:
xref #5864 

**What type of PR is this?**
/kind chore

```release-note
NONE
```

```documentation
NONE
```
