### PR TITLE
api: don't construct upgrade conditions, use KKP logic instead

### DIFF
--- a/modules/api/pkg/handler/common/upgrade.go
+++ b/modules/api/pkg/handler/common/upgrade.go
@@ -34,6 +34,7 @@ import (
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 	"k8c.io/kubermatic/v2/pkg/version"
+	clusterversion "k8c.io/kubermatic/v2/pkg/version/cluster"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,13 +67,6 @@ func GetUpgradesEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGe
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the cloud provider name: %w", err)
 	}
-	var updateConditions []kubermaticv1.ConditionType
-	externalCloudProvider := cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]
-	if externalCloudProvider {
-		updateConditions = append(updateConditions, kubermaticv1.ExternalCloudProviderCondition)
-	} else {
-		updateConditions = append(updateConditions, kubermaticv1.InTreeCloudProviderCondition)
-	}
 
 	config, err := configGetter(ctx)
 	if err != nil {
@@ -81,7 +75,7 @@ func GetUpgradesEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGe
 
 	versionManager := version.NewFromConfiguration(config)
 
-	versions, err := versionManager.GetPossibleUpdates(cluster.Spec.Version.String(), kubermaticv1.ProviderType(providerName), updateConditions...)
+	versions, err := versionManager.GetPossibleUpdates(cluster.Spec.Version.String(), kubermaticv1.ProviderType(providerName), clusterversion.GetVersionConditions(&cluster.Spec)...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

It looks like the API code never used the logic provided by KKP to determine conditions that are used in decision-making on possible upgrade paths. This was changed in https://github.com/kubermatic/kubermatic/pull/13046, but the old logic was also not called (its logic seemed to be copy-pasted into the API code though), so the drift wasn't detected.

This PR removes the logic to determine conditions from the API code and instead just re-uses `k8c.io/kubermatic/v2/pkg/version/clusterGetVersionConditions`, as the KKP code does.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resolve conflict in determining available Kubernetes versions where upgrades where possible in `Cluster` object but not via the Dashboard
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
