### PR TITLE
Migrate card-chip component version 15

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -234,9 +234,9 @@ limitations under the License.
         Cluster Backup
         <i class="km-icon-info km-pointer"
            matTooltip="Enable create backups from this cluster"></i>
-        <mat-chip-row>
+        <mat-chip>
           <div>Experimental</div>
-        </mat-chip-row>
+        </mat-chip>
       </mat-checkbox>
 
       <mat-form-field *ngIf="!!form.get(Controls.ClusterBackup).value && isclusterBackupEnabled"

--- a/modules/web/src/app/cluster/details/cluster/node-list/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/node-list/style.scss
@@ -40,7 +40,6 @@ i.km-icon-warning {
   box-shadow: variables.$border-box-shadow-inset;
   padding: variables.$item-details-padding;
 
-  // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
   mat-card-content {
     border: none;
     margin-top: 15px;

--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -286,19 +286,19 @@ limitations under the License.
               <km-property *ngIf="element.spec.cloud.kubevirt.instancetype as instanceType">
                 <div key>Instance Type</div>
                 <div value>
-                  <mat-chip-row>
+                  <mat-chip>
                     <div>{{getKubeVirtInstanceTypeCategory(instanceType)}}</div>
                     <div class="km-chip-accent">{{instanceType.name}}</div>
-                  </mat-chip-row>
+                  </mat-chip>
                 </div>
               </km-property>
               <km-property *ngIf="element.spec.cloud.kubevirt.preference as preference">
                 <div key>Preference</div>
                 <div value>
-                  <mat-chip-row>
+                  <mat-chip>
                     <div>{{getKubeVirtPreferenceCategory(preference)}}</div>
                     <div class="km-chip-accent">{{preference.name}}</div>
-                  </mat-chip-row>
+                  </mat-chip>
                 </div>
               </km-property>
               <km-property>
@@ -330,13 +330,13 @@ limitations under the License.
               <km-property *ngIf="element.spec.cloud.kubevirt.topologySpreadConstraints?.length > 0">
                 <div key>Topology Spread Constraints</div>
                 <div value>
-                  <mat-chip-grid selectable="false">
-                    <mat-chip-row *ngFor="let constraint of element.spec.cloud.kubevirt.topologySpreadConstraints">
+                  <mat-chip-set selectable="false">
+                    <mat-chip *ngFor="let constraint of element.spec.cloud.kubevirt.topologySpreadConstraints">
                       <div>{{constraint.topologyKey}}</div>
                       <div class="km-chip-accent">{{constraint.maxSkew}}</div>
                       <div>{{constraint.whenUnsatisfiable}}</div>
-                    </mat-chip-row>
-                  </mat-chip-grid>
+                    </mat-chip>
+                  </mat-chip-set>
                 </div>
               </km-property>
             </ng-container>
@@ -372,13 +372,13 @@ limitations under the License.
             <km-property *ngIf="element.spec.cloud.anexia?.disks?.length > 0">
               <div key>Disks</div>
               <div value>
-                <mat-chip-grid selectable="false">
-                  <mat-chip-row *ngFor="let disk of element.spec.cloud.anexia.disks">
+                <mat-chip-set selectable="false">
+                  <mat-chip *ngFor="let disk of element.spec.cloud.anexia.disks">
                     <div>{{disk.size}}GB</div>
                     <div class="km-chip-accent"
                          *ngIf="disk.performanceType">{{disk.performanceType}}</div>
-                  </mat-chip-row>
-                </mat-chip-grid>
+                  </mat-chip>
+                </mat-chip-set>
               </div>
             </km-property>
             <km-property *ngIf="element.spec.cloud.anexia?.templateID">

--- a/modules/web/src/app/cluster/details/external-cluster/external-node-list/style.scss
+++ b/modules/web/src/app/cluster/details/external-cluster/external-node-list/style.scss
@@ -39,7 +39,6 @@ i.km-icon-info {
   box-shadow: variables.$border-box-shadow-inset;
   padding: variables.$item-details-padding;
 
-  // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
   mat-card-content {
     border: none;
     margin-top: 15px;

--- a/modules/web/src/app/cluster/details/external-cluster/template.html
+++ b/modules/web/src/app/cluster/details/external-cluster/template.html
@@ -157,25 +157,25 @@ limitations under the License.
           <km-property>
             <div key>Subnet Ids</div>
             <div value>
-              <mat-chip-grid *ngIf="subnetIds?.length">
+              <mat-chip-set *ngIf="subnetIds?.length">
                 <div *ngFor="let subnetId of subnetIds">
-                  <mat-chip-row>
+                  <mat-chip>
                     <div>{{subnetId}}</div>
-                  </mat-chip-row>
+                  </mat-chip>
                 </div>
-              </mat-chip-grid>
+              </mat-chip-set>
             </div>
           </km-property>
           <km-property>
             <div key>Security Group Ids</div>
             <div value>
-              <mat-chip-grid *ngIf="securityGroupIds?.length">
+              <mat-chip-set *ngIf="securityGroupIds?.length">
                 <div *ngFor="let securityGroupId of securityGroupIds">
-                  <mat-chip-row>
+                  <mat-chip>
                     <div>{{securityGroupId}}</div>
-                  </mat-chip-row>
+                  </mat-chip>
                 </div>
-              </mat-chip-grid>
+              </mat-chip-set>
             </div>
           </km-property>
           <km-property *ngIf="cluster.spec?.eksclusterSpec?.kubernetesNetworkConfig">

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
@@ -32,7 +32,6 @@
 }
 
 .namespaces-label {
-  display: inline-block;
   margin: 20px 0 20px 10px;
 }
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
@@ -226,10 +226,10 @@ END OF TERMS AND CONDITIONS
             [attr.colspan]="columns.length">
           <div class="namespaces-detail">Namespaces</div>
           <div>
-            <mat-chip-row *ngFor="let namespace of element.spec.includedNamespaces"
-                          class="namespaces-label">
+            <mat-chip *ngFor="let namespace of element.spec.includedNamespaces"
+                      class="namespaces-label">
               <div>{{namespace}}</div>
-            </mat-chip-row>
+            </mat-chip>
           </div>
         </td>
       </ng-container>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
@@ -28,7 +28,6 @@
 }
 
 .namespaces-label {
-  display: inline-block;
   margin: 20px 0 20px 10px;
 }
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/template.html
@@ -154,10 +154,10 @@ END OF TERMS AND CONDITIONS
             [attr.colspan]="columns.length">
           <div class="namespaces-detail">Namespaces</div>
           <div>
-            <mat-chip-row *ngFor="let namespace of element.spec.includedNamespaces"
-                          class="namespaces-label">
+            <mat-chip *ngFor="let namespace of element.spec.includedNamespaces"
+                      class="namespaces-label">
               <div>{{namespace}}</div>
-            </mat-chip-row>
+            </mat-chip>
           </div>
         </td>
       </ng-container>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/style.scss
@@ -32,7 +32,6 @@
 }
 
 .namespaces-label {
-  display: inline-block;
   margin: 20px 0 20px 10px;
 }
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/template.html
@@ -210,10 +210,10 @@ END OF TERMS AND CONDITIONS
             [attr.colspan]="columns.length">
           <div class="namespaces-detail">Namespaces</div>
           <div>
-            <mat-chip-row *ngFor="let namespace of element.spec.includedNamespaces"
-                          class="namespaces-label">
+            <mat-chip *ngFor="let namespace of element.spec.includedNamespaces"
+                      class="namespaces-label">
               <div>{{namespace}}</div>
-            </mat-chip-row>
+            </mat-chip>
           </div>
         </td>
       </ng-container>

--- a/modules/web/src/app/dynamic/enterprise/metering/legacy-reports/card/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/metering/legacy-reports/card/style.scss
@@ -20,7 +20,6 @@
 
 @use 'variables';
 
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.
 mat-card-header {
   cursor: pointer;
   height: 32px;
@@ -28,7 +27,6 @@ mat-card-header {
 }
 
 .toggled {
-  // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.
   mat-card-header {
     border-radius: variables.$border-radius;
   }

--- a/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/style.scss
@@ -96,7 +96,6 @@
       width: 270px;
     }
 
-    // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.
     mat-card-content {
       padding: 10px;
     }

--- a/modules/web/src/app/external-cluster-wizard/style.scss
+++ b/modules/web/src/app/external-cluster-wizard/style.scss
@@ -45,12 +45,7 @@
   }
 }
 
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-mat-card {
-  &.mat-mdc-card {
-    margin: 0;
-    padding: 16px 30px 30px;
-  }
+mat-card.mat-mdc-card {
+  margin: 0;
+  padding: 16px 30px 30px;
 }

--- a/modules/web/src/app/kubeone-wizard/style.scss
+++ b/modules/web/src/app/kubeone-wizard/style.scss
@@ -40,12 +40,7 @@
   }
 }
 
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-mat-card {
-  &.mat-mdc-card {
-    margin: 0;
-    padding: 16px 30px 30px;
-  }
+mat-card.mat-mdc-card {
+  margin: 0;
+  padding: 16px 30px 30px;
 }

--- a/modules/web/src/app/settings/admin/defaults/style.scss
+++ b/modules/web/src/app/settings/admin/defaults/style.scss
@@ -24,6 +24,10 @@
     min-width: 316px;
   }
 
+  .mat-mdc-chip {
+    top: 8px;
+  }
+
   .input {
     margin: 0 16px 0 0;
     width: 204px;

--- a/modules/web/src/app/settings/admin/defaults/template.html
+++ b/modules/web/src/app/settings/admin/defaults/template.html
@@ -222,9 +222,9 @@ limitations under the License.
                         [(ngModel)]="settings.enableClusterBackups"
                         (change)="onSettingsChange()">
           </mat-checkbox>
-          <mat-chip-row>
+          <mat-chip>
             <div>Experimental</div>
-          </mat-chip-row>
+          </mat-chip>
           <km-spinner-with-confirmation [isSaved]="isEqual(settings.enableClusterBackups, apiSettings.enableClusterBackups)"></km-spinner-with-confirmation>
         </div>
 

--- a/modules/web/src/app/shared/components/chip/template.html
+++ b/modules/web/src/app/shared/components/chip/template.html
@@ -13,6 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<mat-chip-grid>
-  <mat-chip-row class="km-{{type}}-bg">{{text}}</mat-chip-row>
-</mat-chip-grid>
+<mat-chip-set>
+  <mat-chip class="km-{{type}}-bg">{{text}}</mat-chip>
+</mat-chip-set>

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -826,19 +826,19 @@ limitations under the License.
               <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.instancetype as instanceType">
                 <div key>Instance Type</div>
                 <div value>
-                  <mat-chip-row>
+                  <mat-chip>
                     <div>{{getKubeVirtInstanceTypeCategory(instanceType)}}</div>
                     <div class="km-chip-accent">{{instanceType.name}}</div>
-                  </mat-chip-row>
+                  </mat-chip>
                 </div>
               </km-property>
               <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.preference as preference">
                 <div key>Preference</div>
                 <div value>
-                  <mat-chip-row>
+                  <mat-chip>
                     <div>{{getKubeVirtPreferenceCategory(preference)}}</div>
                     <div class="km-chip-accent">{{preference.name}}</div>
-                  </mat-chip-row>
+                  </mat-chip>
                 </div>
               </km-property>
               <km-property>
@@ -870,13 +870,13 @@ limitations under the License.
               <km-property *ngIf="machineDeployment.spec.template.cloud?.kubevirt.topologySpreadConstraints?.length > 0">
                 <div key>Topology Spread Constraints</div>
                 <div value>
-                  <mat-chip-grid selectable="false">
-                    <mat-chip-row *ngFor="let constraint of machineDeployment.spec.template.cloud?.kubevirt.topologySpreadConstraints">
+                  <mat-chip-set selectable="false">
+                    <mat-chip *ngFor="let constraint of machineDeployment.spec.template.cloud?.kubevirt.topologySpreadConstraints">
                       <div>{{constraint.topologyKey}}</div>
                       <div class="km-chip-accent">{{constraint.maxSkew}}</div>
                       <div>{{constraint.whenUnsatisfiable}}</div>
-                    </mat-chip-row>
-                  </mat-chip-grid>
+                    </mat-chip>
+                  </mat-chip-set>
                 </div>
               </km-property>
             </ng-container>
@@ -995,13 +995,13 @@ limitations under the License.
               <km-property *ngIf="machineDeployment.spec.template.cloud?.anexia?.disks?.length > 0">
                 <div key>Disks</div>
                 <div value>
-                  <mat-chip-grid selectable="false">
-                    <mat-chip-row *ngFor="let disk of machineDeployment.spec.template.cloud?.anexia?.disks">
+                  <mat-chip-set selectable="false">
+                    <mat-chip *ngFor="let disk of machineDeployment.spec.template.cloud?.anexia?.disks">
                       <div>{{disk.size}}GB</div>
                       <div class="km-chip-accent"
                            *ngIf="disk.performanceType">{{disk.performanceType}}</div>
-                    </mat-chip-row>
-                  </mat-chip-grid>
+                    </mat-chip>
+                  </mat-chip-set>
                 </div>
               </km-property>
               <km-property *ngIf="machineDeployment.spec.template.cloud?.anexia?.templateID">

--- a/modules/web/src/app/shared/components/event-card/style.scss
+++ b/modules/web/src/app/shared/components/event-card/style.scss
@@ -14,7 +14,6 @@
 
 @use 'variables';
 
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
 mat-card-header {
   cursor: pointer;
   padding: 0;
@@ -23,7 +22,6 @@ mat-card-header {
 .toggled-events {
   padding-bottom: 8px;
 
-  // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
   mat-card-header {
     border-radius: variables.$border-radius;
   }

--- a/modules/web/src/app/shared/components/labels/component.ts
+++ b/modules/web/src/app/shared/components/labels/component.ts
@@ -57,7 +57,7 @@ export class LabelsComponent implements OnInit, OnChanges {
   }
 
   checkLabelsHeight(): boolean {
-    const labelsElem = 32;
+    const labelsElem = 24;
     if (this.chipListLabels?.nativeElement?.parentElement.offsetHeight > labelsElem) {
       this.hideExtraLabels = true;
     } else {

--- a/modules/web/src/app/shared/components/labels/style.scss
+++ b/modules/web/src/app/shared/components/labels/style.scss
@@ -18,6 +18,7 @@
 }
 
 .show-all-button {
+  margin-top: 5px;
   min-width: 135px;
   padding-right: 10px;
 

--- a/modules/web/src/app/shared/components/labels/template.html
+++ b/modules/web/src/app/shared/components/labels/template.html
@@ -15,17 +15,17 @@ limitations under the License.
 -->
 <div fxLayout="row"
      fxLayoutGap="8px">
-  <mat-chip-grid [ngClass]="{'hide-extra-labels': !showHiddenLabels && oneLineLimit}"
-                 *ngIf="labelKeys.length > 0">
+  <mat-chip-set [ngClass]="{'hide-extra-labels': !showHiddenLabels && oneLineLimit}"
+                *ngIf="labelKeys.length > 0">
     <div #chipListLabels
          *ngFor="let labelKey of labelKeys; let i = index">
-      <mat-chip-row *ngIf="!limit || i < limit">
+      <mat-chip *ngIf="!limit || i < limit">
         <div>{{labelKey}}</div>
         <div class="km-chip-accent"
              *ngIf="!!labels[labelKey]">{{labels[labelKey]}}</div>
-      </mat-chip-row>
+      </mat-chip>
     </div>
-  </mat-chip-grid>
+  </mat-chip-set>
 
   <span *ngIf="checkLabelsHeight()"
         fxLayoutAlign=" start"

--- a/modules/web/src/app/shared/components/taints/template.html
+++ b/modules/web/src/app/shared/components/taints/template.html
@@ -13,12 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<mat-chip-grid *ngIf="taints && taints.length > 0"
-               selectable="false">
-  <mat-chip-row *ngFor="let taint of taints">
+<mat-chip-set *ngIf="taints && taints.length > 0"
+              selectable="false">
+  <mat-chip *ngFor="let taint of taints">
     <div>{{taint.key}}</div>
     <div class="km-chip-accent">{{taint.value}}</div>
     <div>{{taint.effect}}</div>
-  </mat-chip-row>
-</mat-chip-grid>
+  </mat-chip>
+</mat-chip-set>
 <div *ngIf="!taints || taints.length === 0">No assigned taints</div>

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -399,9 +399,9 @@ limitations under the License.
               Cluster Backup
               <i class="km-icon-info km-pointer"
                  matTooltip="Enable create backups from this cluster"></i>
-              <mat-chip-row>
+              <mat-chip>
                 <div>Experimental</div>
-              </mat-chip-row>
+              </mat-chip>
             </mat-checkbox>
 
             <mat-form-field *ngIf="!!controlValue(Controls.ClusterBackup) && isclusterBackupEnabled">

--- a/modules/web/src/app/wizard/style.scss
+++ b/modules/web/src/app/wizard/style.scss
@@ -41,12 +41,7 @@
   }
 }
 
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-mat-card {
-  &.mat-mdc-card {
-    margin: 0;
-    padding: 16px 30px 30px;
-  }
+mat-card.mat-mdc-card {
+  margin: 0;
+  padding: 16px 30px 30px;
 }

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -17,65 +17,59 @@
 @import 'images';
 
 // Cards.
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.*/
-// TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.*/
-mat-card {
-  &.mat-mdc-card {
-    border-radius: variables.$border-radius;
+mat-card.mat-mdc-card {
+  border-radius: variables.$border-radius;
+  box-shadow: variables.$border-box-shadow;
+  margin: 20px 0 0;
+  padding: 30px 0;
+
+  &:not([class*='mat-elevation-z']) {
     box-shadow: variables.$border-box-shadow;
-    margin: 20px 0 0;
-    padding: 30px 0;
+  }
 
-    &:not([class*='mat-elevation-z']) {
-      box-shadow: variables.$border-box-shadow;
-    }
+  .mat-mdc-card-header {
+    border-radius: variables.$border-radius variables.$border-radius 0 0;
+    line-height: 16px;
+    margin: 0;
+    padding: 0 30px;
 
-    .mat-mdc-card-header {
-      border-radius: variables.$border-radius variables.$border-radius 0 0;
-      line-height: 16px;
+    .mat-mdc-card-header-text {
+      flex: 1 1 auto;
       margin: 0;
-      padding: 0 30px;
+    }
 
-      // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.*/
-      .mat-card-header-text {
-        flex: 1 1 auto;
-        margin: 0;
+    .mat-mdc-card-title {
+      font-size: variables.$font-size-card-title;
+      font-weight: normal;
+      padding: 8px 0 16px;
+
+      i {
+        font-size: variables.$font-size-subhead-lg;
+        margin: 0 20px;
       }
 
-      .mat-mdc-card-title {
-        font-size: variables.$font-size-card-title;
-        font-weight: normal;
-        padding: 8px 0 16px;
-
+      .km-search-input {
         i {
-          font-size: variables.$font-size-subhead-lg;
-          margin: 0 20px;
-        }
-
-        .km-search-input {
-          i {
-            margin: 0;
-          }
+          margin: 0;
         }
       }
     }
+  }
 
-    .mat-mdc-card-content {
-      p {
-        font-size: variables.$font-size-caption;
-      }
+  .mat-mdc-card-content {
+    p {
+      font-size: variables.$font-size-caption;
+    }
 
-      button {
-        cursor: pointer;
-        font-size: variables.$font-size-body;
-        outline: none;
-      }
+    button {
+      cursor: pointer;
+      font-size: variables.$font-size-body;
+      outline: none;
     }
   }
 }
 
 km-wizard {
-  // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.*/
   mat-card.mat-mdc-card .mat-mdc-card-header .mat-mdc-card-title {
     margin: 0;
     padding: 26px 0 20px;
@@ -102,8 +96,7 @@ km-wizard {
     font-weight: 400;
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version.*/
-  .mat-card-header-text {
+  .mat-mdc-card-header-text {
     margin: 0;
     padding: 0;
 
@@ -697,7 +690,6 @@ button {
   }
 }
 /* stylelint-enable selector-class-pattern */
-
 
 // Chips.
 .mat-mdc-chip {

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -693,35 +693,44 @@ button {
 
 // Chips.
 .mat-mdc-chip {
-  &.mat-mdc-standard-chip {
-    border-radius: variables.$border-radius;
+  border-radius: variables.$border-radius;
+
+  --mdc-chip-container-height: 24px !important;
+  --mdc-chip-container-shape-radius: 3px !important;
+
+  .mdc-evolution-chip__action {
     box-shadow: none !important;
-    font-size: variables.$font-size-body;
-    font-weight: normal;
-    height: 100%;
-    line-height: 16px;
-    min-height: 22px;
-    overflow: hidden;
-    padding: 0;
-    word-break: break-word;
+    cursor: default;
+  }
 
-    // TODO(mdc-migration): The following rule targets internal classes of chips that may no longer apply for the MDC version.*/
-    div.mat-chip-ripple {
-      display: none;
-    }
+  div {
+    padding: 0 10px;
+  }
 
-    // TODO(mdc-migration): The following rule targets internal classes of chips that may no longer apply for the MDC version.*/
-    div:not(.mat-chip-ripple) {
-      align-items: center;
-      display: flex;
-      height: 100%;
-      justify-content: center;
-      padding: 3px 10px;
+  .mdc-evolution-chip__action--primary {
+    border-radius: variables.$border-radius;
+    padding: 0 !important;
+  }
+
+  div.mat-chip-ripple {
+    display: none;
+  }
+}
+
+.mat-mdc-chip-action-label {
+  display: flex;
+}
+
+.km-chip-list-with-input {
+  .mat-mdc-chip-row {
+    padding: 20px 10px 20px 20px;
+
+    i:hover {
+      cursor: pointer;
     }
   }
 }
 
-// TODO(mdc-migration): The following rule targets internal classes of chips that may no longer apply for the MDC version.*/
 mat-chip-grid {
   cursor: default;
 

--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -391,7 +391,7 @@
     --mdc-checkbox-selected-hover-icon-color: var(--mdc-checkbox-selected-icon-color);
     --mdc-checkbox-selected-focus-icon-color: var(--mdc-checkbox-selected-icon-color);
     --mdc-checkbox-selected-pressed-icon-color: var(--mdc-checkbox-selected-icon-color);
-    --mdc-checkbox-selected-focus-state-layer-color :var(--mdc-checkbox-selected-icon-color);
+    --mdc-checkbox-selected-focus-state-layer-color: var(--mdc-checkbox-selected-icon-color);
     --mdc-checkbox-selected-pressed-state-layer-color: var(--mdc-checkbox-selected-icon-color);
     --mdc-checkbox-selected-focus-state-layer-opacity: 0;
     --mdc-checkbox-unselected-focus-state-layer-opacity: 0;
@@ -399,27 +399,33 @@
 
   // Chips.
   .mat-mdc-chip {
-    &.mat-mdc-standard-chip {
-      background: transparent;
+    --mdc-chip-elevated-container-color: #{map.get($colors, divider)};
+    --mdc-chip-label-text-color: #{map.get($colors, text)};
+    --mdc-chip-focus-state-layer-color: none;
+    --mdc-chip-hover-state-layer-color: none;
+
+    background: transparent;
+
+    .mat-mdc-chip-remove {
+      background-color: map.get($colors, text);
+    }
+
+    .mdc-evolution-chip__action--primary {
       border: 1px solid map.get($colors, divider);
-      color: map.get($colors, text);
+    }
 
-      &::after {
-        background: transparent;
-      }
+    .km-chip-accent {
+      background-color: #fff;
+    }
+  }
 
-      // TODO(mdc-migration): The following rule targets internal classes of chips that may no longer apply for the MDC version. */
-      div:not(.mat-chip-ripple) {
-        background: map.get($colors, divider);
-      }
+  .km-chip-list-with-input {
+    .mat-mdc-chip-row {
+      background-color: #fff !important;
+      border: 1px solid map.get($colors, divider);
 
-      div.km-chip-accent {
-        background: transparent;
-      }
-
-      // TODO(mdc-migration): The following rule targets internal classes of chips that may no longer apply for the MDC version. */
-      .mat-chip-remove {
-        background-color: map.get($colors, text);
+      .mdc-evolution-chip__action--primary {
+        border: none;
       }
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
migrates Angular Material card and chip components from legacy to v15.
**Which issue(s) this PR fixes**:
xref #5864

**What type of PR is this?**
/kind chore


```release-note
NONE
```

```documentation
NONE
```
