### PR TITLE
[release/2.23] hotfix: browser crashes on mat-select

### DIFF
--- a/modules/web/src/app/core/module.ts
+++ b/modules/web/src/app/core/module.ts
@@ -80,6 +80,7 @@ import {KubeVirtService} from '@core/services/provider/kubevirt';
 import {NutanixService} from '@core/services/provider/nutanix';
 import {VMwareCloudDirectorService} from '@core/services/provider/vmware-cloud-director';
 import {DialogModeService} from '@core/services/dialog-mode';
+import {HotfixMatSelectDirective} from '@app/hotfix-mat-select';
 
 const components = [
   SidenavComponent,
@@ -94,6 +95,7 @@ const components = [
   UserPanelComponent,
   ChangelogDialog,
   HelpPanelComponent,
+  HotfixMatSelectDirective,
 ];
 
 const services = [

--- a/modules/web/src/app/core/module.ts
+++ b/modules/web/src/app/core/module.ts
@@ -80,7 +80,6 @@ import {KubeVirtService} from '@core/services/provider/kubevirt';
 import {NutanixService} from '@core/services/provider/nutanix';
 import {VMwareCloudDirectorService} from '@core/services/provider/vmware-cloud-director';
 import {DialogModeService} from '@core/services/dialog-mode';
-import {HotfixMatSelectDirective} from '@app/hotfix-mat-select';
 
 const components = [
   SidenavComponent,
@@ -95,7 +94,6 @@ const components = [
   UserPanelComponent,
   ChangelogDialog,
   HelpPanelComponent,
-  HotfixMatSelectDirective,
 ];
 
 const services = [

--- a/modules/web/src/app/hotfix-mat-select.ts
+++ b/modules/web/src/app/hotfix-mat-select.ts
@@ -1,0 +1,45 @@
+// Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AfterViewInit, Directive, ElementRef} from '@angular/core';
+
+// TODO: Remove this directive once the bug is fixed
+/**
+ * Temporary code to fix Chrome browser crashing.
+ * See: https://issues.chromium.org/issues/335553723?pli=1
+ */
+@Directive({
+  selector: 'mat-select',
+})
+export class HotfixMatSelectDirective implements AfterViewInit {
+  constructor(private elementRef: ElementRef) {}
+
+  ngAfterViewInit(): void {
+    this.removeAriaOwns();
+  }
+
+  private removeAriaOwns(): void {
+    // Get the parent element of mat-select
+    const parentElement = this.elementRef.nativeElement.parentElement;
+
+    // Find the label element within the parent span
+    const labelElement = parentElement.querySelector('span > label');
+
+    if (labelElement) {
+      // Remove the aria-owns attribute from the label element
+      labelElement.removeAttribute('aria-owns');
+      labelElement.removeAttribute('aria-labelledby');
+    }
+  }
+}

--- a/modules/web/src/app/shared/module.ts
+++ b/modules/web/src/app/shared/module.ts
@@ -52,6 +52,7 @@ import {MatLegacyTableModule as MatTableModule} from '@angular/material/legacy-t
 import {MatLegacyTabsModule as MatTabsModule} from '@angular/material/legacy-tabs';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatLegacyTooltipModule as MatTooltipModule} from '@angular/material/legacy-tooltip';
+import {HotfixMatSelectDirective} from '@app/hotfix-mat-select';
 import {OpenstackCredentialsTypeService} from '@app/wizard/step/provider-settings/provider/extended/openstack/service';
 import {NotificationComponent} from '@core/components/notification/component';
 import {AddClusterFromTemplateDialogComponent} from '@shared/components/add-cluster-from-template-dialog/component';
@@ -275,6 +276,7 @@ const directives = [
   OptionDirective,
   InputPasswordDirective,
   ValueChangedIndicatorDirective,
+  HotfixMatSelectDirective,
 ];
 
 @NgModule({


### PR DESCRIPTION
**What this PR does / why we need it**:
Hotfix to mitigate a bug in new releases of chromium that causes a browser crash on `mat-select` component.

- https://issuetracker.google.com/issues/335553723
- https://github.com/angular/components/issues/28905

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Hotfix to mitigate a bug in new releases of chromium that causes browser crashes on `mat-select` component. For more details: https://issuetracker.google.com/issues/335553723
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
