### PR TITLE
Migrate form-field and tool-tip component version 15 (#6655)

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/cni-version/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/cni-version/style.scss
@@ -19,7 +19,7 @@
   margin: 0 30px 0 0;
 
   .cni-version {
-    height: 55px;
+    height: 45px;
 
     * {
       cursor: default;
@@ -60,11 +60,17 @@
     .mat-mdc-form-field {
       font-size: variables.$font-size-subhead;
       max-width: 120px;
+      position: relative;
+      top: 10px;
     }
   }
 
   .enabled {
     &:hover {
+      * {
+        cursor: pointer;
+      }
+
       .cni-version-type {
         border-width: 2px 0 2px 2px;
       }

--- a/modules/web/src/app/cluster/details/cluster/cni-version/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/cni-version/style.scss
@@ -61,7 +61,7 @@
       font-size: variables.$font-size-subhead;
       max-width: 120px;
       position: relative;
-      top: 10px;
+      top: 15px;
     }
   }
 

--- a/modules/web/src/app/cluster/details/cluster/cni-version/template.html
+++ b/modules/web/src/app/cluster/details/cluster/cni-version/template.html
@@ -31,7 +31,7 @@ limitations under the License.
       <i class="km-cni-image-{{cluster.spec.cniPlugin.type}} type-{{cluster.spec.cniPlugin.type}}"></i>
     </div>
 
-    <mat-form-field class="cni-version">
+    <mat-form-field>
       <mat-label>CNI Plugin</mat-label>
       <mat-select [ngModel]="cluster.spec.cniPlugin.version"
                   disabled

--- a/modules/web/src/app/cluster/details/cluster/cni-version/theme.scss
+++ b/modules/web/src/app/cluster/details/cluster/cni-version/theme.scss
@@ -17,9 +17,8 @@
 @mixin theme-cni-version-component($colors) {
   .cni-version-container {
     .cni-version {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-form-field-outline {
-        color: map.get($colors, divider);
+      .mdc-notched-outline {
+        --mdc-outlined-text-field-disabled-outline-color: #{map.get($colors, divider)};
       }
 
       .cni-version-type {
@@ -32,26 +31,36 @@
           color: map.get($colors, text);
         }
 
-        // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
+        .mdc-notched-outline {
+          .mdc-notched-outline__leading {
+            border-radius: 0;
+          }
+        }
+
         div.mat-mdc-form-field-flex label {
           color: map.get($colors, text-secondary);
         }
       }
-    }
 
-    .enabled:hover {
-      .cni-version-type {
-        border-color: map.get($colors, secondary);
-      }
+      &.enabled:hover {
+        .cni-version-type {
+          border-color: map.get($colors, secondary);
+        }
 
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-form-field-outline-thick {
-        color: map.get($colors, secondary);
-      }
+        .mat-mdc-form-field {
+          .mdc-notched-outline {
+            .mdc-notched-outline__leading,
+            .mdc-notched-outline__notch,
+            .mdc-notched-outline__trailing {
+              border-color: map.get($colors, secondary);
+              border-width: 2px;
+            }
+          }
+        }
 
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      div.mat-mdc-form-field-flex label {
-        color: map.get($colors, secondary-dark);
+        div.mat-mdc-form-field-flex label {
+          color: map.get($colors, secondary-dark);
+        }
       }
     }
   }

--- a/modules/web/src/app/cluster/details/cluster/cni-version/theme.scss
+++ b/modules/web/src/app/cluster/details/cluster/cni-version/theme.scss
@@ -26,8 +26,7 @@
       }
 
       .mat-mdc-form-field {
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-        .mat-select-value-text {
+        .mat-mdc-select-value-text {
           color: map.get($colors, text);
         }
 

--- a/modules/web/src/app/cluster/details/shared/version-picker/style.scss
+++ b/modules/web/src/app/cluster/details/shared/version-picker/style.scss
@@ -19,10 +19,10 @@
   margin: 6px 30px 6px 0;
 
   .km-version-picker {
-    height: 50px;
+    height: 45px;
 
     * {
-      cursor: default;
+      cursor: pointer;
     }
 
     .version-picker-type {
@@ -64,6 +64,8 @@
     .mat-mdc-form-field {
       font-size: variables.$font-size-subhead;
       max-width: 140px;
+      position: relative;
+      top: 10px;
 
       &.cluster-external {
         max-width: 200px;

--- a/modules/web/src/app/cluster/details/shared/version-picker/style.scss
+++ b/modules/web/src/app/cluster/details/shared/version-picker/style.scss
@@ -65,7 +65,7 @@
       font-size: variables.$font-size-subhead;
       max-width: 140px;
       position: relative;
-      top: 10px;
+      top: 15px;
 
       &.cluster-external {
         max-width: 200px;

--- a/modules/web/src/app/cluster/details/shared/version-picker/theme.scss
+++ b/modules/web/src/app/cluster/details/shared/version-picker/theme.scss
@@ -17,9 +17,8 @@
 @mixin theme-version-picker-component($colors) {
   .version-picker-container {
     .km-version-picker {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
       .mat-form-field-outline {
-        color: map.get($colors, divider);
+        --mdc-outlined-text-field-disabled-outline-color: #{map.get($colors, divider)};
       }
 
       .version-picker-type {
@@ -32,26 +31,36 @@
           color: map.get($colors, text);
         }
 
-        // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
+        .mdc-notched-outline {
+          .mdc-notched-outline__leading {
+            border-radius: 0;
+          }
+        }
+
         div.mat-mdc-form-field-flex label {
           color: map.get($colors, text-secondary);
         }
       }
-    }
 
-    .km-version-picker-enabled:hover {
-      .version-picker-type {
-        border-color: map.get($colors, secondary);
-      }
+      &.km-version-picker-enabled:hover {
+        .version-picker-type {
+          border-color: map.get($colors, secondary);
+        }
 
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-form-field-outline-thick {
-        color: map.get($colors, secondary);
-      }
+        .mat-mdc-form-field {
+          .mdc-notched-outline {
+            .mdc-notched-outline__leading,
+            .mdc-notched-outline__notch,
+            .mdc-notched-outline__trailing {
+              border-color: map.get($colors, secondary);
+              border-width: 2px;
+            }
+          }
+        }
 
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      div.mat-mdc-form-field-flex label {
-        color: map.get($colors, secondary-dark);
+        div.mat-mdc-form-field-flex label {
+          color: map.get($colors, secondary-dark);
+        }
       }
     }
   }

--- a/modules/web/src/app/cluster/details/shared/version-picker/theme.scss
+++ b/modules/web/src/app/cluster/details/shared/version-picker/theme.scss
@@ -26,8 +26,7 @@
       }
 
       .mat-mdc-form-field {
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-        .mat-select-value-text {
+        .mat-mdc-select-value-text {
           color: map.get($colors, text);
         }
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
@@ -28,7 +28,7 @@
 }
 
 .search-field{
-  margin: 13px 0 0 20px;
+  margin-left: 20px;
 }
 
 .namespaces-label {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
@@ -19,7 +19,6 @@
 // END OF TERMS AND CONDITIONS
 
 .filter-field {
-  margin-left: 20px;
   width: 300px;
 }
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
@@ -24,7 +24,7 @@
 }
 
 .search-field{
-  margin: 13px 0 0 20px;
+  margin-left: 20px;
 }
 
 .namespaces-label {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
@@ -19,7 +19,6 @@
 // END OF TERMS AND CONDITIONS
 
 .filter-field {
-  margin-left: 20px;
   width: 300px;
 }
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/style.scss
@@ -28,7 +28,7 @@
 }
 
 .search-field{
-  margin: 13px 0 0 20px;
+  margin-left: 20px;
 }
 
 .namespaces-label {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/style.scss
@@ -19,7 +19,6 @@
 // END OF TERMS AND CONDITIONS
 
 .filter-field {
-  margin-left: 20px;
   width: 300px;
 }
 

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -120,10 +120,6 @@ hr {
   }
 }
 
-.km-multiple-values-dropdown {
-  margin-left: 30px;
-}
-
 .km-add-dialog-dropdown {
   margin-top: 34px;
 }
@@ -389,12 +385,8 @@ hr {
 
   &.km-version-picker-disabled {
     mat-form-field.mat-primary {
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-      .mat-select-arrow-wrapper {
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-        .mat-select-arrow {
+      .mat-mdc-select-arrow-wrapper {
+        .mat-mdc-select-arrow {
           display: none;
         }
       }
@@ -405,12 +397,8 @@ hr {
 .cni-version {
   &.disabled {
     mat-form-field.mat-primary {
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-      .mat-select-arrow-wrapper {
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-        .mat-select-arrow {
+      .mat-mdc-select-arrow-wrapper {
+        .mat-mdc-select-arrow {
           display: none;
         }
       }
@@ -495,12 +483,10 @@ km-dashboard {
 }
 
 .km-select-ellipsis {
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-  .mat-select-trigger {
+  .mat-mdc-select-trigger {
     height: 18px;
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
   mat-select-trigger {
     align-items: center;
 
@@ -513,15 +499,14 @@ km-dashboard {
     }
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-  .mat-select-value {
+  .mat-mdc-select-value {
     align-self: center;
   }
 }
 
 .km-search-input {
   &.mat-mdc-form-field {
-    margin: -10px 10px -30px 0;
+    // margin: -10px 10px -30px 0;
     max-height: 30px;
     width: 280px;
 
@@ -619,12 +604,8 @@ km-cni-version {
 
   .disabled {
     mat-form-field.mat-primary {
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-      .mat-select-arrow-wrapper {
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-        .mat-select-arrow {
+      .mat-mdc-select-arrow-wrapper {
+        .mat-mdc-select-arrow {
           display: none;
         }
       }
@@ -958,13 +939,11 @@ km-side-nav-field .sub-menu-item:last-child {
     .mat-mdc-text-field-wrapper {
       padding-bottom: 0;
 
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-      .mat-mdc-select .mat-select-trigger {
+      .mat-mdc-select .mat-mdc-select-trigger {
         align-items: flex-end;
         display: flex;
 
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-        .mat-select-arrow-wrapper {
+        .mat-mdc-select-arrow-wrapper {
           align-items: flex-end;
           display: flex;
         }

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -366,22 +366,14 @@ hr {
 
 .km-version-picker {
   .mat-mdc-form-field {
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
     .mat-mdc-form-field-flex {
       height: 49px;
     }
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    .mat-mdc-form-text-infix {
-      padding: 9px 0;
-    }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    .mat-form-field-outline-start {
+    .mdc-notched-outline__leading {
       border-radius: 0;
     }
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
     .mat-mdc-text-field-wrapper {
       padding-bottom: 2px;
     }
@@ -391,12 +383,6 @@ hr {
     &:hover {
       * {
         cursor: pointer;
-      }
-
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-form-field-outline-thick {
-        opacity: 100%;
-        transition: all 0.5s ease;
       }
     }
   }
@@ -435,20 +421,13 @@ hr {
 .km-number-stepper-input {
   &.mat-mdc-form-field {
     &:not(.message) {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-mdc-text-field-wrapper {
-        padding-bottom: 0;
+      .mdc-notched-outline__trailing {
+        border-radius: 0;
       }
     }
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
     .mat-mdc-form-text-infix {
       width: 100%;
-    }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    .mat-form-field-outline-end {
-      border-radius: 0;
     }
   }
 }
@@ -546,16 +525,16 @@ km-dashboard {
     max-height: 30px;
     width: 280px;
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
     .mat-mdc-text-field-wrapper {
       margin: unset;
       padding: unset;
 
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-mdc-form-text-infix {
-        padding: 5.5px 12px 12px;
+      .mat-mdc-form-field-flex {
+        padding-left: 10px;
+
+        .mat-mdc-form-field-infix {
+          padding-left: 10px;
+        }
       }
     }
   }
@@ -611,7 +590,6 @@ km-dashboard {
 }
 
 .mat-mdc-form-field.km-edit-sshkeys-dropdown {
-  // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
   .mat-mdc-text-field-wrapper {
     margin-bottom: 2px;
     padding: 0;
@@ -620,18 +598,15 @@ km-dashboard {
 
 km-cni-version {
   .mat-mdc-form-field {
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
     .mat-mdc-form-field-flex {
       height: 49px;
+
+      .mat-mdc-form-field-infix {
+        width: 120px;
+      }
     }
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    .mat-mdc-form-text-infix {
-      width: 120px;
-    }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    .mat-form-field-outline-start {
+    .mdc-notched-outline__leading {
       border-radius: 0;
     }
   }
@@ -639,12 +614,6 @@ km-cni-version {
   .enabled:hover {
     * {
       cursor: pointer;
-    }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    .mat-form-field-outline-thick {
-      opacity: 100%;
-      transition: all 0.5s ease;
     }
   }
 
@@ -691,7 +660,6 @@ km-cni-version {
 
 .km-external-cluster-delete-confirmation {
   .mat-mdc-form-field {
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
     .mat-mdc-text-field-wrapper {
       padding-bottom: 12px;
     }
@@ -782,7 +750,7 @@ km-cni-version {
 
   &.radio-group-column {
     .mat-mdc-radio-checked {
-      .mdc-radio{
+      .mdc-radio {
         position: relative;
 
         &::after {
@@ -826,17 +794,16 @@ km-cni-version {
   }
 }
 
-// TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-.mat-mdc-form-text-infix:not(:has(textarea)):has(> .km-value-changed),
-.mat-mdc-form-text-infix:has(> textarea):has(> .km-value-changed) {
+.mat-mdc-form-field-infix:not(:has(textarea)):has(> .km-value-changed),
+.mat-mdc-form-field-infix:has(> textarea):has(> .km-value-changed) {
   &::after {
     border-bottom-left-radius: variables.$border-radius;
     border-top-left-radius: variables.$border-radius;
     content: '';
     height: 44px;
-    left: -11px;
+    left: -15px;
     position: absolute;
-    top: -9px;
+    top: 0;
     width: 5px;
   }
 
@@ -985,21 +952,11 @@ km-side-nav-field .sub-menu-item:last-child {
 .km-pagination-page-size-select-container {
   font-size: variables.$font-size-caption;
 
-  mat-form-field.mat-mdc-form-field {
+  .mat-mdc-form-field {
     width: 70px;
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
     .mat-mdc-text-field-wrapper {
       padding-bottom: 0;
-
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-mdc-form-field-subscript-wrapperr {
-        display: none;
-      }
 
       // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
       .mat-mdc-select .mat-select-trigger {
@@ -1012,6 +969,10 @@ km-side-nav-field .sub-menu-item:last-child {
           display: flex;
         }
       }
+    }
+
+    .mat-mdc-form-field-bottom-align::before {
+      display: none;
     }
   }
 }

--- a/modules/web/src/assets/css/global/_theme.scss
+++ b/modules/web/src/assets/css/global/_theme.scss
@@ -287,21 +287,14 @@
   .km-search-input {
     &.mat-mdc-form-field {
       &.mat-form-field-appearance-outline {
-        // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-
-        // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-        &.mat-form-field-should-float {
-          // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-          .mat-form-field-outline-start,
-          .mat-form-field-outline-gap,
-          .mat-form-field-outline-end {
-            border-width: 2px;
-            color: map.get($colors, primary);
-          }
+        .mdc-notched-outline__leading,
+        .mdc-notched-outline__notch,
+        .mdc-notched-outline__trailing {
+          border-width: 2px;
+          color: map.get($colors, primary);
         }
 
-        // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-        .mat-form-field-outline {
+        .mdc-notched-outline {
           color: map.get($colors, search-outline);
         }
       }
@@ -361,8 +354,7 @@
     }
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-  .mat-mdc-form-text-infix:has(> .km-value-changed) {
+  .mat-mdc-form-field-infix:has(> .km-value-changed) {
     &::after {
       background-color: map.get($colors, primary);
     }

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -41,6 +41,7 @@ mat-card.mat-mdc-card {
     .mat-mdc-card-title {
       font-size: variables.$font-size-card-title;
       font-weight: normal;
+      margin-bottom: 12px;
       padding: 8px 0 16px;
 
       i {
@@ -348,28 +349,19 @@ mat-form-field {
     }
 
     &.mat-primary {
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-      // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-      .mat-select-trigger {
+      .mat-mdc-select-trigger {
         display: flex;
 
         .km-select-trigger-button-wrapper {
           margin-bottom: 8px;
         }
 
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-        .mat-select-arrow-wrapper {
-          align-items: center;
-          display: flex;
-          justify-content: center;
+        .mat-mdc-select-arrow-wrapper {
+          margin-right: 10px;
 
-          // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-          .mat-select-arrow {
+          .mat-mdc-select-arrow {
             @include mixins.size(14px);
 
-            color: transparent;
             display: inline-block;
             mask: url('/assets/images/icons/arrow-down.svg');
             mask-repeat: no-repeat;
@@ -381,11 +373,8 @@ mat-form-field {
 
     &.mat-focused {
       &.mat-primary {
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-        // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-        .mat-select-arrow-wrapper {
-          // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-          .mat-select-arrow {
+        .mat-mdc-select-arrow-wrapper {
+          .mat-mdc-select-arrow {
             @include mixins.size(14px);
 
             transform: rotate(180deg);
@@ -404,8 +393,7 @@ mat-form-field {
   }
 
   &.km-dropdown-without-subtext {
-    // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-    .mat-select-arrow-wrapper {
+    .mat-mdc-select-arrow-wrapper {
       height: 20px;
     }
   }
@@ -427,25 +415,21 @@ mat-error {
 .mat-mdc-select {
   width: fit-content;
 
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-  .mat-select-value {
+  .mat-mdc-select-value {
     max-width: 100%;
     min-width: 2ch;
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-  .mat-select-arrow {
+  .mat-mdc-select-arrow {
     display: none;
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-  .mat-select-value-text {
+  .mat-mdc-select-value-text {
     font-size: variables.$font-size-subhead;
     line-height: 20px;
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
-  .mat-select-placeholder {
+  .mat-mdc-select-placeholder {
     font-size: variables.$font-size-subhead;
     line-height: 18px;
     opacity: 70%;
@@ -468,11 +452,15 @@ mat-error {
   }
 }
 
+.mat-mdc-select-panel-above:has(> .mat-mdc-select-panel) {
+    bottom:-20px !important;
+    left: 1060px !important;
+}
+
 .mat-mdc-select-panel {
-  margin-left: 6px;
-  margin-top: 28px;
   max-width: calc(100% + 20px) !important;
   min-width: calc(100% + 20px) !important;
+  padding: 0 !important;
   transform-origin: 50% 0 0;
 
   &.ng-animating {

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -323,10 +323,11 @@ mat-list-item {
 // Forms.
 mat-form-field {
   &.mat-mdc-form-field {
+    margin-bottom: 10px;
     width: 100%;
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
+    --mat-form-field-container-height: 49px;
+
     .mat-mdc-form-field-text-prefix,
     .mat-mdc-form-field-text-suffix {
       .mat-mdc-icon-button {
@@ -336,17 +337,11 @@ mat-form-field {
       }
     }
 
-    &.km-with-hint {
-      margin-bottom: 15px;
-    }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
     .mat-mdc-text-field-wrapper {
-      padding-bottom: 22px;
+      height: 45px;
     }
 
     &.km-long-subscript {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
       .mat-mdc-form-field-subscript-wrapperr {
         position: initial;
       }
@@ -399,83 +394,35 @@ mat-form-field {
       }
     }
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
     .mat-mdc-form-field-flex {
       align-items: center;
     }
-  }
 
-  &.km-dropdown-with-suffix {
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    .mat-mdc-form-text-infix {
-      padding: 9px 0;
+    .mat-mdc-form-field-hint-wrapper {
+      top: 5px;
     }
   }
 
   &.km-dropdown-without-subtext {
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    .mat-mdc-text-field-wrapper {
-      padding-bottom: 0;
-    }
-
     // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version.*/
     .mat-select-arrow-wrapper {
       height: 20px;
     }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    .mat-mdc-form-text-infix {
-      padding: 9px 0;
-    }
   }
 
   &.mat-form-field-appearance-outline {
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    &.mat-form-field-can-float {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-      &.mat-form-field-should-float {
-        // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-        .mat-mdc-floating-label {
-          transform: translateY(-21px) scale(0.75);
-        }
+    .mat-mdc-form-field-subscript-wrapper {
+      i {
+        @include mixins.size(16px, 16px, true);
       }
     }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    .mat-mdc-form-text-infix {
-      padding: 9px 0;
-    }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    .mat-form-field-label-wrapper {
-      top: -20px;
-    }
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-    .mat-mdc-form-field-subscript-wrapperr i {
-      @include mixins.size(16px, 16px, true);
-    }
   }
 }
 
-km-admin-settings-defaults {
-  // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-  mat-form-field.mat-mdc-form-field .mat-mdc-text-field-wrapper {
-    padding-bottom: 0;
-  }
+mat-hint,
+mat-error {
+  font-size: 75%;
 }
-
-/* stylelint-disable */
-// TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version.*/
-mat-form-field.mat-form-field-should-float:not(.mat-focused):not(.ng-invalid):not(.mat-form-field-disabled)
-  div.mat-mdc-form-field-flex:hover
-  label {
-  transition: all 0.2s ease;
-}
-/* stylelint-enable */
 
 .mat-mdc-select {
   width: fit-content;

--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -138,9 +138,8 @@
 
   }
 
-  // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-  .mat-select-arrow {
-    background-color: map.get($colors, text);
+  .mat-mdc-select-arrow {
+    --mat-select-enabled-arrow-color: #{map.get($colors, text)};
   }
 
   .mat-mdc-optgroup-label {

--- a/modules/web/src/assets/css/material/_theme.scss
+++ b/modules/web/src/assets/css/material/_theme.scss
@@ -129,61 +129,13 @@
   // Forms.
   mat-form-field {
     &.mat-mdc-form-field {
-      color: map.get($colors, text);
+      color: map.get($colors, hint-color);
+
+      --mdc-outlined-text-field-outline-color: #{map.get($colors, divider)};
+      --mdc-outlined-text-field-disabled-outline-color: #{map.get($colors, divider-disabled)};
+      --mdc-outlined-text-field-hover-outline-color: #{map.get($colors, secondary-dark)};
     }
 
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    &.mat-form-field-should-float:not(.mat-focused):not(.ng-invalid):not(.mat-form-field-disabled) {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      div.mat-form-field-flex:hover {
-        label {
-          color: map.get($colors, secondary-dark);
-        }
-      }
-    }
-
-    &.mat-focused {
-      &:not(.ng-invalid),
-      &.ng-pristine:not(.ng-touched) {
-        // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-        label.mat-form-field-label {
-          color: map.get($colors, primary-dark);
-        }
-      }
-    }
-  }
-
-  .mat-form-field-appearance-outline {
-    // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-    .mat-form-field-outline {
-      color: map.get($colors, divider);
-    }
-
-    &.mat-focused {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-form-field-outline-thick {
-        color: map.get($colors, primary);
-      }
-    }
-
-    &.mat-form-field-disabled {
-      // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-      .mat-form-field-outline {
-        color: map.get($colors, divider-disabled);
-      }
-    }
-  }
-
-  // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-  .mat-form-field-empty.mat-mdc-floating-label .mat-form-field-required-marker {
-    color: map.get($colors, secondary);
-  }
-
-  // TODO(mdc-migration): The following rule targets internal classes of form-field that may no longer apply for the MDC version. */
-  div.mat-form-field-outline.mat-form-field-outline-thick {
-    color: map.get($colors, secondary);
   }
 
   // TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
@@ -415,7 +367,7 @@
     }
 
     .km-chip-accent {
-      background-color: #fff;
+      background-color: map.get($colors, background-card );
     }
   }
 
@@ -432,7 +384,7 @@
 
   // Tooltips.
   .mat-mdc-tooltip {
-    background-color: map.get($colors, tooltip-background);
+    --mdc-plain-tooltip-container-color: #{map.get($colors, tooltip-background)};
   }
 
   // Spinners.

--- a/modules/web/src/assets/themes/dark.scss
+++ b/modules/web/src/assets/themes/dark.scss
@@ -68,6 +68,7 @@ $colors-dark: (
   estimate-quota-bar: #4ec3ea,
   progress-bar-buffer: #dfe3e5,
   slide-toggle-handle-color: #bdbdbd,
+  hint-color: #b8b8b8b3
 );
 $colors-dark-palette: mat.$blue-palette;
 $colors-dark-palette: map.merge(

--- a/modules/web/src/assets/themes/dark.scss
+++ b/modules/web/src/assets/themes/dark.scss
@@ -221,9 +221,8 @@ $theme-dark: map.merge(
 }
 
 // Make selected option text light blue.
-// TODO(mdc-migration): The following rule targets internal classes of option that may no longer apply for the MDC version.*/
-.mat-mdc-option.mat-mdc-option-multiple.mat-selected .mat-option-text {
-  color: map.get($colors-dark, primary-dark);
+.mat-mdc-option.mat-mdc-option-multiple.mdc-list-item--selected .mdc-list-item__primary-text {
+  --mat-option-selected-state-label-text-color: #{ map.get($colors-dark, primary-dark)};
 }
 
 .mat-mdc-option:hover:not(.mat-option-disabled),

--- a/modules/web/src/assets/themes/light.scss
+++ b/modules/web/src/assets/themes/light.scss
@@ -64,6 +64,7 @@ $colors-light: (
   estimate-quota-bar: #4ec3ea,
   progress-bar-buffer: #dfe3e5,
   slide-toggle-handle-color: #fafafa,
+  hint-color: #7e868f99
 );
 $colors-light-palette: mat.$blue-palette;
 $colors-light-palette: map.merge(


### PR DESCRIPTION
**What this PR does / why we need it**:
migrates Angular Material tool-tip, form-field, mat-option and mat-select components from legacy to v15.

**Add MachineDeployment**
![image](https://github.com/kubermatic/dashboard/assets/85109141/ccaed976-2c7b-4e59-ab41-b5e3d43f3499)

![image](https://github.com/kubermatic/dashboard/assets/85109141/c85c472f-465f-4c85-a4de-eccb4cf8418b)


**wizard**
![image](https://github.com/kubermatic/dashboard/assets/85109141/5ee8f246-5d16-4bbe-b89e-0f52d9b935ef)

![image](https://github.com/kubermatic/dashboard/assets/85109141/84fed355-5243-42c3-9b2c-2c8106839a2b)


**Which issue(s) this PR fixes**:
xref #5864

**What type of PR is this?**
/kind chore

```release-note
NONE
```

```documentation
NONE
```
