### PR TITLE
OSM is always enabled

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -64,7 +64,6 @@ enum Controls {
   Konnectivity = 'konnectivity',
   MLALogging = 'loggingEnabled',
   MLAMonitoring = 'monitoringEnabled',
-  OperatingSystemManager = 'enableOperatingSystemManager',
   KubeLB = 'kubelb',
   KubernetesDashboardEnabled = 'kubernetesDashboardEnabled',
   APIServerAllowedIPRanges = 'apiServerAllowedIPRanges',
@@ -161,7 +160,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       }),
       [Controls.MLALogging]: new FormControl(!!this.cluster.spec.mla && this.cluster.spec.mla.loggingEnabled),
       [Controls.MLAMonitoring]: new FormControl(!!this.cluster.spec.mla && this.cluster.spec.mla.monitoringEnabled),
-      [Controls.OperatingSystemManager]: new FormControl(this.cluster.spec.enableOperatingSystemManager),
       [Controls.KubeLB]: new FormControl(this.cluster.spec.kubelb?.enabled),
       [Controls.KubernetesDashboardEnabled]: new FormControl(!!this.cluster.spec.kubernetesDashboard?.enabled),
       [Controls.AdmissionPlugins]: new FormControl(this.cluster.spec.admissionPlugins),
@@ -397,7 +395,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
           enabled: this.form.get(Controls.KubernetesDashboardEnabled).value,
         },
         disableCsiDriver: this.form.get(Controls.DisableCSIDriver).value,
-        enableOperatingSystemManager: this.form.get(Controls.OperatingSystemManager).value,
         kubelb: {
           enabled: this.form.get(Controls.KubeLB).value,
         },

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -204,14 +204,6 @@ limitations under the License.
         Kubernetes Dashboard
       </mat-checkbox>
 
-      <mat-checkbox [formControlName]="Controls.OperatingSystemManager"
-                    [disabled]="!!cluster.spec.enableOperatingSystemManager"
-                    kmValueChangedIndicator>
-        Operating System Manager
-        <i class="km-icon-info km-pointer"
-           [matTooltip]="form.get(Controls.OperatingSystemManager).value ? 'Operating System Manager cannot be disabled once it has been enabled.' : 'Disabling this is not recommended in a production environment. Enabling/disabling this will not rotate the machines automatically. The users need to update the Machine Deployments manually.'"></i>
-      </mat-checkbox>
-
       <mat-checkbox [formControlName]="Controls.KubeLB"
                     [disabled]="isKubeLBEnforced"
                     *ngIf="isEnterpriseEdition && isKubeLBEnabled"

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -236,8 +236,7 @@ limitations under the License.
             <km-property-health *ngIf="!cluster.spec.cloud.edge"
                                 label="Machine Controller"
                                 [healthState]="health?.machineController"></km-property-health>
-            <km-property-health *ngIf="cluster.spec.enableOperatingSystemManager"
-                                label="Operating System Manager"
+            <km-property-health label="Operating System Manager"
                                 [healthState]="health?.operatingSystemManager"></km-property-health>
             <km-property-health label="User Controller Manager"
                                 [healthState]="health?.userClusterControllerManager"></km-property-health>

--- a/modules/web/src/app/node-data/template.html
+++ b/modules/web/src/app/node-data/template.html
@@ -210,7 +210,7 @@ limitations under the License.
       </div>
     </div>
 
-    <km-autocomplete *ngIf="isOperatingSystemManagerEnabled && form.get(Controls.OperatingSystem).value"
+    <km-autocomplete *ngIf="form.get(Controls.OperatingSystem).value"
                      label="Operating System Profile"
                      [formControlName]="Controls.OperatingSystemProfile"
                      [isLoading]="isLoadingOSProfiles"

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -231,10 +231,6 @@ limitations under the License.
                                  [value]="cluster.spec.kubernetesDashboard?.enabled">
             </km-property-boolean>
 
-            <km-property-boolean *ngIf="cluster.spec.enableOperatingSystemManager"
-                                 label="Operating System Manager"
-                                 [value]="cluster.spec.enableOperatingSystemManager">
-            </km-property-boolean>
             <km-property-boolean *ngIf="cluster.spec.disableCsiDriver"
                                  label="CSI Storage Driver"
                                  [value]="!cluster.spec.disableCsiDriver">

--- a/modules/web/src/app/shared/components/save-cluster-template/component.ts
+++ b/modules/web/src/app/shared/components/save-cluster-template/component.ts
@@ -94,7 +94,7 @@ export class SaveClusterTemplateDialogComponent implements OnInit {
 
   private _getClusterTemplate(): ClusterTemplate {
     let annotations = null;
-    if (this.data.nodeData.operatingSystemProfile && this.data.cluster.spec.enableOperatingSystemManager) {
+    if (this.data.nodeData.operatingSystemProfile) {
       annotations = {
         [this.operatingSystemProfileAnnotation]: this.data.nodeData.operatingSystemProfile,
       };

--- a/modules/web/src/app/shared/entity/cluster.ts
+++ b/modules/web/src/app/shared/entity/cluster.ts
@@ -348,7 +348,6 @@ export class ClusterSpec {
   eventRateLimitConfig?: EventRateLimitConfig;
   admissionPlugins?: string[];
   enableUserSSHKeyAgent?: boolean;
-  enableOperatingSystemManager?: boolean;
   podNodeSelectorAdmissionPluginConfig?: Record<string, string>;
   backupConfig?: BackupConfig;
   mla?: MLASettings;
@@ -525,7 +524,6 @@ export class ClusterSpecPatch {
   usePodSecurityPolicyAdmissionPlugin?: boolean;
   usePodNodeSelectorAdmissionPlugin?: boolean;
   useEventRateLimitAdmissionPlugin?: boolean;
-  enableOperatingSystemManager?: boolean;
   eventRateLimitConfig?: EventRateLimitConfig;
   admissionPlugins?: string[];
   opaIntegration?: OPAIntegration;

--- a/modules/web/src/app/wizard/component.ts
+++ b/modules/web/src/app/wizard/component.ts
@@ -288,7 +288,7 @@ export class WizardComponent implements OnInit, OnDestroy {
     if (cluster.spec.exposeStrategy !== ExposeStrategy.tunneling) {
       clusterModel.cluster.spec.clusterNetwork.tunnelingAgentIP = null;
     }
-    if (nodeData.operatingSystemProfile && cluster.spec.enableOperatingSystemManager) {
+    if (nodeData.operatingSystemProfile) {
       clusterModel.nodeDeployment.annotations = {
         [this.operatingSystemProfileAnnotation]: nodeData.operatingSystemProfile,
       };

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -92,7 +92,6 @@ enum Controls {
   AuditLogging = 'auditLogging',
   AuditPolicyPreset = 'auditPolicyPreset',
   UserSSHKeyAgent = 'userSSHKeyAgent',
-  OperatingSystemManager = 'enableOperatingSystemManager',
   ClusterBackup = 'clusterBackup',
   BackupStorageLocation = 'backupStorageLocation',
   Labels = 'labels',
@@ -374,7 +373,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.get(Controls.AuditLogging).valueChanges,
       this.form.get(Controls.AuditPolicyPreset).valueChanges,
       this.form.get(Controls.UserSSHKeyAgent).valueChanges,
-      this.form.get(Controls.OperatingSystemManager).valueChanges,
       this.form.get(Controls.ClusterBackup).valueChanges,
       this.form.get(Controls.KubernetesDashboardEnabled).valueChanges,
       this.form.get(Controls.OPAIntegration).valueChanges,
@@ -522,7 +520,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.AuditLogging]: this._builder.control(clusterSpec?.auditLogging?.enabled ?? false),
       [Controls.AuditPolicyPreset]: this._builder.control(clusterSpec?.auditLogging?.policyPreset ?? ''),
       [Controls.UserSSHKeyAgent]: this._builder.control(clusterSpec?.enableUserSSHKeyAgent ?? true),
-      [Controls.OperatingSystemManager]: this._builder.control(clusterSpec?.enableOperatingSystemManager ?? true),
       [Controls.ClusterBackup]: this._builder.control(!!clusterSpec?.backupConfig ?? false),
       [Controls.OPAIntegration]: this._builder.control(clusterSpec?.opaIntegration?.enabled ?? false),
       [Controls.Konnectivity]: this._builder.control(clusterSpec?.clusterNetwork?.konnectivityEnabled ?? true),
@@ -616,8 +613,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           [Controls.AuditPolicyPreset]:
             clusterSpec?.auditLogging?.policyPreset ?? this.controlValue(Controls.AuditPolicyPreset),
           [Controls.UserSSHKeyAgent]: clusterSpec?.enableUserSSHKeyAgent ?? this.controlValue(Controls.UserSSHKeyAgent),
-          [Controls.OperatingSystemManager]:
-            clusterSpec?.enableOperatingSystemManager ?? this.controlValue(Controls.OperatingSystemManager),
           [Controls.ClusterBackup]: !!clusterSpec.backupConfig ?? false,
           [Controls.OPAIntegration]: clusterSpec?.opaIntegration?.enabled ?? this.controlValue(Controls.OPAIntegration),
           [Controls.Konnectivity]:
@@ -956,7 +951,6 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         },
         enableUserSSHKeyAgent: this.controlValue(Controls.UserSSHKeyAgent),
         exposeStrategy: this.controlValue(Controls.ExposeStrategy),
-        enableOperatingSystemManager: this.controlValue(Controls.OperatingSystemManager),
         containerRuntime: this.controlValue(Controls.ContainerRuntime),
         clusterNetwork,
         cniPlugin: cniPlugin,

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -445,12 +445,6 @@ limitations under the License.
                  matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
             </mat-checkbox>
 
-            <mat-checkbox [formControlName]="Controls.OperatingSystemManager">
-              Operating System Manager
-              <i class="km-icon-info km-pointer"
-                 matTooltip="Enable to use OSM for creating and managing worker node configurations. Disable this to use legacy machine-controller userdata, its usage in production environment is not recommended."></i>
-            </mat-checkbox>
-
             <ng-container *ngIf="isMLAEnabled">
               <mat-checkbox [formControlName]="Controls.MLALogging">
                 User Cluster Logging

--- a/modules/web/src/app/wizard/step/summary/component.ts
+++ b/modules/web/src/app/wizard/step/summary/component.ts
@@ -84,7 +84,7 @@ export class SummaryStepComponent implements OnInit, OnDestroy {
         maxReplicas: data.maxReplicas,
       },
     };
-    if (data.operatingSystemProfile && this._clusterSpecService.cluster.spec.enableOperatingSystemManager) {
+    if (data.operatingSystemProfile) {
       md.annotations = {
         [OPERATING_SYSTEM_PROFILE_ANNOTATION]: data.operatingSystemProfile,
       };


### PR DESCRIPTION
**What this PR does / why we need it**:
The user-data plugins from machine-controller [have been removed](https://github.com/kubermatic/machine-controller/pull/1789). OSM is mandatory now to create a functional cluster since we can't fall back to user-data generated by machine-controller anymore.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The option to disable the operating system manager on cluster creation has been removed.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
