### PR TITLE
Update to k8c.io/kubermatic/v2@d6685584e4e6

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,7 +70,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.25.1-0.20240430090343-c52142138658
+	k8c.io/kubermatic/v2 v2.25.1-0.20240521070452-d6685584e4e6
 	k8c.io/operating-system-manager v1.5.0
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.29.3

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1411,8 +1411,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.3 h1:KZ2Q6LQMxoiFf9UQ3ugqjid39NccduhJ50bdbP5tdIU=
 k8c.io/kubeone v1.7.3/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.25.1-0.20240430090343-c52142138658 h1:QJWFBYJFoBS+pQ5do8lXDz5IiJP0m/pdi3Tbf0MYtKQ=
-k8c.io/kubermatic/v2 v2.25.1-0.20240430090343-c52142138658/go.mod h1:NwQO4cbYOxet+m8IqKObZlpkfE7qlr/ybhzCe9vT8Ts=
+k8c.io/kubermatic/v2 v2.25.1-0.20240521070452-d6685584e4e6 h1:IAHbBovD+rGrjX2UDCmUGBIbB5BX8nd0hRWWjw0N64s=
+k8c.io/kubermatic/v2 v2.25.1-0.20240521070452-d6685584e4e6/go.mod h1:NwQO4cbYOxet+m8IqKObZlpkfE7qlr/ybhzCe9vT8Ts=
 k8c.io/operating-system-manager v1.5.0 h1:XgdDhnHoGcP4xKFdSsPahFVaBuZqb5sr3+mQe6RW7Dc=
 k8c.io/operating-system-manager v1.5.0/go.mod h1:h7gVySBkNOVDj2LAW90kDw2nwAROS5k9wVHeK6w/1KQ=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=


### PR DESCRIPTION
**What this PR does / why we need it**:

We haven't updated the k8c.io/kubermatic dependency here in a while. This updates it to https://github.com/kubermatic/kubermatic/commit/d6685584e4e6f866e4e32aadd3cc2b2feb04ff0a, e.g. to get Kubernetes 1.30 versions in the dashboard.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
