### PR TITLE
fix: Added nil check to prevent exception on policy load

### DIFF
--- a/modules/api/pkg/provider/cloud/vmwareclouddirector/provider.go
+++ b/modules/api/pkg/provider/cloud/vmwareclouddirector/provider.go
@@ -214,10 +214,15 @@ func ListComputePolicies(ctx context.Context, auth Auth) (apiv1.VMwareCloudDirec
 
 	var policies apiv1.VMwareCloudDirectorComputePolicyList
 	for _, policy := range allPolicies {
+		description := ""
+
+		if policy.VdcComputePolicyV2.Description != nil {
+			description = *policy.VdcComputePolicyV2.Description
+		}
 		policies = append(policies, apiv1.VMwareCloudDirectorComputePolicy{
 			ID:           policy.VdcComputePolicyV2.ID,
 			Name:         policy.VdcComputePolicyV2.Name,
-			Description:  *policy.VdcComputePolicyV2.Description,
+			Description:  description,
 			IsSizingOnly: policy.VdcComputePolicyV2.IsSizingOnly,
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We have placement policies without a description, which causes the requests to fail. This PR just adds a nil check
```2024/05/24 11:36:17 http: panic serving 10.244.0.53:58594: runtime error: invalid memory address or nil pointer dereference
goroutine 2216644 [running]:
net/http.(*conn).serve.func1()
    net/http/server.go:1898 +0xbe
panic({0x487dc60?, 0xc096cc0?})
    runtime/panic.go:770 +0x132
k8c.io/dashboard/v2/pkg/provider/cloud/vmwareclouddirector.ListComputePolicies({0x30?, 0xc0016d7808?}, {{0x0, 0x0}, {0x0, 0x0}, {0xc002bd2420, 0x20}, {0xc000ce565c, 0x4}, ...})
    k8c.io/dashboard/v2/pkg/provider/cloud/vmwareclouddirector/provider.go:220 +0x2c2
k8c.io/dashboard/v2/pkg/handler/v2.Routing.listVMwareCloudDirectorComputePoliciesNoCredentials.VMwareCloudDirectorComputePoliciesWithClusterCredentialsEndpoint.func6({0x5a48858, 0xc00                                                                                                                                                                                                                     320a8d0}, {0x4c23620?, 0xc002effa60?})
    k8c.io/dashboard/v2/pkg/handler/v2/provider/vmwareclouddirector.go:540 +0x134
k8c.io/dashboard/v2/pkg/handler/v2.Routing.listVMwareCloudDirectorComputePoliciesNoCredentials.SetPrivilegedClusterProvider.func4.1({0x5a48858?, 0xc002c12840?}, {0x4c23620, 0xc002effa                                                                                                                                                                                                                     60})
    k8c.io/dashboard/v2/pkg/handler/middleware/middleware.go:169 +0x147
k8c.io/dashboard/v2/pkg/handler/v2.Routing.listVMwareCloudDirectorComputePoliciesNoCredentials.SetClusterProvider.func3.1({0x5a48858?, 0xc002b242a0?}, {0x4c23620, 0xc002effa60})
    k8c.io/dashboard/v2/pkg/handler/middleware/middleware.go:152 +0x83
k8c.io/dashboard/v2/pkg/handler/v2.Routing.listVMwareCloudDirectorComputePoliciesNoCredentials.UserSaver.func2.1({0x5a48858, 0xc002b240c0}, {0x4c23620, 0xc002effa60})
    k8c.io/dashboard/v2/pkg/handler/middleware/middleware.go:208 +0x4d9
k8c.io/dashboard/v2/pkg/handler/v2.Routing.listVMwareCloudDirectorComputePoliciesNoCredentials.TokenVerifier.func1.1({0x5a48858, 0xc002f23b60}, {0x4c23620, 0xc002effa60})
    k8c.io/dashboard/v2/pkg/handler/middleware/middleware.go:306 +0x559
github.com/go-kit/kit/transport/http.Server.ServeHTTP({0xc001c36540, 0x5453140, 0x54526e8, {0xc001c24940, 0x3, 0x4}, {0x0, 0x0, 0x0}, 0x54526f0, ...}, ...)
    github.com/go-kit/kit@v0.13.0/transport/http/server.go:121 +0x337
main.setSecureHeaders.func1({0x7f7ac2a58ac8, 0xc0007b18b0}, 0xc002a71200)
    k8c.io/dashboard/v2/cmd/kubermatic-api/main.go:677 +0x30c
net/http.HandlerFunc.ServeHTTP(0xc002a710e0?, {0x7f7ac2a58ac8?, 0xc0007b18b0?}, 0x0?)
    net/http/server.go:2166 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc00069c000, {0x7f7ac2a58ac8, 0xc0007b18b0}, 0xc002a70ea0)
    github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x5a3a000?, 0xc002a3d680?}, 0xc002a70ea0)
    github.com/prometheus/client_golang@v1.18.0/prometheus/promhttp/instrument_server.go:147 +0xc3
net/http.HandlerFunc.ServeHTTP(0xc000a22008?, {0x5a3a000?, 0xc002a3d680?}, 0x0?)
    net/http/server.go:2166 +0x29
main.createAPIHandler.instrumentHandler.func4({0x5a3a000, 0xc002a3d680}, 0xc002a70ea0)
    k8c.io/dashboard/v2/cmd/kubermatic-api/metrics.go:65 +0x9b
net/http.HandlerFunc.ServeHTTP(0x5a363c0?, {0x5a3a000?, 0xc002a3d680?}, 0x10?)
    net/http/server.go:2166 +0x29
github.com/gorilla/handlers.loggingHandler.ServeHTTP({{0x59f8380, 0xc00012a008}, {0x59f8260, 0xc001717ea0}, 0xc000738bc0}, {0x5a363c0, 0xc00320d180}, 0xc002a70ea0)
    github.com/gorilla/handlers@v1.5.2/logging.go:47 +0xef
net/http.serverHandler.ServeHTTP({0xc002807b90?}, {0x5a363c0?, 0xc00320d180?}, 0x6?)
    net/http/server.go:3137 +0x8e
net/http.(*conn).serve(0xc00283fb00, {0x5a48858, 0xc001756420})
    net/http/server.go:2039 +0x5e8
created by net/http.(*Server).Serve in goroutine 1
    net/http/server.go:3285 +0x4b4
```


**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```