### PR TITLE
Display the used preset in cluster page

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -7147,6 +7147,12 @@
             "x-go-name": "Disabled",
             "name": "disabled",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "name": "name",
+            "in": "query"
           }
         ],
         "responses": {
@@ -16939,6 +16945,12 @@
             "x-go-name": "Disabled",
             "name": "disabled",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "name": "name",
+            "in": "query"
           }
         ],
         "responses": {
@@ -21733,6 +21745,12 @@
           },
           {
             "type": "string",
+            "x-go-name": "Name",
+            "name": "name",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProviderName",
             "name": "provider_name",
             "in": "path",
@@ -24234,6 +24252,12 @@
             "type": "boolean",
             "x-go-name": "Disabled",
             "name": "disabled",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "name": "name",
             "in": "query"
           },
           {

--- a/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_presets_parameters.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_presets_parameters.go
@@ -65,6 +65,9 @@ type ListPresetsParams struct {
 	// Disabled.
 	Disabled *bool
 
+	// Name.
+	Name *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -129,6 +132,17 @@ func (o *ListPresetsParams) SetDisabled(disabled *bool) {
 	o.Disabled = disabled
 }
 
+// WithName adds the name to the list presets params
+func (o *ListPresetsParams) WithName(name *string) *ListPresetsParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the list presets params
+func (o *ListPresetsParams) SetName(name *string) {
+	o.Name = name
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *ListPresetsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -149,6 +163,23 @@ func (o *ListPresetsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		if qDisabled != "" {
 
 			if err := r.SetQueryParam("disabled", qDisabled); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Name != nil {
+
+		// query param name
+		var qrName string
+
+		if o.Name != nil {
+			qrName = *o.Name
+		}
+		qName := qrName
+		if qName != "" {
+
+			if err := r.SetQueryParam("name", qName); err != nil {
 				return err
 			}
 		}

--- a/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_project_presets_parameters.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_project_presets_parameters.go
@@ -65,6 +65,9 @@ type ListProjectPresetsParams struct {
 	// Disabled.
 	Disabled *bool
 
+	// Name.
+	Name *string
+
 	// ProjectID.
 	ProjectID string
 
@@ -132,6 +135,17 @@ func (o *ListProjectPresetsParams) SetDisabled(disabled *bool) {
 	o.Disabled = disabled
 }
 
+// WithName adds the name to the list project presets params
+func (o *ListProjectPresetsParams) WithName(name *string) *ListProjectPresetsParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the list project presets params
+func (o *ListProjectPresetsParams) SetName(name *string) {
+	o.Name = name
+}
+
 // WithProjectID adds the projectID to the list project presets params
 func (o *ListProjectPresetsParams) WithProjectID(projectID string) *ListProjectPresetsParams {
 	o.SetProjectID(projectID)
@@ -163,6 +177,23 @@ func (o *ListProjectPresetsParams) WriteToRequest(r runtime.ClientRequest, reg s
 		if qDisabled != "" {
 
 			if err := r.SetQueryParam("disabled", qDisabled); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Name != nil {
+
+		// query param name
+		var qrName string
+
+		if o.Name != nil {
+			qrName = *o.Name
+		}
+		qName := qrName
+		if qName != "" {
+
+			if err := r.SetQueryParam("name", qName); err != nil {
 				return err
 			}
 		}

--- a/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_project_provider_presets_parameters.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_project_provider_presets_parameters.go
@@ -68,6 +68,9 @@ type ListProjectProviderPresetsParams struct {
 	// Disabled.
 	Disabled *bool
 
+	// Name.
+	Name *string
+
 	// ProjectID.
 	ProjectID string
 
@@ -149,6 +152,17 @@ func (o *ListProjectProviderPresetsParams) SetDisabled(disabled *bool) {
 	o.Disabled = disabled
 }
 
+// WithName adds the name to the list project provider presets params
+func (o *ListProjectProviderPresetsParams) WithName(name *string) *ListProjectProviderPresetsParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the list project provider presets params
+func (o *ListProjectProviderPresetsParams) SetName(name *string) {
+	o.Name = name
+}
+
 // WithProjectID adds the projectID to the list project provider presets params
 func (o *ListProjectProviderPresetsParams) WithProjectID(projectID string) *ListProjectProviderPresetsParams {
 	o.SetProjectID(projectID)
@@ -208,6 +222,23 @@ func (o *ListProjectProviderPresetsParams) WriteToRequest(r runtime.ClientReques
 		if qDisabled != "" {
 
 			if err := r.SetQueryParam("disabled", qDisabled); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Name != nil {
+
+		// query param name
+		var qrName string
+
+		if o.Name != nil {
+			qrName = *o.Name
+		}
+		qName := qrName
+		if qName != "" {
+
+			if err := r.SetQueryParam("name", qName); err != nil {
 				return err
 			}
 		}

--- a/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_provider_presets_parameters.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/client/preset/list_provider_presets_parameters.go
@@ -68,6 +68,9 @@ type ListProviderPresetsParams struct {
 	// Disabled.
 	Disabled *bool
 
+	// Name.
+	Name *string
+
 	// ProviderName.
 	ProviderName string
 
@@ -146,6 +149,17 @@ func (o *ListProviderPresetsParams) SetDisabled(disabled *bool) {
 	o.Disabled = disabled
 }
 
+// WithName adds the name to the list provider presets params
+func (o *ListProviderPresetsParams) WithName(name *string) *ListProviderPresetsParams {
+	o.SetName(name)
+	return o
+}
+
+// SetName adds the name to the list provider presets params
+func (o *ListProviderPresetsParams) SetName(name *string) {
+	o.Name = name
+}
+
 // WithProviderName adds the providerName to the list provider presets params
 func (o *ListProviderPresetsParams) WithProviderName(providerName string) *ListProviderPresetsParams {
 	o.SetProviderName(providerName)
@@ -194,6 +208,23 @@ func (o *ListProviderPresetsParams) WriteToRequest(r runtime.ClientRequest, reg 
 		if qDisabled != "" {
 
 			if err := r.SetQueryParam("disabled", qDisabled); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Name != nil {
+
+		// query param name
+		var qrName string
+
+		if o.Name != nil {
+			qrName = *o.Name
+		}
+		qName := qrName
+		if qName != "" {
+
+			if err := r.SetQueryParam("name", qName); err != nil {
 				return err
 			}
 		}

--- a/modules/web/src/app/cluster/details/cluster/component.spec.ts
+++ b/modules/web/src/app/cluster/details/cluster/component.spec.ts
@@ -59,6 +59,8 @@ import {AddonService} from '@core/services/addon';
 import {MachineDeploymentServiceMock} from '@test/services/machine-deployment-mock';
 import {AddonServiceMock} from '@test/services/addon-mock';
 import {EndOfLifeService} from '@core/services/eol';
+import {PresetsService} from '@app/core/services/wizard/presets';
+import {PresetServiceMock} from '@test/services/preset-mock';
 
 describe('ClusterDetailsComponent', () => {
   let fixture: ComponentFixture<ClusterDetailsComponent>;
@@ -113,6 +115,7 @@ describe('ClusterDetailsComponent', () => {
         {provide: MachineDeploymentService, useClass: MachineDeploymentServiceMock},
         {provide: AddonService, useClass: AddonServiceMock},
         {provide: ApplicationService, useClass: ApplicationServiceMock},
+        {provide: PresetsService, useClass: PresetServiceMock},
         EndOfLifeService,
         GoogleAnalyticsService,
         NotificationService,

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -184,6 +184,18 @@ limitations under the License.
             <span class="km-provider-logo km-provider-logo-{{getProvider(nodeDc?.spec?.provider)}}"></span>
           </div>
         </km-property>
+        <km-property>
+          <div key>Preset</div>
+          <div value>
+            <div>
+              <i *ngIf="cluster?.annotations?.presetName"
+                 [matTooltip]="presetStatus?.message"
+                 [ngClass]="presetStatus?.icon"
+                 class="km-vertical-center"></i>
+              {{cluster.annotations?.presetName ?? "-"}}
+            </div>
+          </div>
+        </km-property>
         <km-property *ngIf="cluster.spec.containerRuntime">
           <div key>Container Runtime</div>
           <div value>{{cluster.spec.containerRuntime}}</div>

--- a/modules/web/src/app/core/services/wizard/presets.ts
+++ b/modules/web/src/app/core/services/wizard/presets.ts
@@ -147,6 +147,11 @@ export class PresetsService {
     return this._http.get<PresetStat>(url);
   }
 
+  getPresetByName(projectID: string, presetName: string): Observable<Preset> {
+    const url = `${environment.newRestRoot}/projects/${projectID}/presets?name=${presetName}`;
+    return this._http.get<Preset>(url);
+  }
+
   updateStatus(
     presetName: string,
     status: UpdatePresetStatusReq,

--- a/modules/web/src/app/shared/utils/health-status.ts
+++ b/modules/web/src/app/shared/utils/health-status.ts
@@ -36,6 +36,8 @@ export enum StatusMassage {
   Updating = 'Updating',
   Disabled = 'Disabled',
   Unknown = 'Unknown',
+  Active = 'active',
+  Deleted = 'deleted',
 }
 
 export class HealthStatus {

--- a/modules/web/src/test/services/preset-mock.ts
+++ b/modules/web/src/test/services/preset-mock.ts
@@ -1,0 +1,24 @@
+// Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Injectable} from '@angular/core';
+import {Preset} from '@app/shared/entity/preset';
+import {Observable, of} from 'rxjs';
+
+@Injectable()
+export class PresetServiceMock {
+  getPresetByName(_projectID: string, _presetName: string): Observable<Preset> {
+    return of({} as Preset);
+  }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Display the name of the preset used when creating the cluster on the cluster detail page.

![image](https://github.com/kubermatic/dashboard/assets/85109141/dc76d558-2a11-42d1-932d-9c4f2d4a834d)


**Which issue(s) this PR fixes**:
Fixes #5656 

**What type of PR is this?**
/kind feature

```release-note
Display the used preset name on the cluster detail page.
```

```documentation
NONE
```
