### PR TITLE
fix dev deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ docker-push: docker-build
 	done
 
 deploy:
-	kubectl -n kubermatic patch kubermaticconfiguration kubermatic --patch '{"spec":{"ui":{"dockerTag":"$(IMAGE_TAG)"}}}' --type=merge
+	kubectl -n kubermatic patch kubermaticconfiguration kubermatic \
+	  --patch '{"spec":{"api":{"dockerTag":"$(IMAGE_TAG)"},"ui":{"dockerTag":"$(IMAGE_TAG)"}}}' \
+	  --type merge
 
 download-gocache:
 	@./hack/ci/download-gocache.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that `spec.api.dockerTag` is a thing, it also needs to be set explicitly when deploying to dev.

**What type of PR is this?**
/kind chore

```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
