### PR TITLE
Fix defaulting for CNI

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -273,7 +273,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
             if (this.controlValue(Controls.CNIPlugin) === CNIPlugin.Cilium) {
               this.control(Controls.CNIPlugin).setValue(CNIPlugin.Canal);
             }
-          } else if (this.controlValue(Controls.CNIPlugin) !== CNIPlugin.Cilium) {
+          } else if (this.controlValue(Controls.CNIPlugin) === '') {
             this.control(Controls.CNIPlugin).setValue(CNIPlugin.Cilium);
           }
         })


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where CNI was always being defaulted to cilium irrespective of what was configured in the cluster template or default cluster template.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where CNI was always being defaulted to cilium irrespective of what was configured in the cluster template or default cluster template
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/cherry-pick release/v2.25