### PR TITLE
Add a "Backup All Namespaces" Checkbox

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
@@ -36,11 +36,16 @@ END OF TERMS AND CONDITIONS
         <input [formControlName]="Controls.Destination"
                matInput
                required>
-        <mat-hint>default-cluster-backup-bsl is the backup storage location created inside the user cluster.</mat-hint>
+               <mat-hint>The name of the backup storage location used during cluster creation.</mat-hint>
       </mat-form-field>
-      <mat-form-field>
+      <mat-checkbox [formControlName]="Controls.AllNamespaces">
+        Backup All Namespaces
+        <i class="km-icon-info km-pointer"
+           matTooltip="Select all namespaces to backup."></i>
+      </mat-checkbox>
+      <mat-form-field *ngIf="!form?.get(Controls.AllNamespaces).value">
         <mat-label>{{namespacesLabel}}</mat-label>
-        <mat-select [formControlName]="Controls.NameSpaces"
+        <mat-select [formControlName]="Controls.Namespaces"
                     multiple
                     panelClass="km-multiple-values-dropdown"
                     disableOptionCentering>
@@ -49,7 +54,7 @@ END OF TERMS AND CONDITIONS
             {{nameSpace}}
           </mat-option>
         </mat-select>
-        <mat-hint>Namespaces to include in the backup. If unspecified, all namespaces are included.</mat-hint>
+        <mat-hint>Namespaces to include in the backup.</mat-hint>
       </mat-form-field>
 
       <mat-form-field *ngIf="isScheduleBackup()"

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
@@ -37,7 +37,7 @@ END OF TERMS AND CONDITIONS
                    inputLabel="Select cluster..."
                    [label]="clusterLabel"
                    [enableResetButton]="false"
-                   [selected]="selectedCluster"
+                   [selected]="selectedCluster?.id"
                    [valueFormatter]="clusterDisplayFn.bind(this)"
                    [options]="clusters"
                    (changed)="onClusterChange($event)">
@@ -139,7 +139,7 @@ END OF TERMS AND CONDITIONS
             class="km-header-cell p-10">Destination</th>
         <td mat-cell
             *matCellDef="let element">
-          <span>{{element.spec.storageLocation}}</span>
+          <span>{{clusterBSL}}</span>
         </td>
       </ng-container>
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/template.html
@@ -37,7 +37,7 @@ END OF TERMS AND CONDITIONS
                    inputLabel="Select cluster..."
                    [label]="clusterLabel"
                    [enableResetButton]="false"
-                   [selected]="selectedCluster"
+                   [selected]="selectedCluster?.id"
                    [options]="clusters"
                    [valueFormatter]="clusterDisplayFn.bind(this)"
                    (changed)="onClusterChange($event)">
@@ -138,7 +138,7 @@ END OF TERMS AND CONDITIONS
             class="km-header-cell p-10">Destination</th>
         <td mat-cell
             *matCellDef="let element">
-          <span>{{element.spec.storageLocation}}</span>
+          <span>{{clusterBSL}}</span>
         </td>
       </ng-container>
 

--- a/modules/web/src/app/shared/entity/backup.ts
+++ b/modules/web/src/app/shared/entity/backup.ts
@@ -139,7 +139,8 @@ export enum BackupType {
   BackupStorageLocation = 'Backup Storage Location',
 }
 
-// this variable is temporary, it will be removed after adding the functionalty for cluster backup storage location.
+// "BackupStorageLocationTempName" is the name of the default and only BSL in the user cluster.
+// This variable is temporary and will be removed after adding the functionality for multiple backup storage locations.
 export const BackupStorageLocationTempName = 'default-cluster-backup-bsl';
 
 export class ClusterBackup {


### PR DESCRIPTION
**What this PR does / why we need it**:
add a check box to select all namespaces, and show the name of the `CBSL`  that was used during cluster creation.

![image](https://github.com/kubermatic/dashboard/assets/85109141/378b5bb3-c22b-4aba-8e10-16fa05b3ced0)

![image](https://github.com/kubermatic/dashboard/assets/85109141/b4d3250a-ea65-450b-8f0d-0ab42a2ed146)

![image](https://github.com/kubermatic/dashboard/assets/85109141/b170c256-c69e-4f16-b45b-5e45fa1960fc)

**Which issue(s) this PR fixes**:
Fixes #6700 

**What type of PR is this?**
/kind design

```release-note
NONE
```

```documentation
NONE
```
