### PR TITLE
Adjust chip list component to have multiple values at once

### DIFF
--- a/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
@@ -119,7 +119,6 @@ limitations under the License.
     </mat-form-field>
 
     <km-chip-list label="Required Emails"
-                  description="Use commas, space or enter key as the separators."
                   [tags]="requiredEmails"
                   (onChange)="onRequiredEmailsChange($event)"
                   [formControlName]="controls.RequiredEmails"

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/preset/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/preset/template.html
@@ -39,7 +39,6 @@ limitations under the License.
   <div class="optional-section">Optional Settings</div>
   <km-chip-list label="Restrict to Domains and Emails"
                 placeholder="Domains..."
-                description="Use commas, space or enter key as the separators."
                 [tags]="domains"
                 (onChange)="onDomainsChange($event)"
                 [formControlName]="controls.Domains"

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vmware-cloud-director/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vmware-cloud-director/template.html
@@ -101,7 +101,6 @@ limitations under the License.
 
   <km-chip-list label="Organization VDC Networks"
                 placeholder="OVDC Networks to attach to the vApps..."
-                description="Use commas, space or enter key as the separators."
                 [tags]="networks"
                 (onChange)="onNetworksChange($event)"
                 [formControlName]="Controls.OvdcNetworks"

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/template.html
@@ -46,7 +46,6 @@ limitations under the License.
 
   <km-chip-list label="Networks"
                 placeholder="Networks to attach to VMs..."
-                description="Use commas, space or enter key as the separators."
                 [tags]="networks"
                 (onChange)="onNetworksChange($event)"
                 [formControlName]="Controls.Networks"

--- a/modules/web/src/app/shared/components/chip-list/component.ts
+++ b/modules/web/src/app/shared/components/chip-list/component.ts
@@ -58,7 +58,7 @@ export class ChipListComponent implements OnChanges, OnDestroy, ControlValueAcce
   readonly controls = Controls;
   @Input() title: string;
   @Input() label: string;
-  @Input() description = 'Use comma, enter or space key as the separator.';
+  @Input() description = 'Use comma, space or enter key as the separator.';
   @Input() placeholder: string;
   @Input() disabled: boolean;
   @Input('kmRequired') required: boolean;
@@ -112,7 +112,14 @@ export class ChipListComponent implements OnChanges, OnDestroy, ControlValueAcce
     }
 
     event.chipInput?.clear();
-    this.tags.push(value);
+    const delimiters = [',', ' '];
+    const splitRegex = new RegExp(`[${delimiters.join('')}]`);
+    if (splitRegex.test(value)) {
+      const multiTags = value.split(splitRegex);
+      multiTags.filter(val => !!val.trim()).forEach(val => this.tags.push(val.trim()));
+    } else {
+      this.tags.push(value);
+    }
     this.onChange.emit(this.tags);
   }
 

--- a/modules/web/src/app/wizard/step/cluster/style.scss
+++ b/modules/web/src/app/wizard/step/cluster/style.scss
@@ -83,5 +83,5 @@ mat-button-toggle-group[group='cniPluginTypeGroup'] {
 
 .tag-list {
   display: block;
-  padding-bottom: 25px;
+  padding: 10px 0 15px;
 }

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -157,7 +157,6 @@ limitations under the License.
                         class="tag-list"
                         label="Allowed IP Ranges for NodePorts"
                         placeholder="IP CIDRs..."
-                        description=""
                         [formControlName]="Controls.NodePortsAllowedIPRanges"
                         [kmPattern]="ipv4AndIPv6CidrRegex"
                         kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjust the km-chip-list component so that the user can add multiple values separated by commas or spaces all at once.

**Which issue(s) this PR fixes**:
Fixes #6684

**What type of PR is this?**
/kind cleanup
/kind design

```release-note
NONE
```

```documentation
NONE
```
