### PR TITLE
remove scary deprecation warning

### DIFF
--- a/modules/api/cmd/kubermatic-api/main.go
+++ b/modules/api/cmd/kubermatic-api/main.go
@@ -18,10 +18,6 @@ limitations under the License.
 //
 // This OpenAPI 2.0 specification describes the REST APIs used by the Kubermatic Kubernetes Platform Dashboard.
 //
-// KKP API is an **internal API** that is built primarily to complement the KKP dashboard. Our users are strongly advised to use Kubernetes APIs i.e. [KKP CRDs](https://docs.kubermatic.com/kubermatic/v2.22/references/crds/) to interact with and integrate KKP into their own platforms.
-//
-// Since KKP API is **not a public API**, users can expect breaking changes without any formal announcements.
-//
 //	Schemes: https
 //	Version: 2.23
 //

--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -10,7 +10,7 @@
   ],
   "swagger": "2.0",
   "info": {
-    "description": "This OpenAPI 2.0 specification describes the REST APIs used by the Kubermatic Kubernetes Platform Dashboard.\n\nKKP API is an **internal API** that is built primarily to complement the KKP dashboard. Our users are strongly advised to use Kubernetes APIs i.e. [KKP CRDs](https://docs.kubermatic.com/kubermatic/v2.22/references/crds/) to interact with and integrate KKP into their own platforms.\n\nSince KKP API is **not a public API**, users can expect breaking changes without any formal announcements.",
+    "description": "This OpenAPI 2.0 specification describes the REST APIs used by the Kubermatic Kubernetes Platform Dashboard.",
     "title": "Kubermatic Kubernetes Platform API",
     "version": "2.23"
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
While technically correct, the warning about the API stability is causing uncertainty with integrators. In practice the KKP REST API is not going away anytime soon, especially not in KKP 2.x, given KKP's architecture and inherent limitations.

CRDs are still the way to go for "simple" setups or setups where a singular entity is managing KKP (like when you have a GitOps pipeline and only scripts modify KKP directly, instead of all members in a team individually connecting to KKP). But I can see how my strong stance on deprecating and de-emphasizing the REST API might have caused more friction than I intended.

/cc @moadqassem 

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
