### PR TITLE
Add YAML editor to configure CBSL config

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/style.scss
@@ -21,3 +21,7 @@
 .region-field {
   margin-top: 15px;
 }
+
+.mat-mdc-checkbox {
+  margin-top: 10px;
+}

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
@@ -67,24 +67,38 @@ END OF TERMS AND CONDITIONS
              matInput>
       <mat-hint>Enter time in the format MMmSSs (e.g., 2m10s),BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.</mat-hint>
     </mat-form-field>
-    <mat-form-field class="region-field">
-      <mat-label>Region</mat-label>
-      <input [formControlName]="Controls.Region"
-             matInput>
-      <mat-hint>The AWS region where the bucket is located.</mat-hint>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>Endpoints</mat-label>
-      <input [formControlName]="Controls.Endpoints"
-             matInput>
-      <mat-hint>You can specify the AWS S3 URL here for explicitness.</mat-hint>
-    </mat-form-field>
+    <mat-checkbox [formControlName]="Controls.AddCustomConfig">Add custom config
+    </mat-checkbox>
+    <ng-container *ngIf="form.get(Controls.AddCustomConfig).value">
+      <km-editor [(model)]="valuesConfig"
+                 height="370px"
+                 header="values.yaml">
+      </km-editor>
+      <km-validate-json-or-yaml [data]="valuesConfig"
+                                [isOnlyYAML]="true"
+                                (dataValid)="isValidYaml($event)"></km-validate-json-or-yaml>
+    </ng-container>
+    <ng-container *ngIf="!form.get(Controls.AddCustomConfig).value">
+
+      <mat-form-field class="region-field">
+        <mat-label>Region</mat-label>
+        <input [formControlName]="Controls.Region"
+               matInput>
+        <mat-hint>The AWS region where the bucket is located.</mat-hint>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Endpoints</mat-label>
+        <input [formControlName]="Controls.Endpoints"
+               matInput>
+        <mat-hint>You can specify the AWS S3 URL here for explicitness.</mat-hint>
+      </mat-form-field>
+    </ng-container>
   </form>
 </mat-dialog-content>
 <mat-dialog-actions>
   <km-button [icon]="icon"
              [label]="label"
-             [disabled]="form.invalid"
+             [disabled]="form.invalid || !isYamlEditorValid"
              [observable]="getObservable()"
              (next)="onNext($event)">
   </km-button>


### PR DESCRIPTION
**What this PR does / why we need it**:
add a yaml editor in the backup storage location dialog to configure the BSL  config.

![image](https://github.com/user-attachments/assets/145e493b-23ad-4416-9f09-bfed251750ab)


**Which issue(s) this PR fixes**:
Fixes #6732 

**What type of PR is this?**
/kind feature

```release-note
Add a `yaml` block field to add additional parameters to the `config` for the backup storage location 
```

```documentation
NONE
```
