### PR TITLE
Allow eBPF proxy mode when cni is none

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -808,8 +808,9 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
   private _updateAvailableProxyModes(): void {
     const proxyModeControl = this.control(Controls.ProxyMode);
+    const controlValueCNIPlugin = this.controlValue(Controls.CNIPlugin);
     let newValue: ProxyMode;
-    if (this.controlValue(Controls.CNIPlugin) === CNIPlugin.Cilium) {
+    if (controlValueCNIPlugin === CNIPlugin.Cilium) {
       if (this.controlValue(Controls.Konnectivity)) {
         this.availableProxyModes = [ProxyMode.iptables, ProxyMode.ebpf];
         if (proxyModeControl.value === ProxyMode.ipvs) {
@@ -820,7 +821,8 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         newValue = ProxyMode.iptables;
       }
     } else {
-      this.availableProxyModes = [ProxyMode.ipvs, ProxyMode.iptables];
+      this.availableProxyModes =
+        controlValueCNIPlugin === CNIPlugin.None ? Object.values(ProxyMode) : [ProxyMode.ipvs, ProxyMode.iptables];
       if (proxyModeControl.pristine || !this.availableProxyModes.includes(proxyModeControl.value)) {
         newValue = this._defaultProxyMode || ProxyMode.ipvs;
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for eBPF proxy mode when the CNI plugin is none.

![image](https://github.com/user-attachments/assets/3c48f2b9-6cc8-4e2c-b04f-4ab9ec6eb8ee)


**Which issue(s) this PR fixes**:
Fixes #6755

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Support for eBPF proxy mode when the CNI plugin is none.
```

**Documentation**:
```documentation
NONE
```
