### PR TITLE
Fix setBaremetal Credential 

### DIFF
--- a/modules/api/pkg/provider/kubernetes/preset.go
+++ b/modules/api/pkg/provider/kubernetes/preset.go
@@ -426,7 +426,7 @@ func (m *PresetProvider) setBaremetalCredentials(preset *kubermaticv1.Preset, cl
 	}
 
 	if cloud.Baremetal.Tinkerbell != nil {
-		cloud.Baremetal.Tinkerbell.Kubeconfig = preset.Spec.Kubevirt.Kubeconfig
+		cloud.Baremetal.Tinkerbell.Kubeconfig = preset.Spec.Baremetal.Tinkerbell.Kubeconfig
 	}
 
 	return &cloud, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will fix nil pointer issue because we're copying kubeconfig from kubevirt when baremetal provider is enabled 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
