### PR TITLE
Enable editing allowed IP ranges for NodePorts

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -113,6 +113,14 @@ limitations under the License.
         </div>
       </div>
 
+      <km-chip-list *ngIf="isAllowedIPRangeSupported"
+                    label="Allowed IP Ranges for NodePorts"
+                    placeholder="IP CIDRs..."
+                    [formControlName]="Controls.NodePortsAllowedIPRanges"
+                    [kmPattern]="ipv4AndIPv6CidrRegex"
+                    kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">
+      </km-chip-list>
+
       <km-chip-list *ngIf="isExposeStrategyLoadBalancer()"
                     class="tag-list"
                     label="Allowed IP Ranges for API server"
@@ -214,7 +222,8 @@ limitations under the License.
       </mat-checkbox>
 
       <mat-checkbox [formControlName]="Controls.DisableCSIDriver"
-                    [disabled]="isCSIDriverDisabled">
+                    [disabled]="isCSIDriverDisabled"
+                    kmValueChangedIndicator>
         Disable CSI Driver
         <i class="km-icon-info km-pointer"
            [matTooltip]="isCSIDriverDisabled ? 'CSI Driver is disabled by your admin in the chosen datacenter.' : 'Disable default CSI storage driver, if available.'"></i>

--- a/modules/web/src/app/shared/directives/value-changed-indicator.ts
+++ b/modules/web/src/app/shared/directives/value-changed-indicator.ts
@@ -37,7 +37,7 @@ export class ValueChangedIndicatorDirective implements OnInit {
 
     const element = this._el.nativeElement;
     const classList = Array.from(element.classList);
-    this._initialValue = this._control.control.value;
+    this._initialValue = _.cloneDeep(this._control.control.value);
 
     if (classList?.includes('mat-input-element')) {
       if (element.getAttribute('type') === 'number') {
@@ -74,6 +74,8 @@ export class ValueChangedIndicatorDirective implements OnInit {
       } else if (classList.includes('ngx-monaco-editor')) {
         this._initialValue = this._initialValue === null ? value : this._initialValue;
         element.classList.toggle('km-value-changed', this._initialValue !== value);
+      } else if (classList?.includes('km-chip-list-with-input')) {
+        element.parentElement.classList.toggle('km-value-changed', !_.isEqual(this._initialValue, value));
       } else {
         this._initialValue = this._initialValue === null ? value : this._initialValue;
         element.classList.toggle('km-value-changed', this._initialValue !== value);

--- a/modules/web/src/app/shared/model/NodeProviderConstants.ts
+++ b/modules/web/src/app/shared/model/NodeProviderConstants.ts
@@ -35,7 +35,12 @@ export enum NodeProvider {
   EDGE = 'edge',
   NONE = '',
 }
-
+export const NODEPORTS_IPRANGES_SUPPORTED_PROVIDERS = [
+  NodeProvider.AWS,
+  NodeProvider.AZURE,
+  NodeProvider.GCP,
+  NodeProvider.OPENSTACK,
+];
 export const EXTERNAL_NODE_PROVIDERS = [NodeProvider.AKS, NodeProvider.EKS, NodeProvider.GKE];
 
 export const INTERNAL_NODE_PROVIDERS = Object.values(NodeProvider).filter(

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -57,7 +57,7 @@ import {
 import {ResourceType} from '@shared/entity/common';
 import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
 import {AdminSettings, StaticLabel} from '@shared/entity/settings';
-import {NodeProvider} from '@shared/model/NodeProviderConstants';
+import {NodeProvider, NODEPORTS_IPRANGES_SUPPORTED_PROVIDERS} from '@shared/model/NodeProviderConstants';
 import {KeyValueEntry} from '@shared/types/common';
 import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plugin';
 import {
@@ -476,9 +476,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   isAllowedIPRangeSupported(): boolean {
-    return [NodeProvider.AWS, NodeProvider.AZURE, NodeProvider.GCP, NodeProvider.OPENSTACK].includes(
-      this._clusterSpecService.provider
-    );
+    return NODEPORTS_IPRANGES_SUPPORTED_PROVIDERS.includes(this._clusterSpecService.provider);
   }
 
   isExposeStrategyLoadBalancer(): boolean {

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -746,6 +746,12 @@ km-cni-version {
     width: 5px;
   }
 
+  &:has(.km-chip-list-with-input)::after {
+    height: 100% !important;
+    left: -15px !important;
+    top: 0 !important;
+  }
+
   &.mat-mdc-checkbox::after {
     left: -12px !important;
     top: 8px !important;


### PR DESCRIPTION
**What this PR does / why we need it**:
add new option to edit the allowed ip ranges in the edit cluster dialog for the supported providers.
**edit cluster dialog**
![image](https://github.com/user-attachments/assets/c3ba8b6d-6bb4-450a-bf4d-815f12b2f826)

**Which issue(s) this PR fixes**:
Fixes #6772

**What type of PR is this?**
/kind feature

```release-note
Enable editing allowed IP ranges for NodePorts 
```
```documentation
NONE
```
