### PR TITLE
correct labels for vSphere InfraManagement credentials

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-provider-settings/vsphere-provider-settings/template.html
@@ -58,7 +58,7 @@ limitations under the License.
 
   <ng-container *ngIf="useCustomCloudCredentials">
     <mat-form-field fxFlex>
-      <mat-label>VSphere Cloud Provider Username</mat-label>
+      <mat-label>Infrastructure Management Username</mat-label>
       <input matInput
              [formControlName]="Control.InfraManagementUsername"
              type="text"
@@ -67,7 +67,7 @@ limitations under the License.
     </mat-form-field>
 
     <mat-form-field fxFlex>
-      <mat-label>VSphere Cloud Provider Password</mat-label>
+      <mat-label>Infrastructure Management Password</mat-label>
       <input matInput
              [formControlName]="Control.InfraManagementPassword"
              kmInputPassword

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -517,7 +517,7 @@ limitations under the License.
               <div value>{{cluster.spec.cloud?.vsphere.username}}</div>
             </km-property>
             <km-property *ngIf="cluster.spec.cloud?.vsphere?.infraManagementUser?.username">
-              <div key>VSphere Cloud Provider Username</div>
+              <div key>Infrastructure Management Username</div>
               <div value>{{cluster.spec.cloud?.vsphere?.infraManagementUser?.username}}</div>
             </km-property>
             <km-property *ngIf="cluster.spec.cloud?.vsphere?.networks">

--- a/modules/web/src/app/wizard/step/provider-settings/provider/basic/vsphere/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/basic/vsphere/template.html
@@ -62,7 +62,7 @@ limitations under the License.
 
   <ng-container *ngIf="useCustomCloudCredentials">
     <mat-form-field fxFlex>
-      <mat-label>VSphere Cloud Provider Username</mat-label>
+      <mat-label>Infrastructure Management Username</mat-label>
       <input matInput
              [formControlName]="Controls.InfraManagementUsername"
              type="text"
@@ -74,7 +74,7 @@ limitations under the License.
     </mat-form-field>
 
     <mat-form-field fxFlex>
-      <mat-label>VSphere Cloud Provider Password</mat-label>
+      <mat-label>Infrastructure Management Password</mat-label>
       <input matInput
              [formControlName]="Controls.InfraManagementPassword"
              kmInputPassword


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the labels for the vSphere InfraManagement credentials to reflect that these credentials are used to manage and provision the infrastructure.

**Which issue(s) this PR fixes**:

Fixes #

**What type of PR is this?**

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```