### PR TITLE
Web terminal: fix warning when sourcing .bashrc

### DIFF
--- a/hack/images/web-terminal/.bashrc
+++ b/hack/images/web-terminal/.bashrc
@@ -7,6 +7,8 @@ alias k=kubectl
 complete -F __start_kubectl k
 
 ### helm
+# prevent 'Warning kubectl file is {world,group}-readable'
+chmod 600 ${KUBECONFIG}
 source <(helm completion bash)
 
 ##### fubectl


### PR DESCRIPTION
**What this PR does / why we need it**:

Since Helm 3.3.3, warning messages are displayed when the KUBECONFIG permissions are group/world readable. https://github.com/helm/helm/pull/8779 writes them to stderr.

The warnings are displayed when opening the web terminal, as 'helm completion' execs when the .bashrc is sourced:

<img width="1028" alt="Screenshot 2024-09-16 at 22 30 01" src="https://github.com/user-attachments/assets/4e0df3f4-9ab8-4a9f-86f3-0ed9d5cf7fff">

... this confuses unexperienced users.

**What type of PR is this?**
/kind enhancement

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fix: remove 'WARNING: Kubernetes configuration file is {group,world}-readable' when launching the Web Terminal.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```