### PR TITLE
[release/v2.25] prepare 2.25.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.9
+KUBERMATIC_VERSION?=v2.25.10
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.9
+KUBERMATIC_VERSION?=v2.25.10
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,7 +70,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.2
-	k8c.io/kubermatic/v2 v2.25.9-0.20240914092535-5213dd6f6caa
+	k8c.io/kubermatic/v2 v2.25.9
 	k8c.io/operating-system-manager v1.5.2
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.29.1

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1421,8 +1421,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.25.9-0.20240914092535-5213dd6f6caa h1:+PqmwLS2jsJnjYmovzEIImKCEbDe4FX8jRnm4kKNUWg=
-k8c.io/kubermatic/v2 v2.25.9-0.20240914092535-5213dd6f6caa/go.mod h1:lW37Zy4mClvBX/h6qzhIKFlbiE5GqPJvar2z7UgQQMw=
+k8c.io/kubermatic/v2 v2.25.9 h1:CTf/PxEwIyJhVjg+miQAGJHxyEionheMunEcpVqRR9k=
+k8c.io/kubermatic/v2 v2.25.9/go.mod h1:lW37Zy4mClvBX/h6qzhIKFlbiE5GqPJvar2z7UgQQMw=
 k8c.io/operating-system-manager v1.5.2 h1:zzRAGytDUNFlegQW31kUE3dc6tVzAdqZ6IxrbDFugOI=
 k8c.io/operating-system-manager v1.5.2/go.mod h1:h7gVySBkNOVDj2LAW90kDw2nwAROS5k9wVHeK6w/1KQ=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.9
+KUBERMATIC_VERSION?=v2.25.10
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.25.9",
+  "version": "2.25.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.25.9",
+      "version": "2.25.10",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.25.9",
+  "version": "2.25.10",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",

--- a/modules/web/src/assets/config/changelog.json
+++ b/modules/web/src/assets/config/changelog.json
@@ -1,17 +1,9 @@
 {
-  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.25.md#v2259",
+  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.25.md#v22510",
   "entries": [
     {
       "category": "fixed",
-      "description": "Fix vSphere degradation because of missing CCM/CSI container images"
-    },
-    {
-      "category": "fixed",
-      "description": "Fix an issue where the cursor in the web terminal kept jumping to the beginning due to a sizing issue"
-    },
-    {
-      "category": "fixed",
-      "description": "When deleting a cluster, the Kubevirt provider waits for the etcd backups to get deleted before removing the namespace"
+      "description": "Fix Cilium application not upgrading properly due to invalid values"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
An upgrade issue in KKP was identified and we will most likely release another out-of-bands release for 2.25.x only very soon.

cf. https://github.com/kubermatic/kubermatic/issues/13734

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
