### PR TITLE
Cluster backup enhancements

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -26,6 +26,7 @@ import {NotificationService} from '@app/core/services/notification';
 import {BackupStorageLocation, CreateBackupStorageLocation, SupportedBSLProviders} from '@app/shared/entity/backup';
 import {Observable, Subject, takeUntil} from 'rxjs';
 import * as y from 'js-yaml';
+import {CBSL_SYNC_PERIOD, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 
 export interface AddBackupStorageLocationDialogConfig {
   projectID: string;
@@ -78,18 +79,24 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
   ) {}
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Name]: this._builder.control(this._config.bslObject?.name ?? '', Validators.required),
+      [Controls.Name]: this._builder.control(this._config.bslObject?.name ?? '', [
+        Validators.required,
+        KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
+      ]),
       [Controls.Bucket]: this._builder.control(
         this._config.bslObject?.spec.objectStorage.bucket ?? '',
         Validators.required
       ),
-      [Controls.Prefix]: this._builder.control(this._config.bslObject?.spec.objectStorage.prefix ?? ''),
-      [Controls.CaCert]: this._builder.control(this._config.bslObject?.spec.objectStorage.caCert ?? ''),
+      [Controls.Prefix]: this._builder.control(this._config.bslObject?.spec.objectStorage?.prefix ?? ''),
+      [Controls.CaCert]: this._builder.control(this._config.bslObject?.spec.objectStorage?.caCert ?? ''),
       [Controls.AccessKeyId]: this._builder.control(''),
       [Controls.SecretAccessKey]: this._builder.control(''),
-      [Controls.BackupSyncPeriod]: this._builder.control(this._config.bslObject?.spec.backupSyncPeriod ?? '0'),
-      [Controls.Region]: this._builder.control(this._config.bslObject?.spec.config.region ?? ''),
-      [Controls.Endpoints]: this._builder.control(this._config.bslObject?.spec.config.s3Url ?? ''),
+      [Controls.BackupSyncPeriod]: this._builder.control(
+        this._config.bslObject?.spec.backupSyncPeriod ?? '0',
+        CBSL_SYNC_PERIOD
+      ),
+      [Controls.Region]: this._builder.control(this._config.bslObject?.spec.config?.region ?? ''),
+      [Controls.Endpoints]: this._builder.control(this._config.bslObject?.spec.config?.s3Url ?? ''),
       [Controls.AddCustomConfig]: this._builder.control(false),
     });
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
@@ -29,6 +29,12 @@ END OF TERMS AND CONDITIONS
              matInput
              required>
       <mat-hint>The name of the created backup storage location.</mat-hint>
+      <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
+        <strong>Required</strong>
+      </mat-error>
+      <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
+        Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
+      </mat-error>
     </mat-form-field>
     <mat-form-field>
       <mat-label>Bucket</mat-label>
@@ -36,6 +42,9 @@ END OF TERMS AND CONDITIONS
              matInput
              required>
       <mat-hint>The bucket in which to store backups.</mat-hint>
+      <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
+        <strong>Required</strong>
+      </mat-error>
     </mat-form-field>
     <mat-form-field>
       <mat-label>Prefix</mat-label>
@@ -66,6 +75,9 @@ END OF TERMS AND CONDITIONS
       <input [formControlName]="Controls.BackupSyncPeriod"
              matInput>
       <mat-hint>Enter time in the format MMmSSs (e.g., 2m10s),BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.</mat-hint>
+      <mat-error *ngIf="form.get(Controls.BackupSyncPeriod).hasError('pattern')">
+        Time must be in the format MMmSSs (e.g., 2m10s).
+      </mat-error>
     </mat-form-field>
     <mat-checkbox [formControlName]="Controls.AddCustomConfig">Add custom config
     </mat-checkbox>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/component.ts
@@ -36,7 +36,7 @@ import {View} from '@app/shared/entity/common';
 import {GroupConfig} from '@app/shared/model/Config';
 import {DeleteBackupDialogComponent} from '../backups/delete-dialog/component';
 import {NotificationService} from '@app/core/services/notification';
-import {HealthStatus, getClusterBackupHealthStatus} from '@app/shared/utils/health-status';
+import {StatusIcon, getClusterBackupHealthStatus} from '@app/shared/utils/health-status';
 
 @Component({
   selector: 'km-backup-storage-locations-list',
@@ -102,8 +102,8 @@ export class BackupStorageLocationsListComponent implements OnInit, OnDestroy {
     this._unsubscribe.complete();
   }
 
-  getStatus(phase: string): HealthStatus {
-    return getClusterBackupHealthStatus(phase);
+  getStatusIcon(phase: string): StatusIcon {
+    return getClusterBackupHealthStatus(phase).icon;
   }
 
   addBackupStorageLocation(): void {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/template.html
@@ -46,8 +46,8 @@ END OF TERMS AND CONDITIONS
             class="km-header-cell"></th>
         <td mat-cell
             *matCellDef="let element">
-          <i [matTooltip]="getStatus(element.status.phase).message"
-             [ngClass]="getStatus(element.status.phase).icon"
+          <i [matTooltip]="element.status?.message"
+             [ngClass]="getStatusIcon(element.status?.phase)"
              class="km-vertical-center"></i>
         </td>
       </ng-container>
@@ -108,7 +108,7 @@ END OF TERMS AND CONDITIONS
             *matCellDef="let element">
           <div fxLayoutAlign=" center"
                fxLayoutGap="8px">
-            <span>{{element.spec.config.region}}</span>
+            <span>{{element.spec?.config?.region}}</span>
           </div>
         </td>
       </ng-container>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
@@ -34,6 +34,7 @@ import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {NotificationService} from '@app/core/services/notification';
 import {KmValidators} from '@app/shared/validators/validators';
 import {Cluster} from '@app/shared/entity/cluster';
+import {Cluster_BACKUP_EXPIRES_IN, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 
 export interface AddClustersBackupsDialogConfig {
   projectID: string;
@@ -97,13 +98,13 @@ export class AddClustersBackupsDialogComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this._getCbslName();
     this.form = this._builder.group({
-      [Controls.Name]: this._builder.control('', Validators.required),
+      [Controls.Name]: this._builder.control('', [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]),
       [Controls.Destination]: this._builder.control(this.cbslName, Validators.required),
       [Controls.AllNamespaces]: this._builder.control(true),
       [Controls.Namespaces]: this._builder.control([]),
       [Controls.DefaultVolumesToFsBackup]: this._builder.control(true),
       [Controls.CronJob]: this._builder.control(''),
-      [Controls.ExpiresIn]: this._builder.control(''),
+      [Controls.ExpiresIn]: this._builder.control('', Cluster_BACKUP_EXPIRES_IN),
       [Controls.Labels]: this._builder.control(''),
     });
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
@@ -24,12 +24,18 @@ END OF TERMS AND CONDITIONS
   <mat-dialog-content>
     <p class="km-dialog-context-description">Cluster name: <b>{{cluster.name}}</b></p>
     <form [formGroup]="form">
-      <mat-form-field>
+      <mat-form-field subscriptSizing="dynamic">
         <mat-label>Name</mat-label>
         <input [formControlName]="Controls.Name"
                matInput
                required>
         <mat-hint>The name of the created cluster {{type.toLowerCase()}}.</mat-hint>
+        <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
+        <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
+          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
+        </mat-error>
       </mat-form-field>
       <mat-form-field>
         <mat-label>Backup Storage Location</mat-label>
@@ -55,10 +61,14 @@ END OF TERMS AND CONDITIONS
           </mat-option>
         </mat-select>
         <mat-hint>Namespaces to include in the backup.</mat-hint>
+        <mat-error *ngIf="form.get(Controls.Namespaces).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
       </mat-form-field>
 
       <mat-form-field *ngIf="isScheduleBackup()"
-                      class="schedule-field">
+                      class="schedule-field"
+                      subscriptSizing="dynamic">
         <mat-label>Schedule</mat-label>
         <input [formControlName]="Controls.CronJob"
                matInput
@@ -71,6 +81,12 @@ END OF TERMS AND CONDITIONS
              fxLayoutAlign=" center"
              rel="noopener noreferrer">here <i class="km-icon-external-link"></i></a>. Please note that specifying seconds is not supported.
         </mat-hint>
+        <mat-error *ngIf="form.get(Controls.CronJob).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
+        <mat-error *ngIf="form.get(Controls.CronJob).hasError('cronExpression')">
+          Schedule must be in corn expression.
+        </mat-error>
       </mat-form-field>
       <mat-form-field subscriptSizing="dynamic">
         <mat-label>Expires In</mat-label>
@@ -78,6 +94,9 @@ END OF TERMS AND CONDITIONS
                matInput>
         <mat-hint>Enter time in the format HHhMMmSSs (e.g., 24h10m10s), The amount of time before this backup is eligible for garbage collection. If not specified,
           a default value of 30 days will be used.</mat-hint>
+        <mat-error *ngIf="form.get(Controls.ExpiresIn).hasError('pattern')">
+          Time must be in the format HHhMMmSSs (e.g., 24h10m10s).
+        </mat-error>
       </mat-form-field>
 
       <mat-checkbox class="default-volumes"

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/component.ts
@@ -37,7 +37,12 @@ import {Cluster} from '@app/shared/entity/cluster';
 import {ClusterService} from '@app/core/services/cluster';
 import {View} from '@app/shared/entity/common';
 import {NotificationService} from '@app/core/services/notification';
-import {HealthStatus, getClusterBackupHealthStatus} from '@app/shared/utils/health-status';
+import {
+  HealthStatus,
+  StatusIcon,
+  clusterBackupStatus,
+  getClusterBackupHealthStatus,
+} from '@app/shared/utils/health-status';
 import {MatPaginator} from '@angular/material/paginator';
 import {MatSort} from '@angular/material/sort';
 
@@ -172,8 +177,23 @@ export class ClustersBackupsListComponent implements OnInit, OnDestroy {
     this.selectAll = false;
   }
 
-  getStatus(phase: string): HealthStatus {
-    return getClusterBackupHealthStatus(phase);
+  getStatus(phase: string, backupName?: string): HealthStatus {
+    const status = getClusterBackupHealthStatus(phase);
+    if (
+      (status.icon === StatusIcon.Error && status.message !== 'Deleting') ||
+      status.icon === StatusIcon.Warning ||
+      status.icon === StatusIcon.Unknown
+    ) {
+      status.message = `${status.message}, Run "velero ${BackupType.Backup} logs ${backupName}" for more information`;
+    }
+    return status;
+  }
+
+  isRunning(phase: string): boolean {
+    if (clusterBackupStatus.running.includes(phase)) {
+      return true;
+    }
+    return false;
   }
 
   toggleBackupDetail(backupName: string): void {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
@@ -95,7 +95,7 @@ END OF TERMS AND CONDITIONS
             class="km-header-cell"></th>
         <td mat-cell
             *matCellDef="let element">
-          <i [matTooltip]="getStatus(element.spec.status).message"
+          <i [matTooltip]="getStatus(element.spec.status, element.name).message"
              [ngClass]="getStatus(element.spec.status).icon"
              class="km-vertical-center"></i>
         </td>
@@ -199,7 +199,7 @@ END OF TERMS AND CONDITIONS
             <button mat-icon-button
                     matTooltip="Restore Backup"
                     (click)="restoreBackup(element); $event.stopPropagation()"
-                    [disabled]="!canAdd">
+                    [disabled]="!canAdd || !isRunning(element.spec.status)">
               <i class="km-icon-mask km-icon-restore"></i>
             </button>
 
@@ -213,7 +213,7 @@ END OF TERMS AND CONDITIONS
             <km-button iconButton="true"
                        icon="km-icon-download"
                        matTooltip="Download Backup"
-                       [disabled]="!canAdd"
+                       [disabled]="!canAdd || !isRunning(element.spec.status)"
                        [observable]="getObservable(element)"
                        (next)="onNext($event)"
                        (click)="$event.stopPropagation()">

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/add-dialog/component.ts
@@ -25,6 +25,7 @@ import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {NotificationService} from '@app/core/services/notification';
 import {ClusterBackup, ClusterRestore} from '@app/shared/entity/backup';
 import {Cluster} from '@app/shared/entity/cluster';
+import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 import {CookieService} from 'ngx-cookie-service';
 import {Observable, Subject} from 'rxjs';
 
@@ -60,7 +61,7 @@ export class AddRestoreDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Name]: this._builder.control('', Validators.required),
+      [Controls.Name]: this._builder.control('', [Validators.required, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR]),
       [Controls.NameSpaces]: this._builder.control('', Validators.required),
     });
   }

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/add-dialog/template.html
@@ -23,12 +23,18 @@ END OF TERMS AND CONDITIONS
   <form [formGroup]="form">
     <km-dialog-title>Restore {{backup.name}} Backup</km-dialog-title>
     <mat-dialog-content>
-      <mat-form-field>
+      <mat-form-field subscriptSizing="dynamic">
         <mat-label>Name</mat-label>
         <input [formControlName]="controls.Name"
                matInput
                required>
         <mat-hint>Choose a unique name for restore. Name can't be changed.</mat-hint>
+        <mat-error *ngIf="form.get(controls.Name).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
+        <mat-error *ngIf="form.get(controls.Name).hasError('pattern')">
+          Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
+        </mat-error>
       </mat-form-field>
       <mat-form-field>
         <mat-label>Choose Namespaces</mat-label>
@@ -41,6 +47,10 @@ END OF TERMS AND CONDITIONS
             {{nameSpace}}
           </mat-option>
         </mat-select>
+        <mat-hint>Namespaces to include in the backup.</mat-hint>
+        <mat-error *ngIf="form.get(controls.NameSpaces).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
       </mat-form-field>
     </mat-dialog-content>
     <mat-dialog-actions>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/component.ts
@@ -21,7 +21,7 @@
 import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {MatTableDataSource} from '@angular/material/table';
-import {ClusterRestore} from '@app/shared/entity/backup';
+import {BackupType, ClusterRestore} from '@app/shared/entity/backup';
 import {DeleteRestoreDialogComponent, DeleteRestoreDialogConfig} from './delete-dialog/component';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {ProjectService} from '@app/core/services/project';
@@ -35,7 +35,7 @@ import {Member} from '@app/shared/entity/member';
 import {GroupConfig} from '@app/shared/model/Config';
 import {View} from '@app/shared/entity/common';
 import {UserService} from '@app/core/services/user';
-import {HealthStatus, getClusterBackupHealthStatus} from '@app/shared/utils/health-status';
+import {HealthStatus, StatusIcon, getClusterBackupHealthStatus} from '@app/shared/utils/health-status';
 import {MatPaginator} from '@angular/material/paginator';
 import {MatSort} from '@angular/material/sort';
 
@@ -160,8 +160,16 @@ export class ClustersRestoresListComponent implements OnInit, OnDestroy {
     this.selectAll = false;
   }
 
-  getStatus(phase: string): HealthStatus {
-    return getClusterBackupHealthStatus(phase);
+  getStatus(phase: string, restoreName?: string): HealthStatus {
+    const status = getClusterBackupHealthStatus(phase);
+    if (
+      (status.icon === StatusIcon.Error && status.message !== 'Deleting') ||
+      status.icon === StatusIcon.Warning ||
+      status.icon === StatusIcon.Unknown
+    ) {
+      status.message = `${status.message}, Run "velero ${BackupType.Restore} logs ${restoreName}" for more information`;
+    }
+    return status;
   }
 
   toggleRestoreDetail(backupName: string): void {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/template.html
@@ -78,7 +78,7 @@ END OF TERMS AND CONDITIONS
             class="km-header-cell"></th>
         <td mat-cell
             *matCellDef="let element">
-          <i [matTooltip]="getStatus(element.spec.status).message"
+          <i [matTooltip]="getStatus(element.spec.status, element.name).message"
              [ngClass]="getStatus(element.spec.status).icon"
              class="km-vertical-center"></i>
         </td>

--- a/modules/web/src/app/shared/entity/backup.ts
+++ b/modules/web/src/app/shared/entity/backup.ts
@@ -136,6 +136,7 @@ export class S3BackupCredentials {
 export enum BackupType {
   Backup = 'Backup',
   Schedule = 'Schedule',
+  Restore = 'Restore',
   BackupStorageLocation = 'Backup Storage Location',
 }
 

--- a/modules/web/src/app/shared/utils/health-status.ts
+++ b/modules/web/src/app/shared/utils/health-status.ts
@@ -40,6 +40,13 @@ export enum StatusMassage {
   Deleted = 'deleted',
 }
 
+export const clusterBackupStatus = {
+  error: ['FailedValidation', 'Failed', 'Unavailable', 'Deleting'],
+  running: ['New', 'Completed', 'Enabled', 'Available'],
+  warning: ['WaitingForPluginOperationsPartiallyFailed', 'PartiallyFailed', 'FinalizingPartiallyFailed'],
+  pending: ['WaitingForPluginOperations', 'FinalizingafterPluginOperations', 'InProgress'],
+};
+
 export class HealthStatus {
   message: string;
   icon: StatusIcon;
@@ -109,17 +116,13 @@ export function getBackupHealthStatus(backup: EtcdBackupConfig, condition: EtcdB
 }
 
 export function getClusterBackupHealthStatus(phase: string): HealthStatus {
-  const statusError: string[] = ['FailedValidation', 'Failed', 'Unavailable', 'Deleting'];
-  const statusRunning = ['New', 'Completed', 'Enabled', 'Available'];
-  const statusWarning = ['WaitingForPluginOperationsPartiallyFailed', 'PartiallyFailed', 'FinalizingPartiallyFailed'];
-  const statusPending = ['WaitingForPluginOperations', 'FinalizingafterPluginOperations', 'InProgress'];
-  if (statusError.includes(phase)) {
+  if (clusterBackupStatus.error.includes(phase)) {
     return new HealthStatus(phase, StatusIcon.Error);
-  } else if (statusPending.includes(phase)) {
+  } else if (clusterBackupStatus.pending.includes(phase)) {
     return new HealthStatus(phase, StatusIcon.Pending);
-  } else if (statusRunning.includes(phase)) {
+  } else if (clusterBackupStatus.running.includes(phase)) {
     return new HealthStatus(phase, StatusIcon.Running);
-  } else if (statusWarning.includes(phase)) {
+  } else if (clusterBackupStatus.warning.includes(phase)) {
     return new HealthStatus(phase, StatusIcon.Warning);
   }
   return new HealthStatus('Unknown', StatusIcon.Unknown);

--- a/modules/web/src/app/shared/validators/cron.validator.ts
+++ b/modules/web/src/app/shared/validators/cron.validator.ts
@@ -28,7 +28,11 @@ export class CronExpressionValidator implements Validator {
   private everyExpressionPrefix = '@every ';
 
   validate(control: AbstractControl): ValidationErrors | null {
-    if (this.allowedCronExpressions.includes(control.value) || control.value.startsWith(this.everyExpressionPrefix)) {
+    if (
+      this.allowedCronExpressions.includes(control.value) ||
+      control.value.startsWith(this.everyExpressionPrefix) ||
+      !control.value
+    ) {
       return null;
     }
 

--- a/modules/web/src/app/shared/validators/others.ts
+++ b/modules/web/src/app/shared/validators/others.ts
@@ -34,3 +34,5 @@ export const GKE_POOL_NAME_VALIDATOR = Validators.pattern('(?:[a-z](?:[-a-z0-9]{
 export const URL_PATTERN_VALIDATOR = Validators.pattern(
   /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+$/
 );
+export const CBSL_SYNC_PERIOD = Validators.pattern('^(0|([0-9]{1,2}m)?[0-9]{1,2}s)$');
+export const Cluster_BACKUP_EXPIRES_IN = Validators.pattern('^(0|[0-9]{1,2}h?[0-9]{1,2}m?[0-9]{1,2}s)$');


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bugs and implement some enhancements for the cluster backup feature.

* Backup storage location page
![image](https://github.com/user-attachments/assets/33bd5fa6-6f8a-4e21-bd90-be2858cd782b)

* Validation for units of backup sync period
![image](https://github.com/user-attachments/assets/b5ad8590-c4bd-4243-8735-6c71f9331cdc)

* cluster backup expires in validation
![image](https://github.com/user-attachments/assets/c077ba91-f025-4702-b0f8-9d9ef614b5dd)

* for now we don't have a message for backup errors we agree to have this message for 2.26 and in the next release will add the message 
![image](https://github.com/user-attachments/assets/106ec628-6b09-464c-ade9-d4b63f66f8c3)

* download backup or create restore will not be enable if the backup not in running state 
![image](https://github.com/user-attachments/assets/4e57933d-e4b9-4a5a-b846-5040b46cc923)

* create schedule validation
![image](https://github.com/user-attachments/assets/09ad84a9-296b-44d6-ac21-a8c59d2e9739)

*  create schedule text overflow fixed
![image](https://github.com/user-attachments/assets/4e8bdf7d-290f-4eae-a936-d62afdb6d471)
  

**Which issue(s) this PR fixes**:
Fixes #6864

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
