### PR TITLE
Show selected value of vSphere VMGroup in edit MD dialog

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/vsphere/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/vsphere/component.ts
@@ -283,7 +283,6 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
   }
 
   private _onVMGroupsLoading(): void {
-    this._clearVMGroup();
     this.vmGroupStateLabel = VMGroupsState.Loading;
     this._cdr.detectChanges();
   }
@@ -298,6 +297,10 @@ export class VSphereBasicNodeDataComponent extends BaseFormValidator implements 
 
   private _setDefaultVMGroup(vmGroups: VSphereVMGroup[]): void {
     this.vmGroups = vmGroups;
+    this.selectedVMGroup = this._nodeDataService.nodeData.spec.cloud.vsphere.vmGroup;
+    if (this.selectedVMGroup && !this.vmGroups.find(vmGroup => vmGroup.name === this.selectedVMGroup)) {
+      this.onVMGroupChange('');
+    }
     this.vmGroupStateLabel = this.vmGroups ? VMGroupsState.Ready : VMGroupsState.Empty;
     this._cdr.detectChanges();
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where selected value of vSphere VMGroup was not shown in edit MD dialog.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
