### PR TITLE
[release/v2.25] Fix CNI plugin defaulting for Edge cloud provider

### DIFF
--- a/modules/api/pkg/handler/v2/cluster_default/cluster_default.go
+++ b/modules/api/pkg/handler/v2/cluster_default/cluster_default.go
@@ -262,8 +262,12 @@ func initializeCloudProviderSpec(dc string, provider kubermaticv1.ProviderType) 
 		cloudSpec.AWS = &kubermaticv1.AWSCloudSpec{}
 	case kubermaticv1.AzureCloudProvider:
 		cloudSpec.Azure = &kubermaticv1.AzureCloudSpec{}
+	case kubermaticv1.BringYourOwnCloudProvider:
+		cloudSpec.BringYourOwn = &kubermaticv1.BringYourOwnCloudSpec{}
 	case kubermaticv1.DigitaloceanCloudProvider:
 		cloudSpec.Digitalocean = &kubermaticv1.DigitaloceanCloudSpec{}
+	case kubermaticv1.EdgeCloudProvider:
+		cloudSpec.Edge = &kubermaticv1.EdgeCloudSpec{}
 	case kubermaticv1.GCPCloudProvider:
 		cloudSpec.GCP = &kubermaticv1.GCPCloudSpec{}
 	case kubermaticv1.HetznerCloudProvider:


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/kubermatic/dashboard/pull/6878

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CNI plugin defaulting for Edge cloud provider
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
