### PR TITLE
Fix default CNI application values in cluster wizard

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -69,6 +69,7 @@ import {
 import {getEditionVersion} from '@shared/utils/common';
 import {AsyncValidators} from '@shared/validators/async.validators';
 import {KmValidators} from '@shared/validators/validators';
+import * as y from 'js-yaml';
 import _ from 'lodash';
 import {combineLatest, merge, Subscription} from 'rxjs';
 import {filter, finalize, switchMap, take, takeUntil, tap} from 'rxjs/operators';
@@ -173,6 +174,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   loadingClusterDefaults = false;
   canEditCNIValues: boolean;
   cniApplicationValues: string;
+  defaultCNIApplicationValues: string;
   backupStorageLocationsList: BackupStorageLocation[];
   backupStorageLocationLabel: BSLListState = BSLListState.Ready;
   provider: NodeProvider;
@@ -442,7 +444,9 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this._applicationService
         .getApplicationDefinition(this._cniCiliumApplicationName)
         .pipe(takeUntil(this._unsubscribe))
-        .subscribe(appDef => (this.cniApplicationValues = this.initializeCiliumValues(appDef.spec.defaultValues)));
+        .subscribe(
+          appDef => (this.defaultCNIApplicationValues = this.initializeCiliumValues(appDef.spec.defaultValuesBlock))
+        );
     }
 
     this.control(Controls.CiliumIngress)
@@ -533,7 +537,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   editCNIValues() {
     const dialogData = {
       data: {
-        applicationValues: this.cniApplicationValues,
+        applicationValues: this.cniApplicationValues || this.defaultCNIApplicationValues,
       } as CiliumApplicationValuesDialogData,
     };
     const dialogRef = this._matDialog.open(CiliumApplicationValuesDialogComponent, dialogData);
@@ -948,7 +952,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   private updateCiliumCNIValues(): void {
     const ciliumIngress = this.controlValue(Controls.CiliumIngress);
     if (ciliumIngress) {
-      let cniApplicationValues = JSON.parse(this.cniApplicationValues);
+      let cniApplicationValues = JSON.parse(this.cniApplicationValues || this.defaultCNIApplicationValues);
       cniApplicationValues = {
         ...cniApplicationValues,
         ingressController: {
@@ -960,7 +964,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       };
       this.cniApplicationValues = JSON.stringify(cniApplicationValues);
     } else {
-      const cniApplicationValues = JSON.parse(this.cniApplicationValues);
+      const cniApplicationValues = JSON.parse(this.cniApplicationValues || this.defaultCNIApplicationValues);
       delete cniApplicationValues.ingressController;
       this.cniApplicationValues = JSON.stringify(cniApplicationValues);
     }
@@ -1101,13 +1105,17 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     return null;
   }
 
-  private initializeCiliumValues(valuesConfig: string | object): string {
-    if (typeof valuesConfig === 'string') {
-      return valuesConfig;
-    }
+  private initializeCiliumValues(valuesConfig: string): string {
     if (!_.isEmpty(valuesConfig)) {
-      return JSON.stringify(valuesConfig);
+      try {
+        let raw = y.load(valuesConfig);
+        raw = !_.isEmpty(raw) ? raw : {};
+
+        return JSON.stringify(raw);
+      } catch (_) {
+        return '';
+      }
     }
-    return null;
+    return '';
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where default values of CNI application were not loading in "Edit CNI Values" dialog. Also, now the initial CNI values are only sent to backend if user interacts with them (Enable Ingress or Save Initial CNI values).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6859 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix default CNI application values in cluster wizard.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
