### PR TITLE
Revert "Web terminal: fix warning when sourcing .bashrc (#6848)"

### DIFF
--- a/hack/images/web-terminal/.bashrc
+++ b/hack/images/web-terminal/.bashrc
@@ -7,8 +7,6 @@ alias k=kubectl
 complete -F __start_kubectl k
 
 ### helm
-# prevent 'Warning kubectl file is {world,group}-readable'
-chmod 600 ${KUBECONFIG}
 source <(helm completion bash)
 
 ##### fubectl


### PR DESCRIPTION
This reverts commit 5d1ec10fcd21ceaa602d316725d86f4472b2c40d.

**What this PR does / why we need it**:

After testing #6848, I realised the `kubeconfig` would be R/O and `0777` (https://github.com/kubernetes/kubernetes/issues/125876) since it's mounted from a secret inside the web-terminal pod. This would result on an extra error on the web-terminal startup: 

```
chmod: /etc/kubernetes/kubeconfig: Read-only file system
```

... rather than solving the warnings from Helm that #6848 intended to fix. This would require a more complex solution involving `fsGroup` + `initContainers` probably.

CC/ @ahmedwaleedmalik @Waseem826 as you took care of the previous PR. Sorry for the noise! 

**Which issue(s) this PR fixes**: N/A

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

```release-note
NONE
```

**Documentation**:

```documentation
NONE
```
