### PR TITLE
Fix `SHOW MORE` labels button

### DIFF
--- a/modules/web/src/app/shared/components/labels/component.ts
+++ b/modules/web/src/app/shared/components/labels/component.ts
@@ -57,8 +57,8 @@ export class LabelsComponent implements OnInit, OnChanges {
   }
 
   checkLabelsHeight(): boolean {
-    const labelsElem = 24;
-    if (this.chipListLabels?.nativeElement?.parentElement.offsetHeight > labelsElem) {
+    const labelsElem = 34;
+    if (this.chipListLabels?.nativeElement?.parentElement.scrollHeight > labelsElem) {
       this.hideExtraLabels = true;
     } else {
       this.hideExtraLabels = false;

--- a/modules/web/src/app/shared/components/labels/style.scss
+++ b/modules/web/src/app/shared/components/labels/style.scss
@@ -28,7 +28,7 @@
 }
 
 .hide-extra-labels {
-  height: 30px;
+  height: 34px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue where the "SHOW MORE" button is displayed even when there are no more labels to show.

**What type of PR is this?**
/kind bug

```release-note
NONE
```

```documentation
NONE
```
