### PR TITLE
Add baremetal to SupportedCloudProviders list in OSP

### DIFF
--- a/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile.go
+++ b/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile.go
@@ -49,7 +49,7 @@ var defaultOperatingSystemProfiles = []apiv2.OperatingSystemProfile{
 	{
 		Name:                    "osp-centos",
 		OperatingSystem:         "centos",
-		SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
+		SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
 	},
 	{
 		Name:                    "osp-flatcar",
@@ -64,12 +64,12 @@ var defaultOperatingSystemProfiles = []apiv2.OperatingSystemProfile{
 	{
 		Name:                    "osp-rockylinux",
 		OperatingSystem:         "rockylinux",
-		SupportedCloudProviders: []string{"aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
+		SupportedCloudProviders: []string{"aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
 	},
 	{
 		Name:                    "osp-ubuntu",
 		OperatingSystem:         "ubuntu",
-		SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "edge", "equinixmetal", "gce", "hetzner", "kubevirt", "nutanix", "openstack", "vmware-cloud-director", "vsphere"},
+		SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "edge", "equinixmetal", "gce", "hetzner", "kubevirt", "nutanix", "openstack", "vmware-cloud-director", "vsphere"},
 	},
 }
 

--- a/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
+++ b/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
@@ -72,7 +72,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-centos",
 					OperatingSystem:         "centos",
-					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-flatcar",
@@ -87,12 +87,12 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-rockylinux",
 					OperatingSystem:         "rockylinux",
-					SupportedCloudProviders: []string{"aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-ubuntu",
 					OperatingSystem:         "ubuntu",
-					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "edge", "equinixmetal", "gce", "hetzner", "kubevirt", "nutanix", "openstack", "vmware-cloud-director", "vsphere"},
+					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "edge", "equinixmetal", "gce", "hetzner", "kubevirt", "nutanix", "openstack", "vmware-cloud-director", "vsphere"},
 				},
 			},
 		},
@@ -110,7 +110,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-centos",
 					OperatingSystem:         "centos",
-					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-flatcar",
@@ -125,12 +125,12 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-rockylinux",
 					OperatingSystem:         "rockylinux",
-					SupportedCloudProviders: []string{"aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-ubuntu",
 					OperatingSystem:         "ubuntu",
-					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "edge", "equinixmetal", "gce", "hetzner", "kubevirt", "nutanix", "openstack", "vmware-cloud-director", "vsphere"},
+					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "edge", "equinixmetal", "gce", "hetzner", "kubevirt", "nutanix", "openstack", "vmware-cloud-director", "vsphere"},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This is PR will add baremetal to OSP, in order to generate OSP for baremetal nodes and execute cloud-init scripts
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
