### PR TITLE
Allow Ubuntu OSP only for baremetal provider

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -69,7 +69,7 @@ require (
 	google.golang.org/api v0.197.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241008131709-30c905bac915
+	k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009231712-d65d7675e446
 	k8c.io/machine-controller v1.59.1-0.20241008125410-cda075d98012
 	k8c.io/operating-system-manager v1.5.1-0.20240822183214-db378951daf3
 	k8c.io/reconciler v0.5.0

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1092,8 +1092,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.3 h1:KZ2Q6LQMxoiFf9UQ3ugqjid39NccduhJ50bdbP5tdIU=
 k8c.io/kubeone v1.7.3/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241008131709-30c905bac915 h1:N4j/GwtnjUk/SgTr753tHK+9ZoIzpRKo42B/g9EPE3w=
-k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241008131709-30c905bac915/go.mod h1:NgOHBH0tiXyslq5hO95B1Wv0Q/2YKg9WYzTCAT3UyNg=
+k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009231712-d65d7675e446 h1:QIsxlQ3FB8ZyCewFJEQPZYG1pld0Karh78H/5Aaj62A=
+k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009231712-d65d7675e446/go.mod h1:NgOHBH0tiXyslq5hO95B1Wv0Q/2YKg9WYzTCAT3UyNg=
 k8c.io/machine-controller v1.59.1-0.20241008125410-cda075d98012 h1:uqmsIPL42h6FyCqvuRtdS+xdV2oib3DIB6hIIq5+Ovw=
 k8c.io/machine-controller v1.59.1-0.20241008125410-cda075d98012/go.mod h1:9kHeELH6oSOeHKUddiKZVvzTSdfZNtfo7V3G7iQBCLQ=
 k8c.io/operating-system-manager v1.5.1-0.20240822183214-db378951daf3 h1:A9V4pXMVwWpmcyX6vq/B81rxIf/BeIjcv09K9z35A+0=

--- a/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile.go
+++ b/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile.go
@@ -49,7 +49,7 @@ var defaultOperatingSystemProfiles = []apiv2.OperatingSystemProfile{
 	{
 		Name:                    "osp-centos",
 		OperatingSystem:         "centos",
-		SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
+		SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
 	},
 	{
 		Name:                    "osp-flatcar",
@@ -64,7 +64,7 @@ var defaultOperatingSystemProfiles = []apiv2.OperatingSystemProfile{
 	{
 		Name:                    "osp-rockylinux",
 		OperatingSystem:         "rockylinux",
-		SupportedCloudProviders: []string{"aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
+		SupportedCloudProviders: []string{"aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
 	},
 	{
 		Name:                    "osp-ubuntu",

--- a/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
+++ b/modules/api/pkg/handler/v2/operatingsystemprofile/operatingsystemprofile_test.go
@@ -72,7 +72,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-centos",
 					OperatingSystem:         "centos",
-					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-flatcar",
@@ -87,7 +87,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-rockylinux",
 					OperatingSystem:         "rockylinux",
-					SupportedCloudProviders: []string{"aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-ubuntu",
@@ -110,7 +110,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-centos",
 					OperatingSystem:         "centos",
-					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"alibaba", "aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "nutanix", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-flatcar",
@@ -125,7 +125,7 @@ func TestListOperatingSystemProfiles(t *testing.T) {
 				{
 					Name:                    "osp-rockylinux",
 					OperatingSystem:         "rockylinux",
-					SupportedCloudProviders: []string{"aws", "azure", "baremetal", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
+					SupportedCloudProviders: []string{"aws", "azure", "digitalocean", "equinixmetal", "hetzner", "kubevirt", "openstack", "vsphere"},
 				},
 				{
 					Name:                    "osp-ubuntu",

--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -400,6 +400,7 @@ func Validate(nd *apiv1.NodeDeployment, controlPlaneVersion *semverlib.Version) 
 		nd.Spec.Template.Cloud.AWS == nil &&
 		nd.Spec.Template.Cloud.Hetzner == nil &&
 		nd.Spec.Template.Cloud.VSphere == nil &&
+		nd.Spec.Template.Cloud.Baremetal == nil &&
 		nd.Spec.Template.Cloud.Azure == nil &&
 		nd.Spec.Template.Cloud.Packet == nil &&
 		nd.Spec.Template.Cloud.GCP == nil &&


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will allow ubuntu OSP only for baremetal provider add Baremetal provider to the node deployment Validate function
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
