### PR TITLE
[release/v2.26] Prepare v2.26.0-rc.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.26.0-rc.0
+KUBERMATIC_VERSION?=v2.26.0-rc.1
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.26.0-rc.0
+KUBERMATIC_VERSION?=v2.26.0-rc.1
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -34302,16 +34302,6 @@
           "description": "Kubeconfig is the cluster's kubeconfig file, encoded with base64.",
           "type": "string",
           "x-go-name": "Kubeconfig"
-        },
-        "subnetName": {
-          "description": "SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).",
-          "type": "string",
-          "x-go-name": "SubnetName"
-        },
-        "vpcName": {
-          "description": "VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt",
-          "type": "string",
-          "x-go-name": "VPCName"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -34360,16 +34350,6 @@
             "$ref": "#/definitions/KubeVirtInfraStorageClass"
           },
           "x-go-name": "StorageClasses"
-        },
-        "subnetName": {
-          "description": "SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).",
-          "type": "string",
-          "x-go-name": "SubnetName"
-        },
-        "vpcName": {
-          "description": "VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt.",
-          "type": "string",
-          "x-go-name": "VPCName"
         }
       },
       "x-go-package": "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -69,7 +69,7 @@ require (
 	google.golang.org/api v0.197.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009231712-d65d7675e446
+	k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009140212-b80665e41816
 	k8c.io/machine-controller v1.59.1-0.20241011055903-713b23c97a6c
 	k8c.io/operating-system-manager v1.5.1-0.20241011111004-2e98e5667070
 	k8c.io/reconciler v0.5.0

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1081,8 +1081,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.3 h1:KZ2Q6LQMxoiFf9UQ3ugqjid39NccduhJ50bdbP5tdIU=
 k8c.io/kubeone v1.7.3/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009231712-d65d7675e446 h1:QIsxlQ3FB8ZyCewFJEQPZYG1pld0Karh78H/5Aaj62A=
-k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009231712-d65d7675e446/go.mod h1:NgOHBH0tiXyslq5hO95B1Wv0Q/2YKg9WYzTCAT3UyNg=
+k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009140212-b80665e41816 h1:25t7fcUjn0rU8HVIiglLndyuqRP43/IzO6v64Uy3mmQ=
+k8c.io/kubermatic/v2 v2.26.0-rc.0.0.20241009140212-b80665e41816/go.mod h1:NgOHBH0tiXyslq5hO95B1Wv0Q/2YKg9WYzTCAT3UyNg=
 k8c.io/machine-controller v1.59.1-0.20241011055903-713b23c97a6c h1:wXd2RGtpYLf0lVobWqhFV6JE5U84sRawuWhuy6kgaXk=
 k8c.io/machine-controller v1.59.1-0.20241011055903-713b23c97a6c/go.mod h1:j9SHRLpzFj5wOMlhdPJL+ub08P8rvVvQOFtg7JaLYb4=
 k8c.io/operating-system-manager v1.5.1-0.20241011111004-2e98e5667070 h1:M3CsqLLhO1sdT1vrdDsigiIVUfs88RJX58xrcFy6jQQ=

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/kubevirt.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/kubevirt.go
@@ -30,12 +30,6 @@ type Kubevirt struct {
 
 	// Kubeconfig is the cluster's kubeconfig file, encoded with base64.
 	Kubeconfig string `json:"kubeconfig,omitempty"`
-
-	// SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
-	SubnetName string `json:"subnetName,omitempty"`
-
-	// VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt
-	VPCName string `json:"vpcName,omitempty"`
 }
 
 // Validate validates this kubevirt

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/kubevirt_cloud_spec.go
@@ -41,12 +41,6 @@ type KubevirtCloudSpec struct {
 	// It contains also some flag specifying which one is the default one.
 	StorageClasses []*KubeVirtInfraStorageClass `json:"storageClasses"`
 
-	// SubnetName is the name of a subnet that is smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
-	SubnetName string `json:"subnetName,omitempty"`
-
-	// VPCName  is a virtual network name dedicated to a single tenant within a KubeVirt.
-	VPCName string `json:"vpcName,omitempty"`
-
 	// credentials reference
 	CredentialsReference *GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
 }

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.26.0-rc.0
+KUBERMATIC_VERSION?=v2.26.0-rc.1
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.26.0-rc.0",
+  "version": "2.26.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.26.0-rc.0",
+      "version": "2.26.0-rc.1",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.26.0-rc.0",
+  "version": "2.26.0-rc.1",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:
rc.0 referred to an inconvenient KKP version, which brought the k8s version selection out of sync and made it impossible to create clusters via the dashboard. Time for a new rc.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
