### PR TITLE
Display only the admin-allowed OS on project add/edit dialog

### DIFF
--- a/modules/web/src/app/project/component.ts
+++ b/modules/web/src/app/project/component.ts
@@ -42,7 +42,7 @@ import {AddProjectDialogComponent} from '@shared/components/add-project-dialog/c
 import {View} from '@shared/entity/common';
 import {Member} from '@shared/entity/member';
 import {Project, ProjectOwner, ProjectStatus} from '@shared/entity/project';
-import {UserSettings} from '@shared/entity/settings';
+import {AllowedOperatingSystems, UserSettings} from '@shared/entity/settings';
 import {getEditionVersion, objectDiff} from '@shared/utils/common';
 import {MemberUtils, Permission} from '@shared/utils/member';
 import _ from 'lodash';
@@ -78,6 +78,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
   hasQuota: boolean;
   isProjectsLoading: boolean;
   editionVersion: string = getEditionVersion();
+  allowedOperatingSystems: AllowedOperatingSystems;
 
   private readonly _maxOwnersLen = 30;
   private _apiSettings: UserSettings;
@@ -185,6 +186,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
     this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
       this.restrictProjectCreation = settings.restrictProjectCreation;
       this.restrictProjectDeletion = settings.restrictProjectDeletion;
+      this.allowedOperatingSystems = settings.allowedOperatingSystems;
     });
 
     this._projectService.projects.pipe(takeUntil(this._unsubscribe)).subscribe((projects: Project[]) => {
@@ -493,8 +495,9 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   addProject(): void {
-    this._matDialog
-      .open(AddProjectDialogComponent)
+    const modal = this._matDialog.open(AddProjectDialogComponent);
+    modal.componentInstance.adminAllowedOperatingSystems = this.allowedOperatingSystems;
+    modal
       .afterClosed()
       .pipe(take(1))
       .subscribe(isAdded => {
@@ -521,6 +524,7 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
     this._dialogModeService.isEditDialog = true;
     const modal = this._matDialog.open(EditProjectComponent);
     modal.componentInstance.project = project;
+    modal.componentInstance.adminAllowedOperatingSystems = this.allowedOperatingSystems;
     modal
       .afterClosed()
       .pipe(take(1))

--- a/modules/web/src/app/project/edit-project/component.spec.ts
+++ b/modules/web/src/app/project/edit-project/component.spec.ts
@@ -28,6 +28,7 @@ import {AppConfigMockService} from '@test/services/app-config-mock';
 import {AppConfigService} from '@app/config.service';
 import {UserMockService} from '@test/services/user-mock';
 import {UserService} from '@app/core/services/user';
+import {DEFAULT_ADMIN_SETTINGS} from '@app/shared/entity/settings';
 
 describe('EditProjectComponent', () => {
   let fixture: ComponentFixture<EditProjectComponent>;
@@ -54,6 +55,7 @@ describe('EditProjectComponent', () => {
     fixture = TestBed.createComponent(EditProjectComponent);
     component = fixture.componentInstance;
     component.project = fakeProject();
+    component.adminAllowedOperatingSystems = DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems;
     component.labels = {};
     component.asyncLabelValidators = [];
     fixture.detectChanges();

--- a/modules/web/src/app/project/edit-project/component.ts
+++ b/modules/web/src/app/project/edit-project/component.ts
@@ -29,6 +29,7 @@ import {QuotaDetails} from '@app/shared/entity/quota';
 import {UserService} from '@app/core/services/user';
 import {Member} from '@app/shared/entity/member';
 import {OperatingSystem} from '@app/shared/model/NodeProviderConstants';
+import {AllowedOperatingSystems} from '@app/shared/entity/settings';
 
 enum Controls {
   Name = 'name',
@@ -45,6 +46,7 @@ enum Controls {
 })
 export class EditProjectComponent implements OnInit {
   @Input() project: Project;
+  @Input() adminAllowedOperatingSystems: AllowedOperatingSystems;
 
   readonly Controls = Controls;
   isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
@@ -126,12 +128,14 @@ export class EditProjectComponent implements OnInit {
       [Controls.CPUQuota]: new FormControl(''),
       [Controls.MemoryQuota]: new FormControl(''),
       [Controls.StorageQuota]: new FormControl(''),
-      [Controls.AllowedOperatingSystems]: new FormControl(Object.values(this.OperatingSystem)),
+      [Controls.AllowedOperatingSystems]: new FormControl(Object.values(this.adminAllowedOperatingSystems)),
     });
 
     const projectOS = this.project.spec?.allowedOperatingSystems;
     if (!_.isEmpty(projectOS)) {
-      const allowedOSValue = Object.keys(projectOS).filter(os => projectOS[os]);
+      const allowedOSValue = Object.keys(projectOS).filter(
+        os => projectOS[os] && this.adminAllowedOperatingSystems[os]
+      );
       this.form.get(Controls.AllowedOperatingSystems).setValue(allowedOSValue);
     }
 

--- a/modules/web/src/app/project/edit-project/template.html
+++ b/modules/web/src/app/project/edit-project/template.html
@@ -49,28 +49,34 @@ limitations under the License.
                                  multiple
                                  fxLayout="row wrap"
                                  kmValueChangedIndicator>
-          <mat-button-toggle [value]="OperatingSystem.Ubuntu">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.ubuntu"
+                             [value]="OperatingSystem.Ubuntu">
             <i class="km-os-image-ubuntu"></i>
             Ubuntu
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.CentOS">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.centos"
+                             [value]="OperatingSystem.CentOS">
             <i class="km-os-image-centos"></i>
             CentOS
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.Flatcar">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.flatcar"
+                             [value]="OperatingSystem.Flatcar">
             <i class="km-os-image-flatcar"></i>
             Flatcar
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.AmazonLinux2">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.amzn2"
+                             [value]="OperatingSystem.AmazonLinux2">
             <i class="km-os-image-amazon-linux-2"></i>
             Amazon Linux 2
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.RHEL"
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.rhel"
+                             [value]="OperatingSystem.RHEL"
                              #rhelToggle>
             <i [ngClass]="rhelToggle.checked ? 'km-os-image-rhel' : 'km-os-image-rhel-gray'"></i>
             RHEL
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.RockyLinux">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.rockylinux"
+                             [value]="OperatingSystem.RockyLinux">
             <i class="km-os-image-rockylinux"></i>
             Rocky Linux
           </mat-button-toggle>

--- a/modules/web/src/app/shared/components/add-project-dialog/component.spec.ts
+++ b/modules/web/src/app/shared/components/add-project-dialog/component.spec.ts
@@ -24,6 +24,7 @@ import {CoreModule} from '@core/module';
 import {ProjectService} from '@core/services/project';
 import {SharedModule} from '@shared/module';
 import {AddProjectDialogComponent} from './component';
+import {DEFAULT_ADMIN_SETTINGS} from '@app/shared/entity/settings';
 
 describe('AddProjectDialogComponent', () => {
   let fixture: ComponentFixture<AddProjectDialogComponent>;
@@ -44,6 +45,7 @@ describe('AddProjectDialogComponent', () => {
   beforeEach(waitForAsync(() => {
     fixture = TestBed.createComponent(AddProjectDialogComponent);
     component = fixture.componentInstance;
+    component.adminAllowedOperatingSystems = DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems;
     component.labels = {};
     component.asyncLabelValidators = [];
     fixture.detectChanges();

--- a/modules/web/src/app/shared/components/add-project-dialog/template.html
+++ b/modules/web/src/app/shared/components/add-project-dialog/template.html
@@ -48,28 +48,34 @@ limitations under the License.
                                  multiple
                                  fxLayout="row wrap"
                                  kmValueChangedIndicator>
-          <mat-button-toggle [value]="OperatingSystem.Ubuntu">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.ubuntu"
+                             [value]="OperatingSystem.Ubuntu">
             <i class="km-os-image-ubuntu"></i>
             Ubuntu
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.CentOS">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.centos"
+                             [value]="OperatingSystem.CentOS">
             <i class="km-os-image-centos"></i>
             CentOS
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.Flatcar">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.flatcar"
+                             [value]="OperatingSystem.Flatcar">
             <i class="km-os-image-flatcar"></i>
             Flatcar
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.AmazonLinux2">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.amzn2"
+                             [value]="OperatingSystem.AmazonLinux2">
             <i class="km-os-image-amazon-linux-2"></i>
             Amazon Linux 2
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.RHEL"
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.rhel"
+                             [value]="OperatingSystem.RHEL"
                              #rhelToggle>
             <i [ngClass]="rhelToggle.checked ? 'km-os-image-rhel' : 'km-os-image-rhel-gray'"></i>
             RHEL
           </mat-button-toggle>
-          <mat-button-toggle [value]="OperatingSystem.RockyLinux">
+          <mat-button-toggle *ngIf="adminAllowedOperatingSystems.rockylinux"
+                             [value]="OperatingSystem.RockyLinux">
             <i class="km-os-image-rockylinux"></i>
             Rocky Linux
           </mat-button-toggle>


### PR DESCRIPTION
**What this PR does / why we need it**:
Only operating systems allowed by the admin will be displayed in the add/edit dialog.

**Admin panel:**
![image](https://github.com/user-attachments/assets/ad2d22fb-58c9-4c43-8fe8-7686d2dbb196)

**Edit project dialog:**
![image](https://github.com/user-attachments/assets/7cd26a39-4d47-4ce5-9f53-c18687d22304)

**Add project dialog:**
![image](https://github.com/user-attachments/assets/7448481a-5bf7-4386-a993-7954cc42c846)

**Which issue(s) this PR fixes**:
Fixes #6952 
/kind design



**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Display only the admin-allowed OS's on project add/edit dialog.
```

**Documentation**:
```documentation
NONE
```
