### PR TITLE
remove empty LabelSelector in Velero objects

### DIFF
--- a/modules/api/pkg/ee/clusterbackup/restore/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/restore/handler.go
@@ -39,6 +39,7 @@ import (
 	handlercommon "k8c.io/dashboard/v2/pkg/handler/common"
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	"k8c.io/dashboard/v2/pkg/handler/v2/cluster"
+	"k8c.io/dashboard/v2/pkg/kubernetes"
 	"k8c.io/dashboard/v2/pkg/provider"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -87,6 +88,11 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 	client, err := handlercommon.GetClusterClientWithClusterID(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, req.ClusterID)
 	if err != nil {
 		return nil, err
+	}
+	// Velero does not work well with existing, but empty label selectors:
+	// https://github.com/vmware-tanzu/velero/issues/2083
+	if kubernetes.IsEmptySelector(restore.Spec.LabelSelector) {
+		restore.Spec.LabelSelector = nil
 	}
 	if err := client.Create(ctx, restore); err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)

--- a/modules/api/pkg/ee/clusterbackup/schedule/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/schedule/handler.go
@@ -39,6 +39,7 @@ import (
 	handlercommon "k8c.io/dashboard/v2/pkg/handler/common"
 	"k8c.io/dashboard/v2/pkg/handler/v1/common"
 	"k8c.io/dashboard/v2/pkg/handler/v2/cluster"
+	"k8c.io/dashboard/v2/pkg/kubernetes"
 	"k8c.io/dashboard/v2/pkg/provider"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -89,6 +90,12 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 	client, err := handlercommon.GetClusterClientWithClusterID(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, req.ClusterID)
 	if err != nil {
 		return nil, err
+	}
+
+	// Velero does not work well with existing, but empty label selectors:
+	// https://github.com/vmware-tanzu/velero/issues/2083
+	if kubernetes.IsEmptySelector(backupSchedule.Spec.Template.LabelSelector) {
+		backupSchedule.Spec.Template.LabelSelector = nil
 	}
 
 	if err := client.Create(ctx, backupSchedule); err != nil {

--- a/modules/api/pkg/kubernetes/helper.go
+++ b/modules/api/pkg/kubernetes/helper.go
@@ -27,6 +27,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/utils/ptr"
@@ -92,4 +93,8 @@ func GetContainerRuntime(ctx context.Context,
 		}
 	}
 	return "", fmt.Errorf("failed to get container runtime from node")
+}
+
+func IsEmptySelector(s *metav1.LabelSelector) bool {
+	return s == nil || (len(s.MatchExpressions) == 0 && len(s.MatchLabels) == 0)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures empty label selectors are removed in order to not confuse Velero.

**Which issue(s) this PR fixes**:
Fixes #6970

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[EE] Fix Cluster Backups failing because of empty label selectors.
```

**Documentation**:
```documentation
NONE
```
