### PR TITLE
Add OPA deprecated warning message

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/style.scss
@@ -82,3 +82,8 @@ km-button {
     }
   }
 }
+
+.mat-mdc-card:has(.km-icon-warning) {
+  margin: 0 0 20px;
+  padding: 0;
+}

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -13,6 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+<mat-card *ngIf="cluster?.spec?.opaIntegration?.enabled">
+  <mat-card-content>
+    <div fxLayout="row"
+         fxLayoutAlign=" center"
+         class="warning-container">
+      <i class="km-icon-warning"></i>
+      <div>OPA (Open Policy Agent) will be deprecated in KKP 2.28, Kyverno will replace it as an EE-only feature for policy management.</div>
+    </div>
+  </mat-card-content>
+</mat-card>
+
 <div *ngIf="isLoaded()"
      fxLayout="column">
   <div fxFlex

--- a/modules/web/src/app/settings/admin/defaults/style.scss
+++ b/modules/web/src/app/settings/admin/defaults/style.scss
@@ -37,8 +37,7 @@
     margin-right: 48px;
   }
 
-  .km-pointer,
-  .km-icon-warning {
+  .km-pointer {
     @include mixins.size(16);
 
     margin-left: 4px;

--- a/modules/web/src/app/settings/admin/defaults/template.html
+++ b/modules/web/src/app/settings/admin/defaults/template.html
@@ -59,7 +59,10 @@ limitations under the License.
             <span>OPA Integration</span>
             <div class="km-icon-info km-pointer"
                  matTooltip='Set "OPA Integration" checkbox on cluster creation to enabled by default. Enable "Enforce" to make users unable to edit the checkbox.'></div>
+            <i class="km-icon-warning km-pointer"
+               matTooltip="OPA (Open Policy Agent) will be deprecated in KKP 2.28, Kyverno will replace it as an EE-only feature for policy management."></i>
           </div>
+
           <div fxFlexAlign=" center"
                fxLayout="row">
             <mat-checkbox [(ngModel)]="settings.opaOptions.enabled"

--- a/modules/web/src/app/settings/admin/opa/component.ts
+++ b/modules/web/src/app/settings/admin/opa/component.ts
@@ -22,6 +22,7 @@ import {takeUntil} from 'rxjs/operators';
 @Component({
   selector: 'km-admin-settings-opa',
   templateUrl: './template.html',
+  styleUrls: ['style.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AdminSettingsOPAComponent implements OnDestroy {

--- a/modules/web/src/app/settings/admin/opa/style.scss
+++ b/modules/web/src/app/settings/admin/opa/style.scss
@@ -1,0 +1,17 @@
+// Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.mat-mdc-card {
+  padding: 0;
+}

--- a/modules/web/src/app/settings/admin/opa/template.html
+++ b/modules/web/src/app/settings/admin/opa/template.html
@@ -13,7 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
+<mat-card>
+  <mat-card-content>
+    <div fxLayout="row"
+         fxLayoutAlign=" center"
+         class="warning-container">
+      <i class="km-icon-warning"></i>
+      <div>OPA (Open Policy Agent) will be deprecated in KKP 2.28, Kyverno will replace it as an EE-only feature for policy management.</div>
+    </div>
+  </mat-card-content>
+</mat-card>
 <km-tab-card id="km-admin-opa-card"
              [dynamicTabs]="dynamicTabs">
   <km-tab label="Constraint Templates">

--- a/modules/web/src/app/wizard/step/cluster/style.scss
+++ b/modules/web/src/app/wizard/step/cluster/style.scss
@@ -91,3 +91,7 @@ mat-button-toggle-group[group='cniPluginTypeGroup'] {
   display: block;
   padding: 10px 0 15px;
 }
+
+.km-icon-warning {
+  margin-left: 10px;
+}

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -494,14 +494,22 @@ limitations under the License.
                           *ngIf="isKubernetesDashboardEnabled">
               Kubernetes Dashboard
             </mat-checkbox>
-
-            <mat-checkbox [formControlName]="Controls.OPAIntegration"
-                          id="km-wizard-opa-integration-checkbox">
-              OPA Integration
-              <i *ngIf="isEnforced(Controls.OPAIntegration)"
-                 class="km-icon-info km-pointer"
-                 matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
-            </mat-checkbox>
+            <div fxLayout="row"
+                 fxLayoutAlign=" center">
+              <mat-checkbox [formControlName]="Controls.OPAIntegration"
+                            id="km-wizard-opa-integration-checkbox"
+                            [matTooltipDisabled]="!form.get(Controls.OPAIntegration).disabled">
+              </mat-checkbox>
+              <div fxLayout="row"
+                   fxLayoutAlign=" center">
+                OPA Integration
+                <i *ngIf="isEnforced(Controls.OPAIntegration)"
+                   class="km-icon-info km-pointer"
+                   matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
+                <i class="km-icon-warning km-pointer"
+                   matTooltip="OPA (Open Policy Agent) will be deprecated in KKP 2.28, Kyverno will replace it as an EE-only feature for policy management."></i>
+              </div>
+            </div>
 
             <ng-container *ngIf="isMLAEnabled">
               <mat-checkbox [formControlName]="Controls.MLALogging">


### PR DESCRIPTION
**What this PR does / why we need it**:
add a warning message for the kkp users that OPA will be deprecated in favor of kyverno.

**create cluster wizard:**
![image](https://github.com/user-attachments/assets/2db376e2-5a8a-4c46-8619-6ee268503008)

**Cluster details page:**
The warning message will be displayed if the OPA integration is enabled for the cluster.
![image](https://github.com/user-attachments/assets/1c818d07-8abf-44f1-8b4b-a5f596fa397c)

**Admin settings:**
Default page:
![image](https://github.com/user-attachments/assets/289f1c87-75d2-4b11-95ec-0d1772dd50cd)

OPA page:
![image](https://github.com/user-attachments/assets/e8a57f05-71e5-4a91-befd-2ef6f1899bc9)


**Which issue(s) this PR fixes**:
Fixes #6988

**What type of PR is this?**
/kind feature


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
OPA (Open Policy Agent) will be deprecated in KKP 2.28, Kyverno will replace it as an EE-only feature for policy management.
```

**Documentation**:
```documentation
NONE
```
