### PR TITLE
Remove the `includedNamespaces` property when select all namespaces

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
@@ -196,7 +196,7 @@ export class AddClustersBackupsDialogComponent implements OnInit, OnDestroy {
     };
 
     if (this.form.get(Controls.AllNamespaces).value) {
-      backup.spec.includedNamespaces = this.nameSpaces;
+      delete backup.spec?.includedNamespaces;
     } else {
       backup.spec.includedNamespaces = this.form.get(Controls.Namespaces).value;
     }
@@ -226,7 +226,7 @@ export class AddClustersBackupsDialogComponent implements OnInit, OnDestroy {
     };
 
     if (this.form.get(Controls.AllNamespaces).value) {
-      scheduleBackup.spec.template.includedNamespaces = this.nameSpaces;
+      delete scheduleBackup.spec?.template.includedNamespaces;
     } else {
       scheduleBackup.spec.template.includedNamespaces = this.form.get(Controls.Namespaces).value;
     }

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -632,7 +632,7 @@ limitations under the License.
                                  label="Upgrade system on the first boot"
                                  [value]="machineDeployment.spec.template.operatingSystem.ubuntu.distUpgradeOnBoot">
             </km-property-boolean>
-            
+
             <km-property-boolean *ngIf="machineDeployment.spec.template.operatingSystem.amzn2?.distUpgradeOnBoot"
                                  label="Upgrade system on the first boot"
                                  [value]="machineDeployment.spec.template.operatingSystem.amzn2.distUpgradeOnBoot">


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the `includedNamespaces` property when select all namespaces in the create backup/schedule 

**Which issue(s) this PR fixes**:
Fixes #7032 

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix backing up all namespaces.
```

**Documentation**:
```documentation
NONE
```
