### PR TITLE
[release/v2.25] Remove includedNamespaces when select all namespaces

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/machine-deployment-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/machine-deployment-list/template.html
@@ -38,7 +38,8 @@ limitations under the License.
       </mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <div *ngIf="!!cluster.spec.cloud.edge" class="kubeadm-manual">
+      <div *ngIf="!!cluster.spec.cloud.edge"
+           class="kubeadm-manual">
         To interact with cluster pods (reading logs, exec into containers, etc…), cluster CSRs must be approved manually per worker node:
         <div class="km-code-block km-copy"
              fxLayoutAlign=" center"

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
@@ -172,7 +172,7 @@ export class AddClustersBackupsDialogComponent implements OnInit, OnDestroy {
     if (this.form.get(Controls.NameSpaces).value.length) {
       backup.spec.includedNamespaces = this.form.get(Controls.NameSpaces).value;
     } else {
-      backup.spec.includedNamespaces = this.nameSpaces;
+      delete backup.spec.includedNamespaces;
     }
 
     if (this.labels) {
@@ -202,7 +202,7 @@ export class AddClustersBackupsDialogComponent implements OnInit, OnDestroy {
     if (this.form.get(Controls.NameSpaces).value.length) {
       scheduleBackup.spec.template.includedNamespaces = this.form.get(Controls.NameSpaces).value;
     } else {
-      scheduleBackup.spec.template.includedNamespaces = this.nameSpaces;
+      delete scheduleBackup.spec.template.includedNamespaces;
     }
 
     if (this.labels) {


### PR DESCRIPTION
**What this PR does / why we need it**:
backport of #7032 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fixed an issue where selecting "Backup All Namespaces" in the create backup/schedule dialog for cluster backups caused new namespaces to be excluded.
```

**Documentation**:
```documentation
NONE
```
