### PR TITLE
[release/v2.26] Remove includedNamespaces when select all namespaces (#7034)

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/component.ts
@@ -196,7 +196,7 @@ export class AddClustersBackupsDialogComponent implements OnInit, OnDestroy {
     };
 
     if (this.form.get(Controls.AllNamespaces).value) {
-      backup.spec.includedNamespaces = this.nameSpaces;
+      delete backup.spec?.includedNamespaces;
     } else {
       backup.spec.includedNamespaces = this.form.get(Controls.Namespaces).value;
     }
@@ -226,7 +226,7 @@ export class AddClustersBackupsDialogComponent implements OnInit, OnDestroy {
     };
 
     if (this.form.get(Controls.AllNamespaces).value) {
-      scheduleBackup.spec.template.includedNamespaces = this.nameSpaces;
+      delete scheduleBackup.spec?.template.includedNamespaces;
     } else {
       scheduleBackup.spec.template.includedNamespaces = this.form.get(Controls.Namespaces).value;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
backport of #7032 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fixed an issue where selecting "Backup All Namespaces" in the create backup/schedule dialog for cluster backups caused new namespaces to be excluded.
```

**Documentation**:
```documentation
NONE
```
