### PR TITLE
Make `Domain` field optional when using application credentials for Openstack provider

### DIFF
--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/openstack/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/openstack/component.ts
@@ -115,7 +115,7 @@ export class OpenstackSettingsComponent extends BaseFormValidator implements OnI
   private _update(): void {
     this._presetDialogService.preset.spec.openstack = {
       ...this._presetDialogService.preset.spec.openstack,
-      domain: this.form.get(Controls.Domain).value,
+      domain: this.form.get(Controls.Domain).value || null,
       network: this.form.get(Controls.Network).value,
       securityGroups: this.form.get(Controls.SecurityGroups).value,
       floatingIPPool: this.form.get(Controls.FloatingIPPool).value,

--- a/modules/web/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/basic/openstack/component.ts
@@ -22,7 +22,10 @@ import {
   ViewChild,
 } from '@angular/core';
 import {FormBuilder, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validators} from '@angular/forms';
-import {OpenstackCredentialsTypeService} from '@app/wizard/step/provider-settings/provider/extended/openstack/service';
+import {
+  CredentialsType,
+  OpenstackCredentialsTypeService,
+} from '@app/wizard/step/provider-settings/provider/extended/openstack/service';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {DatacenterService} from '@core/services/datacenter';
 import {PresetsService} from '@core/services/wizard/presets';
@@ -91,7 +94,7 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Domain]: this._builder.control('', Validators.required),
+      [Controls.Domain]: this._builder.control(''),
       [Controls.Credentials]: this._builder.control(''),
       [Controls.FloatingIPPool]: this._builder.control('', Validators.required),
     });
@@ -139,6 +142,15 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
       .pipe(filter(_ => this._clusterSpecService.provider === NodeProvider.OPENSTACK))
       .pipe(switchMap(_ => this._datacenterService.getDatacenter(this._clusterSpecService.datacenter).pipe(take(1))))
       .pipe(tap(dc => (this._isFloatingPoolIPEnforced = dc?.spec.openstack.enforceFloatingIP)))
+      .pipe(
+        tap(_ => {
+          if (this._credentialsTypeService.credentialsType === CredentialsType.Default) {
+            this.form.get(Controls.Domain).setValidators(Validators.required);
+          } else {
+            this.form.get(Controls.Domain).clearValidators();
+          }
+        })
+      )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this.form.reset());
   }
@@ -150,6 +162,8 @@ export class OpenstackProviderBasicComponent extends BaseFormValidator implement
 
   isRequired(control: Controls): boolean {
     switch (control) {
+      case Controls.Domain:
+        return this.form.get(Controls.Domain).hasValidator(Validators.required);
       case Controls.FloatingIPPool:
         return this._isFloatingPoolIPEnforced;
       default:

--- a/modules/web/src/app/wizard/step/provider-settings/provider/basic/openstack/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/basic/openstack/template.html
@@ -23,7 +23,7 @@ limitations under the License.
            [formControlName]="Controls.Domain"
            [name]="Controls.Domain"
            [matAutocomplete]="autoDomain"
-           required>
+           [required]="isRequired(Controls.Domain)">
     <mat-autocomplete #autoDomain="matAutocomplete">
       <mat-option *ngFor="let domain of domains"
                   [value]="domain.name">


### PR DESCRIPTION
**What this PR does / why we need it**:
Make `Domain` field optional when using application credentials for Openstack provider in cluster creation wizard:

https://github.com/user-attachments/assets/addd19d1-2bc4-4648-933c-996563a1a62f

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7033 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make `Domain` field optional when using application credentials for Openstack provider.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
