### PR TITLE
Fix list images in kubevirt and tinkerbell

### DIFF
--- a/modules/api/pkg/handler/common/provider/baremetal.go
+++ b/modules/api/pkg/handler/common/provider/baremetal.go
@@ -60,6 +60,10 @@ func TinkerbellImages(ctx context.Context, datacenterName string, userInfoGetter
 	httpSource := datacenter.Spec.Baremetal.Tinkerbell.Images.HTTP
 	if httpSource != nil {
 		for os, versions := range httpSource.OperatingSystems {
+			// Ensure the sub-map for the operating system is initialized
+			if _, ok := res.Standard.OperatingSystems[os]; !ok {
+				res.Standard.OperatingSystems[os] = map[string]string{}
+			}
 			for version, link := range versions {
 				res.Standard.OperatingSystems[os][version] = link
 			}

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -640,6 +640,10 @@ func KubeVirtImages(ctx context.Context, datacenterName string, userInfoGetter p
 	httpSource := datacenter.Spec.Kubevirt.Images.HTTP
 	if httpSource != nil {
 		for os, versions := range httpSource.OperatingSystems {
+			// Ensure the sub-map for the operating system is initialized
+			if _, ok := res.Standard.OperatingSystems[os]; !ok {
+				res.Standard.OperatingSystems[os] = map[string]string{}
+			}
 			for version, link := range versions {
 				res.Standard.OperatingSystems[os][version] = link
 			}

--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -291,7 +291,6 @@ func getBaremetalProviderConfig(cluster *kubermaticv1.Cluster, nodeSpec apiv1.No
 	tinkerbellSpec := &tink.TinkerbellPluginSpec{
 		ClusterName: providerconfig.ConfigVarString{Value: cluster.Name},
 		HardwareRef: tinkerbellConfig.HardwareRef,
-		Auth:        tink.Auth{Kubeconfig: providerconfig.ConfigVarString{Value: cluster.Spec.Cloud.Baremetal.Tinkerbell.Kubeconfig}},
 		OSImageURL:  providerconfig.ConfigVarString{Value: tinkerbellConfig.OsImageUrl},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes listing images Tinkerbell and Kubevirt functionality. 

**Which issue(s) this PR fixes**:

* Code would panic if OperatingSystems[os] was nil.

* Listing Kubevirt and Tinkerbell functionality is not working anymore, because of nil sub-maps of Supported Operating systems

* In the original implementation, the code directly attempted to assign values to a sub-map within `res.Standard.OperatingSystems[os]` without verifying if the sub-map was initialized.
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix list images in kubevirt and tinkerbell 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
