### PR TITLE
Pick default value for KubeLB Gateway API from datacenter

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -269,6 +269,15 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           this.isDualStackAllowed = !!datacenter.spec.ipv6Enabled;
           this.isKubeLBEnabled = !!(datacenter.spec.kubelb?.enforced || datacenter.spec.kubelb?.enabled);
           this.isKubeLBEnforced = !!datacenter.spec.kubelb?.enforced;
+
+          if (datacenter.spec.kubelb?.enableGatewayAPI) {
+            this.form.get(Controls.KubeLBEnableGatewayAPI).setValue(true);
+          }
+
+          if (datacenter.spec.kubelb?.useLoadBalancerClass) {
+            this.form.get(Controls.KubeLBUseLoadBalancerClass).setValue(true);
+          }
+
           this.isCSIDriverDisabled = datacenter.spec.disableCsiDriver;
           this.enforcedAuditWebhookSettings = datacenter.spec.enforcedAuditWebhookSettings;
           this._enforce(Controls.AuditLogging, datacenter.spec.enforceAuditLogging);


### PR DESCRIPTION
**What this PR does / why we need it**:
For cluster creation, the default value for EnableGatewayAPI and UseLoadbalancerClass will be picked from datacenter configuration.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeLB: enable gateway API and use load balancer class values will now be picked from the datacenter configuration during cluster creation
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
