### PR TITLE
Add search field in autocomplete options dropdown

### DIFF
--- a/modules/web/src/app/shared/components/autocomplete/component.ts
+++ b/modules/web/src/app/shared/components/autocomplete/component.ts
@@ -50,6 +50,7 @@ export class AutocompleteComponent extends BaseFormValidator implements OnInit {
   @Input() disabled: boolean;
   controls = AutocompleteControls;
   isDropdownOpen: boolean;
+  search: string = '';
 
   constructor(private readonly _builder: FormBuilder) {
     super();
@@ -81,6 +82,7 @@ export class AutocompleteComponent extends BaseFormValidator implements OnInit {
 
   onDropdownOpened(): void {
     this.isDropdownOpen = true;
+    this.search = '';
   }
 
   onDropdownClosed(): void {

--- a/modules/web/src/app/shared/components/autocomplete/style.scss
+++ b/modules/web/src/app/shared/components/autocomplete/style.scss
@@ -17,3 +17,14 @@
     background-color: transparent;
   }
 }
+
+input.search-input {
+  background: none;
+  border: 0;
+  box-sizing: content-box;
+  color: currentcolor;
+  height: 24px;
+  outline: none;
+  padding: 16px 0 16px 16px;
+  width: calc(100% - 16px);
+}

--- a/modules/web/src/app/shared/components/autocomplete/template.html
+++ b/modules/web/src/app/shared/components/autocomplete/template.html
@@ -27,7 +27,7 @@ limitations under the License.
     <mat-spinner matSuffix
                  *ngIf="isLoading && !form.disabled"
                  [diameter]="20"></mat-spinner>
-    <button *ngIf="!isLoading && options"
+    <button *ngIf="!isLoading && options?.length"
             mat-icon-button
             [disabled]="disabled"
             matSuffix
@@ -37,14 +37,25 @@ limitations under the License.
       <i class="km-icon-mask i-14"
          [ngClass]="isDropdownOpen ? 'km-icon-arrow-up' : 'km-icon-arrow-down'"></i>
     </button>
-    <mat-autocomplete autoActiveFirstOption
-                      #auto="matAutocomplete"
+    <mat-autocomplete #auto="matAutocomplete"
                       (opened)="onDropdownOpened()"
                       (closed)="onDropdownClosed()">
-      <mat-option *ngFor="let option of options | filterBy: form.get(controls.Main).value"
-                  [value]="option">
-        {{option}}
-      </mat-option>
+      <input name="search"
+             class="search-input"
+             placeholder="Search..."
+             type="text"
+             autocomplete="off"
+             [(ngModel)]="search"
+             [ngModelOptions]="{standalone: true}"
+             kmAutofocus>
+      <ng-container *ngIf="options | filterBy: search as filteredOptions">
+        <mat-option *ngIf="options?.length && !filteredOptions?.length"
+                    [disabled]="true">No options available</mat-option>
+        <mat-option *ngFor="let option of filteredOptions"
+                    [value]="option">
+          {{ option }}
+        </mat-option>
+      </ng-container>
     </mat-autocomplete>
     <mat-hint>
       <ng-content select="[hint]"></ng-content>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new search field in options dropdown of km-autocomplete instead of using the value for filtering.

https://github.com/user-attachments/assets/1392fc94-5d60-4ad2-b68a-a62c13e79010

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7038

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add search field in options dropdown of autocomplete element.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
