### PR TITLE
[release/v2.26] Bump KKP dependency to 7df79a4

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -69,7 +69,7 @@ require (
 	google.golang.org/api v0.197.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.26.4-0.20250117131350-23be19c123ae
+	k8c.io/kubermatic/v2 v2.26.5-0.20250129153809-7df79a40fe08
 	k8c.io/machine-controller v1.60.1
 	k8c.io/operating-system-manager v1.6.2
 	k8c.io/reconciler v0.5.0

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1087,8 +1087,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.3 h1:KZ2Q6LQMxoiFf9UQ3ugqjid39NccduhJ50bdbP5tdIU=
 k8c.io/kubeone v1.7.3/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.26.4-0.20250117131350-23be19c123ae h1:tPdjJM8H71ckhis6kl9cHEEB+IvHpoNgtZlAnGU4Vnk=
-k8c.io/kubermatic/v2 v2.26.4-0.20250117131350-23be19c123ae/go.mod h1:SNGA6ar7d6lZsOjvzu+Cro4yzKRFI1I2FM6WYZn09qI=
+k8c.io/kubermatic/v2 v2.26.5-0.20250129153809-7df79a40fe08 h1:3X9GSIi5JsSbH9pHuOGC+65Qkavrq47MdjkaQAsIqg0=
+k8c.io/kubermatic/v2 v2.26.5-0.20250129153809-7df79a40fe08/go.mod h1:SNGA6ar7d6lZsOjvzu+Cro4yzKRFI1I2FM6WYZn09qI=
 k8c.io/machine-controller v1.60.1 h1:s/xJD9FIdmHuJyo+CB46Jlkad1xbO0tOfI1MGCtIsD8=
 k8c.io/machine-controller v1.60.1/go.mod h1:j9SHRLpzFj5wOMlhdPJL+ub08P8rvVvQOFtg7JaLYb4=
 k8c.io/operating-system-manager v1.6.2 h1:7hFzsU3RMCTKAST45+Mgd2Q9al0iWTNUCd7qbMV/Bdo=


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump KKP dependency to the commit 7df79a40fe08af42cd307a57039e3344d6b6c4cc so to reflect the k8s version bump changes from KKP.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
