### PR TITLE
Add option to install cluster autoscaling application 

### DIFF
--- a/modules/web/src/app/node-data/template.html
+++ b/modules/web/src/app/node-data/template.html
@@ -241,12 +241,19 @@ limitations under the License.
         <mat-card-title fxFlex
                         fxLayout="row"
                         fxLayoutAlign="start center"
-                        fxlayoutgap="5px">
-          <div>Node Autoscaling</div>
-          <i class="km-icon-info km-pointer"
-             matTooltip='Enable "cluster-autoscaler" addon to apply these changes.'></i>
+                        fxLayoutGap="5px">
+          <div>Cluster Autoscaling</div>
+          <i *ngIf="isDialogView()" class="km-icon-info km-pointer"
+             matTooltip="Autoscaling of machines requires the Cluster Autoscaler application to be installed. NOTE: The addon for cluster-autoscaler has been deprecated in favor of the Application, please make sure to remove the addon from the cluster before enabling this option."></i>
         </mat-card-title>
       </mat-card-header>
+
+      <mat-checkbox *ngIf="!isDialogView()"
+                    [name]="Controls.EnableClusterAutoscalingApp"
+                    [formControlName]="Controls.EnableClusterAutoscalingApp">Enable Cluster Autoscaler Application
+        <i class="km-icon-info km-pointer"
+           matTooltip="Autoscaling of machines requires the Cluster Autoscaler application to be installed. Enable this option to install Cluster Autoscaler Application."></i>
+      </mat-checkbox>
 
       <km-number-stepper label="Max Replicas"
                          mode="all"

--- a/modules/web/src/app/shared/entity/application.ts
+++ b/modules/web/src/app/shared/entity/application.ts
@@ -15,6 +15,8 @@
 import {SafeUrl} from '@angular/platform-browser';
 import semver from 'semver';
 
+export const CLUSTER_AUTOSCALING_APP_DEF_NAME = 'cluster-autoscaler';
+
 export class Application {
   creationTimestamp?: Date;
   deletionTimestamp?: Date;

--- a/modules/web/src/app/shared/model/NodeSpecChange.ts
+++ b/modules/web/src/app/shared/model/NodeSpecChange.ts
@@ -22,6 +22,7 @@ export class NodeData {
   count?: number;
   valid?: boolean;
   dynamicConfig?: boolean;
+  enableClusterAutoscalingApp?: boolean; // This field is used in the UI only
   maxReplicas?: number;
   minReplicas?: number;
   creationTimestamp?: Date;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an option to install `cluster-autoscaler` application when configuring cluster autoscaling in cluster creation wizard.

**Initial Nodes Step:**

<img width="698" alt="Screenshot 2025-02-03 at 7 47 09 PM" src="https://github.com/user-attachments/assets/a145d336-af0f-4002-a864-5cabcabd0d20" />


**Applications Step:**

<img width="677" alt="Screenshot 2025-02-03 at 1 10 46 PM" src="https://github.com/user-attachments/assets/564d0242-0ca7-45f5-8542-33bebfec7373" />


**Add/Edit MD Dialog:**

<img width="645" alt="Screenshot 2025-02-03 at 7 49 18 PM" src="https://github.com/user-attachments/assets/49795317-c0fb-4fa9-9801-d6ed7493027a" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #6699

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new option for cluster autoscaling in initial nodes step of cluster wizard to add cluster autoscaler application.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
