### PR TITLE
Filter KubeVirt Storage Casses based on volume Provisioner

### DIFF
--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -114,6 +114,9 @@ func KubeVirtStorageClasses(ctx context.Context, kubeconfig, datacenterName stri
 
 	storageClasses := apiv2.StorageClassList{}
 	for _, sc := range datacenter.Spec.Kubevirt.InfraStorageClasses {
+		if sc.VolumeProvisioner == kubermaticv1.KubeVirtCSIDriver {
+			continue
+		}
 		storageClasses = append(storageClasses, apiv2.StorageClass{Name: sc.Name})
 	}
 	if len(storageClasses) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
For Kubevirt there are some storage classes that can be used for VM disk images and PVs in the tenant cluster, in addition there are other storage classes that can be used only for PVs in the tenant cluster, This PR make sure that the api would only retrieve storage classes that can be used by CDI to create VM image disks instead of fetching all the storage classes and show them in the UI. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Filter out KubeVirt storage classes in the API/UI based on the the volume provisioner field. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
