### PR TITLE
UX and UI improvements for admin announcements

### DIFF
--- a/modules/web/src/app/core/components/help-panel/component.ts
+++ b/modules/web/src/app/core/components/help-panel/component.ts
@@ -16,7 +16,7 @@ import {Component, ElementRef, HostListener, OnDestroy, OnInit} from '@angular/c
 import {MatDialog} from '@angular/material/dialog';
 import {Router} from '@angular/router';
 import {AppConfigService} from '@app/config.service';
-import {AnnouncementsDialogComponent} from '@app/shared/components/announcements/component';
+import {AnnouncementsDialogComponent} from '@shared/components/announcements-dialog/component';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
 import {slideOut} from '@shared/animations/slide';

--- a/modules/web/src/app/settings/admin/announcements/announcement-dialog/component.ts
+++ b/modules/web/src/app/settings/admin/announcements/announcement-dialog/component.ts
@@ -63,11 +63,11 @@ export class AdminAnnouncementDialogComponent implements OnInit, OnDestroy {
   }
 
   get label(): string {
-    return this._dialogModeService.isEditDialog ? 'Save' : 'Add';
+    return this._dialogModeService.isEditDialog ? 'Save Changes' : 'Add Announcement';
   }
 
   get icon(): string {
-    return this.isEditDialog ? 'km-icon-edit' : 'km-icon-add';
+    return this.isEditDialog ? 'km-icon-save' : 'km-icon-add';
   }
 
   ngOnInit(): void {
@@ -148,7 +148,9 @@ export class AdminAnnouncementDialogComponent implements OnInit, OnDestroy {
 
   onNext(announcement: AdminAnnouncement): void {
     this._dialogRef.close(announcement);
-    this._notificationService.success('created new announcement');
+    this._notificationService.success(
+      this.isEditDialog ? 'Announcement updated successfully.' : 'New announcement created successfully.'
+    );
   }
 
   onTimeChange(time: string): void {

--- a/modules/web/src/app/settings/admin/announcements/announcement-dialog/template.html
+++ b/modules/web/src/app/settings/admin/announcements/announcement-dialog/template.html
@@ -20,6 +20,7 @@ limitations under the License.
       <mat-label>Message</mat-label>
       <textarea matInput
                 [formControlName]="Controls?.Message"
+                rows="4"
                 required></textarea>
       <mat-hint>Add the announcement message</mat-hint>
       <mat-error *ngIf="form?.get(Controls.Message).hasError('required')">The announcement message is required</mat-error>

--- a/modules/web/src/app/settings/admin/announcements/template.html
+++ b/modules/web/src/app/settings/admin/announcements/template.html
@@ -64,7 +64,7 @@ limitations under the License.
       <ng-container [matColumnDef]="Column.CreatedAt">
         <th mat-header-cell
             *matHeaderCellDef
-            class="km-header-cell p-10">Created At
+            class="km-header-cell p-10">Created
         </th>
         <td mat-cell
             *matCellDef="let element">
@@ -80,14 +80,14 @@ limitations under the License.
             *matCellDef="let element">
           <div fxLayoutAlign="end">
             <button mat-icon-button
-                    matTooltip="Delete announcement"
-                    (click)="removeAnnouncement(element)">
-              <i class="km-icon-mask km-icon-delete"></i>
-            </button>
-            <button mat-icon-button
                     matTooltip="Edit announcement"
                     (click)="addAnnouncementDialog(element)">
               <i class="km-icon-mask km-icon-edit"></i>
+            </button>
+            <button mat-icon-button
+                    matTooltip="Delete announcement"
+                    (click)="removeAnnouncement(element)">
+              <i class="km-icon-mask km-icon-delete"></i>
             </button>
           </div>
         </td>

--- a/modules/web/src/app/shared/components/announcement-banner/component.ts
+++ b/modules/web/src/app/shared/components/announcement-banner/component.ts
@@ -17,7 +17,7 @@ import {MatDialog} from '@angular/material/dialog';
 import {NavigationEnd, Router} from '@angular/router';
 import {AdminAnnouncement} from '@app/shared/entity/settings';
 import {filter, Subject, takeUntil} from 'rxjs';
-import {AnnouncementsDialogComponent} from '../announcements/component';
+import {AnnouncementsDialogComponent} from '@shared/components/announcements-dialog/component';
 import {UserService} from '@app/core/services/user';
 
 const PAGES_WITHOUT_ANNOUNCEMENT_BANNER = ['/settings', '/account', '/rest-api', '/terms-of-service$', '/404$'];

--- a/modules/web/src/app/shared/components/announcement-banner/style.scss
+++ b/modules/web/src/app/shared/components/announcement-banner/style.scss
@@ -16,31 +16,39 @@
   align-items: center;
   border-radius: 10px;
   display: flex;
-  flex-wrap: wrap;
   justify-content: space-between;
-  margin: 5px 1%;
-  padding: 10px 20px;
+  margin: 10px 1%;
+  padding: 10px 15px;
   width: 98%;
 
   p {
-    flex: 1;
-    margin: 0;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    margin: 0 50px 0 15px;
+    max-height: 55px;
+    overflow: hidden;
     text-align: left;
+    text-overflow: ellipsis;
+    white-space: normal;
+    width: 100%;
     word-break: break-word;
   }
 
   div {
     align-items: center;
     display: flex;
-    padding-left: 10px;
 
     .mdc-button {
       height: 30px;
-      width: 30px;
 
-      .km-icon-close {
-        position: relative ;
-        top: 4px;
+      &.close-button {
+        width: 30px;
+
+        .km-icon-close {
+          position: relative ;
+          top: 4px;
+        }
       }
     }
   }

--- a/modules/web/src/app/shared/components/announcement-banner/template.html
+++ b/modules/web/src/app/shared/components/announcement-banner/template.html
@@ -16,11 +16,17 @@ limitations under the License.
 
 <div *ngIf="showAnnouncementBanner && !!currentAnnouncementID"
      class="announcement">
+  <i class="km-icon-announcement i-24"></i>
   <p>{{ announcements.get(currentAnnouncementID)?.message }}</p>
   <div>
-    <a (click)="openAnnouncementsDialog()">see all</a>
+    <button mat-flat-button
+            matTooltip="See All Announcements"
+            (click)="openAnnouncementsDialog()">
+      See&nbsp;All
+    </button>
     <button mat-flat-button
             matTooltip="Close"
+            class="close-button"
             (click)="closeBanner()">
       <i class="km-icon-mask km-icon-close"></i>
     </button>

--- a/modules/web/src/app/shared/components/announcements-dialog/style.scss
+++ b/modules/web/src/app/shared/components/announcements-dialog/style.scss
@@ -1,4 +1,4 @@
-// Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+// Copyright 2025 The Kubermatic Kubernetes Platform contributors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,26 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@use 'sass:map';
+@use 'variables';
 
-@mixin theme-announcement-banner-component($colors) {
-  .announcement {
-    background-color: rgb(map.get($colors, primary), 0.8);
+.announcement-message {
+  word-break: break-word;
+}
 
-    .km-icon-announcement {
-      background-color: map.get($colors, announcement-banner-text);
-    }
+.mat-mdc-cell {
+  .mdc-icon-button {
+    position: relative;
+    top: 10px;
 
-    p {
-      color: map.get($colors, announcement-banner-text);
-    }
-
-    div {
-      .mdc-button{
-        &:hover {
-          background-color: map.get($colors, primary-hover);
-        }
-      }
+    .km-icon-check {
+      margin: 0;
     }
   }
 }

--- a/modules/web/src/app/shared/components/announcements-dialog/template.html
+++ b/modules/web/src/app/shared/components/announcements-dialog/template.html
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <km-dialog-title>Announcements</km-dialog-title>
-<mat-dialog-content>
+<mat-dialog-content class="announcements-dialog-content">
   <table mat-table
          matSort
          *ngIf="hasAnnouncements()"
@@ -24,25 +24,34 @@ limitations under the License.
     <ng-container [matColumnDef]="Column.Message">
       <th mat-header-cell
           *matHeaderCellDef
-          class="km-header-cell p-85">Message</th>
+          class="km-header-cell p-70">Message</th>
       <td mat-cell
-          class="events-long-text"
+          class="announcement-message"
           *matCellDef="let element">{{getMessage(element)}}</td>
     </ng-container>
-    <ng-container [matColumnDef]="Column.Read">
+    <ng-container [matColumnDef]="Column.Created">
+      <th mat-header-cell
+          *matHeaderCellDef
+          class="km-header-cell p-20">Created</th>
+      <td mat-cell
+          *matCellDef="let element">
+        <km-relative-time [date]="getCreatedAt(element)"></km-relative-time>
+      </td>
+    </ng-container>
+    <ng-container [matColumnDef]="Column.Actions">
       <th mat-header-cell
           *matHeaderCellDef
           class="km-header-cell"></th>
       <td mat-cell
           *matCellDef="let element">
-        <button *ngIf="!isMessageRead(element) && !isWaiting"
+        <button *ngIf="!isMessageRead(element) && !markingAnnouncementsAsRead[element]"
                 mat-icon-button
                 (click)="markAsRead(element)"
-                matTooltip="mark as read"
+                matTooltip="Mark as read"
                 fxLayoutAlign="center center">
-          <i Class="km-icon-mask km-icon-check"></i>
+          <i class="km-icon-mask km-icon-check"></i>
         </button>
-        <km-spinner-with-confirmation [isSaved]="!(element === awaitedAnnouncementID) "></km-spinner-with-confirmation>
+        <km-spinner-with-confirmation [isSaved]="!markingAnnouncementsAsRead[element]"></km-spinner-with-confirmation>
       </td>
     </ng-container>
     <tr mat-header-row
@@ -50,18 +59,11 @@ limitations under the License.
         *matHeaderRowDef="displayedColumns"></tr>
     <tr mat-row
         *matRowDef="let row; columns: displayedColumns"
-        class="km-mat-row
-        "></tr>
+        class="km-mat-row"
+        [ngClass]="{'unread-announcement': !isMessageRead(row)}"></tr>
   </table>
   <div class="km-row km-empty-list-msg"
        *ngIf="!hasAnnouncements()">No announcements available.</div>
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button mat-flat-button
-          type="button"
-          (click)="closeDialog()">
-    <i class="km-icon-mask km-icon-close"
-       matButtonIcon></i>
-    <span>Close</span>
-  </button>
 </mat-dialog-actions>

--- a/modules/web/src/app/shared/components/announcements-dialog/theme.scss
+++ b/modules/web/src/app/shared/components/announcements-dialog/theme.scss
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.events-long-text {
-  word-break: break-word;
-}
+@use 'sass:map';
 
-.mat-mdc-cell {
-  .mdc-icon-button {
-    position: relative;
-    top: 10px;
+@mixin theme-announcements-dialog-component($colors) {
+  .announcements-dialog-content {
+    --mat-table-background-color:  #{map.get($colors, dialog)};
 
-    .km-icon-check {
-      margin: 0;
+    .mat-mdc-row.unread-announcement {
+      background-color: map.get($colors, option-background-hover) !important;
     }
   }
+
 }

--- a/modules/web/src/app/shared/module.ts
+++ b/modules/web/src/app/shared/module.ts
@@ -139,7 +139,7 @@ import {ValueChangedIndicatorDirective} from './directives/value-changed-indicat
 import {PipesModule} from './pipes/ngx-filter-pipe/module';
 import {RelativeTimePipe} from './pipes/relativetime';
 import {AnnouncementBannerComponent} from './components/announcement-banner/component';
-import {AnnouncementsDialogComponent} from './components/announcements/component';
+import {AnnouncementsDialogComponent} from '@shared/components/announcements-dialog/component';
 
 const modules = [
   CommonModule,

--- a/modules/web/src/assets/css/_images.scss
+++ b/modules/web/src/assets/css/_images.scss
@@ -486,6 +486,14 @@
   @include mixins.mask-image('/assets/images/icons/docs.svg', 18px);
 }
 
+.km-icon-announcement {
+  @include mixins.mask-image('/assets/images/icons/announcement.svg', 18px);
+
+  &.i-24 {
+    @include mixins.size(24px, 24px, true);
+  }
+}
+
 .km-provider-logo-alibaba {
   @include mixins.provider-image('/assets/images/clouds/alibaba.svg', 115px, 30px);
 }

--- a/modules/web/src/assets/css/global/_main.scss
+++ b/modules/web/src/assets/css/global/_main.scss
@@ -556,6 +556,11 @@ km-dashboard {
       }
     }
   }
+
+  &.km-announcements-dialog {
+    max-width: 1000px !important;
+    min-width: 1000px !important;
+  }
 }
 
 .km-quota-inputs {

--- a/modules/web/src/assets/css/theme/_component.scss
+++ b/modules/web/src/assets/css/theme/_component.scss
@@ -39,6 +39,7 @@
 @import 'app/shared/components/terminal/terminal-toolbar/theme';
 @import 'app/shared/components/terminal/terminal-status-bar/theme';
 @import 'app/shared/components/announcement-banner/theme';
+@import 'app/shared/components/announcements-dialog/theme';
 @import 'app/cluster/details/cluster/overlay-terminal/theme';
 @import 'app/cluster/details/cluster/rbac/add-binding-dialog/theme';
 @import 'app/settings/admin/bucket-settings/destinations/theme';
@@ -94,4 +95,5 @@
   @include theme-topology-spread-constraint-form-component($colors);
   @include theme-nutanix-basic-node-data-component($colors);
   @include theme-announcement-banner-component($colors);
+  @include theme-announcements-dialog-component($colors);
 }

--- a/modules/web/src/assets/images/icons/announcement.svg
+++ b/modules/web/src/assets/images/icons/announcement.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+     stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m3 11 18-5v12L3 14v-3z" />
+  <path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" />
+</svg>


### PR DESCRIPTION
**What this PR does / why we need it**:
UX and UI improvements for admin announcements.

**Announcement Banner:**
- Updated the background color.
- Change "See All" to a button instead of anchor link.
- Maximum text limit set to 3 rows.

<img width="1702" alt="Screenshot 2025-02-13 at 3 44 26 PM" src="https://github.com/user-attachments/assets/775adcc0-7408-4ad9-ab5f-b3bf14cf9b03" />


**Announcements Dialog:**
- Increased dialog width to `1000px`.
- Added "Created" column.
- Added a different background color to unread announcements.
- Removed the redundant "Close" button in dialog footer.

<img width="1006" alt="Screenshot 2025-02-13 at 3 45 33 PM" src="https://github.com/user-attachments/assets/4ead2cb5-d8a6-4505-83ae-2e872867e8c5" />


**Admin Announcements Page:**
- Swapped Edit/Delete buttons.
- Added Confirmation Dialog for deleting announcement.

<img width="686" alt="Screenshot 2025-02-13 at 3 58 06 PM" src="https://github.com/user-attachments/assets/b970a644-9f03-4455-92ee-dc74136fa856" />


**Add/Edit Announcements Dialog:**
- Increased rows for announcements message.
- Updated action button text.
- Updated notification messages of adding/updating announcements.

<img width="1423" alt="Screenshot 2025-02-13 at 3 46 02 PM" src="https://github.com/user-attachments/assets/9d68da24-bb74-48b9-acf8-ec871605c520" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
