### PR TITLE
Small enhancements for etcd 

### DIFF
--- a/modules/web/src/app/backup/list/automatic-backup/add-dialog/template.html
+++ b/modules/web/src/app/backup/list/automatic-backup/add-dialog/template.html
@@ -31,6 +31,9 @@ limitations under the License.
                       [value]="cluster.id">{{cluster.name}}</mat-option>
         </mat-select>
         <mat-hint>The list of existing clusters for the selected project.</mat-hint>
+        <mat-error *ngIf="form.get(Controls.Cluster).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
       </mat-form-field>
 
       <mat-form-field>
@@ -39,6 +42,9 @@ limitations under the License.
                matInput
                required>
         <mat-hint>The name of the created automatic backup.</mat-hint>
+        <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
       </mat-form-field>
 
       <div *ngIf="hasClusterInput() && !this.isLoadingDestinations"
@@ -68,6 +74,9 @@ limitations under the License.
           </mat-hint>
           <mat-hint *ngIf="hasDestinations()">The list of existing destinations for the selected cluster seed.
           </mat-hint>
+          <mat-error *ngIf="form.get(Controls.Destination).hasError('required')">
+            <strong>Required</strong>
+          </mat-error>
         </mat-form-field>
       </div>
 
@@ -91,7 +100,7 @@ limitations under the License.
 
         <mat-radio-button [value]="ScheduleOption.Monthly">
           <div class="km-radio-button-title">Monthly</div>
-          <div class="km-radio-button-description">Create a backup every month at 22:00 on 1st day of the month and save each backup for 3 months before it is automatically deleted.
+          <div class="km-radio-button-description">Create a backup every month at 22:00 on the 1st day of the month and save each backup for 3 months before it is automatically deleted.
           </div>
         </mat-radio-button>
 
@@ -115,14 +124,20 @@ limitations under the License.
                  matInput
                  required>
           <mat-hint>Cron expression that describes how often a backup should be
-            created. Must match the criteria specified
-            <a href="https://pkg.go.dev/github.com/robfig/cron?utm_source=godoc"
-               fxLayout="row inline"
-               fxLayoutAlign=" center"
-               target="_blank"
-               rel="noopener noreferrer">here <i class="km-icon-external-link"></i></a>.
-            Please note that specifying seconds is not supported.
+            created.
           </mat-hint>
+          <mat-error *ngIf="form.get(Controls.Schedule).hasError('required')">
+            <strong>Required</strong>
+          </mat-error>
+          <mat-error *ngIf="form.get(Controls.Schedule).hasError('cronExpression')">
+            <strong> Must match the criteria specified
+              <a href="https://pkg.go.dev/github.com/robfig/cron?utm_source=godoc"
+                 fxLayout="row inline"
+                 fxLayoutAlign=" center"
+                 target="_blank"
+                 rel="noopener noreferrer">here <i class="km-icon-external-link"></i></a>.</strong>
+            Please note that specifying seconds is not supported.
+          </mat-error>
         </mat-form-field>
 
         <km-number-stepper [formControlName]="Controls.Keep"

--- a/modules/web/src/app/backup/list/component.ts
+++ b/modules/web/src/app/backup/list/component.ts
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, OnInit} from '@angular/core';
+import {Component, OnDestroy, OnInit} from '@angular/core';
 import {Router} from '@angular/router';
 import {SettingsService} from '@app/core/services/settings';
 import {View} from '@app/shared/entity/common';
 import {AdminSettings} from '@app/shared/entity/settings';
-import {take} from 'rxjs';
+import {Subject, takeUntil} from 'rxjs';
 
 @Component({
   selector: 'km-backups',
   templateUrl: './template.html',
 })
-export class BackupsComponent implements OnInit {
+export class BackupsComponent implements OnInit, OnDestroy {
+  private readonly _unsubscribe = new Subject<void>();
   readonly view = View;
   enableEtcdBackup: boolean;
   etcdBackupType = '';
@@ -35,9 +36,14 @@ export class BackupsComponent implements OnInit {
 
   ngOnInit(): void {
     this.getEtcdBackupType();
-    this._settingsService.adminSettings.pipe(take(1)).subscribe((settings: AdminSettings) => {
+    this._settingsService.adminSettings.pipe(takeUntil(this._unsubscribe)).subscribe((settings: AdminSettings) => {
       this.enableEtcdBackup = settings.enableEtcdBackup;
     });
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribe.next();
+    this._unsubscribe.complete();
   }
 
   getEtcdBackupType(): void {

--- a/modules/web/src/app/backup/list/snapshot/add-dialog/template.html
+++ b/modules/web/src/app/backup/list/snapshot/add-dialog/template.html
@@ -31,6 +31,9 @@ limitations under the License.
                       [value]="cluster.id">{{cluster.name}}</mat-option>
         </mat-select>
         <mat-hint>The list of existing clusters for the selected project.</mat-hint>
+        <mat-error *ngIf="form.get(Controls.Cluster).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
       </mat-form-field>
 
       <mat-form-field>
@@ -39,6 +42,9 @@ limitations under the License.
                matInput
                required>
         <mat-hint>The name of the created automatic backup.</mat-hint>
+        <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
       </mat-form-field>
 
       <div *ngIf="!!this.form.get(Controls.Cluster).value && !this.isLoadingDestinations"
@@ -69,6 +75,9 @@ limitations under the License.
           </mat-hint>
           <mat-hint *ngIf="hasDestinations()">The list of existing destinations for the selected cluster seed.
           </mat-hint>
+          <mat-error *ngIf="form.get(Controls.Destination).hasError('required')">
+            <strong>Required</strong>
+          </mat-error>
         </mat-form-field>
       </div>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add errors messages  for the add dialogs,
fix etcd backup components (automatic backups, snapshot, restore) are not displayed on refresh page.
![Screenshot from 2025-02-14 14-40-38](https://github.com/user-attachments/assets/2b218df2-79ff-4479-ae42-76c7ad1befef)
![Screenshot from 2025-02-14 14-43-07](https://github.com/user-attachments/assets/735c937a-d0f8-494e-bba7-3ada30c21d0f)

**Which issue(s) this PR fixes**:
Fixes #7119 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
