### PR TITLE
Add select all namespaces to restore and few enhancements

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -293,9 +293,6 @@ limitations under the License.
         Cluster Backup
         <i class="km-icon-info km-pointer"
            matTooltip="Enable create backups from this cluster"></i>
-        <mat-chip>
-          <div>Experimental</div>
-        </mat-chip>
       </mat-checkbox>
 
       <mat-form-field *ngIf="!!form.get(Controls.ClusterBackup).value && isclusterBackupEnabled"

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/add-dialog/template.html
@@ -74,25 +74,24 @@ END OF TERMS AND CONDITIONS
                matInput
                required>
         <mat-hint>
-          Cron expression that describes how often a backup should be created. Must match the criteria specified
+          Cron expression that describes how often a backup should be created.
+        </mat-hint>
+        <mat-error *ngIf="form.get(Controls.CronJob).hasError('required')">
+          <strong>Required</strong>
+        </mat-error>
+        <mat-error *ngIf="form.get(Controls.CronJob).hasError('cronExpression')">Schedule must be in cron expression. Must match the criteria specified
           <a href="https://pkg.go.dev/github.com/robfig/cron?utm_source=godoc"
              target="_blank"
              fxLayout="row inline"
              fxLayoutAlign=" center"
              rel="noopener noreferrer">here <i class="km-icon-external-link"></i></a>. Please note that specifying seconds is not supported.
-        </mat-hint>
-        <mat-error *ngIf="form.get(Controls.CronJob).hasError('required')">
-          <strong>Required</strong>
-        </mat-error>
-        <mat-error *ngIf="form.get(Controls.CronJob).hasError('cronExpression')">
-          Schedule must be in corn expression.
         </mat-error>
       </mat-form-field>
       <mat-form-field subscriptSizing="dynamic">
         <mat-label>Expires In</mat-label>
         <input [formControlName]="Controls.ExpiresIn"
                matInput>
-        <mat-hint>Enter time in the format HHhMMmSSs (e.g., 24h10m10s), The amount of time before this backup is eligible for garbage collection. If not specified,
+        <mat-hint>Enter the time in the format HHhMMmSSs (e.g., 24h10m10s). The amount of time before this backup is eligible for garbage collection. If not specified,
           a default value of 30 days will be used.</mat-hint>
         <mat-error *ngIf="form.get(Controls.ExpiresIn).hasError('pattern')">
           Time must be in the format HHhMMmSSs (e.g., 24h10m10s).

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/style.scss
@@ -37,3 +37,7 @@
 .namespaces-detail {
   margin-top: 20px;
 }
+
+.km-icon-delete {
+  display: flex;
+}

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
@@ -50,7 +50,7 @@ END OF TERMS AND CONDITIONS
       <div class="action-button"
            *ngIf="clusters?.length">
         <button *ngIf="selectedBackups.length"
-                mat-icon-button
+                mat-flat-button
                 type="button"
                 matTooltip="Delete selected"
                 (click)="deleteBackups(selectedBackups)">
@@ -248,8 +248,8 @@ END OF TERMS AND CONDITIONS
           *matHeaderRowDef="columns"></tr>
       <tr mat-row
           *matRowDef="let element; columns: columns"
-          class="km-mat-row km-pointer"
-          [ngClass]="{'km-selected': checkSelected(element.id)}"
+          class="km-mat-row"
+          [ngClass]="{'km-selected': checkSelected(element.id), 'km-pointer': element.spec.includedNamespaces}"
           (click)="toggleBackupDetail(element.name)"></tr>
       <tr mat-header-row
           *matRowDef="let element; columns: toggleableColumn"

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/add-dialog/template.html
@@ -36,18 +36,23 @@ END OF TERMS AND CONDITIONS
           Name can only contain alphanumeric characters and dashes (a-z, 0-9 and -). Must not start/end with dash.
         </mat-error>
       </mat-form-field>
-      <mat-form-field>
+      <mat-checkbox [formControlName]="controls.AllNamespaces">
+        Restore All Namespaces
+        <i class="km-icon-info km-pointer"
+           matTooltip="Select all namespaces to restore."></i>
+      </mat-checkbox>
+      <mat-form-field *ngIf="!form?.get(controls.AllNamespaces).value">
         <mat-label>Choose Namespaces</mat-label>
         <mat-select [formControlName]="controls.NameSpaces"
                     multiple
                     panelClass="km-multiple-values-dropdown"
                     disableOptionCentering>
-          <mat-option *ngFor="let nameSpace of backup.spec.includedNamespaces"
+          <mat-option *ngFor="let nameSpace of nameSpaces"
                       [value]="nameSpace">
             {{nameSpace}}
           </mat-option>
         </mat-select>
-        <mat-hint>Namespaces to include in the backup.</mat-hint>
+        <mat-hint>Namespaces to include in the restore.</mat-hint>
         <mat-error *ngIf="form.get(controls.NameSpaces).hasError('required')">
           <strong>Required</strong>
         </mat-error>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/style.scss
@@ -33,3 +33,7 @@
 .namespaces-detail {
   margin-top: 20px;
 }
+
+.km-icon-delete {
+  display: flex;
+}

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/restore/template.html
@@ -42,7 +42,7 @@ END OF TERMS AND CONDITIONS
                      (queryChange)="onSearch($event)"></km-search-field>
     <div fxFlex></div>
     <div *ngIf="selectedRestores.length">
-      <button mat-icon-button
+      <button mat-flat-button
               type="button"
               matTooltip="Delete selected"
               (click)="deleteRestores(selectedRestores)">
@@ -167,12 +167,12 @@ END OF TERMS AND CONDITIONS
           *matHeaderRowDef="columns"></tr>
       <tr mat-row
           *matRowDef="let element; columns: columns"
-          class="km-mat-row km-pointer"
-          [ngClass]="{'km-selected': checkSelected(element.id)}"
+          class="km-mat-row"
+          [ngClass]="{'km-selected': checkSelected(element.id), 'km-pointer': element.spec.includedNamespaces}"
           (click)="toggleRestoreDetail(element.name)"></tr>
       <tr mat-header-row
           *matRowDef="let element; columns: toggleableColumn"
-          [ngClass]="isRestoreToggled(element.name) ? '' : 'km-hidden'"
+          [ngClass]="isRestoreToggled(element.name) && element.spec.includedNamespaces?.length ? '' : 'km-hidden'"
           class="km-mat-row"></tr>
     </table>
 

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/schedule/template.html
@@ -225,12 +225,12 @@ END OF TERMS AND CONDITIONS
           *matHeaderRowDef="columns"></tr>
       <tr mat-row
           *matRowDef="let element; columns: columns"
-          class="km-mat-row km-pointer"
-          [ngClass]="{'km-selected': checkSelected(element.id)}"
+          class="km-mat-row"
+          [ngClass]="{'km-selected': checkSelected(element.id), 'km-pointer': element.spec.includedNamespaces}"
           (click)="toggleScheduleDetail(element.name)"></tr>
       <tr mat-header-row
           *matRowDef="let element; columns: toggleableColumn"
-          [ngClass]="isScheduleToggled(element.name) ? '' : 'km-hidden'"
+          [ngClass]="isScheduleToggled(element.name) && element.spec.includedNamespaces?.length ? '' : 'km-hidden'"
           class="km-mat-row"></tr>
     </table>
 

--- a/modules/web/src/app/settings/admin/defaults/template.html
+++ b/modules/web/src/app/settings/admin/defaults/template.html
@@ -223,9 +223,6 @@ limitations under the License.
                         [(ngModel)]="settings.enableClusterBackups"
                         (change)="onSettingsChange()">
           </mat-checkbox>
-          <mat-chip>
-            <div>Experimental</div>
-          </mat-chip>
           <km-spinner-with-confirmation [isSaved]="isEqual(settings.enableClusterBackups, apiSettings.enableClusterBackups)"></km-spinner-with-confirmation>
         </div>
 

--- a/modules/web/src/app/shared/entity/backup.ts
+++ b/modules/web/src/app/shared/entity/backup.ts
@@ -151,7 +151,7 @@ export class ClusterBackup {
 }
 
 export class ClusterBackupSpec {
-  includedNamespaces?: string[] | string;
+  includedNamespaces?: string[];
   storageLocation: string;
   defaultVolumesToFsBackup: boolean;
   clusterid: string;
@@ -183,7 +183,7 @@ export class ClusterRestore {
 
 export class ClusterRestoreConfigSpec {
   backupName: string;
-  includedNamespaces: string[];
+  includedNamespaces?: string[];
   scheduleName?: string;
   clusterid?: string;
   labels?: Record<string, string>;

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -438,9 +438,6 @@ limitations under the License.
               Cluster Backup
               <i class="km-icon-info km-pointer"
                  matTooltip="Enable create backups from this cluster"></i>
-              <mat-chip>
-                <div>Experimental</div>
-              </mat-chip>
             </mat-checkbox>
 
             <mat-form-field *ngIf="!!controlValue(Controls.ClusterBackup) && isclusterBackupEnabled">

--- a/modules/web/src/assets/css/global/_theme.scss
+++ b/modules/web/src/assets/css/global/_theme.scss
@@ -252,7 +252,7 @@
     background-color: map.get($colors, background-hover);
   }
 
-  .km-mat-row.km-pointer.km-selected {
+  .km-mat-row.km-selected {
     background-color: map.get($colors, background-hover);
 
     td {


### PR DESCRIPTION
**What this PR does / why we need it**:
add select all namespaces for restore dialog, small enhancements, and remove the experimental tag 

![image](https://github.com/user-attachments/assets/153d4354-2854-436b-85cf-e3dd50eec729)

![image](https://github.com/user-attachments/assets/6d23ab97-8c2f-432f-bc43-78b12a4fef8b)

**Which issue(s) this PR fixes**:
Fixes #7125

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
In the cluster backup feature, fix the issue with restoring a backup that includes all namespaces and add the option to restore all namespaces from a backup.
```

**Documentation**:
```documentation
NONE
```
