### PR TITLE
Cover the External Cloud Spec in the API

### DIFF
--- a/modules/api/pkg/machine/convert.go
+++ b/modules/api/pkg/machine/convert.go
@@ -297,6 +297,8 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 		}
 	case providerconfig.CloudProviderEdge:
 		cloudSpec.Edge = &apiv1.EdgeNodeSpec{}
+	case providerconfig.CloudProviderExternal:
+		// do nothing here as the external cloud provider doesn't have any specific cloud spec.
 	case providerconfig.CloudProviderGoogle:
 		config := &gce.CloudProviderSpec{}
 		if err := json.Unmarshal(decodedProviderSpec.CloudProviderSpec.Raw, &config); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR covers the external cloud provider for converting the machine deployment spec into node spec. Otherwise an error such as `unknown cloud provider external: failed to get node cloud spec from machine deployment` will keep showing up in the UI. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
