### PR TITLE
Use the NewExternalWithProxy method to manage UserClusters 

### DIFF
--- a/modules/api/cmd/kubermatic-api/main.go
+++ b/modules/api/cmd/kubermatic-api/main.go
@@ -697,7 +697,7 @@ func clusterProviderFactory(mapper meta.RESTMapper, seedKubeconfigGetter provide
 			return nil, fmt.Errorf("failed to create dynamic seed client: %w", err)
 		}
 
-		userClusterConnectionProvider, err := client.NewExternal(seedCtrlruntimeClient)
+		userClusterConnectionProvider, err := client.NewExternalWithProxy(seedCtrlruntimeClient, seed.GetManagementProxyUrl())
 		if err != nil {
 			return nil, fmt.Errorf("failed to get userClusterConnectionProvider: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains the method call for https://github.com/kubermatic/kubermatic/pull/14159 which adds support for using a proxy between kkp and the userclusters nodeport-proxy


**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
Depends on https://github.com/kubermatic/kubermatic/pull/14159

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
