### PR TITLE
Fix `e2e:mock` script

### DIFF
--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -27,7 +27,7 @@
     "cy": "cypress run --record false -b chrome -e KUBERMATIC_EDITION=\"${KUBERMATIC_EDITION:=ee}\",MOCKS=\"${CYPRESS_MOCKS:='false'}\"",
     "e2e": "start-server-and-test start:e2e http-get://localhost:8000 cy",
     "e2e:local": "start-server-and-test start:e2e:local http-get://localhost:8000 cy",
-    "e2e:mock": "start-server-and-test start:e2e:mock http-get://localhost:8000 cy",
+    "e2e:mock": "CYPRESS_MOCKS=true start-server-and-test start:e2e:mock http-get://localhost:8000 cy",
     "check": "npm run check:ts && npm run check:scss && npm run check:dependency-licenses",
     "check:ts": "gts lint",
     "check:scss": "stylelint \"src/**/*.scss\"",


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we don't explicitly set the value for `CYPRESS_MOCK` in the npm script, it was being set as `false` in case of mock tests through https://github.com/kubermatic/dashboard/blob/main/modules/web/package.json#L27

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
