### PR TITLE
Split large token to multi cookies

### DIFF
--- a/modules/api/cmd/kubermatic-api/main.go
+++ b/modules/api/cmd/kubermatic-api/main.go
@@ -489,6 +489,7 @@ func createAuthClients(options serverRunOptions, prov providers) (authtypes.Toke
 			auth.NewHeaderBearerTokenExtractor("Authorization"),
 			auth.NewCookieHeaderBearerTokenExtractor("token"),
 			auth.NewQueryParamBearerTokenExtractor("token"),
+			auth.NewCookieHeaderBearerMultiTokenExtractor("token"),
 		),
 		options.caBundle.CertPool(),
 	)

--- a/modules/web/src/app/config.ts
+++ b/modules/web/src/app/config.ts
@@ -34,10 +34,12 @@ export interface Cookie {
   autoredirect: string;
   nonce: string;
   token: string;
+  tokenPrefix: string;
 }
 
 export const COOKIE: Cookie = {
   autoredirect: 'autoredirect',
   nonce: 'nonce',
   token: 'token',
+  tokenPrefix: 'token-',
 };

--- a/modules/web/src/app/core/services/token.ts
+++ b/modules/web/src/app/core/services/token.ts
@@ -20,14 +20,23 @@ import {Cookie, COOKIE_DI_TOKEN} from '@app/config';
 @Injectable()
 export class TokenService {
   private readonly _baseTime = 1000;
+  private _token: string;
 
   constructor(
     private readonly _cookieService: CookieService,
     @Inject(COOKIE_DI_TOKEN) private readonly _cookie: Cookie
   ) {}
 
+  set token(token: string) {
+    this._token = token;
+  }
+
+  get token(): string {
+    return this._token;
+  }
+
   hasExpired(): boolean {
-    const token = this._cookieService.get(this._cookie.token);
+    const token = this._cookieService.get(this._cookie.token) || this._token;
     return token ? moment().isBefore(moment(this.decodeToken(token).exp * this._baseTime)) : false;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the issue when the user tries to log in and is a member of many groups/roles, which results in a huge token
**Which issue(s) this PR fixes**:
Fixes #7182 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix KKP login issue when the ID token is too large to be saved in a cookie, by splitting the token into multiple cookies.
```

**Documentation**:
```documentation
TBD
```
