### PR TITLE
[release/v2.27] Bump KKP dependency for KKP Dashboard patch release 2.27.1

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,7 +70,7 @@ require (
 	google.golang.org/api v0.209.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.27.0
+	k8c.io/kubermatic/v2 v2.27.1-0.20250311141421-1c2270778cac
 	k8c.io/machine-controller v1.61.0
 	k8c.io/operating-system-manager v1.6.1-0.20241118134103-5db575f65108
 	k8c.io/reconciler v0.5.0

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1158,8 +1158,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.27.0 h1:SSOcgnY7my14tcw1GIoofN7l8g7UJsHOwd5MWGcwivs=
-k8c.io/kubermatic/v2 v2.27.0/go.mod h1:ig2jw2L4/LVa8dhLfB90OcJh3VfB673ecFF90gKmDIE=
+k8c.io/kubermatic/v2 v2.27.1-0.20250311141421-1c2270778cac h1:5yH+uH3dbfOYnubLBho/oVHGZTshcka510dNI6xIjZw=
+k8c.io/kubermatic/v2 v2.27.1-0.20250311141421-1c2270778cac/go.mod h1:ig2jw2L4/LVa8dhLfB90OcJh3VfB673ecFF90gKmDIE=
 k8c.io/machine-controller v1.61.0 h1:d7KVD2CDG2K76ujSt5RPLUP3BCNDcioObdM1N0BUNlc=
 k8c.io/machine-controller v1.61.0/go.mod h1:ZGDFyUeEp66RHcNB5Ki/OJyFdZFgo9dkHJ9s6YJWPcg=
 k8c.io/operating-system-manager v1.6.1-0.20241118134103-5db575f65108 h1:xiKGpydY/jsBVD5XT3zvAxW2pPKEtgcv526zdVFzbuw=


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump KKP dependency for KKP Dashboard patch release 2.27.1
previous PR https://github.com/kubermatic/dashboard/pull/7185 takes care of version bump.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
