### PR TITLE
(fix): use OSP from node instead of default OSP from dc

### DIFF
--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -75,13 +75,13 @@ func Deployment(ctx context.Context, c *kubermaticv1.Cluster, nd *apiv1.NodeDepl
 	// 3. Allow empty value to let OSM apply its defaulting logic
 	if osp := nd.Annotations[osmresources.MachineDeploymentOSPAnnotation]; osp == "" {
 		osp = getOperatingSystemProfile(nd, dc)
+		if osp != "" {
+			if md.Annotations == nil {
+				md.Annotations = make(map[string]string)
+			}
 
-		if md.Annotations == nil {
-			md.Annotations = make(map[string]string)
+			md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = osp
 		}
-
-		// Set the osp value (even if empty) to enable OSM handling.
-		md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = osp
 	}
 
 	md.Namespace = metav1.NamespaceSystem

--- a/modules/api/pkg/resources/machine/machinedeployment.go
+++ b/modules/api/pkg/resources/machine/machinedeployment.go
@@ -69,7 +69,7 @@ func Deployment(ctx context.Context, c *kubermaticv1.Cluster, nd *apiv1.NodeDepl
 	// Add Annotations to Machine Deployment
 	md.Annotations = nd.Annotations
 
-	osp := getOperatingSystemProfile(nd, dc)
+	osp := getOperatingSystemProfile(nd)
 	if osp != "" {
 		if md.Annotations == nil {
 			md.Annotations = make(map[string]string)
@@ -316,26 +316,13 @@ func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *ku
 	return &config, nil
 }
 
-func getOperatingSystemProfile(nd *apiv1.NodeDeployment, dc *kubermaticv1.Datacenter) string {
-	if dc.Spec.DefaultOperatingSystemProfiles == nil {
-		return ""
+// getOperatingSystemProfile returns the OSP selected while creating the cluster.
+func getOperatingSystemProfile(nd *apiv1.NodeDeployment) string {
+	if osp := nd.Annotations[osmresources.MachineDeploymentOSPAnnotation]; osp != "" {
+		return osp
 	}
 
-	// OS specifics
-	switch {
-	case nd.Spec.Template.OperatingSystem.Ubuntu != nil:
-		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemUbuntu]
-	case nd.Spec.Template.OperatingSystem.RHEL != nil:
-		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemRHEL]
-	case nd.Spec.Template.OperatingSystem.Flatcar != nil:
-		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemFlatcar]
-	case nd.Spec.Template.OperatingSystem.RockyLinux != nil:
-		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemRockyLinux]
-	case nd.Spec.Template.OperatingSystem.AmazonLinux != nil:
-		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemAmazonLinux2]
-	default:
-		return ""
-	}
+	return ""
 }
 
 func getProviderOS(config *providerconfig.Config, nd *apiv1.NodeDeployment) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates `getOperatingSystemProfile` helper to parse Node annotations instead of relying on the dc spec, which needs to be used as a default, not as an enforced OSP

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14028

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updated Dashboard API to use correct OSP which is selected while creating a cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
