### PR TITLE
[release/v2.25] Bump KKP dashboard version and update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.14
+KUBERMATIC_VERSION?=v2.25.15
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.14
+KUBERMATIC_VERSION?=v2.25.15
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,7 +70,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.2
-	k8c.io/kubermatic/v2 v2.25.14-0.20250301202613-f674d4647223
+	k8c.io/kubermatic/v2 v2.25.15-0.20250325122258-85fcff0c1a63
 	k8c.io/operating-system-manager v1.5.2
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.29.1
@@ -129,7 +129,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/distribution/v3 v3.0.0-20230629214736-bac7f02e02a1 // indirect
+	github.com/distribution/distribution/v3 v3.0.0-20230821082436-3e4c4ead4c3a // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.2 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -248,8 +248,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/digitalocean/godo v1.108.0 h1:fWyMENvtxpCpva1UbKzOFnyAS04N1FNuBWWfPeTGquQ=
 github.com/digitalocean/godo v1.108.0/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
-github.com/distribution/distribution/v3 v3.0.0-20230629214736-bac7f02e02a1 h1:yRwt9RluqBtKyDLRY7J0Cf/TVqvG56vKx2Eyndy8qNQ=
-github.com/distribution/distribution/v3 v3.0.0-20230629214736-bac7f02e02a1/go.mod h1:+fqBJ4vPYo4Uu1ZE4d+bUtTLRXfdSL3NvCZIZ9GHv58=
+github.com/distribution/distribution/v3 v3.0.0-20230821082436-3e4c4ead4c3a h1:vPm/5pvt9fYKVOvYttDa7GmS/go9+FFZGKXLMh8Toxg=
+github.com/distribution/distribution/v3 v3.0.0-20230821082436-3e4c4ead4c3a/go.mod h1:WREzLx07iIFUGvbm6tBoqGt40zOC3whiM1qkcWOMFrs=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -1421,8 +1421,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.25.14-0.20250301202613-f674d4647223 h1:TdUXyVt7mufzg+/omOqKz49N8mH2ouR/YLsYOklA2i8=
-k8c.io/kubermatic/v2 v2.25.14-0.20250301202613-f674d4647223/go.mod h1:IrLBU1xfnP6GjbQiLN+tkQF8GQD5bu383IWzGLtZZhk=
+k8c.io/kubermatic/v2 v2.25.15-0.20250325122258-85fcff0c1a63 h1:N/RzjS23vNNyaUI2EYIjQf+519s+DuGyJ4WRLhJ5sa8=
+k8c.io/kubermatic/v2 v2.25.15-0.20250325122258-85fcff0c1a63/go.mod h1:JphDXQUu/C5xUaPpn/kfrfmsn3bKBmp0RJSP2FPFQPE=
 k8c.io/operating-system-manager v1.5.2 h1:zzRAGytDUNFlegQW31kUE3dc6tVzAdqZ6IxrbDFugOI=
 k8c.io/operating-system-manager v1.5.2/go.mod h1:h7gVySBkNOVDj2LAW90kDw2nwAROS5k9wVHeK6w/1KQ=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.14
+KUBERMATIC_VERSION?=v2.25.15
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.25.14",
+  "version": "2.25.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.25.14",
+      "version": "2.25.15",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.25.14",
+  "version": "2.25.15",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",

--- a/modules/web/src/assets/config/changelog.json
+++ b/modules/web/src/assets/config/changelog.json
@@ -1,13 +1,9 @@
 {
-  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.25.md#v22514",
+  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.25.md#v22515",
   "entries": [
     {
-      "category": "fixed",
-      "description": "Fix datacenter creation for Edge provider"
-    },
-    {
-      "category": "fixed",
-      "description": "Fix wrong GCP machine deployment values in Edit Machine Deployment dialog"
+      "category": "changed",
+      "description": "Update Dashboard API to use correct OSP which is selected while creating a cluster"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump KKP dashboard version to 2.25.15 and update KKP dependencies. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
