### PR TITLE
Add logic to select the highest priority role

### DIFF
--- a/modules/web/src/app/shared/utils/member.ts
+++ b/modules/web/src/app/shared/utils/member.ts
@@ -31,12 +31,13 @@ export enum Group {
 
 export class MemberUtils {
   static getGroupInProject(member: Member, projectID: string): string {
-    if (!member || !member.projects) {
-      return '';
-    }
+    if (!member?.projects) return '';
 
-    const project = member.projects.find(memberProject => memberProject.id === projectID);
-    return project ? project.group : '';
+    const priority = [Group.Owner, Group.ProjectManager, Group.Editor, Group.Viewer];
+
+    const groups = member.projects.filter(p => p.id === projectID).map(p => p.group);
+
+    return priority.find(role => groups.includes(role)) || '';
   }
 
   static getGroupDisplayName(groupInternalName: string): string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated the `getGroupInProject` method to return the highest-priority group role for a member within a specific project.

**Which issue(s) this PR fixes**:
Fixes #7270

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add role prioritization: Update logic to return the highest-priority role for members with multiple roles.
```

**Documentation**:
```documentation
NONE
```
