### PR TITLE
Add Input restrictions and escape values to avoid rendering as HTML in dialogs

### DIFF
--- a/modules/web/src/app/backup/details/automatic-backup/component.ts
+++ b/modules/web/src/app/backup/details/automatic-backup/component.ts
@@ -15,7 +15,7 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {ActivatedRoute, Router} from '@angular/router';
-import {HealthStatus, getBackupHealthStatus} from '@app/shared/utils/health-status';
+import {getBackupHealthStatus, HealthStatus} from '@app/shared/utils/health-status';
 import {BackupService} from '@core/services/backup';
 import {ProjectService} from '@core/services/project';
 import {UserService} from '@core/services/user';
@@ -26,6 +26,7 @@ import {Member} from '@shared/entity/member';
 import {Project} from '@shared/entity/project';
 import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member';
+import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, map, switchMap, take, takeUntil} from 'rxjs/operators';
 
@@ -104,7 +105,7 @@ export class AutomaticBackupDetailsComponent implements OnInit, OnDestroy {
     const config: MatDialogConfig = {
       data: {
         title: 'Delete Automatic Backup',
-        message: `Delete <b>${backup.name}</b> automatic backup of <b>${this.selectedProject.name}</b> project and all its associated backups permanently?`,
+        message: `Delete <b>${_.escape(backup.name)}</b> automatic backup of <b>${_.escape(this.selectedProject.name)}</b> project and all its associated backups permanently?`,
         confirmLabel: 'Delete',
       } as ConfirmationDialogConfig,
     };

--- a/modules/web/src/app/backup/list/automatic-backup/add-dialog/component.ts
+++ b/modules/web/src/app/backup/list/automatic-backup/add-dialog/component.ts
@@ -23,6 +23,7 @@ import {NotificationService} from '@core/services/notification';
 import {UserService} from '@core/services/user';
 import {EtcdBackupConfig, EtcdBackupConfigSpec} from '@shared/entity/backup';
 import {Cluster} from '@shared/entity/cluster';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import {EMPTY, iif, Observable, Subject} from 'rxjs';
 import {switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
@@ -122,7 +123,7 @@ export class AddAutomaticBackupDialogComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.form = this._builder.group({
       [Controls.Cluster]: this._builder.control('', Validators.required),
-      [Controls.Name]: this._builder.control('', Validators.required),
+      [Controls.Name]: this._builder.control('', [Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]),
       [Controls.Destination]: this._builder.control('', Validators.required),
       [Controls.Group]: this._builder.control(DefaultSchuleOption.Daily, Validators.required),
       [Controls.Schedule]: this._builder.control(''),

--- a/modules/web/src/app/backup/list/automatic-backup/add-dialog/template.html
+++ b/modules/web/src/app/backup/list/automatic-backup/add-dialog/template.html
@@ -45,6 +45,9 @@ limitations under the License.
         <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
           <strong>Required</strong>
         </mat-error>
+        <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
+          Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+        </mat-error>
       </mat-form-field>
 
       <div *ngIf="hasClusterInput() && !this.isLoadingDestinations"

--- a/modules/web/src/app/backup/list/automatic-backup/component.ts
+++ b/modules/web/src/app/backup/list/automatic-backup/component.ts
@@ -33,6 +33,7 @@ import {Project} from '@shared/entity/project';
 import {GroupConfig} from '@shared/model/Config';
 import {HealthStatus, getBackupHealthStatus} from '@shared/utils/health-status';
 import {MemberUtils, Permission} from '@shared/utils/member';
+import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take, takeUntil} from 'rxjs/operators';
 
@@ -139,7 +140,7 @@ export class AutomaticBackupListComponent implements OnInit, OnDestroy {
     const config: MatDialogConfig = {
       data: {
         title: 'Delete Automatic Backup',
-        message: `Delete <b>${backup.name}</b> automatic backup of <b>${this._selectedProject.name}</b> project and all its associated backups permanently?`,
+        message: `Delete <b>${_.escape(backup.name)}</b> automatic backup of <b>${_.escape(this._selectedProject.name)}</b> project and all its associated backups permanently?`,
         confirmLabel: 'Delete',
       } as ConfirmationDialogConfig,
     };

--- a/modules/web/src/app/backup/list/restore/component.ts
+++ b/modules/web/src/app/backup/list/restore/component.ts
@@ -27,6 +27,7 @@ import {Member} from '@shared/entity/member';
 import {Project} from '@shared/entity/project';
 import {GroupConfig} from '@shared/model/Config';
 import {MemberUtils, Permission} from '@shared/utils/member';
+import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
@@ -112,7 +113,7 @@ export class RestoreListComponent implements OnInit, OnDestroy {
     const config: MatDialogConfig = {
       data: {
         title: 'Delete Restore Object',
-        message: `Delete <b>${restore.name}</b> restore object permanently?`,
+        message: `Delete <b>${_.escape(restore.name)}</b> restore object permanently?`,
         confirmLabel: 'Delete',
       } as ConfirmationDialogConfig,
     };

--- a/modules/web/src/app/cluster-template/component.ts
+++ b/modules/web/src/app/cluster-template/component.ts
@@ -230,7 +230,7 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Cluster Template',
-        message: `Delete <b>${template.name}</b> cluster template permanently? The clusters created using this template will not be deleted.`,
+        message: `Delete <b>${_.escape(template.name)}</b> cluster template permanently? The clusters created using this template will not be deleted.`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/component.ts
@@ -437,7 +437,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'External CCM Migration',
-        message: `Start external CCM migration procedure of ${this.cluster.name} cluster?`,
+        message: `Start external CCM migration procedure of ${_.escape(this.cluster.name)} cluster?`,
         confirmLabel: 'Start',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/constraints/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/constraints/component.ts
@@ -173,7 +173,7 @@ export class ConstraintsComponent implements OnInit, OnChanges, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Constraint',
-        message: `Delete <b>${constraint.name}</b> OPA constraint of <b>${this.cluster.name}</b> cluster permanently?`,
+        message: `Delete <b>${_.escape(constraint.name)}</b> OPA constraint of <b>${_.escape(this.cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/constraints/constraint-dialog/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/constraints/constraint-dialog/component.ts
@@ -20,6 +20,7 @@ import {NotificationService} from '@core/services/notification';
 import {Cluster} from '@shared/entity/cluster';
 import {Constraint, ConstraintTemplate, ConstraintSpec} from '@shared/entity/opa';
 import {DialogActionMode} from '@shared/types/common';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import * as y from 'js-yaml';
 import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
@@ -68,6 +69,7 @@ export class ConstraintDialog implements OnInit, OnDestroy {
     this.form = this._builder.group({
       [Controls.Name]: this._builder.control(this.data.mode === this.Mode.Edit ? this.data.constraint.name : '', [
         Validators.required,
+        NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR,
       ]),
       [Controls.ConstraintTemplate]: this._builder.control(
         {

--- a/modules/web/src/app/cluster/details/cluster/constraints/constraint-dialog/template.html
+++ b/modules/web/src/app/cluster/details/cluster/constraints/constraint-dialog/template.html
@@ -33,6 +33,9 @@ limitations under the License.
       <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
         <strong>Required</strong>
       </mat-error>
+      <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
+        Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex>

--- a/modules/web/src/app/cluster/details/cluster/edit-sshkeys/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-sshkeys/component.ts
@@ -126,8 +126,8 @@ export class EditSSHKeysComponent implements OnInit, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Remove SSH Key',
-        message: `Remove <b>${sshKey.name}</b>
-          SSH key from <b>${this.cluster.name}</b> cluster?`,
+        message: `Remove <b>${_.escape(sshKey.name)}</b>
+          SSH key from <b>${_.escape(this.cluster.name)}</b> cluster?`,
         confirmLabel: 'Remove',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/gatekeeper-config/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/gatekeeper-config/component.ts
@@ -120,7 +120,7 @@ export class GatekeeperConfigComponent implements OnChanges, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Gatekeeper Config',
-        message: `Delete OPA gatekeeper config of <b>${this.cluster.name}</b> cluster permanently?`,
+        message: `Delete OPA gatekeeper config of <b>${_.escape(this.cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
@@ -25,6 +25,7 @@ import {Cluster} from '@shared/entity/cluster';
 import {SeedSettings} from '@shared/entity/datacenter';
 import {AlertmanagerConfig} from '@shared/entity/mla';
 import {AdminSettings} from '@shared/entity/settings';
+import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {AlertmanagerConfigDialog} from './alertmanager-config-dialog/component';
@@ -196,7 +197,7 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Reset Alertmanager Config',
-        message: `Reset Alertmanager config of <b>${this.cluster.name}</b> cluster to default?`,
+        message: `Reset Alertmanager config of <b>${_.escape(this.cluster.name)}</b> cluster to default?`,
         confirmLabel: 'Reset',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/mla/rule-groups/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/mla/rule-groups/component.ts
@@ -139,7 +139,7 @@ export class RuleGroupsComponent implements OnInit, OnChanges, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Rule Group',
-        message: `Delete <b>${ruleGroup.name}</b> recording and alerting rule group of <b>${this.cluster.name}</b> cluster permanently?`,
+        message: `Delete <b>${_.escape(ruleGroup.name)}</b> recording and alerting rule group of <b>${_.escape(this.cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/mla/rule-groups/rule-group-dialog/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/mla/rule-groups/rule-group-dialog/component.ts
@@ -95,7 +95,7 @@ export class RuleGroupDialog implements OnInit, OnDestroy {
       case Mode.Add:
         return 'Create recording and alerting rule group';
       case Mode.Edit:
-        return `Edit <b>${this.data.ruleGroup.name}</b> recording and alerting rule group of <b>${this.data.cluster.name}</b> cluster`;
+        return `Edit <b>${_.escape(this.data.ruleGroup.name)}</b> recording and alerting rule group of <b>${_.escape(this.data.cluster.name)}</b> cluster`;
     }
   }
 

--- a/modules/web/src/app/cluster/details/cluster/node-list/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/node-list/component.ts
@@ -150,7 +150,7 @@ export class NodeListComponent implements OnInit, OnChanges, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Node',
-        message: `Delete <b>${node.name}</b> node of <b>${this.mdName}</b> machine deployment of <b>${this.cluster.name}</b> cluster permanently?`,
+        message: `Delete <b>${_.escape(node.name)}</b> node of <b>${_.escape(this.mdName)}</b> machine deployment of <b>${_.escape(this.cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/cluster/details/cluster/rbac/add-binding-dialog/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/rbac/add-binding-dialog/component.ts
@@ -16,6 +16,7 @@ import {Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {MatButtonToggleChange} from '@angular/material/button-toggle';
 import {MatDialogRef} from '@angular/material/dialog';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
 import {debounceTime, takeUntil, tap} from 'rxjs/operators';
@@ -84,7 +85,7 @@ export class AddBindingDialogComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Email]: new FormControl('', [Validators.required]),
+      [Controls.Email]: new FormControl('', [Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]),
       [Controls.Group]: new FormControl(''),
       [Controls.Role]: new FormControl('', [Validators.required]),
       [Controls.Namespace]: new FormControl(''),
@@ -139,9 +140,9 @@ export class AddBindingDialogComponent implements OnInit, OnDestroy {
     this.form.get(Controls.Email).clearValidators();
     this.form.get(Controls.Group).clearValidators();
     if (this.subjectType === Kind.User) {
-      this.form.get(Controls.Email).setValidators([Validators.required]);
+      this.form.get(Controls.Email).setValidators([Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]);
     } else {
-      this.form.get(Controls.Group).setValidators([Validators.required]);
+      this.form.get(Controls.Group).setValidators([Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]);
     }
     this.form.get(Controls.Email).updateValueAndValidity();
     this.form.get(Controls.Group).updateValueAndValidity();

--- a/modules/web/src/app/cluster/details/cluster/rbac/add-binding-dialog/template.html
+++ b/modules/web/src/app/cluster/details/cluster/rbac/add-binding-dialog/template.html
@@ -43,6 +43,9 @@ limitations under the License.
           <mat-error *ngIf="form.get(Controls.Email).hasError(ErrorType.Required)">
             <strong>Required</strong>
           </mat-error>
+          <mat-error *ngIf="form.get(Controls.Email).hasError('pattern')">
+            User Email cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+          </mat-error>
         </mat-form-field>
 
         <mat-form-field fxFlex
@@ -54,6 +57,9 @@ limitations under the License.
                  autocomplete="off">
           <mat-error *ngIf="form.get(Controls.Group).hasError(ErrorType.Required)">
             <strong>Required</strong>
+          </mat-error>
+          <mat-error *ngIf="form.get(Controls.Group).hasError('pattern')">
+            Group cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
           </mat-error>
         </mat-form-field>
 

--- a/modules/web/src/app/cluster/details/cluster/rbac/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/rbac/component.ts
@@ -13,19 +13,20 @@
 // limitations under the License.
 
 import {Component, Input, OnDestroy} from '@angular/core';
+import {FormControl} from '@angular/forms';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
+import {ClusterServiceAccountService} from '@core/services/cluster-service-account';
 import {NotificationService} from '@core/services/notification';
 import {RBACService} from '@core/services/rbac';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {Cluster} from '@shared/entity/cluster';
 import {ClusterBinding, ClusterServiceAccount, Kind, SimpleClusterBinding} from '@shared/entity/rbac';
+import {iif, Subject} from 'rxjs';
 import {filter, switchMap, take} from 'rxjs/operators';
 import {AddBindingDialogComponent} from './add-binding-dialog/component';
-import {iif, Subject} from 'rxjs';
-import {FormControl} from '@angular/forms';
-import {AddServiceAccountDialogComponent} from './add-service-account-dialog/component';
 import {AddServiceAccountBindingDialogComponent} from './add-service-account-binding-dialog/component';
-import {ClusterServiceAccountService} from '@core/services/cluster-service-account';
+import {AddServiceAccountDialogComponent} from './add-service-account-dialog/component';
+import _ from 'lodash';
 
 @Component({
   selector: 'km-rbac',
@@ -102,7 +103,7 @@ export class RBACComponent implements OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Service Account',
-        message: `Delete service account <b>${element.name}</b> of <b>${this.cluster.name}</b> cluster permanently?`,
+        message: `Delete service account <b>${_.escape(element.name)}</b> of <b>${_.escape(this.cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };
@@ -128,9 +129,7 @@ export class RBACComponent implements OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Binding',
-        message: `Delete binding for ${element.kind.toLowerCase()} <b>${element.name}</b> of <b>${
-          this.cluster.name
-        }</b> cluster permanently?`,
+        message: `Delete binding for ${element.kind.toLowerCase()} <b>${_.escape(element.name)}</b> of <b>${_.escape(this.cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/component.ts
+++ b/modules/web/src/app/cluster/details/external-cluster/external-cluster-delete-confirmation/component.ts
@@ -17,6 +17,7 @@ import {MatDialogRef} from '@angular/material/dialog';
 import {GoogleAnalyticsService} from '@app/google-analytics.service';
 import {NotificationService} from '@core/services/notification';
 import {AdminSettings} from '@shared/entity/settings';
+import _ from 'lodash';
 import {ClipboardService} from 'ngx-clipboard';
 import {Observable, Subject} from 'rxjs';
 import {finalize, take} from 'rxjs/operators';
@@ -72,9 +73,9 @@ export class ExternalClusterDeleteConfirmationComponent implements OnInit, OnDes
           if (machineDeployments.length > 0) {
             const nodegroupNames = machineDeployments.map((md: ExternalMachineDeployment) => md.name).join(', ');
             if (this.clusterProvider === ExternalClusterProvider.EKS) {
-              this.warningMessage = `Cluster has nodegroups attached (<b>${nodegroupNames}</b>). Please delete nodegroups before deleting the cluster.`;
+              this.warningMessage = `Cluster has nodegroups attached (<b>${_.escape(nodegroupNames)}</b>). Please delete nodegroups before deleting the cluster.`;
             } else {
-              this.warningMessage = `Cluster has nodegroups attached (<b>${nodegroupNames}</b>).`;
+              this.warningMessage = `Cluster has nodegroups attached (<b>${_.escape(nodegroupNames)}</b>).`;
             }
           } else {
             this.warningMessage = '';

--- a/modules/web/src/app/core/services/application.ts
+++ b/modules/web/src/app/core/services/application.ts
@@ -14,7 +14,6 @@
 
 import {HttpClient} from '@angular/common/http';
 import {EventEmitter, Injectable} from '@angular/core';
-import {DomSanitizer} from '@angular/platform-browser';
 import {AppConfigService} from '@app/config.service';
 import {environment} from '@environments/environment';
 import {
@@ -39,8 +38,7 @@ export class ApplicationService {
 
   constructor(
     private readonly _appConfigService: AppConfigService,
-    private readonly _httpClient: HttpClient,
-    private readonly _domSanitizer: DomSanitizer
+    private readonly _httpClient: HttpClient
   ) {}
 
   get applications(): Application[] {
@@ -74,7 +72,7 @@ export class ApplicationService {
                   this._applicationDefinitions = appDefs.map(appDef => {
                     const logoData = getApplicationLogoData(appDef);
                     if (logoData) {
-                      appDef.spec.logoData = this._domSanitizer.bypassSecurityTrustUrl(logoData);
+                      appDef.spec.logoData = logoData;
                     }
                     const oldAppDef = this._applicationDefinitions.find(item => item.name === appDef.name);
                     if (oldAppDef) {
@@ -99,7 +97,7 @@ export class ApplicationService {
       tap(appDef => {
         const logoData = getApplicationLogoData(appDef);
         if (logoData) {
-          appDef.spec.logoData = this._domSanitizer.bypassSecurityTrustUrl(logoData);
+          appDef.spec.logoData = logoData;
         }
         this._applicationDefinitions = this._applicationDefinitions.map(item => {
           if (item.name === name) {

--- a/modules/web/src/app/core/services/external-cluster.ts
+++ b/modules/web/src/app/core/services/external-cluster.ts
@@ -33,6 +33,7 @@ import {PresetList} from '@shared/entity/preset';
 import {AKSCluster, AKSLocation, AKSVMSize, AzureResourceGroup} from '@shared/entity/provider/aks';
 import {EKSCluster, EKSClusterRole, EKSSecurityGroup, EKSSubnet, EKSVpc} from '@shared/entity/provider/eks';
 import {GKECluster, GKEZone} from '@shared/entity/provider/gke';
+import _ from 'lodash';
 import {BehaviorSubject, Observable, of, Subject} from 'rxjs';
 import {catchError, filter} from 'rxjs/operators';
 
@@ -364,7 +365,7 @@ export class ExternalClusterService {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Disconnect Cluster',
-        message: `Are you sure you want to disconnect <b>${cluster.name}</b> cluster? This action will not remove the cluster from the cloud provider’s end.`,
+        message: `Are you sure you want to disconnect <b>${_.escape(cluster.name)}</b> cluster? This action will not remove the cluster from the cloud provider’s end.`,
         confirmLabel: 'Disconnect',
         throttleButton: true,
         observable: this.deleteExternalCluster(projectID, cluster.id, DeleteExternalClusterAction.Disconnect),

--- a/modules/web/src/app/core/services/external-machine-deployment.ts
+++ b/modules/web/src/app/core/services/external-machine-deployment.ts
@@ -14,6 +14,7 @@
 
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
+import _ from 'lodash';
 import {Observable, of} from 'rxjs';
 import {catchError, filter, map, mergeMap, switchMap, take} from 'rxjs/operators';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
@@ -148,7 +149,7 @@ export class ExternalMachineDeploymentService {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: `Delete ${cluster?.cloud.eks ? 'Node Group' : 'Node Pool'}`,
-        message: `Delete <b>${md.name}</b> of <b>${cluster.name}</b> cluster permanently?`,
+        message: `Delete <b>${_.escape(md.name)}</b> of <b>${_.escape(cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/core/services/node.ts
+++ b/modules/web/src/app/core/services/node.ts
@@ -20,6 +20,7 @@ import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialo
 import {Cluster} from '@shared/entity/cluster';
 import {MachineDeployment, MachineDeploymentPatch} from '@shared/entity/machine-deployment';
 import {NodeData} from '@shared/model/NodeSpecChange';
+import _ from 'lodash';
 import {Observable, of} from 'rxjs';
 import {catchError, filter, finalize, mergeMap, switchMap, take} from 'rxjs/operators';
 import {MachineDeploymentService} from '@core/services/machine-deployment';
@@ -157,7 +158,7 @@ export class NodeService {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Machine Deployment',
-        message: `Delete <b>${md.name}</b> machine deployment of <b>${cluster.name}</b> cluster permanently?`,
+        message: `Delete <b>${_.escape(md.name)}</b> machine deployment of <b>${_.escape(cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };
@@ -201,7 +202,7 @@ export class NodeService {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Restart Machine Deployment',
-        message: `Perform rolling restart of <b>${md.name}</b> machine deployment of <b>${cluster.name}</b> cluster?`,
+        message: `Perform rolling restart of <b>${_.escape(md.name)}</b> machine deployment of <b>${_.escape(cluster.name)}</b> cluster?`,
         confirmLabel: 'Restart',
       },
     };

--- a/modules/web/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/component.ts
@@ -23,6 +23,7 @@ import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {NotificationService} from '@core/services/notification';
 import {getIconClassForButton} from '@shared/utils/common';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import {Observable, Subject} from 'rxjs';
 import {take} from 'rxjs/operators';
 import {AllowedRegistry} from '../entity';
@@ -66,6 +67,7 @@ export class AllowedRegistryDialog implements OnInit, OnDestroy {
     this.form = this._builder.group({
       [Controls.Name]: new FormControl(this.data.mode === this.Mode.Edit ? this.data.allowedRegistry.name : '', [
         Validators.required,
+        NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR,
       ]),
       [Controls.RegistryPrefix]: new FormControl(
         this.data.mode === this.Mode.Edit ? this.data.allowedRegistry.spec.registryPrefix : '',

--- a/modules/web/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/allowed-registries/allowed-registry-dialog/template.html
@@ -39,6 +39,9 @@ END OF TERMS AND CONDITIONS
       <mat-error *ngIf="form.get(controls.Name).hasError('required')">
         <strong>Required</strong>
       </mat-error>
+      <mat-error *ngIf="form.get(controls.Name).hasError('pattern')">
+        Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex>

--- a/modules/web/src/app/dynamic/enterprise/allowed-registries/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/allowed-registries/component.ts
@@ -138,7 +138,7 @@ export class AllowedRegistriesComponent extends DynamicTab implements OnInit, On
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Allowed Registry',
-        message: `Delete <b>${allowedRegistry.name}</b> allowed registry permanently?`,
+        message: `Delete <b>${_.escape(allowedRegistry.name)}</b> allowed registry permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/dynamic/enterprise/group/add-group-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/group/add-group-dialog/component.ts
@@ -23,6 +23,7 @@ import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {MatDialogRef} from '@angular/material/dialog';
 import {NotificationService} from '@core/services/notification';
 import {Project} from '@shared/entity/project';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import {Observable} from 'rxjs';
 import {Group} from '@app/dynamic/enterprise/group/entity';
 import {GroupService} from '@app/dynamic/enterprise/group/service';
@@ -52,7 +53,7 @@ export class AddGroupDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.form = this._builder.group({
-      [Controls.Group]: this._builder.control('', Validators.required),
+      [Controls.Group]: this._builder.control('', [Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]),
       [Controls.Role]: this._builder.control('', Validators.required),
     });
   }

--- a/modules/web/src/app/dynamic/enterprise/group/add-group-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/group/add-group-dialog/template.html
@@ -37,6 +37,9 @@ END OF TERMS AND CONDITIONS
         <mat-error *ngIf="form.controls.group.hasError('required')">
           <strong>Required</strong>
         </mat-error>
+        <mat-error *ngIf="form.get(Controls.Group).hasError('pattern')">
+          Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+        </mat-error>
       </mat-form-field>
 
       <label class="km-radio-group-label">Select a Role</label>

--- a/modules/web/src/app/dynamic/enterprise/group/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/group/component.ts
@@ -132,7 +132,7 @@ export class GroupComponent extends DynamicTab implements OnInit, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Remove Group',
-        message: `Remove <b>${group.group}</b> group from <b>${this._selectedProject.name}</b> project?`,
+        message: `Remove <b>${_.escape(group.group)}</b> group from <b>${_.escape(this._selectedProject.name)}</b> project?`,
         confirmLabel: 'Remove',
       },
     };

--- a/modules/web/src/app/dynamic/enterprise/metering/legacy-reports/list/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/legacy-reports/list/component.ts
@@ -28,6 +28,7 @@ import {NotificationService} from '@app/core/services/notification';
 import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering';
 import {ConfirmationDialogComponent} from '@app/shared/components/confirmation-dialog/component';
 import {Report} from '@shared/entity/metering';
+import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take, takeUntil} from 'rxjs/operators';
 
@@ -96,7 +97,7 @@ export class MeteringLegacyReportListComponent implements OnInit, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Metering Report',
-        message: `Do you want to delete <b>${reportName}</b> report permanently?`,
+        message: `Do you want to delete <b>${_.escape(reportName)}</b> report permanently?`,
         confirmLabel: 'Delete',
         warning: 'This change is permanent.',
       },

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/component.ts
@@ -30,6 +30,7 @@ import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering
 import {NotificationService} from '@core/services/notification';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {MeteringReportConfiguration} from '@shared/entity/datacenter';
+import _ from 'lodash';
 import {filter, switchMap, take} from 'rxjs';
 
 enum Column {
@@ -111,7 +112,7 @@ export class MeteringScheduleConfigComponent implements OnInit {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Schedule Configuration',
-        message: `Delete <b>${name}</b> schedule permanently?`,
+        message: `Delete <b>${_.escape(name)}</b> schedule permanently?`,
         confirmLabel: 'Delete',
         warning: 'Deleting this will NOT remove reports related to it.',
       },

--- a/modules/web/src/app/dynamic/enterprise/metering/schedule-config/report-list/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/metering/schedule-config/report-list/component.ts
@@ -30,6 +30,7 @@ import {MeteringService} from '@app/dynamic/enterprise/metering/service/metering
 import {ConfirmationDialogComponent} from '@app/shared/components/confirmation-dialog/component';
 import {UserService} from '@core/services/user';
 import {Report} from '@shared/entity/metering';
+import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take, takeUntil} from 'rxjs/operators';
 
@@ -152,7 +153,7 @@ export class MeteringReportListComponent implements OnInit {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Metering Report',
-        message: `Do you want to delete <b>${reportName}</b> report permanently?`,
+        message: `Do you want to delete <b>${_.escape(reportName)}</b> report permanently?`,
         confirmLabel: 'Delete',
         warning: 'This change is permanent.',
       },

--- a/modules/web/src/app/dynamic/enterprise/quotas/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/quotas/component.ts
@@ -188,7 +188,7 @@ export class QuotasComponent implements OnInit {
     const config = {
       data: {
         title: 'Delete Quota',
-        message: `Delete quota for <b>${subjectHumanReadableName ?? name}</b>?`,
+        message: `Delete quota for <b>${_.escape(subjectHumanReadableName ?? name)}</b>?`,
         confirmLabel: 'Delete',
       },
     } as MatDialogConfig;

--- a/modules/web/src/app/member/component.ts
+++ b/modules/web/src/app/member/component.ts
@@ -203,7 +203,7 @@ export class MemberComponent implements OnInit, OnChanges, OnDestroy, AfterViewI
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Remove Member',
-        message: `Remove <b>${member.name}</b> from <b>${this._selectedProject.name}</b> project?`,
+        message: `Remove <b>${_.escape(member.name)}</b> from <b>${_.escape(this._selectedProject.name)}</b> project?`,
         confirmLabel: 'Remove',
       },
     };

--- a/modules/web/src/app/serviceaccount/component.ts
+++ b/modules/web/src/app/serviceaccount/component.ts
@@ -232,7 +232,7 @@ export class ServiceAccountComponent implements OnInit, OnChanges, OnDestroy {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Service Account',
-        message: `Delete <b>${serviceAccount.name}</b> service account of <b>${this._selectedProject.name}</b> project permanently?`,
+        message: `Delete <b>${_.escape(serviceAccount.name)}</b> service account of <b>${_.escape(this._selectedProject.name)}</b> project permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/serviceaccount/create-dialog/component.ts
+++ b/modules/web/src/app/serviceaccount/create-dialog/component.ts
@@ -18,6 +18,7 @@ import {MatDialogRef} from '@angular/material/dialog';
 import {NotificationService} from '@core/services/notification';
 import {Project} from '@shared/entity/project';
 import {ServiceAccount} from '@shared/entity/service-account';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import {take} from 'rxjs/operators';
 import {ServiceAccountService} from '@core/services/service-account';
 import {Observable} from 'rxjs';
@@ -39,7 +40,7 @@ export class CreateServiceAccountDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.form = new FormGroup({
-      name: new FormControl('', [Validators.required]),
+      name: new FormControl('', [Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]),
       group: new FormControl('editors', [Validators.required]),
     });
   }

--- a/modules/web/src/app/serviceaccount/create-dialog/template.html
+++ b/modules/web/src/app/serviceaccount/create-dialog/template.html
@@ -30,6 +30,9 @@ limitations under the License.
       <mat-error *ngIf="form.controls.name.hasError('required')">
         <strong>Required</strong>
       </mat-error>
+      <mat-error *ngIf="form.controls.name.hasError('pattern')">
+        Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+      </mat-error>
     </mat-form-field>
     <label class="km-radio-group-label">Select a Group</label>
     <mat-radio-group formControlName="group"

--- a/modules/web/src/app/serviceaccount/edit-dialog/component.ts
+++ b/modules/web/src/app/serviceaccount/edit-dialog/component.ts
@@ -18,6 +18,7 @@ import {MatDialogRef} from '@angular/material/dialog';
 import {NotificationService} from '@core/services/notification';
 import {Project} from '@shared/entity/project';
 import {ServiceAccount} from '@shared/entity/service-account';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import {take} from 'rxjs/operators';
 import {ServiceAccountService} from '@core/services/service-account';
 import {Observable} from 'rxjs';
@@ -40,7 +41,7 @@ export class EditServiceAccountDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.form = new FormGroup({
-      name: new FormControl(this.serviceaccount.name, [Validators.required]),
+      name: new FormControl(this.serviceaccount.name, [Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]),
       group: new FormControl(this.serviceaccount.group.replace(/(-[\w\d]+$)/, ''), [Validators.required]),
     });
   }

--- a/modules/web/src/app/serviceaccount/edit-dialog/template.html
+++ b/modules/web/src/app/serviceaccount/edit-dialog/template.html
@@ -34,6 +34,9 @@ limitations under the License.
       <mat-error *ngIf="form.controls.name.hasError('required')">
         <strong>Required</strong>
       </mat-error>
+      <mat-error *ngIf="form.controls.name.hasError('pattern')">
+        Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+      </mat-error>
     </mat-form-field>
 
     <label class="km-radio-group-label">Select a Group</label>

--- a/modules/web/src/app/serviceaccount/token/component.ts
+++ b/modules/web/src/app/serviceaccount/token/component.ts
@@ -30,6 +30,7 @@ import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialo
 import {Project} from '@shared/entity/project';
 import {ServiceAccount, ServiceAccountToken} from '@shared/entity/service-account';
 import {GroupConfig} from '@shared/model/Config';
+import _ from 'lodash';
 import {filter, switchMap, take} from 'rxjs/operators';
 
 @Component({
@@ -129,7 +130,7 @@ export class ServiceAccountTokenComponent implements OnInit {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Token',
-        message: `Delete <b>${token.name}</b> token of <b>${this.serviceaccount.name}</b> service account of <b>${this._selectedProject.name}</b> project permanently?`,
+        message: `Delete <b>${_.escape(token.name)}</b> token of <b>${_.escape(this.serviceaccount.name)}</b> service account of <b>${this._selectedProject.name}</b> project permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/settings/admin/admins/component.ts
+++ b/modules/web/src/app/settings/admin/admins/component.ts
@@ -22,6 +22,7 @@ import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {Admin, Member} from '@shared/entity/member';
+import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, take, takeUntil} from 'rxjs/operators';
 import {AddAdminDialogComponent} from './add-admin-dialog/component';
@@ -85,7 +86,7 @@ export class AdminsComponent implements OnInit, OnChanges {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Remove Administrator',
-        message: `Remove <b>${admin.name}</b> from administrators?`,
+        message: `Remove <b>${_.escape(admin.name)}</b> from administrators?`,
         confirmLabel: 'Remove',
       },
     };

--- a/modules/web/src/app/settings/admin/bucket-settings/destinations/component.ts
+++ b/modules/web/src/app/settings/admin/bucket-settings/destinations/component.ts
@@ -22,6 +22,7 @@ import {DatacenterService} from '@core/services/datacenter';
 import {NotificationService} from '@core/services/notification';
 import {ConfirmationDialogComponent, ConfirmationDialogConfig} from '@shared/components/confirmation-dialog/component';
 import {AdminSeed, BackupDestination} from '@shared/entity/datacenter';
+import _ from 'lodash';
 import {filter, switchMap, take} from 'rxjs/operators';
 import {DestinationDialog, Mode} from './destination-dialog/component';
 import {EditCredentialsDialog} from './edit-credentials-dialog/component';
@@ -119,7 +120,7 @@ export class DestinationsComponent implements OnInit {
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Destination',
-        message: `Delete <b>${destination.destinationName}</b> destination permanently?`,
+        message: `Delete <b>${_.escape(destination.destinationName)}</b> destination permanently?`,
         warning: 'Associated backups and snapshots will not be usable after deleting this destination.',
         confirmLabel: 'Delete Destination',
       } as ConfirmationDialogConfig,

--- a/modules/web/src/app/settings/admin/dynamic-datacenters/component.ts
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/component.ts
@@ -174,7 +174,7 @@ export class DynamicDatacentersComponent implements OnInit, OnDestroy, OnChanges
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Datacenter',
-        message: `Delete <b>${datacenter.metadata.name}</b> datacenter permanently?`,
+        message: `Delete <b>${_.escape(datacenter.metadata.name)}</b> datacenter permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
@@ -22,6 +22,7 @@ import {CreateDatacenterModel, Datacenter, MachineFlavorFilter} from '@shared/en
 import {DialogActionMode} from '@shared/types/common';
 import {INTERNAL_NODE_PROVIDERS} from '@shared/model/NodeProviderConstants';
 import {getIconClassForButton} from '@shared/utils/common';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import * as countryCodeLookup from 'country-code-lookup';
 import * as y from 'js-yaml';
 import _ from 'lodash';
@@ -102,7 +103,10 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
     }
 
     this.form = new FormGroup({
-      name: new FormControl(this.data.isEditing ? this.data.datacenter.metadata.name : '', [Validators.required]),
+      name: new FormControl(this.data.isEditing ? this.data.datacenter.metadata.name : '', [
+        Validators.required,
+        NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR,
+      ]),
       provider: new FormControl(
         {value: this.data.isEditing ? this.data.datacenter.spec.provider : '', disabled: this.data.isEditing},
         [Validators.required]

--- a/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
@@ -34,6 +34,9 @@ limitations under the License.
       <mat-error *ngIf="form.get(controls.Name).hasError('required')">
         <strong>Required</strong>
       </mat-error>
+      <mat-error *ngIf="form.get(controls.Name).hasError('pattern')">
+        Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex>

--- a/modules/web/src/app/settings/admin/opa/constraint-templates/component.ts
+++ b/modules/web/src/app/settings/admin/opa/constraint-templates/component.ts
@@ -133,7 +133,7 @@ export class ConstraintTemplatesComponent implements OnInit, OnChanges, OnDestro
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Constraint Template',
-        message: `Delete <b>${constraintTemplate.name}</b> constraint template permanently?`,
+        message: `Delete <b>${_.escape(constraintTemplate.name)}</b> constraint template permanently?`,
         confirmLabel: 'Delete',
         warning: 'Deleting this constraint template will cause all constraints related to it to be deleted as well.',
       },

--- a/modules/web/src/app/settings/admin/opa/default-constraints/component.ts
+++ b/modules/web/src/app/settings/admin/opa/default-constraints/component.ts
@@ -186,7 +186,7 @@ export class DefaultConstraintComponent implements OnInit, OnChanges, OnDestroy 
     const dialogConfig: MatDialogConfig = {
       data: {
         title: 'Delete Default Constraint',
-        message: `Delete <b>${defaultConstraint.name}</b> default constraint permanently?`,
+        message: `Delete <b>${_.escape(defaultConstraint.name)}</b> default constraint permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/component.ts
+++ b/modules/web/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/component.ts
@@ -20,6 +20,7 @@ import {NotificationService} from '@core/services/notification';
 import {Constraint, ConstraintTemplate, ConstraintSpec} from '@shared/entity/opa';
 import {getIconClassForButton} from '@shared/utils/common';
 import {DialogActionMode} from '@shared/types/common';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import * as y from 'js-yaml';
 import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
@@ -77,7 +78,7 @@ export class DefaultConstraintDialog implements OnInit, OnDestroy {
     this.form = this._builder.group({
       [Controls.Name]: this._builder.control(
         this.data.mode === this.Mode.Edit ? this.data.defaultConstraint.name : '',
-        [Validators.required]
+        [Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]
       ),
       [Controls.ConstraintTemplate]: this._builder.control(
         {

--- a/modules/web/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/template.html
+++ b/modules/web/src/app/settings/admin/opa/default-constraints/default-constraint-dialog/template.html
@@ -31,6 +31,9 @@ limitations under the License.
       <mat-error *ngIf="form.get(Controls.Name).hasError('required')">
         <strong>Required</strong>
       </mat-error>
+      <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
+        Constraint Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex>

--- a/modules/web/src/app/settings/admin/presets/component.ts
+++ b/modules/web/src/app/settings/admin/presets/component.ts
@@ -216,8 +216,8 @@ export class PresetListComponent implements OnInit, OnDestroy, OnChanges {
         steps: ['Provider', 'Settings'],
         mode: Mode.Add,
         preset: preset,
-        descriptionProvider: `Add provider to <b>${preset.name}</b> preset`,
-        descriptionSettings: `Specify provider settings for <b>${preset.name}</b> provider preset`,
+        descriptionProvider: `Add provider to <b>${_.escape(preset.name)}</b> preset`,
+        descriptionSettings: `Specify provider settings for <b>${_.escape(preset.name)}</b> provider preset`,
       } as PresetDialogData,
     };
 
@@ -235,8 +235,8 @@ export class PresetListComponent implements OnInit, OnDestroy, OnChanges {
       data: {
         title: 'Edit Preset Provider',
         steps: ['Provider', 'Settings'],
-        descriptionProvider: `Choose a provider of <b>${preset.name}</b> provider preset to edit`,
-        descriptionSettings: `Edit provider settings of <b>${preset.name}</b> provider preset`,
+        descriptionProvider: `Choose a provider of <b>${_.escape(preset.name)}</b> provider preset to edit`,
+        descriptionSettings: `Edit provider settings of <b>${_.escape(preset.name)}</b> provider preset`,
         mode: Mode.Edit,
         preset: preset,
       } as PresetDialogData,

--- a/modules/web/src/app/settings/admin/rule-groups/component.ts
+++ b/modules/web/src/app/settings/admin/rule-groups/component.ts
@@ -173,7 +173,7 @@ export class AdminSettingsRuleGroupsComponent implements OnInit, OnChanges, OnDe
       hasBackdrop: true,
       data: {
         title: 'Delete Rule Group',
-        message: `Delete <b>${adminRuleGroup.name}</b> rule group of <b>${adminRuleGroup.seed}</b> seed permanently?`,
+        message: `Delete <b>${_.escape(adminRuleGroup.name)}</b> rule group of <b>${_.escape(adminRuleGroup.seed)}</b> seed permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/shared/components/add-ssh-key-dialog/component.ts
+++ b/modules/web/src/app/shared/components/add-ssh-key-dialog/component.ts
@@ -18,6 +18,7 @@ import {MatDialogRef} from '@angular/material/dialog';
 import {GoogleAnalyticsService} from '@app/google-analytics.service';
 import {NotificationService} from '@core/services/notification';
 import {SSHKey} from '@shared/entity/ssh-key';
+import {NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR} from '@shared/validators/others';
 import {SSHKeyFormValidator} from '@shared/validators/ssh-key-form.validator';
 import {SSHKeyService} from '@core/services/ssh-key';
 import {Observable} from 'rxjs';
@@ -49,7 +50,7 @@ export class AddSshKeyDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.form = this.formBuilder.group({
-      [Controls.Name]: ['', [Validators.required]],
+      [Controls.Name]: ['', [Validators.required, NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR]],
       [Controls.Key]: ['', [Validators.required, SSHKeyFormValidator()]],
     });
     this.googleAnalyticsService.emitEvent('addSshKey', 'addSshKeyDialogOpened');

--- a/modules/web/src/app/shared/components/add-ssh-key-dialog/template.html
+++ b/modules/web/src/app/shared/components/add-ssh-key-dialog/template.html
@@ -29,6 +29,9 @@ limitations under the License.
       <mat-error *ngIf="form.get(controls.Name).hasError('required')">
         <strong>Required</strong>
       </mat-error>
+      <mat-error *ngIf="form.get(controls.Name).hasError('pattern')">
+        Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field class="km-ssh-key-textarea">

--- a/modules/web/src/app/shared/components/addon-list/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/component.ts
@@ -165,7 +165,7 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
     const config: MatDialogConfig = {
       data: {
         title: 'Delete Addon',
-        message: `Delete <b>${addon.name}</b> addon of <b>${this.cluster.name}</b> cluster permanently?`,
+        message: `Delete <b>${_.escape(addon.name)}</b> addon of <b>${_.escape(this.cluster.name)}</b> cluster permanently?`,
         confirmLabel: 'Delete',
       },
     };

--- a/modules/web/src/app/shared/components/addon-list/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/component.ts
@@ -14,7 +14,6 @@
 
 import {Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges} from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
-import {DomSanitizer, SafeUrl} from '@angular/platform-browser';
 import {Addon, AddonConfig, getAddonLogoData, hasAddonLogoData} from '@shared/entity/addon';
 import {Cluster} from '@shared/entity/cluster';
 import _ from 'lodash';
@@ -56,7 +55,6 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
   constructor(
     private readonly _addonService: AddonService,
     private readonly _matDialog: MatDialog,
-    private readonly _domSanitizer: DomSanitizer,
     private readonly _dialogModeService: DialogModeService
   ) {}
 
@@ -96,8 +94,8 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
     return hasAddonLogoData(this.addonConfigs.get(name));
   }
 
-  getAddonLogo(name: string): SafeUrl {
-    return this._domSanitizer.bypassSecurityTrustUrl(getAddonLogoData(this.addonConfigs.get(name)));
+  getAddonLogo(name: string): string {
+    return getAddonLogoData(this.addonConfigs.get(name));
   }
 
   canAdd(): boolean {

--- a/modules/web/src/app/shared/components/addon-list/edit-addon-dialog/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/edit-addon-dialog/component.ts
@@ -15,7 +15,6 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, ValidatorFn, Validators} from '@angular/forms';
 import {MatDialogRef} from '@angular/material/dialog';
-import {DomSanitizer, SafeUrl} from '@angular/platform-browser';
 
 import {
   AddonConfig,
@@ -57,7 +56,6 @@ export class EditAddonDialogComponent implements OnInit {
 
   constructor(
     public dialogRef: MatDialogRef<EditAddonDialogComponent>,
-    private readonly _domSanitizer: DomSanitizer,
     private readonly _builder: FormBuilder
   ) {}
 
@@ -87,8 +85,8 @@ export class EditAddonDialogComponent implements OnInit {
     return hasAddonLogoData(this.addonConfig);
   }
 
-  getAddonLogo(): SafeUrl {
-    return this._domSanitizer.bypassSecurityTrustUrl(getAddonLogoData(this.addonConfig));
+  getAddonLogo(): string {
+    return getAddonLogoData(this.addonConfig);
   }
 
   private _getAddonPatch(): Addon {

--- a/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
@@ -14,7 +14,6 @@
 
 import {Component, Input, ViewChild} from '@angular/core';
 import {MatDialogRef} from '@angular/material/dialog';
-import {DomSanitizer, SafeUrl} from '@angular/platform-browser';
 
 import {
   Addon,
@@ -62,7 +61,6 @@ export class InstallAddonDialogComponent {
 
   constructor(
     public dialogRef: MatDialogRef<Component>,
-    private readonly _domSanitizer: DomSanitizer,
     private readonly _builder: FormBuilder
   ) {}
 
@@ -74,8 +72,8 @@ export class InstallAddonDialogComponent {
     return hasAddonFormData(this.addonConfigs.get(name));
   }
 
-  getAddonLogo(name: string): SafeUrl {
-    return this._domSanitizer.bypassSecurityTrustUrl(getAddonLogoData(this.addonConfigs.get(name)));
+  getAddonLogo(name: string): string {
+    return getAddonLogoData(this.addonConfigs.get(name));
   }
 
   getAddonShortDescription(name: string): string {

--- a/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
@@ -28,6 +28,7 @@ import {
 import {FormBuilder, FormControl, FormGroup, ValidatorFn, Validators} from '@angular/forms';
 import {MatStepper} from '@angular/material/stepper';
 import {getEditionVersion} from '@shared/utils/common';
+import _ from 'lodash';
 
 export enum Controls {
   ContinuouslyReconcile = 'continuouslyReconcile',
@@ -78,7 +79,7 @@ export class InstallAddonDialogComponent {
   }
 
   getAddonShortDescription(name: string): string {
-    return getAddonShortDescription(this.addonConfigs.get(name));
+    return _.escape(getAddonShortDescription(this.addonConfigs.get(name)));
   }
 
   select(name: string): void {

--- a/modules/web/src/app/shared/components/application-list/component.ts
+++ b/modules/web/src/app/shared/components/application-list/component.ts
@@ -267,8 +267,8 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
       const config: MatDialogConfig = {
         data: {
           title: 'Delete Application',
-          message: `Delete <b>${application.name}</b> application${
-            this.cluster ? ` of <b>${this.cluster.name}</b> cluster permanently` : ''
+          message: `Delete <b>${_.escape(application.name)}</b> application${
+            this.cluster ? ` of <b>${_.escape(this.cluster.name)}</b> cluster permanently` : ''
           }?`,
           confirmLabel: 'Delete',
         },

--- a/modules/web/src/app/shared/entity/addon.ts
+++ b/modules/web/src/app/shared/entity/addon.ts
@@ -66,7 +66,6 @@ export function hasAddonLogoData(addonConfig: AddonConfig): boolean {
   return !!addonConfig && !!addonConfig.spec && !!addonConfig.spec.logo && !!addonConfig.spec.logoFormat;
 }
 
-// Before using it in HTML it has to be go through DomSanitizer.bypassSecurityTrustUrl() method.
 export function getAddonLogoData(addonConfig: AddonConfig): string {
   return addonConfig && addonConfig.spec
     ? `data:image/${addonConfig.spec.logoFormat};base64,${addonConfig.spec.logo}`

--- a/modules/web/src/app/shared/entity/application.ts
+++ b/modules/web/src/app/shared/entity/application.ts
@@ -170,7 +170,6 @@ export enum ApplicationLabelValue {
   KKP = 'kkp',
 }
 
-// Before using it in HTML it has to be go through DomSanitizer.bypassSecurityTrustUrl() method.
 export function getApplicationLogoData(applicationDefinition: ApplicationDefinition): string {
   return applicationDefinition?.spec?.logo && applicationDefinition.spec.logoFormat
     ? `data:image/${applicationDefinition.spec.logoFormat};base64,${applicationDefinition.spec.logo}`

--- a/modules/web/src/app/shared/validators/others.ts
+++ b/modules/web/src/app/shared/validators/others.ts
@@ -40,3 +40,6 @@ export const Cluster_BACKUP_EXPIRES_IN = Validators.pattern('^(0|[0-9]{1,2}h?[0-
 // String shouldn't start with ( or [ or } or ) or |
 export const KUBERNETES_ANNOTATION_VALUE_PATTERN = '^[^(})|\\[]*';
 export const KUBERNETES_ANNOTATION_VALUE_PATTERN_VALIDATOR = Validators.pattern(KUBERNETES_ANNOTATION_VALUE_PATTERN);
+
+export const NON_SPECIAL_CHARACTERS_PATTERN = /^[^|"<>[\]{}`\\';&]+$/;
+export const NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR = Validators.pattern(NON_SPECIAL_CHARACTERS_PATTERN);

--- a/modules/web/src/app/sshkey/component.ts
+++ b/modules/web/src/app/sshkey/component.ts
@@ -154,7 +154,7 @@ export class SSHKeyComponent implements OnInit, OnChanges, OnDestroy {
       data: {
         dialogId: 'km-delete-sshkey-dialog',
         title: 'Delete SSH Key',
-        message: `Delete <b>${sshKey.name}</b> SSH key of <b>${this.project.name}</b> project permanently?`,
+        message: `Delete <b>${_.escape(sshKey.name)}</b> SSH key of <b>${_.escape(this.project.name)}</b> project permanently?`,
         confirmLabel: 'Delete',
         confirmLabelId: 'km-delete-sshkey-dialog-btn',
       },

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -32,6 +32,7 @@ import {
   IPV4_CIDR_PATTERN_VALIDATOR,
   IPV4_IPV6_CIDR_PATTERN,
   IPV6_CIDR_PATTERN_VALIDATOR,
+  NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR,
 } from '@app/shared/validators/others';
 import {ClusterService} from '@core/services/cluster';
 import {ClusterSpecService} from '@core/services/cluster-spec';
@@ -573,6 +574,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.Name]: this._builder.control(this._clusterSpecService?.cluster?.name ?? '', [
         Validators.required,
         Validators.minLength(this._minNameLength),
+        NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR,
       ]),
       [Controls.Version]: this._builder.control(clusterSpec?.version ?? '', [Validators.required]),
       [Controls.ContainerRuntime]: this._builder.control(clusterSpec?.containerRuntime ?? ContainerRuntime.Containerd, [

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -54,6 +54,9 @@ limitations under the License.
         <mat-error *ngIf="form.get(Controls.Name).hasError('minlength')">
           Name must be at least {{ control(Controls.Name).getError('minlength').requiredLength }} characters.
         </mat-error>
+        <mat-error *ngIf="form.get(Controls.Name).hasError('pattern')">
+          Name cannot contain special characters like | " &lt; &gt; &lbrace; &rbrace; [ ] ` \ ' ; &
+        </mat-error>
       </mat-form-field>
 
       <mat-card-header class="km-no-padding">


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where a value containing HTML characters was being rendered as HTML in Confirmation Dialog. This has been fixed by escaping the values to convert any HTML characters into HTML entities. As a result this would output the values as text rather than being executed as HTML.

<img width="669" alt="Screenshot 2025-04-11 at 9 47 40 PM" src="https://github.com/user-attachments/assets/dd366354-eca8-40b4-940c-19203c28aafb" />

In addition to that, this PR also adds pattern validator on value inputs (which can possibly be rendered as HTML) to prevent certain special characters (``| " < > { } [ ] ` \ ' ; &``) from being input.

<img width="653" alt="Screenshot 2025-04-11 at 9 29 19 PM" src="https://github.com/user-attachments/assets/cf8922fd-4566-4ba4-af20-0ece0d2a22b2" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7269

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
Since we use `innerHTML` to display the message in Confirmation Dialog (and other places), Angular has built-in DOM sanitization which prevents most common cross-site scripting attacks. I chose to convert the HTML characters into HTML entities instead of using Angular Dom Sanitizer's `sanitize` method because:
- Angular uses the same method internally to sanitize the DOM.
- `sanitize` method would alter the value by adding/removing any HTML code blocks.
- Value would still be rendered/executed as HTML.


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add special characters restriction on Inputs and escape values to avoid rendering as HTML.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
