### PR TITLE
Prevent installing autoscaler if not defined in app definitions.

### DIFF
--- a/modules/web/src/app/node-data/template.html
+++ b/modules/web/src/app/node-data/template.html
@@ -249,12 +249,14 @@ limitations under the License.
         </mat-card-title>
       </mat-card-header>
 
-      <mat-checkbox *ngIf="!isDialogView()"
-                    [name]="Controls.EnableClusterAutoscalingApp"
-                    [formControlName]="Controls.EnableClusterAutoscalingApp">Enable Cluster Autoscaler Application
+      <div fxLayoutAlign=" center"
+           *ngIf="!isDialogView()">
+        <mat-checkbox [name]="Controls.EnableClusterAutoscalingApp"
+                      [formControlName]="Controls.EnableClusterAutoscalingApp">Enable Cluster Autoscaler Application
+        </mat-checkbox>
         <i class="km-icon-info km-pointer"
-           matTooltip="Autoscaling of machines requires the Cluster Autoscaler application to be installed. Enable this option to install Cluster Autoscaler Application."></i>
-      </mat-checkbox>
+           [matTooltip]="autoscalingTooltipText"></i>
+      </div>
 
       <km-number-stepper label="Min Replicas"
                          mode="all"


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent users from enabling the Cluster Autoscaler option if the corresponding application is not defined in the application definitions.

![image](https://github.com/user-attachments/assets/fd8fb9e1-c152-410e-94b2-2acf7aa42a16)


**Which issue(s) this PR fixes**:
Fixes #7216 

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
 Disable the Cluster Autoscaler option when the cluster autoscaler application is not defined in applications catalog.
```

**Documentation**:
```documentation
NONE
```
