### PR TITLE
(fix): OpenStack - pass ConfigDrive value to JSON patch during machine updates

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -37614,6 +37614,11 @@
           "type": "string",
           "x-go-name": "AvailabilityZone"
         },
+        "configDrive": {
+          "description": "ConfigDrive enables a configuration drive that will be attached to the instance when it boots.",
+          "type": "boolean",
+          "x-go-name": "ConfigDrive"
+        },
         "diskSize": {
           "description": "if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor",
           "type": "integer",

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -1931,6 +1931,9 @@ type OpenstackNodeSpec struct {
 	// UUID of the server group, used to configure affinity or anti-affinity of the VM instances relative to hypervisor
 	// required: false
 	ServerGroup string `json:"serverGroup"`
+	// ConfigDrive enables a configuration drive that will be attached to the instance when it boots.
+	// required: false
+	ConfigDrive bool `json:"configDrive"`
 }
 
 func (spec *OpenstackNodeSpec) MarshalJSON() ([]byte, error) {
@@ -1958,6 +1961,7 @@ func (spec *OpenstackNodeSpec) MarshalJSON() ([]byte, error) {
 		InstanceReadyCheckPeriod  string            `json:"instanceReadyCheckPeriod"`
 		InstanceReadyCheckTimeout string            `json:"instanceReadyCheckTimeout"`
 		ServerGroup               string            `json:"serverGroup"`
+		ConfigDrive               bool              `json:"configDrive"`
 	}{
 		Flavor:                    spec.Flavor,
 		Image:                     spec.Image,
@@ -1968,6 +1972,7 @@ func (spec *OpenstackNodeSpec) MarshalJSON() ([]byte, error) {
 		InstanceReadyCheckPeriod:  spec.InstanceReadyCheckPeriod,
 		InstanceReadyCheckTimeout: spec.InstanceReadyCheckTimeout,
 		ServerGroup:               spec.ServerGroup,
+		ConfigDrive:               spec.ConfigDrive,
 	}
 
 	return json.Marshal(&res)

--- a/modules/api/pkg/api/v1/types_test.go
+++ b/modules/api/pkg/api/v1/types_test.go
@@ -389,7 +389,7 @@ func TestOpenstackNodeSpec_MarshalJSON(t *testing.T) {
 				Flavor: "test-flavor",
 				Image:  "test-image",
 			},
-			"{\"flavor\":\"test-flavor\",\"image\":\"test-image\",\"diskSize\":null,\"availabilityZone\":\"\",\"instanceReadyCheckPeriod\":\"\",\"instanceReadyCheckTimeout\":\"\",\"serverGroup\":\"\",\"configDrive\":false"}",
+			"{\"flavor\":\"test-flavor\",\"image\":\"test-image\",\"diskSize\":null,\"availabilityZone\":\"\",\"instanceReadyCheckPeriod\":\"\",\"instanceReadyCheckTimeout\":\"\",\"serverGroup\":\"\",\"configDrive\":false}",
 		},
 	}
 

--- a/modules/api/pkg/api/v1/types_test.go
+++ b/modules/api/pkg/api/v1/types_test.go
@@ -389,7 +389,7 @@ func TestOpenstackNodeSpec_MarshalJSON(t *testing.T) {
 				Flavor: "test-flavor",
 				Image:  "test-image",
 			},
-			"{\"flavor\":\"test-flavor\",\"image\":\"test-image\",\"diskSize\":null,\"availabilityZone\":\"\",\"instanceReadyCheckPeriod\":\"\",\"instanceReadyCheckTimeout\":\"\",\"serverGroup\":\"\"}",
+			"{\"flavor\":\"test-flavor\",\"image\":\"test-image\",\"diskSize\":null,\"availabilityZone\":\"\",\"instanceReadyCheckPeriod\":\"\",\"instanceReadyCheckTimeout\":\"\",\"serverGroup\":\"\",\"configDrive\":\"false\"}",
 		},
 	}
 

--- a/modules/api/pkg/api/v1/types_test.go
+++ b/modules/api/pkg/api/v1/types_test.go
@@ -389,7 +389,7 @@ func TestOpenstackNodeSpec_MarshalJSON(t *testing.T) {
 				Flavor: "test-flavor",
 				Image:  "test-image",
 			},
-			"{\"flavor\":\"test-flavor\",\"image\":\"test-image\",\"diskSize\":null,\"availabilityZone\":\"\",\"instanceReadyCheckPeriod\":\"\",\"instanceReadyCheckTimeout\":\"\",\"serverGroup\":\"\",\"configDrive\":\"false\"}",
+			"{\"flavor\":\"test-flavor\",\"image\":\"test-image\",\"diskSize\":null,\"availabilityZone\":\"\",\"instanceReadyCheckPeriod\":\"\",\"instanceReadyCheckTimeout\":\"\",\"serverGroup\":\"\",\"configDrive\":false"}",
 		},
 	}
 

--- a/modules/api/pkg/machine/convert.go
+++ b/modules/api/pkg/machine/convert.go
@@ -215,6 +215,9 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 		if config.RootDiskSizeGB != nil && *config.RootDiskSizeGB > 0 {
 			cloudSpec.Openstack.RootDiskSizeGB = config.RootDiskSizeGB
 		}
+		if cd := config.ConfigDrive.Value; cd != nil {
+			cloudSpec.Openstack.ConfigDrive = *cd
+		}
 	case providerconfig.CloudProviderHetzner:
 		config := &hetzner.RawConfig{}
 		if err := json.Unmarshal(decodedProviderSpec.CloudProviderSpec.Raw, &config); err != nil {

--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -390,6 +390,7 @@ func GetOpenstackProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec
 		InstanceReadyCheckTimeout: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckTimeout},
 		TrustDevicePath:           providerconfig.ConfigVarBool{Value: ptr.To(false)},
 		ServerGroup:               providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.ServerGroup},
+		ConfigDrive:               providerconfig.ConfigVarBool{Value: ptr.To(nodeSpec.Cloud.Openstack.ConfigDrive)},
 	}
 
 	config.SecurityGroups = []providerconfig.ConfigVarString{}

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/openstack_node_spec.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/openstack_node_spec.go
@@ -22,6 +22,9 @@ type OpenstackNodeSpec struct {
 	// if not set, the default AZ from the Datacenter spec will be used
 	AvailabilityZone string `json:"availabilityZone,omitempty"`
 
+	// ConfigDrive enables a configuration drive that will be attached to the instance when it boots.
+	ConfigDrive bool `json:"configDrive,omitempty"`
+
 	// instance flavor
 	// Required: true
 	Flavor *string `json:"flavor"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a logic where configDrive is set to null during updates; which causes extra machines to rollout since the JSON patch detects difference between `null` and boolean value.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/14215
**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Pass ConfigDrive value to JSON patch during machine updates  for OpenStack
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
