### PR TITLE
[release/v2.25] Bump KKP Dashboard version and dependencies for May 2025

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.16
+KUBERMATIC_VERSION?=v2.25.17
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.16
+KUBERMATIC_VERSION?=v2.25.17
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,7 +70,7 @@ require (
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.2
-	k8c.io/kubermatic/v2 v2.25.16-0.20250407185614-8addaaee9dca
+	k8c.io/kubermatic/v2 v2.25.17-0.20250429124054-45c86a2d771b
 	k8c.io/operating-system-manager v1.5.5
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.29.1

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1421,8 +1421,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.25.16-0.20250407185614-8addaaee9dca h1:70hOA+a3iN5P7r4vlaOa/Yaf8xVdn1Y5ViqSoPSVNiQ=
-k8c.io/kubermatic/v2 v2.25.16-0.20250407185614-8addaaee9dca/go.mod h1:bbgxvcVvUNxchLd76Df5zuLne34Bm7SD9CKuiPa8pEM=
+k8c.io/kubermatic/v2 v2.25.17-0.20250429124054-45c86a2d771b h1:c5MR5tQCNgPo+cmzKlV1sQaynDIRM8R/LMPDnu34OQg=
+k8c.io/kubermatic/v2 v2.25.17-0.20250429124054-45c86a2d771b/go.mod h1:bbgxvcVvUNxchLd76Df5zuLne34Bm7SD9CKuiPa8pEM=
 k8c.io/operating-system-manager v1.5.5 h1:q/J07WTUaW2oPJALlbRm+FEKdDC/wu98/58AUCA7NsM=
 k8c.io/operating-system-manager v1.5.5/go.mod h1:h7gVySBkNOVDj2LAW90kDw2nwAROS5k9wVHeK6w/1KQ=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=

--- a/modules/api/pkg/handler/test/helper.go
+++ b/modules/api/pkg/handler/test/helper.go
@@ -126,8 +126,8 @@ const (
 	TestSeedDatacenter = "us-central1"
 	// TestServiceAccountHashKey authenticates the service account's token value using HMAC.
 	TestServiceAccountHashKey = "eyJhbGciOiJIUzI1NeyJhbGciOiJIUzI1N"
-	// TestFakeToken signed JWT token with fake data. It will expire after 3 years from 12-04-2022. To generate new token use kubermatic/pkg/serviceaccount/jwt_test.go.
-	TestFakeToken = "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjE3NDQ0NjQ1OTYsImlhdCI6MTY0OTc3MDE5NiwibmJmIjoxNjQ5NzcwMTk2LCJwcm9qZWN0X2lkIjoidGVzdFByb2plY3QiLCJ0b2tlbl9pZCI6InRlc3RUb2tlbiJ9.IGcnVhrTGeemEZ_dOGCRE1JXwpSMWJEbrG8hylpTEUY"
+	// TestFakeToken signed JWT token with fake data. It will expire after 3 years from 17-04-2025. To generate new token use kubermatic/pkg/serviceaccount/jwt_test.go.
+	TestFakeToken = "eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjE4Mzk1OTM4NzksImlhdCI6MTc0NDg5OTQ3OSwibmJmIjoxNzQ0ODk5NDc5LCJwcm9qZWN0X2lkIjoidGVzdFByb2plY3QiLCJ0b2tlbl9pZCI6InRlc3RUb2tlbiJ9.mv9UeGNARagYpMc_WBGyS6PGKnnYq7GmwdGsnuTVcHk"
 	// TestOSdomain OpenStack domain.
 	TestOSdomain = "OSdomain"
 	// TestOSuserPass OpenStack user password.

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.25.16
+KUBERMATIC_VERSION?=v2.25.17
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.25.16",
+  "version": "2.25.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.25.16",
+      "version": "2.25.17",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.25.16",
+  "version": "2.25.17",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",

--- a/modules/web/src/assets/config/changelog.json
+++ b/modules/web/src/assets/config/changelog.json
@@ -1,9 +1,13 @@
 {
-  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.25.md#v22515",
+  "externalChangelogURL": "https://github.com/kubermatic/kubermatic/blob/main/docs/changelogs/CHANGELOG-2.25.md#v22517",
   "entries": [
     {
-      "category": "changed",
-      "description": "Update Dashboard API to use correct OSP which is selected while creating a cluster"
+      "category": "fixed",
+      "description": "Add role prioritization: Update logic to return the highest-priority role for members with multiple roles"
+    },
+    {
+      "category": "fixed",
+      "description": "Add special characters restriction on Inputs and escape values to avoid rendering as HTML"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump KKP Dashboard version and dependencies for KKP patch release v2.25.17 May 2025. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
