### PR TITLE
Add support for global viewer role in middleware

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -73,7 +73,7 @@ require (
 	google.golang.org/api v0.232.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.10.0
-	k8c.io/kubermatic/sdk/v2 v2.0.0-20250508144759-54d4fe7fcadd
+	k8c.io/kubermatic/sdk/v2 v2.0.0-20250509182904-004e10a959a2
 	k8c.io/kubermatic/v2 v2.27.1-0.20250508144759-54d4fe7fcadd
 	k8c.io/machine-controller/sdk v0.0.0-20250408084312-a9dc4e656d96
 	k8c.io/operating-system-manager v1.6.5

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1561,8 +1561,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/sdk/v2 v2.0.0-20250508144759-54d4fe7fcadd h1:j10djSrvybtCGLBvmG3avEl5uZI7QwpKczclmyj06/s=
-k8c.io/kubermatic/sdk/v2 v2.0.0-20250508144759-54d4fe7fcadd/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
+k8c.io/kubermatic/sdk/v2 v2.0.0-20250509182904-004e10a959a2 h1:rkSXYRw/En4w9wQxF4pcOskJKKPxIpJhAVc1YAFewkI=
+k8c.io/kubermatic/sdk/v2 v2.0.0-20250509182904-004e10a959a2/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
 k8c.io/kubermatic/v2 v2.27.1-0.20250508144759-54d4fe7fcadd h1:TAg35INvkBxPV7lXE97b7emSG7Adh+yXBlchYWeCyqE=
 k8c.io/kubermatic/v2 v2.27.1-0.20250508144759-54d4fe7fcadd/go.mod h1:poRJ1ScD6xUG7OkWK5Tr8euNVGBIqNgN+CUL6XaDdo4=
 k8c.io/machine-controller v1.61.1 h1:Zy3kg9t0WrDN0Wo3y/pAJp7jdkThcJt070f0fAL9MVc=

--- a/modules/api/pkg/handler/middleware/middleware.go
+++ b/modules/api/pkg/handler/middleware/middleware.go
@@ -252,6 +252,7 @@ func UserInfoUnauthorized(userProjectMapper provider.ProjectMemberMapper, userPr
 				uInfo := &provider.UserInfo{Email: user.Spec.Email, IsAdmin: true}
 				return next(context.WithValue(ctx, UserInfoContextKey, uInfo), request)
 			}
+
 			uInfo, err := createUserInfo(ctx, user, projectID, userProjectMapper)
 			if err != nil {
 				return nil, common.KubernetesErrorToHTTPError(err)
@@ -402,7 +403,7 @@ func createUserInfo(ctx context.Context, user *kubermaticv1.User, projectID stri
 		groups.Insert(user.Spec.Groups...)
 	}
 
-	return &provider.UserInfo{Email: user.Spec.Email, Groups: sets.List(groups), Roles: roles}, nil
+	return &provider.UserInfo{Email: user.Spec.Email, Groups: sets.List(groups), Roles: roles, IsGlobalViewer: user.Spec.IsGlobalViewer}, nil
 }
 
 func GetClusterProvider(ctx context.Context, request interface{}, seedsGetter provider.SeedsGetter, clusterProviderGetter provider.ClusterProviderGetter) (provider.ClusterProvider, context.Context, error) {

--- a/modules/api/pkg/handler/v1/project/project.go
+++ b/modules/api/pkg/handler/v1/project/project.go
@@ -259,7 +259,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		if (req.DisplayAll && userInfo.IsAdmin) || (userInfo.IsGlobalViewer) {
+		if req.DisplayAll && (userInfo.IsAdmin || userInfo.IsGlobalViewer) {
 			return getAllProjectsForAdmin(ctx, userInfo, projectProvider, memberProvider, userProvider, clusterProviderGetter, seedsGetter)
 		}
 

--- a/modules/api/pkg/handler/v1/project/project.go
+++ b/modules/api/pkg/handler/v1/project/project.go
@@ -259,7 +259,7 @@ func ListEndpoint(userInfoGetter provider.UserInfoGetter, projectProvider provid
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		if req.DisplayAll && userInfo.IsAdmin {
+		if (req.DisplayAll && userInfo.IsAdmin) || (userInfo.IsGlobalViewer) {
 			return getAllProjectsForAdmin(ctx, userInfo, projectProvider, memberProvider, userProvider, clusterProviderGetter, seedsGetter)
 		}
 

--- a/modules/api/pkg/provider/kubernetes/member.go
+++ b/modules/api/pkg/provider/kubernetes/member.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
+	"k8c.io/dashboard/v2/pkg/ee/group-project-binding/handler"
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1/helper"
@@ -202,6 +203,11 @@ func (p *ProjectMemberProvider) MapUserToGroups(ctx context.Context, user *kuber
 	if user.Spec.IsAdmin {
 		groups.Insert(fmt.Sprintf("owners-%s", projectID))
 	}
+
+	if user.Spec.IsGlobalViewer {
+		groups.Insert(fmt.Sprintf("viewers-%s", projectID))
+	}
+
 	if groups.Len() > 0 {
 		return groups, nil
 	} else {
@@ -285,6 +291,11 @@ func (p *ProjectMemberProvider) MapUserToRoles(ctx context.Context, user *kuberm
 		roles.Insert("owners")
 		return roles, nil
 	}
+
+	if user.Spec.IsGlobalViewer {
+		roles.Insert(handler.ViewersRole)
+	}
+
 	for _, gpb := range groupProjectBindings.Items {
 		if slice.ContainsString(user.Spec.Groups, gpb.Spec.Group, nil) && gpb.Spec.ProjectID == projectID {
 			roles.Insert(gpb.Spec.Role)

--- a/modules/api/pkg/provider/types.go
+++ b/modules/api/pkg/provider/types.go
@@ -393,10 +393,11 @@ type ProjectProvider interface {
 
 // UserInfo represent authenticated user.
 type UserInfo struct {
-	Email   string
-	Groups  []string
-	Roles   sets.Set[string]
-	IsAdmin bool
+	Email          string
+	Groups         []string
+	Roles          sets.Set[string]
+	IsAdmin        bool
+	IsGlobalViewer bool
 }
 
 // ProjectMemberListOptions allows to set filters that will be applied to filter the result.

--- a/modules/api/pkg/provider/userinfo.go
+++ b/modules/api/pkg/provider/userinfo.go
@@ -61,6 +61,6 @@ func UserInfoGetterFactory(userProjectMapper ProjectMemberMapper) (UserInfoGette
 			}
 		}
 
-		return &UserInfo{Email: user.Spec.Email, Groups: sets.List(groups), IsAdmin: user.Spec.IsAdmin, Roles: roles}, nil
+		return &UserInfo{Email: user.Spec.Email, Groups: sets.List(groups), IsAdmin: user.Spec.IsAdmin, Roles: roles, IsGlobalViewer: user.Spec.IsGlobalViewer}, nil
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds support for the `globalViewer` role in Kubermatic.
- Users with `globalViewer: true` in their User CR are automatically granted read-only access to all projects and clusters. This is achieved through dynamic group and role injection in the API middleware, without the need for explicit UserProjectBinding resources.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
- Global viewers are now resolved dynamically in the `UserInfo` middleware layer.
- `isGlobalViewer` and `isAdmin` are mutually exclusive, validated by webhook.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Users marked with globalViewer: true now receive read-only access to all projects and clusters via dynamic groups and roles injection. No need to create UserProjectBindings for them.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
