### PR TITLE
fix(global-viewer): fix users api for global viewer use

### DIFF
--- a/modules/api/pkg/handler/v1/user/user.go
+++ b/modules/api/pkg/handler/v1/user/user.go
@@ -114,7 +114,7 @@ func getMemberList(ctx context.Context, userInfoGetter provider.UserInfoGetter, 
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	if !userInfo.IsAdmin {
+	if !userInfo.IsAdmin && !userInfo.IsGlobalViewer {
 		userInfo, err = userInfoGetter(ctx, project.Name)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes a permission issue where users with globalViewer access were unable to retrieve members for a project.
  - For more info, ref: https://github.com/kubermatic/dashboard/issues/7325#issuecomment-2886864590

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
