### PR TITLE
Add global viewer role to the dashboard

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -27738,6 +27738,11 @@
           "type": "boolean",
           "x-go-name": "IsAdmin"
         },
+        "isGlobalViewer": {
+          "description": "IsGlobalViewer indicates GlobalViewer role",
+          "type": "boolean",
+          "x-go-name": "IsGlobalViewer"
+        },
         "name": {
           "description": "Name of the admin user",
           "type": "string",
@@ -40903,6 +40908,11 @@
           "description": "IsAdmin indicates admin role",
           "type": "boolean",
           "x-go-name": "IsAdmin"
+        },
+        "isGlobalViewer": {
+          "description": "IsGlobalViewer indicates GlobalViewer role",
+          "type": "boolean",
+          "x-go-name": "IsGlobalViewer"
         },
         "lastSeen": {
           "description": "LastSeen holds a time in UTC format when the user has been using the API last time",

--- a/modules/api/pkg/api/v1/types.go
+++ b/modules/api/pkg/api/v1/types.go
@@ -582,6 +582,9 @@ type User struct {
 	// IsAdmin indicates admin role
 	IsAdmin bool `json:"isAdmin,omitempty"`
 
+	// IsGlobalViewer indicates GlobalViewer role
+	IsGlobalViewer bool `json:"isGlobalViewer,omitempty"`
+
 	// Projects holds the list of project the user belongs to
 	// along with the group names
 	Projects []ProjectGroup `json:"projects,omitempty"`
@@ -626,6 +629,7 @@ func ConvertInternalUserToExternal(internalUser *kubermaticv1.User, includeSetti
 		Email:             internalUser.Spec.Email,
 		Groups:            internalUser.Spec.Groups,
 		IsAdmin:           internalUser.Spec.IsAdmin,
+		IsGlobalViewer:    internalUser.Spec.IsGlobalViewer,
 		Projects:          []ProjectGroup{},
 		ReadAnnouncements: internalUser.Spec.ReadAnnouncements,
 	}
@@ -686,7 +690,9 @@ type Admin struct {
 	// Name of the admin user
 	Name string `json:"name,omitempty"`
 	// IsAdmin indicates admin role
-	IsAdmin bool `json:"isAdmin"`
+	IsAdmin *bool `json:"isAdmin,omitempty"`
+	// IsGlobalViewer indicates GlobalViewer role
+	IsGlobalViewer *bool `json:"isGlobalViewer,omitempty"`
 }
 
 // ProjectGroup is a helper data structure that

--- a/modules/api/pkg/handler/v1/admin/admin.go
+++ b/modules/api/pkg/handler/v1/admin/admin.go
@@ -44,7 +44,7 @@ func GetAdminEndpoint(userInfoGetter provider.UserInfoGetter, adminProvider prov
 
 		var resultList []apiv1.Admin
 		for _, admin := range admins {
-			resultList = append(resultList, apiv1.Admin{Email: admin.Spec.Email, IsAdmin: admin.Spec.IsAdmin, Name: admin.Spec.Name})
+			resultList = append(resultList, apiv1.Admin{Email: admin.Spec.Email, IsAdmin: &admin.Spec.IsAdmin, Name: admin.Spec.Name})
 		}
 
 		return resultList, nil
@@ -67,16 +67,23 @@ func SetAdminEndpoint(userInfoGetter provider.UserInfoGetter, adminProvider prov
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
-
-		admin, err := adminProvider.SetAdmin(ctx, userInfo, req.Body.Email, req.Body.IsAdmin)
+		admin, err := adminProvider.SetAdmin(ctx, userInfo, req.Body)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
+		}
+
+		if req.Body.IsGlobalViewer != nil {
+			return apiv1.Admin{
+				Email:          admin.Spec.Email,
+				Name:           admin.Spec.Name,
+				IsGlobalViewer: &admin.Spec.IsGlobalViewer,
+			}, nil
 		}
 
 		return apiv1.Admin{
 			Email:   admin.Spec.Email,
 			Name:    admin.Spec.Name,
-			IsAdmin: admin.Spec.IsAdmin,
+			IsAdmin: &admin.Spec.IsAdmin,
 		}, nil
 	}
 }

--- a/modules/api/pkg/provider/types.go
+++ b/modules/api/pkg/provider/types.go
@@ -681,7 +681,7 @@ type SettingsProvider interface {
 
 // AdminProvider declares the set of methods for interacting with admin.
 type AdminProvider interface {
-	SetAdmin(ctx context.Context, userInfo *UserInfo, email string, isAdmin bool) (*kubermaticv1.User, error)
+	SetAdmin(ctx context.Context, userInfo *UserInfo, adminBody apiv1.Admin) (*kubermaticv1.User, error)
 	GetAdmins(ctx context.Context, userInfo *UserInfo) ([]kubermaticv1.User, error)
 }
 

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/admin.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/admin.go
@@ -23,11 +23,11 @@ type Admin struct {
 	// IsAdmin indicates admin role
 	IsAdmin bool `json:"isAdmin,omitempty"`
 
-	// Name of the admin user
-	Name string `json:"name,omitempty"`
-
 	// IsGlobalViewer indicates GlobalViewer role
 	IsGlobalViewer bool `json:"isGlobalViewer,omitempty"`
+
+	// Name of the admin user
+	Name string `json:"name,omitempty"`
 }
 
 // Validate validates this admin

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/admin.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/admin.go
@@ -25,6 +25,9 @@ type Admin struct {
 
 	// Name of the admin user
 	Name string `json:"name,omitempty"`
+
+	// IsGlobalViewer indicates GlobalViewer role
+	IsGlobalViewer bool `json:"isGlobalViewer,omitempty"`
 }
 
 // Validate validates this admin

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/user.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/user.go
@@ -43,6 +43,9 @@ type User struct {
 	// IsAdmin indicates admin role
 	IsAdmin bool `json:"isAdmin,omitempty"`
 
+	// IsGlobalViewer indicates GlobalViewer role
+	IsGlobalViewer bool `json:"isGlobalViewer,omitempty"`
+
 	// LastSeen holds a time in UTC format when the user has been using the API last time
 	// Format: date-time
 	LastSeen strfmt.DateTime `json:"lastSeen,omitempty"`

--- a/modules/web/src/app/project/template.html
+++ b/modules/web/src/app/project/template.html
@@ -374,7 +374,7 @@ limitations under the License.
 </ng-template>
 
 <ng-template #allProjectToggle>
-  <mat-slide-toggle *ngIf="isAdmin"
+  <mat-slide-toggle *ngIf="isAdmin || currentUser.isGlobalViewer"
                     class="all-projects-toggle"
                     [disabled]="isProjectsLoading"
                     labelPosition="before"

--- a/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/component.ts
+++ b/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from "@angular/core";
+import { FormControl, FormGroup, Validators } from "@angular/forms";
+import { MatDialogRef } from "@angular/material/dialog";
+import { NotificationService } from "@app/core/services/notification";
+import { SettingsService } from "@app/core/services/settings";
+import { Admin } from "@app/shared/entity/member";
+import { Observable } from "rxjs";
+
+@Component({
+  selector: 'km-add-global-viewer-dialog',
+  templateUrl: './template.html',
+  standalone: false,
+})
+export class AddGlobalViewerDialogComponenet implements OnInit {
+  form: FormGroup;
+
+  constructor(
+    private readonly _settingsService: SettingsService,
+    private readonly _matDialogRef: MatDialogRef<AddGlobalViewerDialogComponenet>,
+    private readonly _notificationService: NotificationService
+  ) {}
+
+  ngOnInit(): void {
+    this.form = new FormGroup({
+      email: new FormControl('', [Validators.required, Validators.email])
+    })
+  }
+
+   getObservable(): Observable<Admin> {
+      return this._settingsService.setAdmin({
+        email: this.form.controls.email.value,
+        isGlobalViewer: true,
+      });
+    }
+
+    onNext(adminViewer: Admin): void {
+      this._matDialogRef.close(adminViewer);
+      this._notificationService.success(`Added the ${adminViewer.name} user to the global viewer group`);
+    }
+}

--- a/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/component.ts
+++ b/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/component.ts
@@ -1,10 +1,24 @@
-import { Component, OnInit } from "@angular/core";
-import { FormControl, FormGroup, Validators } from "@angular/forms";
-import { MatDialogRef } from "@angular/material/dialog";
-import { NotificationService } from "@app/core/services/notification";
-import { SettingsService } from "@app/core/services/settings";
-import { Admin } from "@app/shared/entity/member";
-import { Observable } from "rxjs";
+// Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Component, OnInit} from '@angular/core';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {MatDialogRef} from '@angular/material/dialog';
+import {NotificationService} from '@app/core/services/notification';
+import {SettingsService} from '@app/core/services/settings';
+import {Admin} from '@app/shared/entity/member';
+import {Observable} from 'rxjs';
 
 @Component({
   selector: 'km-add-global-viewer-dialog',
@@ -22,19 +36,19 @@ export class AddGlobalViewerDialogComponenet implements OnInit {
 
   ngOnInit(): void {
     this.form = new FormGroup({
-      email: new FormControl('', [Validators.required, Validators.email])
-    })
+      email: new FormControl('', [Validators.required, Validators.email]),
+    });
   }
 
-   getObservable(): Observable<Admin> {
-      return this._settingsService.setAdmin({
-        email: this.form.controls.email.value,
-        isGlobalViewer: true,
-      });
-    }
+  getObservable(): Observable<Admin> {
+    return this._settingsService.setAdmin({
+      email: this.form.controls.email.value,
+      isGlobalViewer: true,
+    });
+  }
 
-    onNext(adminViewer: Admin): void {
-      this._matDialogRef.close(adminViewer);
-      this._notificationService.success(`Added the ${adminViewer.name} user to the global viewer group`);
-    }
+  onNext(adminViewer: Admin): void {
+    this._matDialogRef.close(adminViewer);
+    this._notificationService.success(`Added the ${adminViewer.name} user to the global viewer group`);
+  }
 }

--- a/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/template.html
+++ b/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/template.html
@@ -1,0 +1,29 @@
+<km-dialog-title>Add Global Viewer</km-dialog-title>
+<mat-dialog-content>
+  <form [formGroup]="form"
+        fxLayout="column">
+    <mat-form-field fxFlex>
+      <mat-label>Email</mat-label>
+      <input matInput
+             required
+             formControlName="email"
+             type="text"
+             autocomplete="off"
+             cdkFocusInitial />
+      <mat-error *ngIf="form.controls.email.hasError('required')">
+        <strong>Required</strong>
+      </mat-error>
+      <mat-error *ngIf="form.controls.email.hasError('email')">
+        <strong>Invalid email</strong>
+      </mat-error>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <km-button icon="km-icon-add"
+             label="Add Global Viewer"
+             [disabled]="!form.valid"
+             [observable]="getObservable()"
+             (next)="onNext($event)">
+  </km-button>
+</mat-dialog-actions>

--- a/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/template.html
+++ b/modules/web/src/app/settings/admin/global-viewer/add-global-viewer-dialog/template.html
@@ -1,3 +1,18 @@
+<!--
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <km-dialog-title>Add Global Viewer</km-dialog-title>
 <mat-dialog-content>
   <form [formGroup]="form"

--- a/modules/web/src/app/settings/admin/global-viewer/component.ts
+++ b/modules/web/src/app/settings/admin/global-viewer/component.ts
@@ -1,0 +1,112 @@
+import { Component, OnChanges, OnInit, ViewChild } from "@angular/core";
+import { MatPaginator } from "@angular/material/paginator";
+import { MatSort } from "@angular/material/sort";
+import { MatTableDataSource } from "@angular/material/table";
+import { SettingsService } from "@app/core/services/settings";
+import { UserService } from "@app/core/services/user";
+import { Admin, Member } from "@app/shared/entity/member";
+import { filter, Subject, take, takeUntil } from "rxjs";
+import { MatDialog, MatDialogConfig } from "@angular/material/dialog";
+import _ from 'lodash';
+import { ConfirmationDialogComponent } from "@app/shared/components/confirmation-dialog/component";
+import { NotificationService } from "@app/core/services/notification";
+import { AddGlobalViewerDialogComponenet } from "./add-global-viewer-dialog/component";
+
+@Component({
+  selector: 'km-global-viewer',
+  templateUrl: './template.html',
+  styleUrl: './style.scss',
+  standalone: false
+})
+export class GlobalViewerComponent implements OnInit, OnChanges {
+  globalViewers: Member[] = [];
+  isLoading: boolean = false;
+  dataSource = new MatTableDataSource<Member>();
+  displayedColumns: string[] = ['name', 'email', 'actions'];
+  @ViewChild(MatSort, {static: true}) sort: MatSort;
+  @ViewChild(MatPaginator, {static: true}) paginator: MatPaginator;
+  private _unsubscribe = new Subject<void>();
+  constructor(
+    private readonly _settingsService: SettingsService,
+    private readonly _userService: UserService,
+    private readonly _matDialog: MatDialog,
+    private readonly _notificationService: NotificationService,
+
+  ) {}
+
+  ngOnInit(): void {
+    this.dataSource.sort = this.sort;
+    this.dataSource.paginator = this.paginator;
+    this.sort.active = 'name';
+    this.sort.direction = 'asc';
+
+    this._getGlobalViewers();
+
+    this._userService.currentUserSettings.pipe(takeUntil(this._unsubscribe)).subscribe(settings => {
+      this.paginator.pageSize = settings.itemsPerPage;
+      this.dataSource.paginator = this.paginator;
+    });
+
+  }
+
+  ngOnChanges(): void {
+      this._unsubscribe.next();
+      this._unsubscribe.complete();
+  }
+
+  add(): void {
+    this._matDialog.open(AddGlobalViewerDialogComponenet)
+    .afterClosed()
+    .pipe(take(1))
+      .subscribe(gv => {
+        if (gv) {
+          this._getGlobalViewers();
+        }
+      });
+  }
+
+  delete(user: Member): void {
+      const dialogConfig: MatDialogConfig = {
+          data: {
+            title: 'Remove Global Viewer',
+            message: `Remove <b>${_.escape(user.name)}</b> from Global Viewers Group?`,
+            confirmLabel: 'Remove',
+          },
+        };
+      this._matDialog
+            .open(ConfirmationDialogComponent, dialogConfig)
+            .afterClosed()
+            .pipe(filter(isConfirmed => isConfirmed))
+            .pipe(take(1))
+            .subscribe(_ => {
+              const adminViewer: Admin = {
+                email: user.email,
+                isGlobalViewer: false
+              }
+              this._updateGlobalViewer(adminViewer);
+            });
+  }
+
+  isPaginatorVisible(): boolean {
+    return this.globalViewers && !!this.globalViewers.length
+  }
+
+  private _getGlobalViewers(): void {
+    this.isLoading = true;
+    this._settingsService.users.pipe(takeUntil(this._unsubscribe)).subscribe(users => {
+      this.globalViewers = users.filter(user => user.email && user.name && user.isGlobalViewer)
+      this.isLoading = false
+      this.dataSource.data = this.globalViewers;
+    })
+  }
+
+   private _updateGlobalViewer(gv: Admin): void {
+      this._settingsService
+        .setAdmin(gv)
+        .pipe(take(1))
+        .subscribe(() => {
+          this._notificationService.success(`Removed the ${gv.name} user from the global viewer group`);
+          this._getGlobalViewers();
+        });
+    }
+}

--- a/modules/web/src/app/settings/admin/global-viewer/module.ts
+++ b/modules/web/src/app/settings/admin/global-viewer/module.ts
@@ -1,18 +1,32 @@
-import { NgModule } from "@angular/core";
-import { SharedModule } from "@app/shared/module";
-import { GlobalViewerComponent } from "./component";
-import { RouterModule, Routes } from "@angular/router";
-import { AddGlobalViewerDialogComponenet } from "./add-global-viewer-dialog/component";
+// Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {NgModule} from '@angular/core';
+import {SharedModule} from '@app/shared/module';
+import {GlobalViewerComponent} from './component';
+import {RouterModule, Routes} from '@angular/router';
+import {AddGlobalViewerDialogComponenet} from './add-global-viewer-dialog/component';
 
 const routes: Routes = [
   {
     path: '',
-    component: GlobalViewerComponent
-  }
+    component: GlobalViewerComponent,
+  },
 ];
 
 @NgModule({
   imports: [SharedModule, RouterModule.forChild(routes)],
-  declarations: [GlobalViewerComponent, AddGlobalViewerDialogComponenet]
+  declarations: [GlobalViewerComponent, AddGlobalViewerDialogComponenet],
 })
 export class GlobalViewerModule {}

--- a/modules/web/src/app/settings/admin/global-viewer/module.ts
+++ b/modules/web/src/app/settings/admin/global-viewer/module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from "@angular/core";
+import { SharedModule } from "@app/shared/module";
+import { GlobalViewerComponent } from "./component";
+import { RouterModule, Routes } from "@angular/router";
+import { AddGlobalViewerDialogComponenet } from "./add-global-viewer-dialog/component";
+
+const routes: Routes = [
+  {
+    path: '',
+    component: GlobalViewerComponent
+  }
+];
+
+@NgModule({
+  imports: [SharedModule, RouterModule.forChild(routes)],
+  declarations: [GlobalViewerComponent, AddGlobalViewerDialogComponenet]
+})
+export class GlobalViewerModule {}

--- a/modules/web/src/app/settings/admin/global-viewer/style.scss
+++ b/modules/web/src/app/settings/admin/global-viewer/style.scss
@@ -1,3 +1,17 @@
+// Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 .mat-mdc-card-title {
   .km-icon-add {

--- a/modules/web/src/app/settings/admin/global-viewer/style.scss
+++ b/modules/web/src/app/settings/admin/global-viewer/style.scss
@@ -1,0 +1,7 @@
+
+.mat-mdc-card-title {
+  .km-icon-add {
+    margin-left: 0;
+    margin-right: 12px;
+  }
+}

--- a/modules/web/src/app/settings/admin/global-viewer/template.html
+++ b/modules/web/src/app/settings/admin/global-viewer/template.html
@@ -1,0 +1,80 @@
+<mat-card appearance="outlined">
+  <mat-card-header>
+    <mat-card-title fxFlex
+                    fxLayout="row"
+                    fxLayoutAlign=" center">
+      <div fxFlex>Global Viewers</div>
+      <button mat-flat-button
+              color="quaternary"
+              (click)="add()">
+        <i class="km-icon-mask km-icon-add"
+           matButtonIcon></i>
+        <span>Add Global Viewer</span>
+      </button>
+    </mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <table class="km-table"
+           mat-table
+           matSort
+           [dataSource]="dataSource">
+           <ng-container matColumnDef="name">
+            <th mat-header-cell
+                *matHeaderCellDef
+                class="km-header-cell p-40"
+                mat-sort-header>Name
+            </th>
+            <td mat-cell
+                *matCellDef="let element">{{element.name}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="email">
+            <th mat-header-cell
+                *matHeaderCellDef
+                class="km-header-cell p-60"
+                mat-sort-header>Email
+            </th>
+            <td mat-cell
+                *matCellDef="let element">{{element?.email}}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell
+                *matHeaderCellDef
+                class="km-header-cell"></th>
+            <td mat-cell
+                *matCellDef="let element">
+              <div class="km-table-actions"
+                   fxLayoutAlign="end">
+                <button mat-icon-button
+                        (click)="delete(element)">
+                  <i class="km-icon-mask km-icon-delete"></i>
+                </button>
+              </div>
+            </td>
+          </ng-container>
+          <tr mat-header-row
+              class="km-header-row"
+              *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row
+              *matRowDef="let row; columns: displayedColumns"
+              class="km-mat-row"></tr>
+    </table>
+
+    <ng-container *ngIf="isLoading">
+      <div class="km-row">
+        <mat-spinner color="accent"
+                     class="km-spinner"
+                     [diameter]="25"></mat-spinner>
+      </div>
+    </ng-container>
+    <div [hidden]="!isPaginatorVisible()"
+         class="km-paginator-container">
+      <div fxLayout="row"
+           fxLayoutAlign="flex-end center">
+        <km-pagination-page-size></km-pagination-page-size>
+        <mat-paginator showFirstLastButtons></mat-paginator>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/modules/web/src/app/settings/admin/global-viewer/template.html
+++ b/modules/web/src/app/settings/admin/global-viewer/template.html
@@ -1,3 +1,18 @@
+<!--
+Copyright 2025 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <mat-card appearance="outlined">
   <mat-card-header>
     <mat-card-title fxFlex
@@ -18,47 +33,47 @@
            mat-table
            matSort
            [dataSource]="dataSource">
-           <ng-container matColumnDef="name">
-            <th mat-header-cell
-                *matHeaderCellDef
-                class="km-header-cell p-40"
-                mat-sort-header>Name
-            </th>
-            <td mat-cell
-                *matCellDef="let element">{{element.name}}</td>
-          </ng-container>
+      <ng-container matColumnDef="name">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-40"
+            mat-sort-header>Name
+        </th>
+        <td mat-cell
+            *matCellDef="let element">{{element.name}}</td>
+      </ng-container>
 
-          <ng-container matColumnDef="email">
-            <th mat-header-cell
-                *matHeaderCellDef
-                class="km-header-cell p-60"
-                mat-sort-header>Email
-            </th>
-            <td mat-cell
-                *matCellDef="let element">{{element?.email}}</td>
-          </ng-container>
+      <ng-container matColumnDef="email">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-60"
+            mat-sort-header>Email
+        </th>
+        <td mat-cell
+            *matCellDef="let element">{{element?.email}}</td>
+      </ng-container>
 
-          <ng-container matColumnDef="actions">
-            <th mat-header-cell
-                *matHeaderCellDef
-                class="km-header-cell"></th>
-            <td mat-cell
-                *matCellDef="let element">
-              <div class="km-table-actions"
-                   fxLayoutAlign="end">
-                <button mat-icon-button
-                        (click)="delete(element)">
-                  <i class="km-icon-mask km-icon-delete"></i>
-                </button>
-              </div>
-            </td>
-          </ng-container>
-          <tr mat-header-row
-              class="km-header-row"
-              *matHeaderRowDef="displayedColumns"></tr>
-          <tr mat-row
-              *matRowDef="let row; columns: displayedColumns"
-              class="km-mat-row"></tr>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell"></th>
+        <td mat-cell
+            *matCellDef="let element">
+          <div class="km-table-actions"
+               fxLayoutAlign="end">
+            <button mat-icon-button
+                    (click)="delete(element)">
+              <i class="km-icon-mask km-icon-delete"></i>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+      <tr mat-header-row
+          class="km-header-row"
+          *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row
+          *matRowDef="let row; columns: displayedColumns"
+          class="km-mat-row"></tr>
     </table>
 
     <ng-container *ngIf="isLoading">

--- a/modules/web/src/app/settings/admin/nav/template.html
+++ b/modules/web/src/app/settings/admin/nav/template.html
@@ -272,6 +272,14 @@ limitations under the License.
           <span>{{adminPanelViewDisplayName.Administrators}}</span>
         </a>
       </div>
+      <div class="sub-menu-item"
+           routerLinkActive="active">
+        <a id="km-nav-item-administrators"
+           fxLayoutAlign=" center"
+           [routerLink]="getRouterLink(adminPanelView.GlobalViewers)">
+          <span>{{adminPanelViewDisplayName.GlobalViewers}}</span>
+        </a>
+      </div>
     </ng-container>
     <ng-container *ngIf="isSidenavCollapsed">
       <a fxLayoutAlign=" center"
@@ -285,6 +293,12 @@ limitations under the License.
          [routerLink]="getRouterLink(adminPanelView.Administrators)"
          class="collapsed-sub-menu-item">
         <span>{{adminPanelViewDisplayName.Administrators}}</span>
+      </a>
+      <a fxLayoutAlign=" center"
+         routerLinkActive="active"
+         [routerLink]="getRouterLink(adminPanelView.GlobalViewers)"
+         class="collapsed-sub-menu-item">
+        <span>{{adminPanelViewDisplayName.GlobalViewers}}</span>
       </a>
     </ng-container>
   </km-side-nav-field>

--- a/modules/web/src/app/settings/admin/routing.ts
+++ b/modules/web/src/app/settings/admin/routing.ts
@@ -38,6 +38,10 @@ const routes: Routes = [
         loadChildren: () => import('./admins/module').then(m => m.AdministratorsModule),
       },
       {
+        path: 'globalviewers',
+        loadChildren: () => import('./global-viewer/module').then(m => m.GlobalViewerModule),
+      },
+      {
         path: 'customization',
         loadChildren: () => import('./customization/module').then(m => m.AdminSettingsCustomizationModule),
       },

--- a/modules/web/src/app/shared/components/side-nav-field/component.ts
+++ b/modules/web/src/app/shared/components/side-nav-field/component.ts
@@ -105,7 +105,11 @@ export class SideNavExpansionMenuComponent implements AfterViewChecked, OnInit {
       case AdminPanelSections.Monitoring:
         return this.checkUrl(AdminPanelView.RuleGroups) || this.checkUrl(AdminPanelView.Metering);
       case AdminPanelSections.Users:
-        return this.checkUrl(AdminPanelView.Accounts) || this.checkUrl(AdminPanelView.Administrators) || this.checkUrl(AdminPanelView.GlobalViewers);
+        return (
+          this.checkUrl(AdminPanelView.Accounts) ||
+          this.checkUrl(AdminPanelView.Administrators) ||
+          this.checkUrl(AdminPanelView.GlobalViewers)
+        );
       default:
         return false;
     }

--- a/modules/web/src/app/shared/components/side-nav-field/component.ts
+++ b/modules/web/src/app/shared/components/side-nav-field/component.ts
@@ -105,7 +105,7 @@ export class SideNavExpansionMenuComponent implements AfterViewChecked, OnInit {
       case AdminPanelSections.Monitoring:
         return this.checkUrl(AdminPanelView.RuleGroups) || this.checkUrl(AdminPanelView.Metering);
       case AdminPanelSections.Users:
-        return this.checkUrl(AdminPanelView.Accounts) || this.checkUrl(AdminPanelView.Administrators);
+        return this.checkUrl(AdminPanelView.Accounts) || this.checkUrl(AdminPanelView.Administrators) || this.checkUrl(AdminPanelView.GlobalViewers);
       default:
         return false;
     }

--- a/modules/web/src/app/shared/entity/common.ts
+++ b/modules/web/src/app/shared/entity/common.ts
@@ -118,7 +118,7 @@ export enum AdminPanelView {
   Accounts = 'accounts',
   Administrators = 'administrators',
   Applications = 'applications',
-  GlobalViewers = 'globalviewers'
+  GlobalViewers = 'globalviewers',
 }
 
 export enum AdminPanelViewDisplayName {
@@ -137,7 +137,7 @@ export enum AdminPanelViewDisplayName {
   Administrators = 'Administrators',
   Applications = 'Applications',
   Announcements = 'Announcements',
-  GlobalViewers = 'Global Viewers'
+  GlobalViewers = 'Global Viewers',
 }
 
 export enum AdminPanelSections {

--- a/modules/web/src/app/shared/entity/common.ts
+++ b/modules/web/src/app/shared/entity/common.ts
@@ -118,6 +118,7 @@ export enum AdminPanelView {
   Accounts = 'accounts',
   Administrators = 'administrators',
   Applications = 'applications',
+  GlobalViewers = 'globalviewers'
 }
 
 export enum AdminPanelViewDisplayName {
@@ -136,6 +137,7 @@ export enum AdminPanelViewDisplayName {
   Administrators = 'Administrators',
   Applications = 'Applications',
   Announcements = 'Announcements',
+  GlobalViewers = 'Global Viewers'
 }
 
 export enum AdminPanelSections {

--- a/modules/web/src/app/shared/entity/member.ts
+++ b/modules/web/src/app/shared/entity/member.ts
@@ -20,6 +20,7 @@ export class Member {
   email: string;
   groups?: string[];
   isAdmin?: boolean;
+  isGlobalViewer?: boolean;
   id: string;
   name: string;
   userSettings?: UserSettings;
@@ -42,4 +43,5 @@ export class Admin {
   name?: string;
   email?: string;
   isAdmin?: boolean;
+  isGlobalViewer?: boolean;
 }

--- a/modules/web/src/app/shared/utils/member.ts
+++ b/modules/web/src/app/shared/utils/member.ts
@@ -36,8 +36,10 @@ export class MemberUtils {
     const priority = [Group.Owner, Group.ProjectManager, Group.Editor, Group.Viewer];
 
     const groups = member.projects.filter(p => p.id === projectID).map(p => p.group);
-
-    return (priority.find(role => groups.includes(role))) ?? (member.isGlobalViewer ? Group.Viewer : '');
+    if (member.isGlobalViewer) {
+      groups.push(Group.Viewer);
+    }
+    return priority.find(role => groups.includes(role)) || '';
   }
 
   static getGroupDisplayName(groupInternalName: string): string {

--- a/modules/web/src/app/shared/utils/member.ts
+++ b/modules/web/src/app/shared/utils/member.ts
@@ -37,7 +37,7 @@ export class MemberUtils {
 
     const groups = member.projects.filter(p => p.id === projectID).map(p => p.group);
 
-    return priority.find(role => groups.includes(role)) || '';
+    return (priority.find(role => groups.includes(role))) ?? (member.isGlobalViewer ? Group.Viewer : '');
   }
 
   static getGroupDisplayName(groupInternalName: string): string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a new role called Global Viewer to the dashboard, where the admin can manage global viewers from the new `obalviewers` page in the admin panel.

**Which issue(s) this PR fixes**:
Fixes #7313 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
New page in the admin panel to manage the Global Viewer role.
```

**Documentation**:
```documentation
TBD
```
