### PR TITLE
fix(7343): add labels for backup objects

### DIFF
--- a/modules/api/pkg/ee/clusterbackup/backup/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/backup/handler.go
@@ -60,7 +60,11 @@ type clusterBackupBody struct {
 
 const (
 	UserClusterBackupNamespace = "velero"
-	backupOrigin               = "kkp-controllers"
+
+	projectIdKey    = "project-id"
+	clusterIdKey    = "cluster-id"
+	backupOriginKey = "backup-origin"
+	backupOrigin    = "kubermatic/kkp-controllers"
 )
 
 type clusterBackupUI struct {
@@ -126,9 +130,9 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 
 func getLabels(backupOrigin, projectID, clusterID string) map[string]string {
 	labels := make(map[string]string)
-	labels["project-id"] = projectID
-	labels["cluster-id"] = clusterID
-	labels["backup-origin"] = backupOrigin
+	labels[projectIdKey] = projectID
+	labels[clusterIdKey] = clusterID
+	labels[backupOriginKey] = backupOrigin
 	return labels
 }
 

--- a/modules/api/pkg/ee/clusterbackup/backup/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/backup/handler.go
@@ -60,6 +60,7 @@ type clusterBackupBody struct {
 
 const (
 	UserClusterBackupNamespace = "velero"
+	backupOrigin               = "kkp-controllers"
 )
 
 type clusterBackupUI struct {
@@ -93,6 +94,16 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 		},
 		Spec: *req.Body.Spec.DeepCopy(),
 	}
+
+	// These labels are added to the Backup CR to distinguish between backups created via the KKP controllers and those uploaded through the UI.
+	if clusterBackup.Spec.Labels == nil {
+		clusterBackup.Spec.Labels = getLabels(backupOrigin, req.ProjectID, req.ClusterID)
+	} else {
+		for k, v := range getLabels(backupOrigin, req.ProjectID, req.ClusterID) {
+			clusterBackup.Spec.Labels[k] = v
+		}
+	}
+
 	client, err := handlercommon.GetClusterClientWithClusterID(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, req.ClusterID)
 	if err != nil {
 		return nil, err
@@ -111,6 +122,14 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 		Name: clusterBackup.Name,
 		Spec: *clusterBackup.Spec.DeepCopy(),
 	}, nil
+}
+
+func getLabels(backupOrigin, projectID, clusterID string) map[string]string {
+	labels := make(map[string]string)
+	labels["project-id"] = projectID
+	labels["cluster-id"] = clusterID
+	labels["backup-origin"] = backupOrigin
+	return labels
 }
 
 type createClusterBackupReq struct {

--- a/modules/api/pkg/ee/clusterbackup/backup/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/backup/handler.go
@@ -61,10 +61,10 @@ type clusterBackupBody struct {
 const (
 	UserClusterBackupNamespace = "velero"
 
-	projectIdKey    = "project-id"
-	clusterIdKey    = "cluster-id"
-	backupOriginKey = "backup-origin"
-	backupOrigin    = "kubermatic/kkp-controllers"
+	projectIdKey    = "system/project"
+	clusterIdKey    = "system/cluster"
+	backupOriginKey = "system/backup-origin"
+	backupOrigin    = "kkp-controllers"
 )
 
 type clusterBackupUI struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `spec.labels` to ClusterBackup objects created via the KKP controllers. These labels help identify and distinguish controller-initiated backups from those manually uploaded via the UI. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref #7343 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cluster backups created by KKP controllers now include spec.labels to distinguish controller-initiated backups from those manually uploaded via the UI. 

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
