### PR TITLE
Display source of cluster backups

### DIFF
--- a/modules/api/pkg/ee/clusterbackup/backup/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/backup/handler.go
@@ -78,7 +78,8 @@ type clusterBackupUISpec struct {
 	StorageLocation    string                `json:"storageLocation,omitempty"`
 	ClusterID          string                `json:"clusterid,omitempty"`
 	TTL                string                `json:"ttl,omitempty"`
-	Labels             *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	Labels             map[string]string     `json:"labels,omitempty"`
+	LabelSelector      *metav1.LabelSelector `json:"labelSelector,omitempty"`
 	Status             string                `json:"status,omitempty"`
 	CreatedAt          apiv1.Time            `json:"createdAt,omitempty"`
 }
@@ -185,7 +186,8 @@ func ListEndpoint(ctx context.Context, request interface{}, userInfoGetter provi
 				StorageLocation:    item.Spec.StorageLocation,
 				ClusterID:          req.ClusterID,
 				TTL:                item.Spec.TTL.Duration.String(),
-				Labels:             item.Spec.LabelSelector,
+				Labels:             item.Spec.Labels,
+				LabelSelector:      item.Spec.LabelSelector,
 				Status:             string(item.Status.Phase),
 				CreatedAt:          apiv1.Time(item.GetObjectMeta().GetCreationTimestamp()),
 			},

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/template.html
@@ -161,6 +161,24 @@ END OF TERMS AND CONDITIONS
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="source">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-10">
+          <div fxLayout="row"
+               fxLayoutGap="2px"
+               fxLayoutAlign=" center">
+            <div>Source</div>
+            <i class="km-icon-info km-pointer"
+               matTooltip="Indicates whether this backup was created through KKP or uploaded externally."></i>
+          </div>
+        </th>
+        <td mat-cell
+            *matCellDef="let element">
+          <span>{{getBackupSource(element)}}</span>
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="TTL">
         <th mat-header-cell
             *matHeaderCellDef
@@ -185,8 +203,8 @@ END OF TERMS AND CONDITIONS
                fxLayoutGap="4px"
                fxLayoutAlign=" center">
             <div>Namespaces</div>
-            <div class="km-icon-info km-pointer"
-                 matTooltip="Number of namespaces in the backup"></div>
+            <i class="km-icon-info km-pointer"
+               matTooltip="Number of namespaces in the backup"></i>
           </div>
         </th>
         <td mat-cell

--- a/modules/web/src/app/shared/entity/backup.ts
+++ b/modules/web/src/app/shared/entity/backup.ts
@@ -168,6 +168,7 @@ export class ClusterBackupSpec {
   labelSelector?: {
     matchLabels?: Record<string, string>;
   };
+  labels?: Record<string, string>;
   status?: string;
   createdAt?: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new column in backups table to display source of cluster backups based on value of `system/backup-origin` label.

<img width="1418" alt="Screenshot 2025-05-21 at 10 48 08 PM" src="https://github.com/user-attachments/assets/9ee93590-9fe8-4366-9dc7-8c4e52eb008e" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7343 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Display source of cluster backups.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
