### PR TITLE
Display KubeVirt Subnet CIDRs in UI

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -35745,6 +35745,10 @@
       "type": "object",
       "title": "KubeVirtSubnet represents a KubeVirt Subnet.",
       "properties": {
+        "cidr": {
+          "type": "string",
+          "x-go-name": "CIDR"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"
@@ -40765,6 +40769,11 @@
       "type": "object",
       "title": "Subnet a smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).",
       "properties": {
+        "cidr": {
+          "description": "CIDR is the subnet IPV4 CIDR.",
+          "type": "string",
+          "x-go-name": "CIDR"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -73,7 +73,7 @@ require (
 	google.golang.org/api v0.232.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.10.0
-	k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.1.0.20250523173643-694b261d0ef9
+	k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.3.0.20250526164945-db7f68ecd04f
 	k8c.io/kubermatic/v2 v2.28.0-alpha.2.0.20250523173643-694b261d0ef9
 	k8c.io/machine-controller/sdk v0.0.0-20250520212857-7a93ac526de3
 	k8c.io/operating-system-manager v1.6.5

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1561,8 +1561,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.1.0.20250523173643-694b261d0ef9 h1:s5DeNg3YRFLhwyu60W5+gzYsSWzUFdeFh7+0/uOHWl8=
-k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.1.0.20250523173643-694b261d0ef9/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
+k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.3.0.20250526164945-db7f68ecd04f h1:RsBDn7wXRlxiH3cUlvKgikbt/9AIxL5XS/XKT5cDICg=
+k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.3.0.20250526164945-db7f68ecd04f/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
 k8c.io/kubermatic/v2 v2.28.0-alpha.2.0.20250523173643-694b261d0ef9 h1:qsGref5rKvUnk8eMms58Ud3RlomUZljsZiPoqLGyOdo=
 k8c.io/kubermatic/v2 v2.28.0-alpha.2.0.20250523173643-694b261d0ef9/go.mod h1:ASQ0QOyNiXm2hVbRjfMHr0SpIZVCP5bQx0aKNvAnwi8=
 k8c.io/machine-controller v1.61.1 h1:Zy3kg9t0WrDN0Wo3y/pAJp7jdkThcJt070f0fAL9MVc=

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1758,6 +1758,7 @@ type KubeVirtVPCList []KubeVirtVPC
 // swagger:model KubeVirtSubnet
 type KubeVirtSubnet struct {
 	Name string `json:"name"`
+	CIDR string `json:"cidr"`
 }
 
 // KubeVirtSubnetList represents an array of KubeVirt Subnets.

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -198,6 +198,7 @@ func KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 								if scRegions.HasAll(subnet.Regions...) && scZones.HasAll(subnet.Zones...) {
 									kvSubnet := apiv2.KubeVirtSubnet{
 										Name: subnet.Name,
+										CIDR: subnet.CIDR,
 									}
 
 									kvSubnets = append(kvSubnets, kvSubnet)
@@ -207,6 +208,7 @@ func KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 					} else {
 						kvSubnet := apiv2.KubeVirtSubnet{
 							Name: subnet.Name,
+							CIDR: subnet.CIDR,
 						}
 
 						kvSubnets = append(kvSubnets, kvSubnet)

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -468,16 +468,7 @@ func KubeVirtVPCSubnets(ctx context.Context, kubeconfig string, vpcName string) 
 		return nil, err
 	}
 
-	subnets, err := kubevirt.GetProviderNetworkSubnets(ctx, client, vpcName)
-	if err != nil {
-		return nil, err
-	}
-
-	var subnetAPIList apiv2.KubeVirtSubnetList
-	for _, subnet := range subnets {
-		subnetAPIList = append(subnetAPIList, apiv2.KubeVirtSubnet{Name: subnet})
-	}
-	return subnetAPIList, nil
+	return kubevirt.GetProviderNetworkSubnets(ctx, client, vpcName)
 }
 
 func instancetypeReconciler(w instancetypeWrapper) reconciling.NamedVirtualMachineInstancetypeReconcilerFactory {

--- a/modules/api/pkg/handler/v2/provider/kubevirt.go
+++ b/modules/api/pkg/handler/v2/provider/kubevirt.go
@@ -348,6 +348,7 @@ func KubeVirtSubnetsEndpoint(presetsProvider provider.PresetProvider, userInfoGe
 									if scRegions.HasAll(subnet.Regions...) && scZones.HasAll(subnet.Zones...) {
 										kvSubnet := apiv2.KubeVirtSubnet{
 											Name: subnet.Name,
+											CIDR: subnet.CIDR,
 										}
 
 										kvSubnets = append(kvSubnets, kvSubnet)
@@ -357,6 +358,7 @@ func KubeVirtSubnetsEndpoint(presetsProvider provider.PresetProvider, userInfoGe
 						} else {
 							kvSubnet := apiv2.KubeVirtSubnet{
 								Name: subnet.Name,
+								CIDR: subnet.CIDR,
 							}
 
 							kvSubnets = append(kvSubnets, kvSubnet)

--- a/modules/api/pkg/provider/cloud/kubevirt/networks.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/networks.go
@@ -18,6 +18,7 @@ package kubevirt
 
 import (
 	"context"
+	"fmt"
 
 	"k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt/providernetworks/kubeovn"
 
@@ -56,7 +57,8 @@ func GetProviderNetworkSubnets(ctx context.Context, client ctrlruntimeclient.Cli
 
 	subnets := make([]string, 0, len(subs))
 	for _, subnet := range subs {
-		subnets = append(subnets, subnet.Name)
+		subnetName := fmt.Sprintf("%v (%v)", subnet.Name, subnet.CIDRBlock)
+		subnets = append(subnets, subnetName)
 	}
 
 	return subnets, nil

--- a/modules/api/pkg/provider/cloud/kubevirt/networks.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/networks.go
@@ -18,8 +18,8 @@ package kubevirt
 
 import (
 	"context"
-	"fmt"
 
+	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	"k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt/providernetworks/kubeovn"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +44,7 @@ func GetProviderNetworkVPCs(ctx context.Context, client ctrlruntimeclient.Client
 	return vpcNames, nil
 }
 
-func GetProviderNetworkSubnets(ctx context.Context, client ctrlruntimeclient.Client, vpcName string) ([]string, error) {
+func GetProviderNetworkSubnets(ctx context.Context, client ctrlruntimeclient.Client, vpcName string) (apiv2.KubeVirtSubnetList, error) {
 	ovnProvider, err := kubeovn.New(client)
 	if err != nil {
 		return nil, nil
@@ -55,11 +55,10 @@ func GetProviderNetworkSubnets(ctx context.Context, client ctrlruntimeclient.Cli
 		return nil, err
 	}
 
-	subnets := make([]string, 0, len(subs))
+	var subnetAPIList apiv2.KubeVirtSubnetList
 	for _, subnet := range subs {
-		subnetName := fmt.Sprintf("%v (%v)", subnet.Name, subnet.CIDRBlock)
-		subnets = append(subnets, subnetName)
+		subnetAPIList = append(subnetAPIList, apiv2.KubeVirtSubnet{Name: subnet.Name, CIDR: subnet.CIDRBlock})
 	}
 
-	return subnets, nil
+	return subnetAPIList, nil
 }

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/kube_virt_subnet.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/kube_virt_subnet.go
@@ -17,6 +17,9 @@ import (
 // swagger:model KubeVirtSubnet
 type KubeVirtSubnet struct {
 
+	// c ID r
+	CIDR string `json:"cidr,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 }

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/subnet.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/subnet.go
@@ -17,6 +17,9 @@ import (
 // swagger:model Subnet
 type Subnet struct {
 
+	// CIDR is the subnet IPV4 CIDR.
+	CIDR string `json:"cidr,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -324,6 +324,10 @@ export class KubeVirtBasicNodeDataComponent
     return this._preferences?.preferences?.[group] || [];
   }
 
+  getSubnetOptionName(subnet: KubeVirtSubnet): string {
+    return subnet.name !== '' ? subnet.name + ' (' + subnet.cidr + ')' : subnet.name;
+  }
+
   preferenceDisplayName(preferenceId: string): string {
     if (preferenceId) {
       // only display name of selected preference

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -324,8 +324,18 @@ export class KubeVirtBasicNodeDataComponent
     return this._preferences?.preferences?.[group] || [];
   }
 
-  getSubnetOptionName(subnet: KubeVirtSubnet): string {
-    return subnet.name !== '' ? subnet.name + ' (' + subnet.cidr + ')' : subnet.name;
+  getSubnetOptionName(subnetName: string): string {
+    const subnet = this.subnets.find(subnet => subnet.name === subnetName);
+    if (!subnet) {
+      return subnetName;
+    }
+
+    let result = `${subnet.name}`;
+    if (subnet.cidr) {
+      result = `${result} (${subnet.cidr})`;
+    }
+
+    return `${result}`;
   }
 
   preferenceDisplayName(preferenceId: string): string {

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
@@ -119,7 +119,7 @@ limitations under the License.
                (changed)="onSubnetChange($event)"
                inputLabel="Select Subnet..."
                filterBy="name">
-    <div *option="let subnet">{{subnet.name}}</div>
+    <div *option="let subnet">{{getSubnetOptionName(subnet)}}</div>
   </km-combobox>
 
   <mat-card-header class="km-no-padding">

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/template.html
@@ -117,9 +117,10 @@ limitations under the License.
                hint="Use specific subnet for the machines. VPC needs to be selected first to use this option."
                [required]="isSubnetsRequired"
                (changed)="onSubnetChange($event)"
+               [valueFormatter]="getSubnetOptionName.bind(this)"
                inputLabel="Select Subnet..."
                filterBy="name">
-    <div *option="let subnet">{{getSubnetOptionName(subnet)}}</div>
+    <div *option="let subnet">{{getSubnetOptionName(subnet.name)}}</div>
   </km-combobox>
 
   <mat-card-header class="km-no-padding">

--- a/modules/web/src/app/shared/entity/provider/kubevirt.ts
+++ b/modules/web/src/app/shared/entity/provider/kubevirt.ts
@@ -93,6 +93,7 @@ export class KubeVirtVPC {
 
 export class KubeVirtSubnet {
   name: string;
+  cidr: string;
 }
 
 export class KubeVirtTopologySpreadConstraint {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR supports showing the kubevirt subnets CIDR in the UI. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Display KubeVirt Subnet CIDRs in UI
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
