### PR TITLE
Make subnets as required on kubevirt

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -305,7 +305,7 @@ export class KubeVirtBasicNodeDataComponent
   }
 
   get isSubnetsRequired(): boolean {
-    return !!this._clusterSpecService.cluster?.spec?.cloud?.kubevirt?.vpcName;
+    return !!this._clusterSpecService.cluster?.spec?.cloud?.kubevirt?.vpcName || this.subnets?.length > 0;
   }
 
   getInstanceTypeOptions(group: string): KubeVirtInstanceType[] {


### PR DESCRIPTION
**What this PR does / why we need it**:
in the case of using a preset that have vpcs then user need to chose a subnet (if they are exist)

**Which issue(s) this PR fixes:**
Fixes #7329

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
