### PR TITLE
Prepare for Alpha.5 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.28.0-alpha.4
+KUBERMATIC_VERSION?=v2.28.0-alpha.5
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.28.0-alpha.4
+KUBERMATIC_VERSION?=v2.28.0-alpha.5
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -73,8 +73,8 @@ require (
 	google.golang.org/api v0.232.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.10.0
-	k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.3.0.20250530073112-176b0de7682b
-	k8c.io/kubermatic/v2 v2.28.0-alpha.4.0.20250530110911-0f15adb86ffa
+	k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.4.0.20250530160510-3ffa9f57cf6f
+	k8c.io/kubermatic/v2 v2.28.0-alpha.4.0.20250530160510-3ffa9f57cf6f
 	k8c.io/machine-controller/sdk v0.0.0-20250520212857-7a93ac526de3
 	k8c.io/operating-system-manager v1.6.5
 	k8c.io/reconciler v0.5.0

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1561,10 +1561,10 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.3.0.20250530073112-176b0de7682b h1:kUYGXJ3go9rFSqXIQoT3LUTh/fjgp3LVHDX5Smv47J0=
-k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.3.0.20250530073112-176b0de7682b/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
-k8c.io/kubermatic/v2 v2.28.0-alpha.4.0.20250530110911-0f15adb86ffa h1:KJLpglWuRokcyIGO6zf6RzO/aLQh2b7i9y4+anj3CTs=
-k8c.io/kubermatic/v2 v2.28.0-alpha.4.0.20250530110911-0f15adb86ffa/go.mod h1:ASQ0QOyNiXm2hVbRjfMHr0SpIZVCP5bQx0aKNvAnwi8=
+k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.4.0.20250530160510-3ffa9f57cf6f h1:7qkrCB5ic+9ErXO8RdNc0/252ykth1QEJ/ZVYK63v+c=
+k8c.io/kubermatic/sdk/v2 v2.28.0-alpha.4.0.20250530160510-3ffa9f57cf6f/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
+k8c.io/kubermatic/v2 v2.28.0-alpha.4.0.20250530160510-3ffa9f57cf6f h1:HpJFCIDLqHgwHLIG9xnLb/SlGqQq9l4dK5RpYrdDM+s=
+k8c.io/kubermatic/v2 v2.28.0-alpha.4.0.20250530160510-3ffa9f57cf6f/go.mod h1:V5lajVicy75vJfPQsGD7gSwz8Kbv+3apfhGcvPsG8a0=
 k8c.io/machine-controller v1.61.1 h1:Zy3kg9t0WrDN0Wo3y/pAJp7jdkThcJt070f0fAL9MVc=
 k8c.io/machine-controller v1.61.1/go.mod h1:ZGDFyUeEp66RHcNB5Ki/OJyFdZFgo9dkHJ9s6YJWPcg=
 k8c.io/machine-controller/sdk v0.0.0-20250520212857-7a93ac526de3 h1:v+qpvb17Rl/0HDaT1pZW/Gp4xba0t+JLMx2B7plNgAs=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.28.0-alpha.4
+KUBERMATIC_VERSION?=v2.28.0-alpha.5
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.28.0-alpha.4",
+  "version": "2.28.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.28.0-alpha.4",
+      "version": "2.28.0-alpha.5",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.28.0-alpha.4",
+  "version": "2.28.0-alpha.5",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR prepares for the 2.28-alpha.5 release and bumps the KKP GO dependency. 
 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
