### PR TITLE
UI fixes for system applications

### DIFF
--- a/modules/web/src/app/shared/components/application-list/component.ts
+++ b/modules/web/src/app/shared/components/application-list/component.ts
@@ -12,7 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, EventEmitter, Input, OnDestroy, OnInit, Output, SimpleChanges, ViewChild} from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from '@angular/core';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {MatSort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
@@ -74,7 +84,7 @@ enum Column {
   styleUrls: ['style.scss'],
   standalone: false,
 })
-export class ApplicationListComponent implements OnInit, OnDestroy {
+export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
   @Input() applications: Application[] = [];
   @Input() cluster: Cluster;
   @Input() projectID: string;
@@ -187,6 +197,28 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
     return this.isEnforcedApplication(application) ? 'km-icon-mask km-icon-show' : 'km-icon-mask km-icon-edit';
   }
 
+  getApplicationType(application: Application): string {
+    if (this.isSystemApplication(application)) {
+      return 'System';
+    } else if (this.isDefaultedApplication(application)) {
+      return 'Default';
+    } else if (this.isEnforcedApplication(application)) {
+      return 'Enforced';
+    }
+    return '';
+  }
+
+  getApplicationTypeDescription(application: Application): string {
+    if (this.isSystemApplication(application)) {
+      return 'This is a system application managed by KKP.';
+    } else if (this.isDefaultedApplication(application)) {
+      return 'This application is automatically installed by default.';
+    } else if (this.isEnforcedApplication(application)) {
+      return 'This application is automatically installed and cannot be updated or deleted.';
+    }
+    return '';
+  }
+
   isSystemApplication(application: Application): boolean {
     return application.labels?.[ApplicationLabel.ManagedBy] === ApplicationLabelValue.KKP;
   }
@@ -288,7 +320,7 @@ export class ApplicationListComponent implements OnInit, OnDestroy {
 
   private get _visibleApplications(): Application[] {
     let filteredApplications = this.applications || [];
-    if (!this.showSystemApplications) {
+    if (!this.showSystemApplications && this.view === ApplicationsListView.Default) {
       filteredApplications = filteredApplications.filter(application => !this.isSystemApplication(application));
     }
     return filteredApplications;

--- a/modules/web/src/app/shared/components/application-list/style.scss
+++ b/modules/web/src/app/shared/components/application-list/style.scss
@@ -121,5 +121,9 @@ td .km-application-logo {
       font-size: variables.$font-size-subhead;
       margin-top: 15px;
     }
+
+    .km-label-primary {
+      max-width: max-content;
+    }
   }
 }

--- a/modules/web/src/app/shared/components/application-list/template.html
+++ b/modules/web/src/app/shared/components/application-list/template.html
@@ -83,8 +83,6 @@ limitations under the License.
                           fxLayoutAlign=" center"
                           fxLayoutGap="5px">
             <span>{{getApplicationName(application.name)}}</span>
-            <span *ngIf="isSystemApplication(application)"
-                  class="km-label-primary">System</span>
           </mat-card-title>
           <div *ngIf="view !== ApplicationListView.Summary"
                fxFlex
@@ -134,20 +132,15 @@ limitations under the License.
                  matTooltip="Application Resources Namespace"></i>
               <span>{{application.spec.namespace.name}}</span>
             </div>
-            <div *ngIf="isDefaultedApplication(application) || isEnforcedApplication(application)"
+            <div *ngIf="getApplicationType(application) as applicationType"
                  fxLayout="row"
                  fxLayoutGap="10px"
                  fxLayoutAlign=" center">
               <i class="km-icon-mask km-icon-default km-icon-warning-event"
                  matTooltip="Application Type"></i>
-              <span [matTooltip]="
-                  isEnforcedApplication(application)
-                    ? 'This application is automatically installed and cannot be updated or deleted.'
-                    : isDefaultedApplication(application)
-                    ? 'This application is automatically installed by default.'
-                    : ''">
-                {{ isEnforcedApplication(application) ? 'Enforced Application' : isDefaultedApplication(application) ?
-                'Default Application' : '' }}
+              <span class="km-label-primary"
+                    [matTooltip]="getApplicationTypeDescription(application)">
+                {{ applicationType }}
               </span>
             </div>
           </div>
@@ -194,8 +187,9 @@ limitations under the License.
             *matCellDef="let element"
             [attr.id]="'km-application-name-' + element.name">
           {{element.name}}
-          <span *ngIf="isSystemApplication(element)"
-                class="km-label-primary">System</span>
+          <span *ngIf="getApplicationType(element) as applicationType"
+                class="km-label-primary"
+                [matTooltip]="getApplicationTypeDescription(element)">{{applicationType}}</span>
         </td>
       </ng-container>
 

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -232,7 +232,7 @@ limitations under the License.
                                  [value]="cluster.spec.opaIntegration?.enabled">
             </km-property-boolean>
 
-            <km-property-boolean *ngIf="cluster.spec.kyverno.enabled"
+            <km-property-boolean *ngIf="cluster.spec.kyverno?.enabled"
                                  label="Kyverno Policy Management"
                                  [value]="cluster.spec.kyverno.enabled">
             </km-property-boolean>


### PR DESCRIPTION
**What this PR does / why we need it**:
- Display system applications in cluster creation wizard.
- Fix application type label for system applications.
- Make all application type labels look consistent.

**Cards View:**

<img width="1406" alt="Screenshot 2025-06-02 at 6 28 37 PM" src="https://github.com/user-attachments/assets/f8799924-37ad-4c0b-8deb-a3dee141d5e4" />

**Table View:**

<img width="1406" alt="Screenshot 2025-06-02 at 6 28 55 PM" src="https://github.com/user-attachments/assets/715daeaf-3c6a-4f45-94d9-c318dac7ea57" />

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Display system applications in cluster creation wizard and fix application type label for system applications.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
