### PR TITLE
Fix token cookie cleaning by passing path argument to delete method

### DIFF
--- a/modules/web/src/app/core/services/auth/service.ts
+++ b/modules/web/src/app/core/services/auth/service.ts
@@ -190,10 +190,8 @@ export class Auth {
   }
 
   private _deleteToken(): void {
-    if (this._cookieService.check(this._cookie.token)) {
-      this._cookieService.delete(this._cookie.token);
-      return;
-    }
+    this._cookieService.delete(this._cookie.token, '/');
+    this._tokenService.token = null;
     let count = 1;
     let tokenPart = this._cookieService.get(`${this._cookie.tokenPrefix}${count}`);
     while (tokenPart) {
@@ -201,7 +199,6 @@ export class Auth {
       count++;
       tokenPart = this._cookieService.get(`${this._cookie.tokenPrefix}${count}`);
     }
-    this._tokenService.token = null;
   }
 
   private _getTokenFromQuery(): string {


### PR DESCRIPTION
**What this PR does / why we need it**:
The `path` argument was missing while calling cookie delete method due to which token cookie was not being deleted. This would result in application using an invalid token hence rendering the dashboard useless until token cookie was deleted manually.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
