### PR TITLE
Fix: Add labels to backup objects created by a schedule.

### DIFF
--- a/modules/api/pkg/ee/clusterbackup/backup/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/backup/handler.go
@@ -64,7 +64,7 @@ const (
 	projectIdKey    = "system/project"
 	clusterIdKey    = "system/cluster"
 	backupOriginKey = "system/backup-origin"
-	backupOrigin    = "kkp-controllers"
+	BackupOrigin    = "kkp-controllers"
 )
 
 type clusterBackupUI struct {
@@ -102,9 +102,9 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 
 	// These labels are added to the Backup CR to distinguish between backups created via the KKP controllers and those uploaded through the UI.
 	if clusterBackup.Spec.Labels == nil {
-		clusterBackup.Spec.Labels = getLabels(backupOrigin, req.ProjectID, req.ClusterID)
+		clusterBackup.Spec.Labels = GetLabels(BackupOrigin, req.ProjectID, req.ClusterID)
 	} else {
-		for k, v := range getLabels(backupOrigin, req.ProjectID, req.ClusterID) {
+		for k, v := range GetLabels(BackupOrigin, req.ProjectID, req.ClusterID) {
 			clusterBackup.Spec.Labels[k] = v
 		}
 	}
@@ -129,7 +129,7 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 	}, nil
 }
 
-func getLabels(backupOrigin, projectID, clusterID string) map[string]string {
+func GetLabels(backupOrigin, projectID, clusterID string) map[string]string {
 	labels := make(map[string]string)
 	labels[projectIdKey] = projectID
 	labels[clusterIdKey] = clusterID

--- a/modules/api/pkg/ee/clusterbackup/schedule/handler.go
+++ b/modules/api/pkg/ee/clusterbackup/schedule/handler.go
@@ -87,6 +87,14 @@ func CreateEndpoint(ctx context.Context, request interface{}, userInfoGetter pro
 		},
 		Spec: *req.Body.Spec.DeepCopy(),
 	}
+	// These labels are added to the Backup CR to distinguish between backups created via the KKP controllers and those uploaded through the UI.
+	if backupSchedule.Spec.Template.Labels == nil {
+		backupSchedule.Spec.Template.Labels = clusterbackup.GetLabels(clusterbackup.BackupOrigin, req.ProjectID, req.ClusterID)
+	} else {
+		for k, v := range clusterbackup.GetLabels(clusterbackup.BackupOrigin, req.ProjectID, req.ClusterID) {
+			backupSchedule.Spec.Template.Labels[k] = v
+		}
+	}
 	client, err := handlercommon.GetClusterClientWithClusterID(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, req.ProjectID, req.ClusterID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `backupSpec.labels` to Schedule objects created via the KKP controllers. These labels help identify and distinguish controller-initiated backups from those manually uploaded via the UI. 


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cluster backup schedules created by KKP controllers now include backupSpec.labels to distinguish controller-initiated backups from those manually uploaded via the UI. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
