### PR TITLE
Use infra management user credentials (if configured) to fetch data for vSphere

### DIFF
--- a/modules/web/src/app/core/services/node-data/provider/vsphere.ts
+++ b/modules/web/src/app/core/services/node-data/provider/vsphere.ts
@@ -52,8 +52,12 @@ export class NodeDataVSphereProvider {
             switchMap(cluster =>
               this._presetService
                 .provider(NodeProvider.VSPHERE)
-                .username(cluster.spec.cloud.vsphere.username)
-                .password(cluster.spec.cloud.vsphere.password)
+                .username(
+                  cluster.spec.cloud.vsphere.infraManagementUser?.username || cluster.spec.cloud.vsphere.username
+                )
+                .password(
+                  cluster.spec.cloud.vsphere.infraManagementUser?.password || cluster.spec.cloud.vsphere.password
+                )
                 .credential(this._presetService.preset)
                 .datacenter(this._clusterSpecService.datacenter)
                 .tagCategories(onLoadingCb)
@@ -104,8 +108,12 @@ export class NodeDataVSphereProvider {
             switchMap(cluster =>
               this._presetService
                 .provider(NodeProvider.VSPHERE)
-                .username(cluster.spec.cloud.vsphere.username)
-                .password(cluster.spec.cloud.vsphere.password)
+                .username(
+                  cluster.spec.cloud.vsphere.infraManagementUser?.username || cluster.spec.cloud.vsphere.username
+                )
+                .password(
+                  cluster.spec.cloud.vsphere.infraManagementUser?.password || cluster.spec.cloud.vsphere.password
+                )
                 .credential(this._presetService.preset)
                 .datacenter(this._clusterSpecService.datacenter)
                 .tags(category, onLoadingCb)
@@ -153,8 +161,12 @@ export class NodeDataVSphereProvider {
             switchMap(cluster =>
               this._presetService
                 .provider(NodeProvider.VSPHERE)
-                .username(cluster.spec.cloud.vsphere.username)
-                .password(cluster.spec.cloud.vsphere.password)
+                .username(
+                  cluster.spec.cloud.vsphere.infraManagementUser?.username || cluster.spec.cloud.vsphere.username
+                )
+                .password(
+                  cluster.spec.cloud.vsphere.infraManagementUser?.password || cluster.spec.cloud.vsphere.password
+                )
                 .credential(this._presetService.preset)
                 .datacenter(this._clusterSpecService.datacenter)
                 .vmGroups(onLoadingCb)

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
@@ -284,9 +284,10 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
 
   hasRequiredCredentials(): boolean {
     return (
-      (!!this._clusterSpecService.cluster.spec.cloud.vsphere &&
-        !!this._clusterSpecService.cluster.spec.cloud.vsphere.username &&
-        !!this._clusterSpecService.cluster.spec.cloud.vsphere.password) ||
+      (!!this._clusterSpecService.cluster.spec.cloud.vsphere?.username &&
+        !!this._clusterSpecService.cluster.spec.cloud.vsphere?.password) ||
+      (!!this._clusterSpecService.cluster.spec.cloud.vsphere?.infraManagementUser?.username &&
+        !!this._clusterSpecService.cluster.spec.cloud.vsphere?.infraManagementUser?.password) ||
       (!!this._clusterSpecService.cluster.spec.cloud.vsphere && !!this._presets.preset)
     );
   }
@@ -298,8 +299,8 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
 
   private _handleClusterChange(cluster: Cluster): void {
     let markAsChanged = false;
-    const username = cluster.spec.cloud.vsphere.username;
-    const password = cluster.spec.cloud.vsphere.password;
+    const username = cluster.spec.cloud.vsphere.infraManagementUser?.username || cluster.spec.cloud.vsphere.username;
+    const password = cluster.spec.cloud.vsphere.infraManagementUser?.password || cluster.spec.cloud.vsphere.password;
 
     if (username !== this._username) {
       this._username = username;
@@ -352,8 +353,14 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
   private _networkListObservable(): Observable<VSphereNetwork[]> {
     return this._presets
       .provider(NodeProvider.VSPHERE)
-      .username(this._clusterSpecService.cluster.spec.cloud.vsphere.username)
-      .password(this._clusterSpecService.cluster.spec.cloud.vsphere.password)
+      .username(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.username ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.username
+      )
+      .password(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.password ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.password
+      )
       .datacenter(this._clusterSpecService.datacenter)
       .networks(this._onNetworksLoading.bind(this))
       .pipe(map(networks => _.sortBy(networks, n => n.name.toLowerCase())))
@@ -381,8 +388,14 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
   private _folderListObservable(): Observable<VSphereFolder[]> {
     return this._presets
       .provider(NodeProvider.VSPHERE)
-      .username(this._clusterSpecService.cluster.spec.cloud.vsphere.username)
-      .password(this._clusterSpecService.cluster.spec.cloud.vsphere.password)
+      .username(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.username ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.username
+      )
+      .password(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.password ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.password
+      )
       .datacenter(this._clusterSpecService.datacenter)
       .folders(this._onFoldersLoading.bind(this))
       .pipe(
@@ -396,8 +409,14 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
   private _tagCategoryListObservable(): Observable<VSphereTagCategory[]> {
     return this._presets
       .provider(NodeProvider.VSPHERE)
-      .username(this._clusterSpecService.cluster.spec.cloud.vsphere.username)
-      .password(this._clusterSpecService.cluster.spec.cloud.vsphere.password)
+      .username(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.username ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.username
+      )
+      .password(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.password ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.password
+      )
       .credential(this._presets.preset)
       .datacenter(this._clusterSpecService.datacenter)
       .tagCategories(this._onTagCategoryLoading.bind(this))
@@ -437,8 +456,14 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
   private _datastoresObservable(): Observable<string[]> {
     return this._presets
       .provider(NodeProvider.VSPHERE)
-      .username(this._clusterSpecService.cluster.spec.cloud.vsphere.username)
-      .password(this._clusterSpecService.cluster.spec.cloud.vsphere.password)
+      .username(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.username ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.username
+      )
+      .password(
+        this._clusterSpecService.cluster.spec.cloud.vsphere.infraManagementUser?.password ||
+          this._clusterSpecService.cluster.spec.cloud.vsphere.password
+      )
       .datacenter(this._clusterSpecService.datacenter)
       .datastores(() => this._setIsLoadingDatastores(true))
       .pipe(


### PR DESCRIPTION
**What this PR does / why we need it**:
If infra management user credentials are configured for vSphere, then those credentials should take priority over CCM user credentials for fetching data (e.g. folders, vmgroups, tags etc.).


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7383 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use infra management user credentials (if configured) to fetch data for vSphere.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
