### PR TITLE
[release/v2.27] bump KKP

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -31019,6 +31019,11 @@
       "type": "object",
       "title": "DatacenterSpecKubevirt describes a kubevirt datacenter.",
       "properties": {
+        "ccmLoadBalancerEnabled": {
+          "description": "Optional: indicates if the ccm should create and manage the clusters load balancers.",
+          "type": "boolean",
+          "x-go-name": "CCMLoadBalancerEnabled"
+        },
         "ccmZoneAndRegionEnabled": {
           "description": "Optional: indicates if region and zone labels from the cloud provider should be fetched.",
           "type": "boolean",

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,8 +70,8 @@ require (
 	google.golang.org/api v0.209.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.27.4-0.20250506093457-a0144c86d480
-	k8c.io/machine-controller v1.61.1
+	k8c.io/kubermatic/v2 v2.27.5-0.20250602165514-9b87866aaf37
+	k8c.io/machine-controller v1.61.2
 	k8c.io/operating-system-manager v1.6.5
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.31.3

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1147,10 +1147,10 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.27.4-0.20250506093457-a0144c86d480 h1:/7pobTFIaXpB5VfHVWbUaWGPMZvmo9T9uOSLTKtTlZA=
-k8c.io/kubermatic/v2 v2.27.4-0.20250506093457-a0144c86d480/go.mod h1:6gxHUzvh33Vwyq4kcg5BjxsiHSATdPH44LGpk1TxHPU=
-k8c.io/machine-controller v1.61.1 h1:Zy3kg9t0WrDN0Wo3y/pAJp7jdkThcJt070f0fAL9MVc=
-k8c.io/machine-controller v1.61.1/go.mod h1:ZGDFyUeEp66RHcNB5Ki/OJyFdZFgo9dkHJ9s6YJWPcg=
+k8c.io/kubermatic/v2 v2.27.5-0.20250602165514-9b87866aaf37 h1:NH12w8hDcVDHvJcqtW8pNwqFwRhAwQ696AkDwTnx1m4=
+k8c.io/kubermatic/v2 v2.27.5-0.20250602165514-9b87866aaf37/go.mod h1:TNysG/oe6ZZgfUlVxSdR3yHYMxxdJRLcFHV6+8aDnEg=
+k8c.io/machine-controller v1.61.2 h1:F1DQgrTRICkFUoxM3MReQ78HVG9ztXF0xPYPYSXQnJc=
+k8c.io/machine-controller v1.61.2/go.mod h1:ZGDFyUeEp66RHcNB5Ki/OJyFdZFgo9dkHJ9s6YJWPcg=
 k8c.io/operating-system-manager v1.6.5 h1:F7oBJKEv2t3uzG8k4e9s9j9vCAvXN1FGEkqV0+dMh60=
 k8c.io/operating-system-manager v1.6.5/go.mod h1:Dh9IZp5pb5G3s2r6ZrHUb+gTuHw5AmbIFYuFxIcgU7o=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/datacenter_spec_kubevirt.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/datacenter_spec_kubevirt.go
@@ -19,6 +19,9 @@ import (
 // swagger:model DatacenterSpecKubevirt
 type DatacenterSpecKubevirt struct {
 
+	// Optional: indicates if the ccm should create and manage the clusters load balancers.
+	CCMLoadBalancerEnabled bool `json:"ccmLoadBalancerEnabled,omitempty"`
+
 	// Optional: indicates if region and zone labels from the cloud provider should be fetched.
 	CCMZoneAndRegionEnabled bool `json:"ccmZoneAndRegionEnabled,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the KKP dependency to its latest 2.27.x version.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
