### PR TITLE
Kyverno bug fixes and enhancements

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/cluster-policies/add-policy-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/cluster-policies/add-policy-dialog/component.ts
@@ -51,7 +51,7 @@ export class AddPolicyDialogComponent implements OnInit, OnDestroy {
       .valueChanges.pipe(takeUntil(this._unsubscribe))
       .subscribe((template: PolicyTemplate) => {
         this.selectedTemplate = template;
-        if (template.spec.namespacedPolicy) {
+        if (template.spec?.namespacedPolicy) {
           this.form.get(Controls.Namespace).addValidators(Validators.required);
         } else {
           this.form.get(Controls.Namespace).clearValidators();

--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/cluster-policies/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/cluster-policies/component.ts
@@ -198,6 +198,9 @@ export class KyvernoClusterPoliciesListComponent implements OnInit, OnDestroy {
   }
 
   private _isMatchedLabel(key: string, value: string): boolean {
-    return this.cluster.labels[key] && this.cluster.labels[key] === value;
+    if (!this.cluster.labels) {
+      return false;
+    }
+    return !!this.cluster?.labels[key] && this.cluster?.labels[key] === value;
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/add-template/template.html
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/add-template/template.html
@@ -73,34 +73,26 @@ END OF TERMS AND CONDITIONS
       <mat-hint>Indicates the category this policy belongs to</mat-hint>
     </mat-form-field>
     <mat-form-field>
-      <mat-label>Scopes</mat-label>
-      <mat-select [formControlName]="controls.Scope">
-        <mat-option *ngFor="let scope of scopesArray"
-                    [value]="scope">{{scope}}</mat-option>
-      </mat-select>
+      <input [formControlName]="controls.Scope"
+             matInput>
       <mat-hint>Defines who is allowed to manage the template<i class="km-icon-info km-pointer"
            matTooltip="Global is managed by admins; project can be managed by admins and project owners."></i>
       </mat-hint>
-      <mat-error *ngIf="form.get(controls.Scope).hasError('required')">
-        <strong>Required</strong>
-      </mat-error>
     </mat-form-field>
-    <mat-form-field *ngIf="form.get(controls.Scope).value !== scopes.Global">
+    <mat-form-field *ngIf="form.get(controls.Scope).value === scopes.Project">
       <mat-label>Project</mat-label>
-      <mat-select [formControlName]="controls.Project">
-        <mat-option *ngFor="let project of projects"
-                    [value]="project.id">{{project.name}}</mat-option>
-      </mat-select>
+      <input [formControlName]="controls.Project"
+             matInput>
       <mat-hint>The project for which the policy template is created</mat-hint>
     </mat-form-field>
     <mat-checkbox [formControlName]="controls.Default">Default Policy
     </mat-checkbox>
     <i class="km-icon-info km-pointer"
-       matTooltip="Create a policy from this template upon creation."></i>
+       matTooltip="Default policies are automatically applied to new clusters. Users can delete them afterward."></i>
     <mat-checkbox [formControlName]="controls.Enforced">Enforce Policy
     </mat-checkbox>
     <i class="km-icon-info km-pointer"
-       matTooltip="Creates a policy from this template upon creation that users can't delete."></i>
+       matTooltip="Enforced policies will be applied to all targeted clusters. Users can't delete them."></i>
     <mat-checkbox [formControlName]="controls.NamespacedPolicy">Namespaced Policy
     </mat-checkbox>
     <km-label-form *ngIf="form.get(controls.Scope).value === scopes.Global"

--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/component.ts
@@ -38,7 +38,12 @@ import {
 import {NotificationService} from '@app/core/services/notification';
 import {MatSlideToggleChange} from '@angular/material/slide-toggle';
 import {ParamsService} from '@app/core/services/params';
+import {HealthStatus, StatusIcon} from '@app/shared/utils/health-status';
 
+enum PolicyTemplateStatus {
+  Active = 'Active',
+  Inactive = 'Inactive',
+}
 @Component({
   selector: 'km-kyverno-policiy-template-list',
   templateUrl: './template.html',
@@ -53,7 +58,7 @@ export class KyvernoPoliciyTemplateListComponent implements OnInit, OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
   dataSource = new MatTableDataSource<PolicyTemplate>();
   policyTemplates: PolicyTemplate[] = [];
-  columns = ['name', 'default', 'enforce', 'category', 'scope', 'actions'];
+  columns = ['status', 'name', 'default', 'enforce', 'category', 'scope', 'actions'];
   loadingTemplates = false;
   hasOwnerRole = false;
 
@@ -67,6 +72,9 @@ export class KyvernoPoliciyTemplateListComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.projectID = this._ParamsService.get('projectID');
+    if (!this.projectID) {
+      this.columns.shift();
+    }
     this.dataSource.sort = this.sort;
     this.dataSource.paginator = this.paginator;
     this.sort.direction = 'asc';
@@ -166,5 +174,12 @@ export class KyvernoPoliciyTemplateListComponent implements OnInit, OnDestroy {
         this._notificationService.success(`Update the ${template.name} policy template`);
         this.getPolicyTemplates();
       });
+  }
+
+  getStatusIcon(policyTemplate: PolicyTemplate): HealthStatus {
+    if (policyTemplate.spec.enforced || policyTemplate.spec.default) {
+      return new HealthStatus(PolicyTemplateStatus.Active, StatusIcon.Running);
+    }
+    return new HealthStatus(PolicyTemplateStatus.Inactive, StatusIcon.Stopped);
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/template.html
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/template.html
@@ -42,6 +42,18 @@ END OF TERMS AND CONDITIONS
            mat-table
            matSort
            [dataSource]="dataSource">
+      <ng-container *ngIf="projectID"
+                    matColumnDef="status">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell"></th>
+        <td mat-cell
+            *matCellDef="let element">
+          <i [matTooltip]="getStatusIcon(element)?.message"
+             [ngClass]="getStatusIcon(element)?.icon"
+             class="km-vertical-center"></i>
+        </td>
+      </ng-container>
       <ng-container matColumnDef="name">
         <th mat-header-cell
             *matHeaderCellDef
@@ -57,7 +69,7 @@ END OF TERMS AND CONDITIONS
             class="km-header-cell p-15">
           Default
           <div class="km-icon-info km-pointer tooltip"
-               matTooltip="Create a policy from this template."></div>
+               matTooltip="Default policies are automatically applied to new clusters. Users can delete them afterward."></div>
         </th>
         <td mat-cell
             *matCellDef="let element">


### PR DESCRIPTION
**What this PR does / why we need it**:

this PR fix: 

- Project scope policies should not be visible on the admin panel. By default admins can only add “Global” level policies.
- Policies on project level page limit usability because all policies are disabled. showing the status of policies
- Unable to add policy on a cluster because the “Add Policy” dialog doesn’t display any policies.
- Cluster scoped policy (using cluster label selector) is not visible on the cluster details page.
- Cluster and project label selector keys are not removed when editing a policy.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
