### PR TITLE
Rework KubeLB validation

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -597,6 +597,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     }
   }
 
+  isKubeLBEnabledForCluster(): boolean {
+    return !!this.cluster?.spec?.kubelb?.enabled;
+  }
+
   ngOnDestroy(): void {
     this._unsubscribe.next();
     this._unsubscribe.complete();

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -263,7 +263,7 @@ limitations under the License.
 
       <mat-checkbox [formControlName]="Controls.KubeLB"
                     [disabled]="isKubeLBEnforced"
-                    *ngIf="isEnterpriseEdition && isKubeLBEnabled"
+                    *ngIf="isEnterpriseEdition && (isKubeLBEnabled || isKubeLBEnabledForCluster())"
                     kmValueChangedIndicator>
         Kubermatic KubeLB
         <i class="km-icon-info km-pointer"


### PR DESCRIPTION
**What this PR does / why we need it**:
It should be possible to "uninstall" KubeLB from a cluster even if the KubeLB integration is disabled for the data center or the seed. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/dashboard/issues/7342#issuecomment-2937260429

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

These are mostly changes against https://github.com/kubermatic/dashboard/issues/7341, which is new feature for 2.28.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
