### PR TITLE
Update official depreciation links for equinox provide

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -30,7 +30,7 @@ limitations under the License.
       <div>
         Equinix Metal has been deprecated in KKP 2.28 and will be <strong>removed in KKP 2.29</strong>. Please plan your migration to a supported provider as soon as possible to ensure continued service. This change is due to Equinix's
         announcement to discontinue Equinix Metal service by June 2026. For more information, please refer to the
-        <a href="https://deploy.equinix.com/blog/sunsetting-equinix-metal"
+        <a href="https://docs.equinix.com/metal/#sunsetting-equinix-metal"
            target="_blank"
            rel="noopener noreferrer">official Equinix Metal Sunset Announcement</a>.
       </div>

--- a/modules/web/src/app/settings/admin/seed-configurations/seed-configurations-details/template.html
+++ b/modules/web/src/app/settings/admin/seed-configurations/seed-configurations-details/template.html
@@ -23,7 +23,7 @@ limitations under the License.
       <div>
         Equinix Metal has been deprecated in KKP 2.28 and will be <strong>removed in KKP 2.29</strong>. Please plan your migration to a supported provider as soon as possible to ensure continued service. This change is due to Equinix's
         announcement to discontinue Equinix Metal service by June 2026. For more information, please refer to the
-        <a href="https://deploy.equinix.com/blog/sunsetting-equinix-metal"
+        <a href="https://docs.equinix.com/metal/#sunsetting-equinix-metal"
            target="_blank"
            rel="noopener noreferrer">official Equinix Metal Sunset Announcement</a>.
       </div>

--- a/modules/web/src/app/wizard/step/provider-datacenter/template.html
+++ b/modules/web/src/app/wizard/step/provider-datacenter/template.html
@@ -44,7 +44,7 @@ limitations under the License.
     <div>
       Equinix Metal has been deprecated in KKP 2.28 and will be <strong>removed in KKP 2.29</strong>. Please plan your migration to a supported provider as soon as possible to ensure continued service. This change is due to Equinix's
       announcement to discontinue Equinix Metal service by June 2026. For more information, please refer to the
-      <a href="https://deploy.equinix.com/blog/sunsetting-equinix-metal"
+      <a href="https://docs.equinix.com/metal/#sunsetting-equinix-metal"
          target="_blank"
          rel="noopener noreferrer">official Equinix Metal Sunset Announcement</a>.
     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixed outdated link for officially sunsetting the Equivinx provider

Places Impact:

Provider Page:
![Screenshot 2025-06-04 at 5 43 02 PM](https://github.com/user-attachments/assets/e0f32d6e-7d3c-44bd-b0ff-7f32f988c882)

Cluster Details Page:
Cluster is not created therefore updated directly

Seed DataCenter Details Page:
![Screenshot 2025-06-04 at 5 22 42 PM](https://github.com/user-attachments/assets/b5ea00e6-e0b0-4b40-9e59-245cb770fb7b)


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
