### PR TITLE
Display help panel if there are announcements

### DIFF
--- a/modules/web/src/app/core/components/help-panel/component.ts
+++ b/modules/web/src/app/core/components/help-panel/component.ts
@@ -109,7 +109,8 @@ export class HelpPanelComponent implements OnInit, OnDestroy {
     return (
       !this.adminSettings.disableChangelogPopup ||
       this.adminSettings.displayAPIDocs ||
-      this.adminSettings.customLinks.some(link => link.location === CustomLinkLocation.HelpPanel)
+      this.adminSettings.customLinks.some(link => link.location === CustomLinkLocation.HelpPanel) ||
+      !!this.adminSettings.announcements
     );
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where if `Display API Docs` and `Display What's New` are disabled then Help Panel is hidden even if there are announcements which causes the announcements page to be unreachable.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
