### PR TITLE
Preserve CustomDiskSize checkbox value and fields on Edit Machine Deployment

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/openstack/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/openstack/component.ts
@@ -283,9 +283,11 @@ export class OpenstackBasicNodeDataComponent extends BaseFormValidator implement
         `PT${this._nodeDataService.nodeData.spec.cloud.openstack.instanceReadyCheckTimeout}`.toUpperCase()
       ).asSeconds();
 
+      const diskSize = this._nodeDataService.nodeData.spec.cloud.openstack.diskSize;
       this.form.get(Controls.UseFloatingIP).setValue(this._nodeDataService.nodeData.spec.cloud.openstack.useFloatingIP);
       this.form.get(Controls.Image).setValue(this._nodeDataService.nodeData.spec.cloud.openstack.image);
-      this.form.get(Controls.CustomDiskSize).setValue(this._nodeDataService.nodeData.spec.cloud.openstack.diskSize);
+      this.form.get(Controls.CustomDiskSize).setValue(diskSize);
+      this.form.get(Controls.UseCustomDisk).setValue(!!diskSize);
       this.form.get(Controls.InstanceReadyCheckPeriod).setValue(instanceReadyCheckPeriod);
       this.form.get(Controls.InstanceReadyCheckTimeout).setValue(instanceReadyCheckTimeout);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes to preserve "Custom Disk" checkbox in Edit Machine Deployment Dialog and display DiskSize field.


https://github.com/user-attachments/assets/6a0bf9e7-baf4-4099-a6ea-a74f169560a6


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7281 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Checks presence of diskSize in case of "Custom Disk" option is selected

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Shows custom disk fields when a custom disk is configured in the Machine Deployment edit dialog.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
