### PR TITLE
Reset tunnelingAgentIP based on expose strategy selection

### DIFF
--- a/modules/web/src/app/wizard/component.ts
+++ b/modules/web/src/app/wizard/component.ts
@@ -24,7 +24,7 @@ import {NotificationService} from '@core/services/notification';
 import {ProjectService} from '@core/services/project';
 import {WizardService} from '@core/services/wizard/wizard';
 import {SaveClusterTemplateDialogComponent} from '@shared/components/save-cluster-template/component';
-import {Cluster, CreateClusterModel, ExposeStrategy} from '@shared/entity/cluster';
+import {Cluster, CreateClusterModel} from '@shared/entity/cluster';
 import {Project} from '@shared/entity/project';
 import {OPERATING_SYSTEM_PROFILE_ANNOTATION} from '@shared/entity/machine-deployment';
 import {NodeData} from '@shared/model/NodeSpecChange';
@@ -287,9 +287,6 @@ export class WizardComponent implements OnInit, OnDestroy {
       },
       applications: applications,
     };
-    if (cluster.spec.exposeStrategy !== ExposeStrategy.tunneling) {
-      clusterModel.cluster.spec.clusterNetwork.tunnelingAgentIP = null;
-    }
     if (nodeData.operatingSystemProfile) {
       clusterModel.nodeDeployment.annotations = {
         ...clusterModel.nodeDeployment.annotations,

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -432,9 +432,17 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.get(Controls.APIServerAllowedIPRanges).valueChanges
     )
       .pipe(takeUntil(this._unsubscribe))
-      .subscribe(
-        _ => (this._clusterSpecService.cluster.spec.apiServerAllowedIPRanges = this.getAPIServerAllowedIPRange())
-      );
+      .subscribe(_ => {
+        this._clusterSpecService.cluster.spec.apiServerAllowedIPRanges = this.getAPIServerAllowedIPRange();
+
+        const exposeStrategy = this.form.get(Controls.ExposeStrategy).value;
+        const clusterNetwork = this._clusterSpecService.cluster.spec.clusterNetwork;
+        if (exposeStrategy === ExposeStrategy.tunneling) {
+          clusterNetwork.tunnelingAgentIP = clusterNetwork.tunnelingAgentIP || '100.64.30.10';
+        } else {
+          clusterNetwork.tunnelingAgentIP = null;
+        }
+      });
 
     merge(this.form.get(Controls.CNIPlugin).valueChanges, this.form.get(Controls.CNIPluginVersion).valueChanges)
       .pipe(takeUntil(this._unsubscribe))

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -437,9 +437,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
         const exposeStrategy = this.form.get(Controls.ExposeStrategy).value;
         const clusterNetwork = this._clusterSpecService.cluster.spec.clusterNetwork;
-        if (exposeStrategy === ExposeStrategy.tunneling) {
-          clusterNetwork.tunnelingAgentIP = clusterNetwork.tunnelingAgentIP || '100.64.30.10';
-        } else {
+        if (exposeStrategy !== ExposeStrategy.tunneling) {
           clusterNetwork.tunnelingAgentIP = null;
         }
       });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows saving the cluster/cluster template when the expose strategy is set to NodePort or LoadBalancer.

**Video:** 

https://github.com/user-attachments/assets/8b004f10-ea60-4a8a-9e0a-0983f3686add


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7302 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix validation error when switching expose strategy from Tunneling to LoadBalancer by clearing tunnelingAgentIP automatically.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
