### PR TITLE
Allow manual installation of system applications except with type `cni`

### DIFF
--- a/modules/web/src/app/shared/components/application-list/add-application-dialog/component.ts
+++ b/modules/web/src/app/shared/components/application-list/add-application-dialog/component.ts
@@ -149,7 +149,7 @@ export class AddApplicationDialogComponent implements OnInit, OnChanges, OnDestr
 
   private get _allowedApplicationDefinitions() {
     return this.applicationDefinitions?.filter(
-      appDef => !appDef.labels || appDef.labels[ApplicationLabel.ManagedBy] !== ApplicationLabelValue.KKP
+      appDef => !appDef.labels || appDef.labels[ApplicationLabel.Type] !== ApplicationLabelValue.CNI
     );
   }
 

--- a/modules/web/src/app/shared/components/application-list/component.ts
+++ b/modules/web/src/app/shared/components/application-list/component.ts
@@ -118,7 +118,7 @@ export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
   applicationsSourceMap: ApplicationSourceMap = {};
   applicationsStatusMap: ApplicationStatusMap = {};
   editionVersion: string = getEditionVersion();
-  showSystemApplications = false;
+  showSystemApplications = true;
 
   private readonly _unsubscribe: Subject<void> = new Subject<void>();
 
@@ -320,7 +320,7 @@ export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
 
   private get _visibleApplications(): Application[] {
     let filteredApplications = this.applications || [];
-    if (!this.showSystemApplications && this.view === ApplicationsListView.Default) {
+    if (!this.showSystemApplications) {
       filteredApplications = filteredApplications.filter(application => !this.isSystemApplication(application));
     }
     return filteredApplications;

--- a/modules/web/src/app/shared/entity/application.ts
+++ b/modules/web/src/app/shared/entity/application.ts
@@ -158,6 +158,7 @@ export namespace ApplicationMethod {
 
 export enum ApplicationLabel {
   ManagedBy = 'apps.kubermatic.k8c.io/managed-by',
+  Type = 'apps.kubermatic.k8c.io/type',
 }
 
 export enum ApplicationAnnotations {
@@ -168,6 +169,7 @@ export enum ApplicationAnnotations {
 
 export enum ApplicationLabelValue {
   KKP = 'kkp',
+  CNI = 'cni',
 }
 
 export function getApplicationLogoData(applicationDefinition: ApplicationDefinition): string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds functionality to allow manually installing system applications except with type `cni`. This is useful especially for installing cluster autoscaler application after cluster creation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow manual installation of system applications except with type `cni`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
