### PR TITLE
Removing TenantID filter for listing openstack networks

### DIFF
--- a/modules/api/pkg/provider/cloud/openstack/provider.go
+++ b/modules/api/pkg/provider/cloud/openstack/provider.go
@@ -125,7 +125,7 @@ func GetNetworks(ctx context.Context, authURL, region string, credentials *resou
 		return nil, fmt.Errorf("couldn't get auth client: %w", err)
 	}
 
-	networks, err := getAllNetworks(authClient, osnetworks.ListOpts{TenantID: credentials.ProjectID})
+	networks, err := getAllNetworks(authClient, osnetworks.ListOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get networks: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the TenantID filter to get all the floating IP pools, including the shared ones.
**Which issue(s) this PR fixes**:
Fixes #7436

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
List all OpenStack networks in the UI wizard during cluster creation.
```

**Documentation**:
```documentation
NONE
```
