### PR TITLE
prepare for 2.28.0-rc.1

### DIFF
--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -73,8 +73,8 @@ require (
 	google.golang.org/api v0.232.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.10.0
-	k8c.io/kubermatic/sdk/v2 v2.28.0-rc.0.0.20250610072617-e4e12ca87461
-	k8c.io/kubermatic/v2 v2.28.0-rc.0.0.20250610072617-e4e12ca87461
+	k8c.io/kubermatic/sdk/v2 v2.28.0-rc.0.0.20250619121543-6b33828d5bb9
+	k8c.io/kubermatic/v2 v2.28.0-rc.0.0.20250619121543-6b33828d5bb9
 	k8c.io/machine-controller/sdk v0.0.0-20250609084715-bab47c4563be
 	k8c.io/operating-system-manager v1.6.5
 	k8c.io/reconciler v0.5.0

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1561,10 +1561,10 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/sdk/v2 v2.28.0-rc.0.0.20250610072617-e4e12ca87461 h1:wgQVnqkmIct6U4y5tKM/v1zLdyTN5CTDJQFoarjAfyA=
-k8c.io/kubermatic/sdk/v2 v2.28.0-rc.0.0.20250610072617-e4e12ca87461/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
-k8c.io/kubermatic/v2 v2.28.0-rc.0.0.20250610072617-e4e12ca87461 h1:bcwM+/XmEX+CHgPcE+90Zm7OvtQ3rWgbVXhaV6Pi8zE=
-k8c.io/kubermatic/v2 v2.28.0-rc.0.0.20250610072617-e4e12ca87461/go.mod h1:7ogG1JT3NiApyT3Q9jnwitO2fo327wmI34xGBzwhVnE=
+k8c.io/kubermatic/sdk/v2 v2.28.0-rc.0.0.20250619121543-6b33828d5bb9 h1:fVb95UlPhBGlgsWm1b2KBhI8W+Abuq89z5SwuHqviJM=
+k8c.io/kubermatic/sdk/v2 v2.28.0-rc.0.0.20250619121543-6b33828d5bb9/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
+k8c.io/kubermatic/v2 v2.28.0-rc.0.0.20250619121543-6b33828d5bb9 h1:a85pa/oFqSGEGZWZBcqUUddoSYPuukj09dh8eWTi6qM=
+k8c.io/kubermatic/v2 v2.28.0-rc.0.0.20250619121543-6b33828d5bb9/go.mod h1:7ogG1JT3NiApyT3Q9jnwitO2fo327wmI34xGBzwhVnE=
 k8c.io/machine-controller v1.61.1 h1:Zy3kg9t0WrDN0Wo3y/pAJp7jdkThcJt070f0fAL9MVc=
 k8c.io/machine-controller v1.61.1/go.mod h1:ZGDFyUeEp66RHcNB5Ki/OJyFdZFgo9dkHJ9s6YJWPcg=
 k8c.io/machine-controller/sdk v0.0.0-20250609084715-bab47c4563be h1:LKNrVjJJUyqyhhAAI00NGf82e/RmzzN71yulCLmSk5g=


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bump KKP GO dependency to prepare for 2.28.0rc.1
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
