### PR TITLE
Set default backup sync period to null if value is empty

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -192,7 +192,7 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
           prefix: this.form.get(Controls.Prefix).value,
           caCert: this.form.get(Controls.CaCert).value,
         },
-        backupSyncPeriod: this.form.get(Controls.BackupSyncPeriod).value,
+        backupSyncPeriod: this.form.get(Controls.BackupSyncPeriod).value === '' ? null : this.form.get(Controls.BackupSyncPeriod).value,
         config: {
           region: this.form.get(Controls.Region).value,
           s3Url: this.form.get(Controls.Endpoints).value,

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -192,7 +192,8 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
           prefix: this.form.get(Controls.Prefix).value,
           caCert: this.form.get(Controls.CaCert).value,
         },
-        backupSyncPeriod: this.form.get(Controls.BackupSyncPeriod).value === '' ? null : this.form.get(Controls.BackupSyncPeriod).value,
+        backupSyncPeriod:
+          this.form.get(Controls.BackupSyncPeriod).value === '' ? null : this.form.get(Controls.BackupSyncPeriod).value,
         config: {
           region: this.form.get(Controls.Region).value,
           s3Url: this.form.get(Controls.Endpoints).value,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets the default backupSyncPeriod to null if the form value is an empty string.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7222 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unset backup sync period if value is empty.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
