### PR TITLE
Prevent project viewer from creating cluster templates

### DIFF
--- a/modules/api/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/modules/api/pkg/handler/v2/cluster_template/cluster_template.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v3"
-
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	handlercommon "k8c.io/dashboard/v2/pkg/handler/common"
@@ -335,7 +334,7 @@ func getClusterTemplate(ctx context.Context, projectProvider provider.ProjectPro
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	userInfo, err := userInfoGetter(ctx, "")
+	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -436,7 +435,7 @@ func createOrUpdateClusterTemplate(ctx context.Context, userInfoGetter provider.
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	adminUserInfo, err := userInfoGetter(ctx, "")
+	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -483,7 +482,7 @@ func createOrUpdateClusterTemplate(ctx context.Context, userInfoGetter provider.
 
 	newClusterTemplate.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation] = partialCluster.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]
 
-	newClusterTemplate.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey] = adminUserInfo.Email
+	newClusterTemplate.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey] = userInfo.Email
 	newClusterTemplate.Labels[kubermaticv1.ClusterTemplateProjectLabelKey] = project.Name
 	newClusterTemplate.Labels[kubermaticv1.ClusterTemplateScopeLabelKey] = scope
 	newClusterTemplate.Labels[kubermaticv1.ClusterTemplateHumanReadableNameLabelKey] = name
@@ -516,7 +515,7 @@ func createOrUpdateClusterTemplate(ctx context.Context, userInfoGetter provider.
 		}
 	}
 
-	ct, err := clusterTemplateProvider.CreateorUpdate(ctx, adminUserInfo, newClusterTemplate, scope, project.Name, isUpdateRequest)
+	ct, err := clusterTemplateProvider.CreateorUpdate(ctx, userInfo, newClusterTemplate, scope, project.Name, isUpdateRequest)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -536,7 +535,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		userInfo, err := userInfoGetter(ctx, "")
+		userInfo, err := userInfoGetter(ctx, req.ProjectID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/modules/api/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/modules/api/pkg/handler/v2/cluster_template/cluster_template.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v3"
+
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	handlercommon "k8c.io/dashboard/v2/pkg/handler/common"

--- a/modules/api/pkg/handler/v2/cluster_template/cluster_template_test.go
+++ b/modules/api/pkg/handler/v2/cluster_template/cluster_template_test.go
@@ -146,6 +146,48 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
+		// scenario 7
+		{
+			Name:             "scenario 7: viewer can't create cluster template in user scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"user","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope user"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 8
+		{
+			Name:             "scenario 8: viewer can't create cluster template in project scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"project","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope project"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 9
+		{
+			Name:             "scenario 9: viewer can't create cluster template in global scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"global","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":500,"message":"the global scope is reserved only for admins"}}`,
+			HTTPStatus:       http.StatusInternalServerError,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
 	}
 
 	dummyKubermaticConfiguration := kubermaticv1.KubermaticConfiguration{
@@ -548,6 +590,20 @@ func TestDeleteClusterTemplates(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
+		// scenario 6
+		{
+			Name:             "scenario 6: viewer can't delete cluster template",
+			TemplateID:       "ctID6",
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't delete template ctID6"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+				test.GenClusterTemplate("ct6", "ctID6", test.GenDefaultProject().Name, kubermaticv1.UserClusterTemplateScope, "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
 	}
 
 	for _, tc := range testcases {
@@ -828,6 +884,48 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 				},
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
+		},
+		// scenario 5
+		{
+			Name:             "scenario 5: viewer can't import cluster template in user scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"user","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope user"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 6
+		{
+			Name:             "scenario 6: viewer can't import cluster template in project scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"project","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope project"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 7
+		{
+			Name:             "scenario 7: viewer can't import cluster template in global scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"global","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":500,"message":"the global scope is reserved only for admins"}}`,
+			HTTPStatus:       http.StatusInternalServerError,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
 		},
 	}
 

--- a/modules/api/pkg/handler/v2/cluster_template/cluster_template_test.go
+++ b/modules/api/pkg/handler/v2/cluster_template/cluster_template_test.go
@@ -150,7 +150,7 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 7: viewer can't create cluster template in user scope",
 			Body:             fmt.Sprintf(`{"name":"test","scope":"user","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
-			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope user"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -164,7 +164,7 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 8: viewer can't create cluster template in project scope",
 			Body:             fmt.Sprintf(`{"name":"test","scope":"project","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
-			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope project"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -594,7 +594,7 @@ func TestDeleteClusterTemplates(t *testing.T) {
 		{
 			Name:             "scenario 6: viewer can't delete cluster template",
 			TemplateID:       "ctID6",
-			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't delete template ctID6"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot delete cluster templates regardless of any scope"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
 				test.GenTestSeed(),
@@ -889,7 +889,7 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 5: viewer can't import cluster template in user scope",
 			Body:             fmt.Sprintf(`{"name":"test","scope":"user","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
-			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope user"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -903,7 +903,7 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 		{
 			Name:             "scenario 6: viewer can't import cluster template in project scope",
 			Body:             fmt.Sprintf(`{"name":"test","scope":"project","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
-			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com can't create or update cluster templates in scope project"}}`,
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
 			HTTPStatus:       http.StatusForbidden,
 			ProjectToSync:    test.GenDefaultProject().Name,
 			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(

--- a/modules/api/pkg/provider/kubernetes/cluster_template.go
+++ b/modules/api/pkg/provider/kubernetes/cluster_template.go
@@ -68,7 +68,7 @@ func (p *ClusterTemplateProvider) CreateorUpdate(ctx context.Context, userInfo *
 	}
 
 	if userInfo.Roles.Has("viewers") && userInfo.Roles.Len() == 1 {
-		return nil, utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't create or update cluster templates in scope %s", userInfo.Email, scope))
+		return nil, utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s has viewer role and cannot create or update cluster templates regardless of any scope", userInfo.Email))
 	}
 
 	if scope == kubermaticv1.ProjectClusterTemplateScope && projectID == "" {
@@ -181,7 +181,7 @@ func (p *ClusterTemplateProvider) Delete(ctx context.Context, userInfo *provider
 	}
 
 	if userInfo.Roles.Has("viewers") && userInfo.Roles.Len() == 1 {
-		return utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't delete template %s", userInfo.Email, templateID))
+		return utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s has viewer role and cannot delete cluster templates regardless of any scope", userInfo.Email))
 	}
 
 	return p.clientPrivileged.Delete(ctx, result)

--- a/modules/api/pkg/provider/kubernetes/cluster_template.go
+++ b/modules/api/pkg/provider/kubernetes/cluster_template.go
@@ -67,8 +67,8 @@ func (p *ClusterTemplateProvider) CreateorUpdate(ctx context.Context, userInfo *
 		return nil, errors.New("the global scope is reserved only for admins")
 	}
 
-	if userInfo.Roles.Has("viewers") && userInfo.Roles.Len() == 1 && scope != kubermaticv1.UserClusterTemplateScope {
-		return nil, fmt.Errorf("viewer is not allowed to create cluster template for the %s scope", scope)
+	if userInfo.Roles.Has("viewers") && userInfo.Roles.Len() == 1 {
+		return nil, utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't create or update cluster templates in scope %s", userInfo.Email, scope))
 	}
 
 	if scope == kubermaticv1.ProjectClusterTemplateScope && projectID == "" {
@@ -177,6 +177,10 @@ func (p *ClusterTemplateProvider) Delete(ctx context.Context, userInfo *provider
 
 	// only admin can delete global templates
 	if !userInfo.IsAdmin && result.Labels[kubermaticv1.ClusterTemplateScopeLabelKey] == kubermaticv1.GlobalClusterTemplateScope {
+		return utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't delete template %s", userInfo.Email, templateID))
+	}
+
+	if userInfo.Roles.Has("viewers") && userInfo.Roles.Len() == 1 {
 		return utilerrors.New(http.StatusForbidden, fmt.Sprintf("user %s can't delete template %s", userInfo.Email, templateID))
 	}
 

--- a/modules/web/src/app/cluster-template/component.ts
+++ b/modules/web/src/app/cluster-template/component.ts
@@ -277,9 +277,13 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
       case ClusterTemplateScope.Global:
         return this.isAdmin;
       case ClusterTemplateScope.User:
-        return this.isAdmin || this.currentUser.email === template.user;
+        return this.isAdmin || this._isTemplateOwner(template);
       case ClusterTemplateScope.Project:
         return this.can(permission);
     }
+  }
+
+  private _isTemplateOwner(template: ClusterTemplate): boolean {
+    return this.currentUser?.email === template.user;
   }
 }

--- a/modules/web/src/app/cluster-template/component.ts
+++ b/modules/web/src/app/cluster-template/component.ts
@@ -51,6 +51,8 @@ import {filter, startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators
   standalone: false,
 })
 export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
+  readonly Permission = Permission;
+
   templates: ClusterTemplate[] = [];
   templateDatacenterMap: Map<string, Datacenter> = new Map<string, Datacenter>();
   isInitializing = true;
@@ -84,6 +86,9 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     private readonly _notificationService: NotificationService
   ) {}
 
+  get isAdmin(): boolean {
+    return !!this.currentUser?.isAdmin;
+  }
   ngOnInit(): void {
     this._setupList();
     this._loadUser();
@@ -181,29 +186,12 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     return Cluster.getProvider(cluster);
   }
 
-  canCreate(): boolean {
-    return MemberUtils.hasPermission(
-      this.currentUser,
-      this._currentGroupConfig,
-      View.ClusterTemplates,
-      Permission.Create
+  can(permission: Permission): boolean {
+    return (
+      this.currentUser &&
+      this._currentGroupConfig &&
+      MemberUtils.hasPermission(this.currentUser, this._currentGroupConfig, View.ClusterTemplates, permission)
     );
-  }
-
-  canEdit(template: ClusterTemplate): boolean {
-    switch (template.scope) {
-      case ClusterTemplateScope.Global:
-        return this.currentUser.isAdmin;
-      case ClusterTemplateScope.User:
-        return this.currentUser.isAdmin || this.currentUser.email === template.user;
-      case ClusterTemplateScope.Project:
-        return MemberUtils.hasPermission(
-          this.currentUser,
-          this._currentGroupConfig,
-          View.ClusterTemplates,
-          Permission.Edit
-        );
-    }
   }
 
   create(): void {
@@ -212,20 +200,12 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
+  canEdit(template: ClusterTemplate): boolean {
+    return this._canModify(template, Permission.Edit);
+  }
+
   canDelete(template: ClusterTemplate): boolean {
-    switch (template.scope) {
-      case ClusterTemplateScope.Global:
-        return this.currentUser.isAdmin;
-      case ClusterTemplateScope.User:
-        return this.currentUser.isAdmin || this.currentUser.email === template.user;
-      case ClusterTemplateScope.Project:
-        return MemberUtils.hasPermission(
-          this.currentUser,
-          this._currentGroupConfig,
-          View.ClusterTemplates,
-          Permission.Delete
-        );
-    }
+    return this._canModify(template, Permission.Delete);
   }
 
   delete(template: ClusterTemplate): void {
@@ -290,5 +270,16 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     this._projectService.onProjectChange.pipe(startWith({id}), takeUntil(this._unsubscribe)).subscribe(({id}) => {
       component.projectId = id;
     });
+  }
+
+  private _canModify(template: ClusterTemplate, permission: Permission): boolean {
+    switch (template.scope) {
+      case ClusterTemplateScope.Global:
+        return this.isAdmin;
+      case ClusterTemplateScope.User:
+        return this.isAdmin || this.currentUser.email === template.user;
+      case ClusterTemplateScope.Project:
+        return this.can(permission);
+    }
   }
 }

--- a/modules/web/src/app/cluster-template/template.html
+++ b/modules/web/src/app/cluster-template/template.html
@@ -29,16 +29,16 @@ limitations under the License.
         <router-outlet name="quota-widget"
                        (activate)="onActivate($event)"></router-outlet>
       </div>
-      <button mat-flat-button
-              type="button"
-              [matTooltip]="projectViewOnlyToolTip"
-              [matTooltipDisabled]="canCreate()"
-              (click)="create()"
-              [disabled]="!canCreate() || isGroupConfigLoading">
-        <i class="km-icon-mask km-icon-add"
-           matButtonIcon></i>
-        <span>Create Cluster Template</span>
-      </button>
+      <span [matTooltip]="!can(Permission.Create) ? projectViewOnlyToolTip : ''">
+        <button mat-flat-button
+                type="button"
+                (click)="create()"
+                [disabled]="!can(Permission.Create) || isGroupConfigLoading">
+          <i class="km-icon-mask km-icon-add"
+             matButtonIcon></i>
+          <span>Create Cluster Template</span>
+        </button>
+      </span>
     </div>
   </div>
 

--- a/modules/web/src/assets/config/userGroupConfig.json
+++ b/modules/web/src/assets/config/userGroupConfig.json
@@ -30,7 +30,7 @@
       "create": true,
       "delete": true
     },
-    "clusterTemplates": {
+    "clustertemplates": {
       "view": true,
       "edit": true,
       "create": true,
@@ -116,7 +116,7 @@
       "create": true,
       "delete": true
     },
-    "clusterTemplates": {
+    "clustertemplates": {
       "view": true,
       "edit": true,
       "create": true,
@@ -202,7 +202,7 @@
       "create": false,
       "delete": false
     },
-    "clusterTemplates": {
+    "clustertemplates": {
       "view": true,
       "edit": false,
       "create": false,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents users with the Project Viewer role from creating cluster templates. Viewers will now only have read-only access.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7409 



**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

In the video, the Edit/Delete buttons on the cluster template list page are enabled based on existing permissions defined by the template scope.

See Template Scope  Permission  [here](https://github.com/kubermatic/dashboard/pull/7446/files#diff-e2469aa9f9189ca73cb2aae2f33b0f6e493ae82de9e58a81dd8ad8688cb3834bR274)

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Project viewers can now only view cluster templates and can no longer create them on Viewer mode
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
