### PR TITLE
Moving web-terminal clean job to seed

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -12657,13 +12657,6 @@
         "parameters": [
           {
             "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -12675,6 +12668,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {
@@ -13317,12 +13317,6 @@
         "parameters": [
           {
             "type": "string",
-            "x-go-name": "StorageClassName",
-            "name": "storageClassName",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13334,6 +13328,12 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "StorageClassName",
+            "name": "storageClassName",
+            "in": "query"
           }
         ],
         "responses": {

--- a/modules/api/pkg/watcher/types.go
+++ b/modules/api/pkg/watcher/types.go
@@ -32,6 +32,7 @@ type Providers struct {
 	PrivilegedProjectProvider provider.PrivilegedProjectProvider
 	UserInfoGetter            provider.UserInfoGetter
 	SeedsGetter               provider.SeedsGetter
+	SeedClientGetter          provider.SeedClientGetter
 	ClusterProviderGetter     provider.ClusterProviderGetter
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Move the web-terminal cleanup job from the user cluster to the seed cluster, but keep it in the user cluster’s namespace. This way, the job will use the admin kubeconfig, so a refresh token won’t be required.

**Which issue(s) this PR fixes**:
Fixes #7268 

**What type of PR is this?**
/kind bug



**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Move web-terminal cleanup job to seed to fix cleanup not working when the token is expired.
```

**Documentation**:
```documentation
NONE
```
