### PR TITLE
KubeLB: Fix a bug with kubelb enforcement

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -258,6 +258,12 @@ export class EditClusterComponent implements OnInit, OnDestroy {
           seedSettings?.kubelb?.enableForAllDatacenters
         );
         this.isKubeLBEnforced = !!datacenter.spec.kubelb?.enforced;
+
+        // If KubeLB is enforced, we need to enable the kubelb control
+        if (this.isKubeLBEnforced) {
+          this.form.get(Controls.KubeLB).setValue(true);
+        }
+
         this.isCSIDriverDisabled = datacenter.spec.disableCsiDriver;
         this._provider = datacenter.spec.provider;
         this.isAllowedIPRangeSupported = (NODEPORTS_IPRANGES_SUPPORTED_PROVIDERS as string[]).includes(this._provider);

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -278,6 +278,11 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
           this.isDualStackAllowed = !!datacenter.spec.ipv6Enabled;
           this.isKubeLBEnforced = !!datacenter.spec.kubelb?.enforced;
 
+          // If KubeLB is enforced, we need to enable the kubelb control
+          if (this.isKubeLBEnforced) {
+            this.form.get(Controls.KubeLB).setValue(true);
+          }
+
           if (datacenter.spec.kubelb?.enableGatewayAPI) {
             this.form.get(Controls.KubeLBEnableGatewayAPI).setValue(true);
           }


### PR DESCRIPTION
**What this PR does / why we need it**:
When KubeLB was enforced for a datacenter, we were not "enabling" KubeLB which results in it not being deployed for the cluster and users can't change it afterwards as well since it's a disabled control in the UI.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeLB: Fix a bug where enforcement on a datacenter was not enabling KubeLB for the user clusters in the dashboard.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
