### PR TITLE
Fix KubeLB checkbox state tooltip and rendering issues

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -261,16 +261,17 @@ limitations under the License.
         Kubernetes Dashboard
       </mat-checkbox>
 
-      <mat-checkbox [formControlName]="Controls.KubeLB"
-                    [disabled]="isKubeLBEnforced"
-                    *ngIf="isEnterpriseEdition && (isKubeLBEnabled || isKubeLBEnabledForCluster())"
-                    kmValueChangedIndicator>
-        Kubermatic KubeLB
+      <div fxLayout="row" fxLayoutAlign=" center" *ngIf="isEnterpriseEdition && (isKubeLBEnabled || isKubeLBEnabledForCluster())">
+        <mat-checkbox [formControlName]="Controls.KubeLB"
+                      [disabled]="isKubeLBEnforced"
+                      kmValueChangedIndicator>
+          Kubermatic KubeLB
+        </mat-checkbox>
         <i class="km-icon-info km-pointer"
            [matTooltip]="isKubeLBEnforced ? 'Kubermatic KubeLB is enforced by your admin in the chosen datacenter.' : 'Enable to use Kubermatic KubeLB for managing load balancers in your cluster. This allows automatic provisioning and management of load balancers for your services.'"></i>
-      </mat-checkbox>
+      </div>
 
-      <ng-container *ngIf="form.get(Controls.KubeLB).value">
+      <ng-container *ngIf="isEnterpriseEdition && (isKubeLBEnabled || isKubeLBEnabledForCluster()) && form.get(Controls.KubeLB).value">
         <div class="km-suboption">
           <mat-checkbox [formControlName]="Controls.KubeLBUseLoadBalancerClass">
             Use LoadBalancer Class

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -261,7 +261,9 @@ limitations under the License.
         Kubernetes Dashboard
       </mat-checkbox>
 
-      <div fxLayout="row" fxLayoutAlign=" center" *ngIf="isEnterpriseEdition && (isKubeLBEnabled || isKubeLBEnabledForCluster())">
+      <div fxLayout="row"
+           fxLayoutAlign=" center"
+           *ngIf="isEnterpriseEdition && (isKubeLBEnabled || isKubeLBEnabledForCluster())">
         <mat-checkbox [formControlName]="Controls.KubeLB"
                       [disabled]="isKubeLBEnforced"
                       kmValueChangedIndicator>

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -464,15 +464,18 @@ limitations under the License.
                  [matTooltip]="isCSIDriverDisabled ? 'CSI Driver is disabled by your admin in the chosen datacenter.' : 'Disable default CSI storage driver, if available.'"></i>
             </mat-checkbox>
 
-            <mat-checkbox [formControlName]="Controls.KubeLB"
-                          *ngIf="isEnterpriseEdition && isKubeLBEnabled"
-                          [disabled]="isKubeLBEnforced">
-              Kubermatic KubeLB
+            <div fxLayout="row"
+                 fxLayoutAlign=" center"
+                 *ngIf="isEnterpriseEdition && isKubeLBEnabled">
+              <mat-checkbox [formControlName]="Controls.KubeLB"
+                            [disabled]="isKubeLBEnforced">
+                Kubermatic KubeLB
+              </mat-checkbox>
               <i class="km-icon-info km-pointer"
                  [matTooltip]="isKubeLBEnforced ? 'Kubermatic KubeLB is enforced by your admin in the chosen datacenter.' : 'Enable to use Kubermatic KubeLB, responsible for provisioning and managing load balancers.'"></i>
-            </mat-checkbox>
+            </div>
 
-            <ng-container *ngIf="form.get(Controls.KubeLB).value">
+            <ng-container *ngIf="isEnterpriseEdition && isKubeLBEnabled && form.get(Controls.KubeLB).value">
               <div class="km-suboption">
                 <mat-checkbox [formControlName]="Controls.KubeLBUseLoadBalancerClass">
                   Use LoadBalancer Class


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes KubeLB checkbox state when switching datacenters, improves tooltip visibility on disabled elements, and eliminates UI flickering caused by delayed API responses.

Wizard
<img width="1302" alt="Screenshot 2025-06-26 at 9 16 09 PM" src="https://github.com/user-attachments/assets/32fcf983-e9ee-434d-b0d3-4cf5576f8dfe" />

Dialog

<img width="1282" alt="Screenshot 2025-06-26 at 9 15 57 PM" src="https://github.com/user-attachments/assets/a5570e7b-c93d-448b-92b2-555e48e62e6c" />

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed KubeLB checkbox state management and UI flickering issues in cluster creation wizard/edit cluster dialog
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
