### PR TITLE
[release/v2.27] Prevent project viewer from creating cluster templates 

### DIFF
--- a/modules/api/pkg/handler/v2/cluster_template/cluster_template.go
+++ b/modules/api/pkg/handler/v2/cluster_template/cluster_template.go
@@ -335,7 +335,7 @@ func getClusterTemplate(ctx context.Context, projectProvider provider.ProjectPro
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
 
-	userInfo, err := userInfoGetter(ctx, "")
+	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -436,7 +436,7 @@ func createOrUpdateClusterTemplate(ctx context.Context, userInfoGetter provider.
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
-	adminUserInfo, err := userInfoGetter(ctx, "")
+	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -483,7 +483,7 @@ func createOrUpdateClusterTemplate(ctx context.Context, userInfoGetter provider.
 
 	newClusterTemplate.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation] = partialCluster.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]
 
-	newClusterTemplate.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey] = adminUserInfo.Email
+	newClusterTemplate.Annotations[kubermaticv1.ClusterTemplateUserAnnotationKey] = userInfo.Email
 	newClusterTemplate.Labels[kubermaticv1.ClusterTemplateProjectLabelKey] = project.Name
 	newClusterTemplate.Labels[kubermaticv1.ClusterTemplateScopeLabelKey] = scope
 	newClusterTemplate.Labels[kubermaticv1.ClusterTemplateHumanReadableNameLabelKey] = name
@@ -516,7 +516,7 @@ func createOrUpdateClusterTemplate(ctx context.Context, userInfoGetter provider.
 		}
 	}
 
-	ct, err := clusterTemplateProvider.CreateorUpdate(ctx, adminUserInfo, newClusterTemplate, scope, project.Name, isUpdateRequest)
+	ct, err := clusterTemplateProvider.CreateorUpdate(ctx, userInfo, newClusterTemplate, scope, project.Name, isUpdateRequest)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
 	}
@@ -536,7 +536,7 @@ func DeleteEndpoint(projectProvider provider.ProjectProvider, privilegedProjectP
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 
-		userInfo, err := userInfoGetter(ctx, "")
+		userInfo, err := userInfoGetter(ctx, req.ProjectID)
 		if err != nil {
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}

--- a/modules/api/pkg/handler/v2/cluster_template/cluster_template_test.go
+++ b/modules/api/pkg/handler/v2/cluster_template/cluster_template_test.go
@@ -146,6 +146,48 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
+		// scenario 7
+		{
+			Name:             "scenario 7: viewer can't create cluster template in user scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"user","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 8
+		{
+			Name:             "scenario 8: viewer can't create cluster template in project scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"project","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 9
+		{
+			Name:             "scenario 9: viewer can't create cluster template in global scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"global","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":500,"message":"the global scope is reserved only for admins"}}`,
+			HTTPStatus:       http.StatusInternalServerError,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
 	}
 
 	dummyKubermaticConfiguration := kubermaticv1.KubermaticConfiguration{
@@ -548,6 +590,20 @@ func TestDeleteClusterTemplates(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
+		// scenario 6
+		{
+			Name:             "scenario 6: viewer can't delete cluster template",
+			TemplateID:       "ctID6",
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot delete cluster templates regardless of any scope"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+				test.GenClusterTemplate("ct6", "ctID6", test.GenDefaultProject().Name, kubermaticv1.UserClusterTemplateScope, "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
 	}
 
 	for _, tc := range testcases {
@@ -828,6 +884,48 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 				},
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
+		},
+		// scenario 5
+		{
+			Name:             "scenario 5: viewer can't import cluster template in user scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"user","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 6
+		{
+			Name:             "scenario 6: viewer can't import cluster template in project scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"project","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":403,"message":"user viewer@acme.com has viewer role and cannot create or update cluster templates regardless of any scope"}}`,
+			HTTPStatus:       http.StatusForbidden,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
+		},
+		// scenario 7
+		{
+			Name:             "scenario 7: viewer can't import cluster template in global scope",
+			Body:             fmt.Sprintf(`{"name":"test","scope":"global","cluster":{"name":"keen-snyder","spec":{"version":"%s","cloud":{"fake":{"token":"dummy_token"},"dc":"fake-dc"}}}}`, version),
+			ExpectedResponse: `{"error":{"code":500,"message":"the global scope is reserved only for admins"}}`,
+			HTTPStatus:       http.StatusInternalServerError,
+			ProjectToSync:    test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenBinding("my-first-project-ID", "viewer@acme.com", "viewers"),
+				test.GenUser("", "Viewer", "viewer@acme.com"),
+			),
+			ExistingAPIUser: test.GenAPIUser("Viewer", "viewer@acme.com"),
 		},
 	}
 

--- a/modules/web/src/app/cluster-template/component.ts
+++ b/modules/web/src/app/cluster-template/component.ts
@@ -49,6 +49,8 @@ import {filter, startWith, switchMap, take, takeUntil, tap} from 'rxjs/operators
   styleUrls: ['./style.scss'],
 })
 export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
+  readonly Permission = Permission;
+
   templates: ClusterTemplate[] = [];
   templateDatacenterMap: Map<string, Datacenter> = new Map<string, Datacenter>();
   isInitializing = true;
@@ -81,6 +83,9 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     private readonly _notificationService: NotificationService
   ) {}
 
+  get isAdmin(): boolean {
+    return !!this.currentUser?.isAdmin;
+  }
   ngOnInit(): void {
     this._setupList();
     this._loadUser();
@@ -178,29 +183,12 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     return Cluster.getProvider(cluster);
   }
 
-  canCreate(): boolean {
-    return MemberUtils.hasPermission(
-      this.currentUser,
-      this._currentGroupConfig,
-      View.ClusterTemplates,
-      Permission.Create
+  can(permission: Permission): boolean {
+    return (
+      this.currentUser &&
+      this._currentGroupConfig &&
+      MemberUtils.hasPermission(this.currentUser, this._currentGroupConfig, View.ClusterTemplates, permission)
     );
-  }
-
-  canEdit(template: ClusterTemplate): boolean {
-    switch (template.scope) {
-      case ClusterTemplateScope.Global:
-        return this.currentUser.isAdmin;
-      case ClusterTemplateScope.User:
-        return this.currentUser.isAdmin || this.currentUser.email === template.user;
-      case ClusterTemplateScope.Project:
-        return MemberUtils.hasPermission(
-          this.currentUser,
-          this._currentGroupConfig,
-          View.ClusterTemplates,
-          Permission.Edit
-        );
-    }
   }
 
   create(): void {
@@ -209,20 +197,12 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
+  canEdit(template: ClusterTemplate): boolean {
+    return this._canModify(template, Permission.Edit);
+  }
+
   canDelete(template: ClusterTemplate): boolean {
-    switch (template.scope) {
-      case ClusterTemplateScope.Global:
-        return this.currentUser.isAdmin;
-      case ClusterTemplateScope.User:
-        return this.currentUser.isAdmin || this.currentUser.email === template.user;
-      case ClusterTemplateScope.Project:
-        return MemberUtils.hasPermission(
-          this.currentUser,
-          this._currentGroupConfig,
-          View.ClusterTemplates,
-          Permission.Delete
-        );
-    }
+    return this._canModify(template, Permission.Delete);
   }
 
   delete(template: ClusterTemplate): void {
@@ -287,5 +267,20 @@ export class ClusterTemplateComponent implements OnInit, OnChanges, OnDestroy {
     this._projectService.onProjectChange.pipe(startWith({id}), takeUntil(this._unsubscribe)).subscribe(({id}) => {
       component.projectId = id;
     });
+  }
+
+  private _canModify(template: ClusterTemplate, permission: Permission): boolean {
+    switch (template.scope) {
+      case ClusterTemplateScope.Global:
+        return this.isAdmin;
+      case ClusterTemplateScope.User:
+        return this.isAdmin || this._isTemplateOwner(template);
+      case ClusterTemplateScope.Project:
+        return this.can(permission);
+    }
+  }
+
+  private _isTemplateOwner(template: ClusterTemplate): boolean {
+    return this.currentUser?.email === template.user;
   }
 }

--- a/modules/web/src/app/cluster-template/template.html
+++ b/modules/web/src/app/cluster-template/template.html
@@ -29,16 +29,16 @@ limitations under the License.
         <router-outlet name="quota-widget"
                        (activate)="onActivate($event)"></router-outlet>
       </div>
-      <button mat-flat-button
-              type="button"
-              [matTooltip]="projectViewOnlyToolTip"
-              [matTooltipDisabled]="canCreate()"
-              (click)="create()"
-              [disabled]="!canCreate() || isGroupConfigLoading">
-        <i class="km-icon-mask km-icon-add"
-           matButtonIcon></i>
-        <span>Create Cluster Template</span>
-      </button>
+      <span [matTooltip]="!can(Permission.Create) ? projectViewOnlyToolTip : ''">
+        <button mat-flat-button
+                type="button"
+                (click)="create()"
+                [disabled]="!can(Permission.Create) || isGroupConfigLoading">
+          <i class="km-icon-mask km-icon-add"
+             matButtonIcon></i>
+          <span>Create Cluster Template</span>
+        </button>
+      </span>
     </div>
   </div>
 

--- a/modules/web/src/assets/config/userGroupConfig.json
+++ b/modules/web/src/assets/config/userGroupConfig.json
@@ -30,7 +30,7 @@
       "create": true,
       "delete": true
     },
-    "clusterTemplates": {
+    "clustertemplates": {
       "view": true,
       "edit": true,
       "create": true,
@@ -110,7 +110,7 @@
       "create": true,
       "delete": true
     },
-    "clusterTemplates": {
+    "clustertemplates": {
       "view": true,
       "edit": true,
       "create": true,
@@ -190,7 +190,7 @@
       "create": false,
       "delete": false
     },
-    "clusterTemplates": {
+    "clustertemplates": {
       "view": true,
       "edit": false,
       "create": false,


### PR DESCRIPTION
This is an manual cherry-pick of #7446

/assign KhizerRehan

```release-note
Project viewers can now only view cluster templates. Create, update, and delete actions are restricted except deletion by the owner.
```

/kind bug