### PR TITLE
Add skip router reconciliation option for OpenStack clusters

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -309,6 +309,11 @@ limitations under the License.
            matTooltip="Enable create backups from this cluster"></i>
       </mat-checkbox>
 
+      <mat-checkbox *ngIf="datacenter?.spec?.provider === NodeProvider.OPENSTACK"
+                    [formControlName]="Controls.RouterReconciliation">
+        Skip Router Reconciliation
+      </mat-checkbox>
+
       <mat-form-field *ngIf="!!form.get(Controls.ClusterBackup).value && isclusterBackupEnabled"
                       class="bsl-field">
         <mat-label>{{backupStorageLocationLabel}}</mat-label>

--- a/modules/web/src/app/shared/components/annotation-form/component.ts
+++ b/modules/web/src/app/shared/components/annotation-form/component.ts
@@ -31,6 +31,7 @@ import {SettingsService} from '@core/services/settings';
 import _ from 'lodash';
 import {Observable, of, Subject, takeUntil} from 'rxjs';
 import {LabelFormValidators} from '../../validators/label-form.validators';
+import {InternalClusterSpecAnnotations} from '@app/shared/entity/cluster';
 
 @Component({
   selector: 'km-annotation-form',
@@ -59,6 +60,7 @@ export class AnnotationFormComponent implements OnInit, ControlValueAccessor, As
   form: FormGroup;
   protectedAnnotations: Set<string> = new Set();
   hiddenAnnotations: Set<string> = new Set();
+  internalClusterSpecAnnotations: string[] = Object.values(InternalClusterSpecAnnotations);
   removedAnnotations: {key: string; value: string}[] = [];
   initialAnnotations: Record<string, string>;
 
@@ -199,7 +201,7 @@ export class AnnotationFormComponent implements OnInit, ControlValueAccessor, As
 
     if (!_.isEmpty(this.annotations)) {
       Object.entries(this.annotations).forEach(([key, value]) => {
-        if (!this.hiddenAnnotations.has(key)) {
+        if (!this.hiddenAnnotations.has(key) && !this.internalClusterSpecAnnotations.includes(key)) {
           this.addAnnotation(key, value, this.protectedAnnotations.has(key));
         }
       });
@@ -209,7 +211,11 @@ export class AnnotationFormComponent implements OnInit, ControlValueAccessor, As
 
   private keyValidator(control: AbstractControl): ValidationErrors | null {
     const key = control.value;
-    if (this.protectedAnnotations.has(key) || this.hiddenAnnotations.has(key)) {
+    if (
+      this.protectedAnnotations.has(key) ||
+      this.hiddenAnnotations.has(key) ||
+      this.internalClusterSpecAnnotations.includes(key)
+    ) {
       return {forbiddenKey: true};
     }
     return null;

--- a/modules/web/src/app/shared/entity/cluster.ts
+++ b/modules/web/src/app/shared/entity/cluster.ts
@@ -56,6 +56,11 @@ const PROVIDER_DISPLAY_NAMES = new Map<Provider, string>([
   [Provider.VMwareCloudDirector, 'VMware Cloud Director'],
 ]);
 
+// Internal annotation used by KKP for system-level configuration.
+export enum InternalClusterSpecAnnotations {
+  SkipRouterReconciliation = 'reconciliation.kubermatic.k8c.io/skip-router',
+}
+
 export function getProviderDisplayName(provider: Provider): string {
   return PROVIDER_DISPLAY_NAMES.get(provider);
 }

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -544,6 +544,11 @@ limitations under the License.
                  matTooltip="Enable to deploy User SSH Key Agent to the cluster. It cannot be changed once the cluster is created."></i>
             </mat-checkbox>
 
+            <mat-checkbox *ngIf="provider === NodeProvider.OPENSTACK"
+                          [formControlName]="Controls.RouterReconciliation">
+              Skip Router Reconciliation
+            </mat-checkbox>
+
             <km-label-form [title]="'Labels'"
                            [labels]="labels"
                            [asyncKeyValidators]="asyncLabelValidators"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a checkbox in the cluster settings to enable or disable skipping router reconciliation for OpenStack clusters via the reconciliation.kubermatic.k8c.io/skip-router annotation.reconciliation.

![image](https://github.com/user-attachments/assets/96921279-25cf-4e12-9751-2cc61f52e8b3)


ref: https://github.com/kubermatic/kubermatic/pull/14771

**Which issue(s) this PR fixes**:
Fixes #7476 

**What type of PR is this?**
/kind feature


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
