### PR TITLE
[release/v2.27] Bump KKP and OSM dependencies for KKP patch release 2.27.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.27.4
+KUBERMATIC_VERSION?=v2.27.6
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.27.4
+KUBERMATIC_VERSION?=v2.27.6
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -70,9 +70,9 @@ require (
 	google.golang.org/api v0.209.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.27.6-0.20250627130054-13ad5101d4e5
+	k8c.io/kubermatic/v2 v2.27.6-0.20250708191423-b2ed9845b758
 	k8c.io/machine-controller v1.61.3
-	k8c.io/operating-system-manager v1.6.5
+	k8c.io/operating-system-manager v1.6.7
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.31.3
 	k8s.io/apiextensions-apiserver v0.31.3

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1147,12 +1147,12 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.27.6-0.20250627130054-13ad5101d4e5 h1:Nm5jMyFo+Q0a+zoyIdxKLrK4tEbropTLRFuWSdeD9Qo=
-k8c.io/kubermatic/v2 v2.27.6-0.20250627130054-13ad5101d4e5/go.mod h1:TNysG/oe6ZZgfUlVxSdR3yHYMxxdJRLcFHV6+8aDnEg=
+k8c.io/kubermatic/v2 v2.27.6-0.20250708191423-b2ed9845b758 h1:HOSTr0Xt0u8D1wsdpGBwziri18cJemhgNC1o6uXfD/4=
+k8c.io/kubermatic/v2 v2.27.6-0.20250708191423-b2ed9845b758/go.mod h1:TNysG/oe6ZZgfUlVxSdR3yHYMxxdJRLcFHV6+8aDnEg=
 k8c.io/machine-controller v1.61.3 h1:oQwk7/LB71zd95d9ZeuSZ2FV4ywgSIwfeSnvOfkCs0o=
 k8c.io/machine-controller v1.61.3/go.mod h1:ZGDFyUeEp66RHcNB5Ki/OJyFdZFgo9dkHJ9s6YJWPcg=
-k8c.io/operating-system-manager v1.6.5 h1:F7oBJKEv2t3uzG8k4e9s9j9vCAvXN1FGEkqV0+dMh60=
-k8c.io/operating-system-manager v1.6.5/go.mod h1:Dh9IZp5pb5G3s2r6ZrHUb+gTuHw5AmbIFYuFxIcgU7o=
+k8c.io/operating-system-manager v1.6.7 h1:n7rViYgFeccEUmMeFAqvtyappr/0kxAVtKJNe66x+KU=
+k8c.io/operating-system-manager v1.6.7/go.mod h1:Dh9IZp5pb5G3s2r6ZrHUb+gTuHw5AmbIFYuFxIcgU7o=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=
 k8c.io/reconciler v0.5.0/go.mod h1:pT1+SVcVXJQeBJhpJBXQ5XW64QnKKeYTnVlQf0dGE0k=
 k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.27.4
+KUBERMATIC_VERSION?=v2.27.6
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.27.4",
+  "version": "2.27.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.27.4",
+      "version": "2.27.6",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.27.4",
+  "version": "2.27.6",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump KKP and OSM dependencies for KKP patch release 2.27.6

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
