### PR TITLE
Refresh and update token for webterminal kubeconfig when token is expired

### DIFF
--- a/modules/api/.gitignore
+++ b/modules/api/.gitignore
@@ -29,6 +29,7 @@
 .settings/
 .vscode/*
 .nvmrc
+.history
 
 # Misc.
 /.sass-cache

--- a/modules/api/pkg/handler/common/kubeconfig.go
+++ b/modules/api/pkg/handler/common/kubeconfig.go
@@ -582,15 +582,10 @@ func createKubeconfigSecret(ctx context.Context, client ctrlruntimeclient.Client
 		resources.KubeconfigSecretKey: kubeconfig,
 	}
 
-	// return if already exists
-	if existingSecret.Name != "" {
-		return nil
-	}
-
-	return createSecret(ctx, client, kubeconfigSecretName, email, secretData)
+	return createSecret(ctx, client, kubeconfigSecretName, email, secretData, existingSecret.Name)
 }
 
-func createSecret(ctx context.Context, client ctrlruntimeclient.Client, name, email string, secretData map[string][]byte) error {
+func createSecret(ctx context.Context, client ctrlruntimeclient.Client, name, email string, secretData map[string][]byte, existingSecretName string) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -599,6 +594,10 @@ func createSecret(ctx context.Context, client ctrlruntimeclient.Client, name, em
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: secretData,
+	}
+
+	if existingSecretName != "" {
+		return client.Update(ctx, secret)
 	}
 	return client.Create(ctx, secret)
 }

--- a/modules/api/pkg/handler/middleware/middleware.go
+++ b/modules/api/pkg/handler/middleware/middleware.go
@@ -1032,7 +1032,7 @@ func OIDCProviders(clusterProviderGetter provider.ClusterProviderGetter, oidcIss
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			oidcIssuerVerifier, err := getOIDCIssuerVerifier(ctx, clusterProviderGetter, oidcIssuerVerifierGetter, seedsGetter, seedCluster.ClusterID)
+			oidcIssuerVerifier, err := GetOIDCIssuerVerifier(ctx, clusterProviderGetter, oidcIssuerVerifierGetter, seedsGetter, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -1042,7 +1042,7 @@ func OIDCProviders(clusterProviderGetter provider.ClusterProviderGetter, oidcIss
 	}
 }
 
-func getOIDCIssuerVerifier(
+func GetOIDCIssuerVerifier(
 	ctx context.Context,
 	clusterProviderGetter provider.ClusterProviderGetter,
 	oidcIssuerVerifierGetter provider.OIDCIssuerVerifierGetter,

--- a/modules/api/pkg/handler/test/fake_auth.go
+++ b/modules/api/pkg/handler/test/fake_auth.go
@@ -139,6 +139,18 @@ func (o *IssuerVerifier) Exchange(ctx context.Context, code, overwriteRedirectUR
 	}, nil
 }
 
+// RefreshAccessToken simulates refreshing an access token.
+func (o *IssuerVerifier) RefreshAccessToken(ctx context.Context, refToken string) (authtypes.OIDCToken, error) {
+	if refToken != refreshToken {
+		return authtypes.OIDCToken{}, errors.New("invalid refresh token")
+	}
+
+	return authtypes.OIDCToken{
+		IDToken:      IDToken,
+		RefreshToken: refreshToken,
+	}, nil
+}
+
 // Verify parses a raw ID Token, verifies it's been signed by the provider, performs
 // any additional checks depending on the Config, and returns the payload as TokenClaims.
 func (o *IssuerVerifier) Verify(ctx context.Context, token string) (authtypes.TokenClaims, error) {

--- a/modules/api/pkg/handler/websocket/terminal.go
+++ b/modules/api/pkg/handler/websocket/terminal.go
@@ -19,6 +19,7 @@ package websocket
 import (
 	"context"
 	"crypto/md5"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -26,11 +27,13 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
 
 	handlercommon "k8c.io/dashboard/v2/pkg/handler/common"
+	authtypes "k8c.io/dashboard/v2/pkg/provider/auth/types"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -44,6 +47,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +64,7 @@ const (
 	maxNumberOfExpirationRefreshes    = 48              // it means maximum 24h for a pod lifetime of 30 minutes
 	remainingExpirationTimeForWarning = 5 * time.Minute // should be lesser than "podLifetime"
 	expirationCheckInterval           = 1 * time.Minute // should be lesser than "remainingExpirationTimeForWarning"
+	remainingTokenExpirationTime      = 5 * time.Minute
 	expirationTimestampKey            = "ExpirationTimestamp"
 	expirationRefreshesKey            = "ExpirationRefreshes"
 	pingInterval                      = 30 * time.Second
@@ -73,6 +79,8 @@ type TerminalConnStatus string
 
 const (
 	KubeconfigSecretMissing TerminalConnStatus = "KUBECONFIG_SECRET_MISSING"
+	WebTerminalTokenExpired TerminalConnStatus = "WEBTERMINAL_TOKEN_EXPIRED"
+	WebTerminalTokenValid   TerminalConnStatus = "WEBTERMINAL_TOKEN_VALID"
 	WebterminalPodPending   TerminalConnStatus = "WEBTERMINAL_POD_PENDING"
 	WebterminalPodFailed    TerminalConnStatus = "WEBTERMINAL_POD_FAILED"
 	ConnectionPoolExceeded  TerminalConnStatus = "CONNECTION_POOL_EXCEEDED"
@@ -267,6 +275,77 @@ func pingRoutine(websocketConn *websocket.Conn) {
 	}
 }
 
+func checkTokenAndRefreshIfNeeded(ctx context.Context, clusterClient ctrlruntimeclient.Client, oidcIssuerVerifier authtypes.OIDCIssuerVerifier, kubeconfigSecret *corev1.Secret, websocketConn *websocket.Conn) {
+	for {
+		// Update the kubeconfig secret in case it gets recreated.
+		if err := clusterClient.Get(ctx, ctrlruntimeclient.ObjectKey{
+			Namespace: metav1.NamespaceSystem,
+			Name:      kubeconfigSecret.Name,
+		}, kubeconfigSecret); err != nil {
+			log.Logger.Debug(err)
+			return
+		}
+		cfg, err := clientcmd.Load(kubeconfigSecret.Data["kubeconfig"])
+		if err != nil {
+			log.Logger.Debug(err)
+			return
+		}
+
+		user, err := getFirstUser(cfg.AuthInfos)
+		if err != nil {
+			log.Logger.Debug(err)
+			return
+		}
+
+		tokenExpirationTime, err := GetTokenExpiration(user.AuthProvider.Config["id-token"])
+		if err != nil {
+			log.Logger.Debug(err)
+			return
+		}
+
+		// Only refresh the token when it’s close to expiring.
+		if time.Until(tokenExpirationTime) <= remainingTokenExpirationTime {
+			refreshToken := user.AuthProvider.Config["refresh-token"]
+
+			newToken, err := oidcIssuerVerifier.RefreshAccessToken(ctx, refreshToken)
+			if err != nil {
+				log.Logger.Debug(err)
+				onFailedUpdatingToken(ctx, websocketConn, tokenExpirationTime)
+				continue
+			}
+
+			user.AuthProvider.Config["id-token"] = newToken.IDToken
+			user.AuthProvider.Config["refresh-token"] = newToken.RefreshToken
+			updatedKubeconfig, err := clientcmd.Write(*cfg)
+			if err != nil {
+				log.Logger.Debug(err)
+				onFailedUpdatingToken(ctx, websocketConn, tokenExpirationTime)
+				continue
+			}
+			kubeconfigSecret.Data["kubeconfig"] = updatedKubeconfig
+			if err := clusterClient.Update(ctx, kubeconfigSecret); err != nil {
+				log.Logger.Debug(err)
+				onFailedUpdatingToken(ctx, websocketConn, tokenExpirationTime)
+				continue
+			}
+			tokenExpirationTime, err = GetTokenExpiration(user.AuthProvider.Config["id-token"])
+			if err != nil {
+				log.Logger.Debug(err)
+				return
+			}
+		}
+
+		// check again 5 min before the token expiration or at the token expiration time
+		_ = SendMessage(websocketConn, string(WebTerminalTokenValid))
+		sleepDuration := time.Until(tokenExpirationTime) - remainingTokenExpirationTime
+		if sleepDuration > 0 {
+			time.Sleep(sleepDuration)
+		} else {
+			time.Sleep(time.Until(tokenExpirationTime))
+		}
+	}
+}
+
 func expirationCheckRoutine(ctx context.Context, clusterClient ctrlruntimeclient.Client, userEmailID string, websocketConn *websocket.Conn) {
 	for {
 		time.Sleep(expirationCheckInterval)
@@ -295,7 +374,7 @@ func expirationCheckRoutine(ctx context.Context, clusterClient ctrlruntimeclient
 
 // startProcess is called by terminal session creation.
 // Executed cmd in the container specified in request and connects it up with the ptyHandler (a session).
-func startProcess(ctx context.Context, client, seedClient ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster, options *kubermaticv1.WebTerminalOptions, cmd []string, ptyHandler PtyHandler, websocketConn *websocket.Conn) error {
+func startProcess(ctx context.Context, client, seedClient ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster, options *kubermaticv1.WebTerminalOptions, oidcIssuerVerifier authtypes.OIDCIssuerVerifier, kubeconfigSecret *corev1.Secret, cmd []string, ptyHandler PtyHandler, websocketConn *websocket.Conn) error {
 	userAppName := userAppName(userEmailID)
 	// check if WEB terminal Pod exists, if not create
 	pod := &corev1.Pod{}
@@ -353,6 +432,8 @@ func startProcess(ctx context.Context, client, seedClient ctrlruntimeclient.Clie
 	go pingRoutine(websocketConn)
 
 	go expirationCheckRoutine(ctx, client, userEmailID, websocketConn)
+
+	go checkTokenAndRefreshIfNeeded(ctx, client, oidcIssuerVerifier, kubeconfigSecret, websocketConn)
 
 	req := k8sClient.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -730,7 +811,7 @@ func getVolumeMounts() []corev1.VolumeMount {
 }
 
 // Terminal is called for any new websocket connection.
-func Terminal(ctx context.Context, ws *websocket.Conn, client, seedClient ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster, options *kubermaticv1.WebTerminalOptions) {
+func Terminal(ctx context.Context, ws *websocket.Conn, client, seedClient ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster, options *kubermaticv1.WebTerminalOptions, oidcIssuerVerifier authtypes.OIDCIssuerVerifier, kubeconfigSecret *corev1.Secret) {
 	if err := startProcess(
 		ctx,
 		client,
@@ -740,6 +821,8 @@ func Terminal(ctx context.Context, ws *websocket.Conn, client, seedClient ctrlru
 		userEmailID,
 		cluster,
 		options,
+		oidcIssuerVerifier,
+		kubeconfigSecret,
 		[]string{"bash", "-c", "cd /data/terminal && /bin/bash"},
 		TerminalSession{
 			websocketConn: ws,
@@ -775,4 +858,48 @@ func SendMessage(wsConn *websocket.Conn, message string) error {
 		Op:   "msg",
 		Data: message,
 	})
+}
+
+// The kubeconfig secret must contain a single user, so we return the first one.
+func getFirstUser(authInfos map[string]*clientcmdapi.AuthInfo) (*clientcmdapi.AuthInfo, error) {
+	for _, u := range authInfos {
+		return u, nil
+	}
+	return nil, fmt.Errorf("no user found in kubeconfig")
+}
+
+func GetTokenExpiration(token string) (time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return time.Time{}, fmt.Errorf("invalid token format")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to decode token: %w", err)
+	}
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return time.Time{}, fmt.Errorf("failed to unmarshal claims: %w", err)
+	}
+
+	expFloat := claims["exp"].(float64)
+
+	return time.Unix(int64(expFloat), 0), nil
+}
+
+func onFailedUpdatingToken(ctx context.Context, websocketConn *websocket.Conn, tokenExpirationTime time.Time) {
+	// If the token is already expired, send a message to the client and check every 5 seconds if the user authenticates again (update the kubeconfig secret).
+	if time.Until(tokenExpirationTime) <= 0 {
+		log.Logger.Debug("Token is already expired, and cannot be refreshed")
+		_ = SendMessage(websocketConn, string(WebTerminalTokenExpired))
+		time.Sleep(5 * time.Second)
+	} else {
+		// If the token is still valid but can't be refreshed, try again after 1 minute.
+		if time.Until(tokenExpirationTime) <= 1*time.Minute {
+			time.Sleep(time.Until(tokenExpirationTime)) // wait until the token is expired
+		}
+		time.Sleep(1 * time.Minute)
+	}
 }

--- a/modules/api/pkg/provider/auth/types/types.go
+++ b/modules/api/pkg/provider/auth/types/types.go
@@ -52,6 +52,9 @@ type OIDCIssuer interface {
 	// Exchange converts an authorization code into a token.
 	Exchange(ctx context.Context, code, overwriteRedirectURI string) (OIDCToken, error)
 
+	// RefreshAccessToken uses a refresh token to obtain a new OIDC token.
+	RefreshAccessToken(ctx context.Context, refreshToken string) (OIDCToken, error)
+
 	// OIDCConfig returns the issuers OIDC config
 	OIDCConfig() *OIDCConfiguration
 }

--- a/modules/api/pkg/watcher/types.go
+++ b/modules/api/pkg/watcher/types.go
@@ -34,6 +34,7 @@ type Providers struct {
 	SeedsGetter               provider.SeedsGetter
 	SeedClientGetter          provider.SeedClientGetter
 	ClusterProviderGetter     provider.ClusterProviderGetter
+	OIDCIssuerVerifierGetter  provider.OIDCIssuerVerifierGetter
 }
 
 type SettingsWatcher interface {

--- a/modules/web/.gitignore
+++ b/modules/web/.gitignore
@@ -34,6 +34,7 @@
 .settings/
 .vscode/*
 .nvmrc
+.history
 
 # Misc.
 /.sass-cache

--- a/modules/web/src/app/shared/components/terminal/component.ts
+++ b/modules/web/src/app/shared/components/terminal/component.ts
@@ -62,6 +62,7 @@ enum Operations {
 
 enum ErrorOperations {
   KubeConfigSecretMissing = 'KUBECONFIG_SECRET_MISSING',
+  KubeConfigSecretInvalid = 'KUBECONFIG_SECRET_INVALID',
   WebTerminalTokenExpired = 'WEBTERMINAL_TOKEN_EXPIRED',
   WebTerminalPodPending = 'WEBTERMINAL_POD_PENDING',
   ConnectionPoolExceeded = 'CONNECTION_POOL_EXCEEDED',
@@ -285,39 +286,48 @@ export class TerminalComponent implements OnChanges, OnInit, OnDestroy, AfterVie
       this._initializeTerminalOnSuccess.complete();
       this._logToTerminal(frame.Data);
     } else if (frame.Op === Operations.Msg) {
-      if (frame.Data === ErrorOperations.KubeConfigSecretMissing) {
-        if (!this.isDexAuthenticationPageOpened) {
-          const url = this._getWebTerminalProxyURL();
-          window.open(url, '_blank');
-          this.isDexAuthenticationPageOpened = true;
-        }
-        this.message = 'Please wait, authenticate in order to access web terminal...';
-      } else if (frame.Data === ErrorOperations.WebTerminalPodPending) {
-        this.message = 'Please wait, provisioning your Web Terminal pod...';
-      } else if (frame.Data === ErrorOperations.WebTerminalTokenExpired) {
-        this.isTokenExpired = true;
-      } else if (frame.Data === MessageTypes.WebTerminalTokenValid) {
-        this.isTokenExpired = false;
-      } else if (frame.Data === ErrorOperations.ConnectionPoolExceeded) {
-        const message = `Oops! There could be ${this.MAX_SESSION_SUPPORTED} concurrent session per user. Please either discard or close other sessions`;
-        if (this.terminal) {
-          this._logToTerminal(message);
-        } else {
-          this.message = message;
-        }
-      } else if (frame.Data === ErrorOperations.RefreshesLimitExceeded) {
-        const clusterName = this.cluster && this.cluster.name;
-        this._logToTerminal(
-          `Oops! Max limit of ${this.MAX_EXPIRATION_REFRESHES} refreshes is reached. You are not allowed to extend the session for \x1b[1;34m${clusterName}\x1B[0m\n\n\r`
-        );
-      } else if (frame.Data === MessageTypes.Ping) {
-        if (this.terminal) {
-          // Note: Periodic exchange of messages with server to keep the web Terminal connection alive
-          this._keepConnectionAlive(MessageTypes.Pong);
-        }
-      }
+      this._handelOperationsError(frame.Data);
+      this._handelMessageTypes(frame.Data);
     } else if (frame.Op === Operations.Expiration) {
       this.isSessionExpiring = true;
+    }
+  }
+
+  private _handelOperationsError(data: string): void {
+    if (data === ErrorOperations.KubeConfigSecretMissing) {
+      if (!this.isDexAuthenticationPageOpened) {
+        const url = this._getWebTerminalProxyURL();
+        window.open(url, '_blank');
+        this.isDexAuthenticationPageOpened = true;
+      }
+      this.message = 'Please wait, authenticate in order to access web terminal...';
+    } else if (data === ErrorOperations.WebTerminalPodPending) {
+      this.message = 'Please wait, provisioning your Web Terminal pod...';
+    } else if (data === ErrorOperations.WebTerminalTokenExpired || data === ErrorOperations.KubeConfigSecretInvalid) {
+      this.isTokenExpired = true;
+    } else if (data === ErrorOperations.ConnectionPoolExceeded) {
+      const message = `Oops! There could be ${this.MAX_SESSION_SUPPORTED} concurrent session per user. Please either discard or close other sessions`;
+      if (this.terminal) {
+        this._logToTerminal(message);
+      } else {
+        this.message = message;
+      }
+    } else if (data === ErrorOperations.RefreshesLimitExceeded) {
+      const clusterName = this.cluster && this.cluster.name;
+      this._logToTerminal(
+        `Oops! Max limit of ${this.MAX_EXPIRATION_REFRESHES} refreshes is reached. You are not allowed to extend the session for \x1b[1;34m${clusterName}\x1B[0m\n\n\r`
+      );
+    }
+  }
+
+  private _handelMessageTypes(data: string): void {
+    if (data === MessageTypes.WebTerminalTokenValid) {
+      this.isTokenExpired = false;
+    } else if (data === MessageTypes.Ping) {
+      if (this.terminal) {
+        // Note: Periodic exchange of messages with server to keep the web Terminal connection alive
+        this._keepConnectionAlive(MessageTypes.Pong);
+      }
     }
   }
 

--- a/modules/web/src/app/shared/components/terminal/template.html
+++ b/modules/web/src/app/shared/components/terminal/template.html
@@ -38,11 +38,13 @@ limitations under the License.
                          (openInNewTab)="openInSeparateView()"
                          (close)="onClose()"></km-terminal-toolbar>
 
-    <km-terminal-status-bar *ngIf="isConnectionLost || isSessionExpiring"
+    <km-terminal-status-bar *ngIf="isConnectionLost || isSessionExpiring || isTokenExpired"
                             [isConnectionLost]="isConnectionLost"
                             [isSessionExpiring]="isSessionExpiring"
+                            [isTokenExpired]="isTokenExpired"
                             (reconnect)="onReconnect()"
-                            (extendSession)="onExtendSession()">
+                            (extendSession)="onExtendSession()"
+                            (tokenExpired)="onTokenExpired()">
     </km-terminal-status-bar>
 
     <div #terminal></div>

--- a/modules/web/src/app/shared/components/terminal/terminal-status-bar/component.ts
+++ b/modules/web/src/app/shared/components/terminal/terminal-status-bar/component.ts
@@ -14,7 +14,11 @@
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
-type SessionState = 'expired' | 'connectionLost' | 'expiring';
+enum TerminalState {
+  Expired = 'expired',
+  ConnectionLost = 'connectionLost',
+  Expiring = 'expiring',
+}
 
 @Component({
   selector: 'km-terminal-status-bar',
@@ -29,11 +33,12 @@ export class TerminalStatusBarComponent {
   @Output() reconnect = new EventEmitter<void>();
   @Output() extendSession = new EventEmitter<void>();
   @Output() tokenExpired = new EventEmitter<void>();
+  terminalState = TerminalState;
 
-  get sessionState(): SessionState {
-    if (this.isTokenExpired) return 'expired';
-    if (this.isConnectionLost) return 'connectionLost';
-    return 'expiring';
+  get sessionState(): TerminalState {
+    if (this.isTokenExpired) return TerminalState.Expired;
+    if (this.isConnectionLost) return TerminalState.ConnectionLost;
+    return TerminalState.Expiring;
   }
 
   onExtendSession(): void {

--- a/modules/web/src/app/shared/components/terminal/terminal-status-bar/component.ts
+++ b/modules/web/src/app/shared/components/terminal/terminal-status-bar/component.ts
@@ -14,6 +14,8 @@
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
+type SessionState = 'expired' | 'connectionLost' | 'expiring';
+
 @Component({
   selector: 'km-terminal-status-bar',
   templateUrl: './template.html',
@@ -23,8 +25,16 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 export class TerminalStatusBarComponent {
   @Input() isConnectionLost: boolean;
   @Input() isSessionExpiring: boolean;
+  @Input() isTokenExpired: boolean;
   @Output() reconnect = new EventEmitter<void>();
   @Output() extendSession = new EventEmitter<void>();
+  @Output() tokenExpired = new EventEmitter<void>();
+
+  get sessionState(): SessionState {
+    if (this.isTokenExpired) return 'expired';
+    if (this.isConnectionLost) return 'connectionLost';
+    return 'expiring';
+  }
 
   onExtendSession(): void {
     this.extendSession.emit();
@@ -32,5 +42,9 @@ export class TerminalStatusBarComponent {
 
   onReconnect(): void {
     this.reconnect.emit();
+  }
+
+  onTokenExpired(): void {
+    this.tokenExpired.emit();
   }
 }

--- a/modules/web/src/app/shared/components/terminal/terminal-status-bar/template.html
+++ b/modules/web/src/app/shared/components/terminal/terminal-status-bar/template.html
@@ -22,15 +22,15 @@ limitations under the License.
       <i class="km-icon-warning"></i>
     </div>
     <div [ngSwitch]="sessionState">
-      <p *ngSwitchCase="'expired'">
+      <p *ngSwitchCase="terminalState.Expired">
         Session expired. Authenticate again and wait a few seconds for the new kubeconfig to mount.
       </p>
 
-      <p *ngSwitchCase="'connectionLost'">
+      <p *ngSwitchCase="terminalState.ConnectionLost">
         The connection to your Web Terminal was lost.
       </p>
 
-      <p *ngSwitchCase="'expiring'">
+      <p *ngSwitchCase="terminalState.Expiring">
         The web session will expire soon.
       </p>
     </div>

--- a/modules/web/src/app/shared/components/terminal/terminal-status-bar/template.html
+++ b/modules/web/src/app/shared/components/terminal/terminal-status-bar/template.html
@@ -21,23 +21,37 @@ limitations under the License.
     <div>
       <i class="km-icon-warning"></i>
     </div>
-    <div>
+    <div [ngSwitch]="sessionState">
+      <p *ngSwitchCase="'expired'">
+        Session expired. Authenticate again and wait a few seconds for the new kubeconfig to mount.
+      </p>
 
-      <ng-container *ngIf="isConnectionLost; else sessionExpiration">
-        <p>The connection to your Web Terminal was lost.</p>
-      </ng-container>
+      <p *ngSwitchCase="'connectionLost'">
+        The connection to your Web Terminal was lost.
+      </p>
 
-      <ng-template #sessionExpiration>
-        <p>The web session will expire soon.</p>
-      </ng-template>
+      <p *ngSwitchCase="'expiring'">
+        The web session will expire soon.
+      </p>
     </div>
   </div>
 
-  <div fxFlex
+  <div [ngSwitch]="sessionState"
+       fxFlex
        fxLayout="row"
        fxLayoutAlign="end center"
        fxLayoutGap="10px">
-    <button *ngIf="isConnectionLost"
+    <button *ngSwitchCase="'expired'"
+            mat-flat-button
+            class="button-border-box"
+            matTooltip="Authenticate again to regain access"
+            (click)="onTokenExpired()">
+      <i class="km-icon-mask km-icon-reconnect"
+         matButtonIcon></i>
+      <span>Authenticate</span>
+    </button>
+
+    <button *ngSwitchCase="'connectionLost'"
             mat-flat-button
             class="button-border-box"
             matTooltip="Gain lost connection to terminal"
@@ -47,7 +61,7 @@ limitations under the License.
       <span>Reconnect</span>
     </button>
 
-    <button *ngIf="isSessionExpiring"
+    <button *ngSwitchCase="'expiring'"
             mat-flat-button
             class="button-border-box"
             matTooltip="Retain current session to terminal"


### PR DESCRIPTION
**What this PR does / why we need it**:
Refresh the token for the web terminal kubeconfig when it has expired. If the refresh fails, prompt the user to authenticate again.

**Which issue(s) this PR fixes**:
Fixes #7271

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix web terminal token expiration by refreshing expired tokens automatically.
```

**Documentation**:
```documentation
TBD
```
