### PR TITLE
Install k9s, krew, and oidc-login in terminal image

### DIFF
--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -19,14 +19,20 @@ ARG TARGETARCH
 
 LABEL maintainer="support@kubermatic.com"
 
-# Source: https://dl.k8s.io/release/stable-1.31.txt
-ENV KUBECTL_VERSION=v1.31.8
+# Source: https://dl.k8s.io/release/stable-1.32.txt
+ENV KUBECTL_VERSION=v1.32.7
 
 # Source: https://github.com/helm/helm/releases
-ENV HELM_VERSION=v3.17.3
+ENV HELM_VERSION=v3.17.4
 
 # Source: https://github.com/k8sgpt-ai/k8sgpt/releases
-ENV K8SGPT_VERSION=v0.4.15
+ENV K8SGPT_VERSION=v0.4.22
+
+# Source: https://github.com/derailed/k9s/releases
+ENV K9S_VERSION=v0.50.9
+
+# Source: https://github.com/kubernetes-sigs/krew/releases
+ENV KREW_VERSION=v0.4.5
 
 ENV USER=webshell
 ENV GROUP=webshell
@@ -52,15 +58,43 @@ RUN apk add --no-cache -U \
   openssh-client \
   unzip \
   tar \
-  wget
+  wget \
+  ncurses
 
+# Install kubectl
 RUN curl -Lo /usr/bin/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
   chmod +x /usr/bin/kubectl && \
   kubectl version --client
 
+# Install helm
 RUN curl --fail -L https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz | tar -xzO linux-${TARGETARCH}/helm > /usr/local/bin/helm && \
   chmod +x /usr/local/bin/helm && \
   helm version --short
+
+# Install k9s
+RUN curl -LO https://github.com/derailed/k9s/releases/download/${K9S_VERSION}/k9s_Linux_${TARGETARCH}.tar.gz && \
+  tar -xzf k9s_Linux_${TARGETARCH}.tar.gz && \
+  mv k9s /usr/local/bin/k9s && \
+  chmod +x /usr/local/bin/k9s && \
+  k9s version
+
+# Install krew
+RUN curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew-linux_${TARGETARCH}.tar.gz" && \
+  tar -xzf krew-linux_${TARGETARCH}.tar.gz && \
+  ./krew-linux_${TARGETARCH} install krew && \
+  echo "export PATH=${KREW_ROOT:-$HOME/.krew}/bin:$PATH" >> /root/.bashrc
+
+ENV PATH="/root/.krew/bin:$PATH"
+
+# Krew plugins
+RUN PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH" && \
+  kubectl krew update && \
+  kubectl krew install oidc-login && \
+  kubectl krew install ctx && \
+  kubectl krew install ns
+
+RUN mkdir -p /home/webshell/.local/state && \
+    chown -R webshell:webshell /home/webshell/.local
 
 USER ${USER}
 

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 source hack/lib.sh
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.10.0
+VERSION=0.11.0
 SUFFIX=""
 ARCHITECTURES="${ARCHITECTURES:-linux/amd64,linux/arm64/v8}"
 IMAGE="$REPOSITORY:$VERSION$SUFFIX"

--- a/modules/api/pkg/handler/websocket/terminal.go
+++ b/modules/api/pkg/handler/websocket/terminal.go
@@ -65,7 +65,7 @@ const (
 	pingMessage                       = "PING"
 	pongMessage                       = "PONG"
 
-	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.10.0"
+	webTerminalImage                   = resources.RegistryQuay + "/kubermatic/web-terminal:0.11.0"
 	webTerminalContainerKubeconfigPath = "/etc/kubernetes/kubeconfig/kubeconfig"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated the web-terminal image with:
- Latest kubectl, helm, and k8sgpt versions
- Install k9s, krew, and krew plugins ns, ctx, and oidc-login

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Update web-terminal image to v0.11.0
- web-terminal: k9s, krew, and krew plugins ns, ctx, and oidc-login are available to use in the web-terminal image
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
