### PR TITLE
Fix OpenStack network selection to handle networks without name

### DIFF
--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/default/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/default/component.ts
@@ -112,7 +112,6 @@ export class OpenstackProviderExtendedCredentialsComponent
   private _applicationCredentialID = '';
   private _applicationCredentialSecret = '';
   private _preset = '';
-  private _currentNetworkId = '';
 
   constructor(
     private readonly _builder: FormBuilder,
@@ -254,7 +253,6 @@ export class OpenstackProviderExtendedCredentialsComponent
   }
 
   onNetworkChange(networkId: string): void {
-    this._currentNetworkId = networkId;
     const network: OpenstackNetwork = this.networks.find((n: OpenstackNetwork) => n.id === networkId);
     if (network) {
       this.openstackNetwork = network.name || network.id;
@@ -296,8 +294,11 @@ export class OpenstackProviderExtendedCredentialsComponent
   }
 
   networkDisplayName(id: string): string {
-    const network: OpenstackNetwork = this.networks.find(network => network.id === id);
-    return network ? network.name || network.id : '';
+    if (!id) {
+      return '';
+    }
+    const network: OpenstackNetwork = this.networks.find((network: OpenstackNetwork) => network.id === id);
+    return network ? network.name || `(ID: ${network.id})` : '';
   }
 
   ipv4SubnetIDDisplayName(id: string): string {
@@ -327,9 +328,6 @@ export class OpenstackProviderExtendedCredentialsComponent
 
     if (selectedNetwork && !network) {
       this._networkCombobox.reset();
-      this._currentNetworkId = '';
-    } else if (!this._currentNetworkId) {
-      this._currentNetworkId = network.id;
     }
     this.networksLabel = !_.isEmpty(this.networks) ? NetworkState.Ready : NetworkState.Empty;
     this._cdr.detectChanges();
@@ -527,7 +525,6 @@ export class OpenstackProviderExtendedCredentialsComponent
     this.networks = [];
     this._networkCombobox.reset();
     this.networksLabel = NetworkState.Empty;
-    this._currentNetworkId = '';
     this._cdr.detectChanges();
   }
 

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/default/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/default/template.html
@@ -46,7 +46,7 @@ limitations under the License.
                filterBy="name"
                selectBy="id">
     <div *option="let network">
-      {{network.name || network.id}}
+      {{networkDisplayName(network.id)}}
     </div>
   </km-combobox>
 

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/default/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/openstack/default/template.html
@@ -41,10 +41,12 @@ limitations under the License.
                [formControlName]="Controls.Network"
                (changed)="onNetworkChange($event)"
                [label]="networksLabel"
+               [valueFormatter]="networkDisplayName.bind(this)"
                inputLabel="Select network..."
-               filterBy="name">
+               filterBy="name"
+               selectBy="id">
     <div *option="let network">
-      {{network.name}}
+      {{network.name || network.id}}
     </div>
   </km-combobox>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolves issues with unnamed OpenStack networks by displaying their ID in the dropdown and properly loading associated subnets.

**Before**
<img width="614" height="526" alt="image" src="https://github.com/user-attachments/assets/2b41254b-872a-4c95-86fd-21ea7cdbf01e" />

**After**
**Network**
<img width="637" height="457" alt="Screenshot 2025-07-31 at 10 10 05 AM" src="https://github.com/user-attachments/assets/baa0ec73-0776-4edd-ab27-76b8cfa0508f" />

**Subnets**
<img width="652" height="445" alt="Screenshot 2025-07-31 at 10 10 44 AM" src="https://github.com/user-attachments/assets/f987879e-7568-463c-8a90-a698cd357563" />




**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7099 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
API Provides a fallback mechanism in case it fails to list by name it search network with network ID which is always generated by openstack network provider.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes network selection to display network ID when name is missing in OpenStack.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
tbd
```
