### PR TITLE
Enable of config drive for open stack

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/openstack/style.scss
+++ b/modules/web/src/app/node-data/basic/provider/openstack/style.scss
@@ -22,7 +22,3 @@
   align-self: center;
   margin-left: 5px;
 }
-
-.use-floating-ip-checkbox {
-  padding-bottom: 20px;
-}

--- a/modules/web/src/app/node-data/basic/provider/openstack/template.html
+++ b/modules/web/src/app/node-data/basic/provider/openstack/template.html
@@ -96,15 +96,23 @@ limitations under the License.
     </div>
   </km-combobox>
 
-  <mat-checkbox class="use-floating-ip-checkbox"
-                [formControlName]="Controls.UseFloatingIP"
-                fxFlex
-                kmValueChangedIndicator>
-    Allocate Floating IP
+  <div>
+    <mat-checkbox [formControlName]="Controls.UseFloatingIP"
+                  kmValueChangedIndicator>
+      Allocate Floating IP
+    </mat-checkbox>
     <i *ngIf="isFloatingIPEnforced()"
        class="km-icon-info icon-info km-pointer"
        matTooltip="Floating IP usage is enforced by selected datacenter"></i>
-  </mat-checkbox>
+  </div>
+  <div>
+    <mat-checkbox [formControlName]="Controls.EnableConfigDrive">
+      Enable Config Drive
+    </mat-checkbox>
+    <i *ngIf="isConfigDriveEnforced()"
+       class="km-icon-info icon-info km-pointer"
+       matTooltip="Config Drive usage is enforced by selected datacenter"></i>
+  </div>
 
   <km-number-stepper [formControlName]="Controls.InstanceReadyCheckPeriod"
                      mode="errors"

--- a/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
@@ -187,9 +187,21 @@ limitations under the License.
     <km-machine-flavor-filter class="km-machine-flavor-filter"
                               [formControl]="form.get(controls.MachineFlavorFilter)"
                               [machineFlavorFilter]="machineFlavorFilter"></km-machine-flavor-filter>
-  </form>
+    <mat-card-title class="property-name">Provider Configuration</mat-card-title>
+    <ng-container *ngIf="form.get(controls.Provider).value === Provider.OpenStack">
+      <mat-checkbox [formControlName]="controls.EnableConfigDrive">
 
-  <div class="property-name">Provider Configuration</div>
+        <div fxLayout="row"
+             fxLayoutAlign=" center"
+             fxLayoutGap="4px">
+          <span>Enable Config Drive</span>
+          <i class="km-icon-info km-pointer"
+             matTooltip="Enabling Config Drive will enforce it for all newly created machine deployments using this datacenter.">
+          </i>
+        </div>
+      </mat-checkbox>
+    </ng-container>
+  </form>
   <km-editor [(model)]="providerConfig"
              header="YAML"></km-editor>
   <mat-hint>If not specified default configuration will be used.</mat-hint>

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -1186,6 +1186,9 @@ limitations under the License.
               <km-property-boolean label="Allocate Floating IP"
                                    [value]="machineDeployment.spec.template.cloud?.openstack?.useFloatingIP">
               </km-property-boolean>
+              <km-property-boolean label="Enable Config Drive"
+                                   [value]="machineDeployment.spec.template.cloud?.openstack?.configDrive">
+              </km-property-boolean>
             </ng-container>
 
             <!-- AWS Tags -->

--- a/modules/web/src/app/shared/entity/datacenter.ts
+++ b/modules/web/src/app/shared/entity/datacenter.ts
@@ -134,6 +134,7 @@ export class OpenStackDatacenterSpec {
   region: string;
   images: DatacenterOperatingSystemOptions;
   enforceFloatingIP: boolean;
+  enableConfigDrive?: boolean;
 }
 
 export class EquinixDatacenterSpec {

--- a/modules/web/src/app/shared/entity/node.ts
+++ b/modules/web/src/app/shared/entity/node.ts
@@ -265,6 +265,7 @@ export class OpenstackNodeSpec {
   availabilityZone?: string;
   instanceReadyCheckPeriod: string;
   instanceReadyCheckTimeout: string;
+  configDrive?: boolean;
 }
 
 export class EquinixNodeSpec {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new checkbox to enable the config drive for MD in the OpenStack provider, and also add an option at the datacenter level to enforce enabling it on all MDs.

<img width="588" height="381" alt="image" src="https://github.com/user-attachments/assets/caf0f19a-c6a6-4028-bcb6-5b8a938e1fe4" />

<img width="588" height="381" alt="image" src="https://github.com/user-attachments/assets/608d7343-8bd3-4320-ba9d-db66bbfb63f5" />



**Which issue(s) this PR fixes**:
Fixes #6733 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Added a new option to enable the config drive on the OpenStack provider for machine deployments, along with a datacenter-level option to enforce it for all machine deployments.
```

**Documentation**:
```documentation
TBD
```
