### PR TITLE
[release/v2.26] Moving web-terminal clean job to seed

### DIFF
--- a/modules/api/pkg/watcher/types.go
+++ b/modules/api/pkg/watcher/types.go
@@ -32,6 +32,7 @@ type Providers struct {
 	PrivilegedProjectProvider provider.PrivilegedProjectProvider
 	UserInfoGetter            provider.UserInfoGetter
 	SeedsGetter               provider.SeedsGetter
+	SeedClientGetter          provider.SeedClientGetter
 	ClusterProviderGetter     provider.ClusterProviderGetter
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a cherry-pick of #7451

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Move web-terminal cleanup job to seed to fix cleanup not working when the token is expired.
```


