### PR TITLE
[release/v2.26] Refresh and update token for webterminal kubeconfig when token is expired

### DIFF
--- a/modules/api/.gitignore
+++ b/modules/api/.gitignore
@@ -29,6 +29,7 @@
 .settings/
 .vscode/*
 .nvmrc
+.history
 
 # Misc.
 /.sass-cache

--- a/modules/api/pkg/handler/common/kubeconfig.go
+++ b/modules/api/pkg/handler/common/kubeconfig.go
@@ -582,15 +582,10 @@ func createKubeconfigSecret(ctx context.Context, client ctrlruntimeclient.Client
 		resources.KubeconfigSecretKey: kubeconfig,
 	}
 
-	// return if already exists
-	if existingSecret.Name != "" {
-		return nil
-	}
-
-	return createSecret(ctx, client, kubeconfigSecretName, email, secretData)
+	return createSecret(ctx, client, kubeconfigSecretName, email, secretData, existingSecret.Name)
 }
 
-func createSecret(ctx context.Context, client ctrlruntimeclient.Client, name, email string, secretData map[string][]byte) error {
+func createSecret(ctx context.Context, client ctrlruntimeclient.Client, name, email string, secretData map[string][]byte, existingSecretName string) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -599,6 +594,10 @@ func createSecret(ctx context.Context, client ctrlruntimeclient.Client, name, em
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: secretData,
+	}
+
+	if existingSecretName != "" {
+		return client.Update(ctx, secret)
 	}
 	return client.Create(ctx, secret)
 }

--- a/modules/api/pkg/handler/middleware/middleware.go
+++ b/modules/api/pkg/handler/middleware/middleware.go
@@ -1031,7 +1031,7 @@ func OIDCProviders(clusterProviderGetter provider.ClusterProviderGetter, oidcIss
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			seedCluster := request.(seedClusterGetter).GetSeedCluster()
 
-			oidcIssuerVerifier, err := getOIDCIssuerVerifier(ctx, clusterProviderGetter, oidcIssuerVerifierGetter, seedsGetter, seedCluster.ClusterID)
+			oidcIssuerVerifier, err := GetOIDCIssuerVerifier(ctx, clusterProviderGetter, oidcIssuerVerifierGetter, seedsGetter, seedCluster.ClusterID)
 			if err != nil {
 				return nil, err
 			}
@@ -1041,7 +1041,7 @@ func OIDCProviders(clusterProviderGetter provider.ClusterProviderGetter, oidcIss
 	}
 }
 
-func getOIDCIssuerVerifier(
+func GetOIDCIssuerVerifier(
 	ctx context.Context,
 	clusterProviderGetter provider.ClusterProviderGetter,
 	oidcIssuerVerifierGetter provider.OIDCIssuerVerifierGetter,

--- a/modules/api/pkg/handler/test/fake_auth.go
+++ b/modules/api/pkg/handler/test/fake_auth.go
@@ -139,6 +139,18 @@ func (o *IssuerVerifier) Exchange(ctx context.Context, code, overwriteRedirectUR
 	}, nil
 }
 
+// RefreshAccessToken simulates refreshing an access token.
+func (o *IssuerVerifier) RefreshAccessToken(ctx context.Context, refToken string) (authtypes.OIDCToken, error) {
+	if refToken != refreshToken {
+		return authtypes.OIDCToken{}, errors.New("invalid refresh token")
+	}
+
+	return authtypes.OIDCToken{
+		IDToken:      IDToken,
+		RefreshToken: refreshToken,
+	}, nil
+}
+
 // Verify parses a raw ID Token, verifies it's been signed by the provider, performs
 // any additional checks depending on the Config, and returns the payload as TokenClaims.
 func (o *IssuerVerifier) Verify(ctx context.Context, token string) (authtypes.TokenClaims, error) {

--- a/modules/api/pkg/provider/auth/types/types.go
+++ b/modules/api/pkg/provider/auth/types/types.go
@@ -52,6 +52,9 @@ type OIDCIssuer interface {
 	// Exchange converts an authorization code into a token.
 	Exchange(ctx context.Context, code, overwriteRedirectURI string) (OIDCToken, error)
 
+	// RefreshAccessToken uses a refresh token to obtain a new OIDC token.
+	RefreshAccessToken(ctx context.Context, refreshToken string) (OIDCToken, error)
+
 	// OIDCConfig returns the issuers OIDC config
 	OIDCConfig() *OIDCConfiguration
 }

--- a/modules/api/pkg/watcher/types.go
+++ b/modules/api/pkg/watcher/types.go
@@ -34,6 +34,7 @@ type Providers struct {
 	SeedsGetter               provider.SeedsGetter
 	SeedClientGetter          provider.SeedClientGetter
 	ClusterProviderGetter     provider.ClusterProviderGetter
+	OIDCIssuerVerifierGetter  provider.OIDCIssuerVerifierGetter
 }
 
 type SettingsWatcher interface {

--- a/modules/web/.gitignore
+++ b/modules/web/.gitignore
@@ -34,6 +34,7 @@
 .settings/
 .vscode/*
 .nvmrc
+.history
 
 # Misc.
 /.sass-cache

--- a/modules/web/src/app/shared/components/terminal/component.ts
+++ b/modules/web/src/app/shared/components/terminal/component.ts
@@ -62,6 +62,8 @@ enum Operations {
 
 enum ErrorOperations {
   KubeConfigSecretMissing = 'KUBECONFIG_SECRET_MISSING',
+  KubeConfigSecretInvalid = 'KUBECONFIG_SECRET_INVALID',
+  WebTerminalTokenExpired = 'WEBTERMINAL_TOKEN_EXPIRED',
   WebTerminalPodPending = 'WEBTERMINAL_POD_PENDING',
   ConnectionPoolExceeded = 'CONNECTION_POOL_EXCEEDED',
   RefreshesLimitExceeded = 'REFRESHES_LIMIT_EXCEEDED',
@@ -70,6 +72,7 @@ enum ErrorOperations {
 enum MessageTypes {
   Ping = 'PING',
   Pong = 'PONG',
+  WebTerminalTokenValid = 'WEBTERMINAL_TOKEN_VALID',
 }
 @Component({
   selector: 'km-terminal',
@@ -89,6 +92,7 @@ export class TerminalComponent implements OnChanges, OnInit, OnDestroy, AfterVie
   terminal: Terminal;
   isConnectionLost: boolean;
   isSessionExpiring: boolean;
+  isTokenExpired: boolean;
   isLoadingTerminal = true;
   isDexAuthenticationPageOpened = false;
   showCloseButtonOnToolbar: boolean;
@@ -245,6 +249,11 @@ export class TerminalComponent implements OnChanges, OnInit, OnDestroy, AfterVie
     this.isSessionExpiring = false;
   }
 
+  onTokenExpired(): void {
+    const url = this._getWebTerminalProxyURL();
+    window.open(url, '_blank');
+  }
+
   private _getWebTerminalProxyURL(): string {
     const userId = this._user?.id;
     return this._clusterService.getWebTerminalProxyURL(this.projectId, this.cluster.id, userId);
@@ -276,35 +285,48 @@ export class TerminalComponent implements OnChanges, OnInit, OnDestroy, AfterVie
       this._initializeTerminalOnSuccess.complete();
       this._logToTerminal(frame.Data);
     } else if (frame.Op === Operations.Msg) {
-      if (frame.Data === ErrorOperations.KubeConfigSecretMissing) {
-        if (!this.isDexAuthenticationPageOpened) {
-          const url = this._getWebTerminalProxyURL();
-          window.open(url, '_blank');
-          this.isDexAuthenticationPageOpened = true;
-        }
-        this.message = 'Please wait, authenticate in order to access web terminal...';
-      } else if (frame.Data === ErrorOperations.WebTerminalPodPending) {
-        this.message = 'Please wait, provisioning your Web Terminal pod...';
-      } else if (frame.Data === ErrorOperations.ConnectionPoolExceeded) {
-        const message = `Oops! There could be ${this.MAX_SESSION_SUPPORTED} concurrent session per user. Please either discard or close other sessions`;
-        if (this.terminal) {
-          this._logToTerminal(message);
-        } else {
-          this.message = message;
-        }
-      } else if (frame.Data === ErrorOperations.RefreshesLimitExceeded) {
-        const clusterName = this.cluster && this.cluster.name;
-        this._logToTerminal(
-          `Oops! Max limit of ${this.MAX_EXPIRATION_REFRESHES} refreshes is reached. You are not allowed to extend the session for \x1b[1;34m${clusterName}\x1B[0m\n\n\r`
-        );
-      } else if (frame.Data === MessageTypes.Ping) {
-        if (this.terminal) {
-          // Note: Periodic exchange of messages with server to keep the web Terminal connection alive
-          this._keepConnectionAlive(MessageTypes.Pong);
-        }
-      }
+      this._handelOperationsError(frame.Data);
+      this._handelMessageTypes(frame.Data);
     } else if (frame.Op === Operations.Expiration) {
       this.isSessionExpiring = true;
+    }
+  }
+
+  private _handelOperationsError(data: string): void {
+    if (data === ErrorOperations.KubeConfigSecretMissing) {
+      if (!this.isDexAuthenticationPageOpened) {
+        const url = this._getWebTerminalProxyURL();
+        window.open(url, '_blank');
+        this.isDexAuthenticationPageOpened = true;
+      }
+      this.message = 'Please wait, authenticate in order to access web terminal...';
+    } else if (data === ErrorOperations.WebTerminalPodPending) {
+      this.message = 'Please wait, provisioning your Web Terminal pod...';
+    } else if (data === ErrorOperations.WebTerminalTokenExpired || data === ErrorOperations.KubeConfigSecretInvalid) {
+      this.isTokenExpired = true;
+    } else if (data === ErrorOperations.ConnectionPoolExceeded) {
+      const message = `Oops! There could be ${this.MAX_SESSION_SUPPORTED} concurrent session per user. Please either discard or close other sessions`;
+      if (this.terminal) {
+        this._logToTerminal(message);
+      } else {
+        this.message = message;
+      }
+    } else if (data === ErrorOperations.RefreshesLimitExceeded) {
+      const clusterName = this.cluster && this.cluster.name;
+      this._logToTerminal(
+        `Oops! Max limit of ${this.MAX_EXPIRATION_REFRESHES} refreshes is reached. You are not allowed to extend the session for \x1b[1;34m${clusterName}\x1B[0m\n\n\r`
+      );
+    }
+  }
+
+  private _handelMessageTypes(data: string): void {
+    if (data === MessageTypes.WebTerminalTokenValid) {
+      this.isTokenExpired = false;
+    } else if (data === MessageTypes.Ping) {
+      if (this.terminal) {
+        // Note: Periodic exchange of messages with server to keep the web Terminal connection alive
+        this._keepConnectionAlive(MessageTypes.Pong);
+      }
     }
   }
 

--- a/modules/web/src/app/shared/components/terminal/template.html
+++ b/modules/web/src/app/shared/components/terminal/template.html
@@ -38,11 +38,13 @@ limitations under the License.
                          (openInNewTab)="openInSeparateView()"
                          (close)="onClose()"></km-terminal-toolbar>
 
-    <km-terminal-status-bar *ngIf="isConnectionLost || isSessionExpiring"
+    <km-terminal-status-bar *ngIf="isConnectionLost || isSessionExpiring || isTokenExpired"
                             [isConnectionLost]="isConnectionLost"
                             [isSessionExpiring]="isSessionExpiring"
+                            [isTokenExpired]="isTokenExpired"
                             (reconnect)="onReconnect()"
-                            (extendSession)="onExtendSession()">
+                            (extendSession)="onExtendSession()"
+                            (tokenExpired)="onTokenExpired()">
     </km-terminal-status-bar>
 
     <div #terminal></div>

--- a/modules/web/src/app/shared/components/terminal/terminal-status-bar/component.ts
+++ b/modules/web/src/app/shared/components/terminal/terminal-status-bar/component.ts
@@ -14,6 +14,12 @@
 
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
+enum TerminalState {
+  Expired = 'expired',
+  ConnectionLost = 'connectionLost',
+  Expiring = 'expiring',
+}
+
 @Component({
   selector: 'km-terminal-status-bar',
   templateUrl: './template.html',
@@ -22,8 +28,17 @@ import {Component, EventEmitter, Input, Output} from '@angular/core';
 export class TerminalStatusBarComponent {
   @Input() isConnectionLost: boolean;
   @Input() isSessionExpiring: boolean;
+  @Input() isTokenExpired: boolean;
   @Output() reconnect = new EventEmitter<void>();
   @Output() extendSession = new EventEmitter<void>();
+  @Output() tokenExpired = new EventEmitter<void>();
+  terminalState = TerminalState;
+
+  get sessionState(): TerminalState {
+    if (this.isTokenExpired) return TerminalState.Expired;
+    if (this.isConnectionLost) return TerminalState.ConnectionLost;
+    return TerminalState.Expiring;
+  }
 
   onExtendSession(): void {
     this.extendSession.emit();
@@ -31,5 +46,9 @@ export class TerminalStatusBarComponent {
 
   onReconnect(): void {
     this.reconnect.emit();
+  }
+
+  onTokenExpired(): void {
+    this.tokenExpired.emit();
   }
 }

--- a/modules/web/src/app/shared/components/terminal/terminal-status-bar/template.html
+++ b/modules/web/src/app/shared/components/terminal/terminal-status-bar/template.html
@@ -21,23 +21,37 @@ limitations under the License.
     <div>
       <i class="km-icon-warning"></i>
     </div>
-    <div>
+    <div [ngSwitch]="sessionState">
+      <p *ngSwitchCase="terminalState.Expired">
+        Session expired. Authenticate again and wait a few seconds for the new kubeconfig to mount.
+      </p>
 
-      <ng-container *ngIf="isConnectionLost; else sessionExpiration">
-        <p>The connection to your Web Terminal was lost.</p>
-      </ng-container>
+      <p *ngSwitchCase="terminalState.ConnectionLost">
+        The connection to your Web Terminal was lost.
+      </p>
 
-      <ng-template #sessionExpiration>
-        <p>The web session will expire soon.</p>
-      </ng-template>
+      <p *ngSwitchCase="terminalState.Expiring">
+        The web session will expire soon.
+      </p>
     </div>
   </div>
 
-  <div fxFlex
+  <div [ngSwitch]="sessionState"
+       fxFlex
        fxLayout="row"
        fxLayoutAlign="end center"
        fxLayoutGap="10px">
-    <button *ngIf="isConnectionLost"
+    <button *ngSwitchCase="'expired'"
+            mat-flat-button
+            class="button-border-box"
+            matTooltip="Authenticate again to regain access"
+            (click)="onTokenExpired()">
+      <i class="km-icon-mask km-icon-reconnect"
+         matButtonIcon></i>
+      <span>Authenticate</span>
+    </button>
+
+    <button *ngSwitchCase="'connectionLost'"
             mat-flat-button
             class="button-border-box"
             matTooltip="Gain lost connection to terminal"
@@ -47,7 +61,7 @@ limitations under the License.
       <span>Reconnect</span>
     </button>
 
-    <button *ngIf="isSessionExpiring"
+    <button *ngSwitchCase="'expiring'"
             mat-flat-button
             class="button-border-box"
             matTooltip="Retain current session to terminal"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a cherry-pick of #7508 

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix web terminal token expiration by refreshing expired tokens automatically.
```

**Documentation**:
```documentation
NONE
```
