### PR TITLE
[release/v2.28] Bump chrome-headless image to  1.8.1 and fix noctx lint issues

### DIFF
--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.8.0
+        - image: quay.io/kubermatic/chrome-headless:v1.8.1
           imagePullPolicy: Always
           command:
             - make
@@ -49,7 +49,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.8.0
+        - image: quay.io/kubermatic/chrome-headless:v1.8.1
           imagePullPolicy: Always
           command:
             - make
@@ -77,7 +77,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.8.0
+        - image: quay.io/kubermatic/chrome-headless:v1.8.1
           command:
             - make
             - web-test-headless
@@ -179,7 +179,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.8.0
+        - image: quay.io/kubermatic/chrome-headless:v1.8.1
           imagePullPolicy: Always
           command:
             - make
@@ -234,7 +234,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.8.0
+        - image: quay.io/kubermatic/chrome-headless:v1.8.1
           imagePullPolicy: Always
           command:
             - make

--- a/modules/api/.golangci.yml
+++ b/modules/api/.golangci.yml
@@ -122,12 +122,8 @@ linters:
         text: cyclomatic complexity [0-9]+ of func `GetAPIV2NodeCloudSpec` is high
       - path: (.+)\.go$
         text: loop variable tc captured by func literal
-      # TODO (#sig-api): Fix the following lint issues
       - path: (.+)\.go$
         text: The Packet / Equinix Metal provider is deprecated
-      # TODO (#sig-api): Should be fixed via https://github.com/kubermatic/dashboard/issues/7544
-      - path: (.+)\.go$
-        text: net/http\.NewRequest must not be called\. use net/http\.NewRequestWithContext
     paths:
       - modules/api/pkg/provider/cloud/eks/authenticator
       - third_party$

--- a/modules/api/pkg/test/e2e/utils/dex/client.go
+++ b/modules/api/pkg/test/e2e/utils/dex/client.go
@@ -126,7 +126,7 @@ func (c *Client) fetchLoginURL(ctx context.Context, connector ConnectorType) (*u
 
 	c.log.Debugw("Fetching OIDC login page", "url", loginURL.String())
 
-	req, err := http.NewRequest(http.MethodGet, loginURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, loginURL.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for login page: %w", err)
 	}
@@ -174,7 +174,7 @@ func (c *Client) authenticate(ctx context.Context, loginURL *url.URL, login stri
 	c.log.Debugw("Sending login request", "url", loginURL.String(), "login", login)
 
 	// prepare request
-	req, err := http.NewRequest(http.MethodPost, loginURL.String(), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, loginURL.String(), buf)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump chrome-headless image version to 1.8.1 and fix noctx lint issues.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
