### PR TITLE
[release/v2.28] Bump Go version to v1.24.7

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
           command:
             - "./hack/ci/run-api-e2e.sh"
           env:
@@ -60,7 +60,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-9
           command:
             - make
           args:
@@ -81,7 +81,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-9
           command:
             - make
             - api-lint
@@ -101,7 +101,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-9
           command:
             - make
             - api-verify
@@ -121,7 +121,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-9
           command:
             - make
             - api-build

--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
           command:
             - ./hack/ci/verify.sh
           resources:

--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -103,7 +103,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
           command:
             - make
             - web-check-dependencies
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-9
           command:
             - make
             - web-lint
@@ -139,7 +139,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-8
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
           command:
             - make
             - web-check

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-8 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -2,7 +2,7 @@ module k8c.io/dashboard/v2
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.24.7
 
 require (
 	code.cloudfoundry.org/go-pubsub v0.0.0-20250325104231-893079a7322c

--- a/modules/api/hack/gen-api-client.sh
+++ b/modules/api/hack/gen-api-client.sh
@@ -24,7 +24,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-8 containerize ./modules/api/hack/gen-api-client.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./modules/api/hack/gen-api-client.sh
 
 cd $API/cmd/kubermatic-api/
 SWAGGER_FILE="swagger.json"

--- a/modules/api/hack/update-swagger.sh
+++ b/modules/api/hack/update-swagger.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-8 containerize ./$API/hack/update-swagger.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./$API/hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd $API/cmd/kubermatic-api/

--- a/modules/api/hack/verify-licenses.sh
+++ b/modules/api/hack/verify-licenses.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-8 containerize ./$API/hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./$API/hack/verify-licenses.sh
 
 cd $API
 go mod vendor

--- a/modules/web/containers/chrome-headless/Dockerfile
+++ b/modules/web/containers/chrome-headless/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-8
+FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
 
 LABEL maintainer="support@kubermatic.com"
 
 # Install Google Chrome and dependencies required by Cypress.
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor | tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
     apt-get update -qq && \
     apt-get install -y \
       google-chrome-stable \
-      libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+      libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb

--- a/modules/web/containers/chrome-headless/release.sh
+++ b/modules/web/containers/chrome-headless/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v1.8.1
+TAG=v1.8.2
 
 set -euo pipefail
 

--- a/modules/web/containers/custom-dashboard/Dockerfile
+++ b/modules/web/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-8
+FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump Go version to v1.24.7 which includes 2 CVE fixes [CVE-2025-47907](https://github.com/golang/go/issues/74832) and [CVE-2025-47906](https://github.com/golang/go/issues/74803). Also bump chrome-headless image to v1.8.2"

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Go version to v1.24.7
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
