### PR TITLE
Disable min/max option if autoscaler is not available

### DIFF
--- a/modules/web/src/app/core/interceptors/error-notifications.ts
+++ b/modules/web/src/app/core/interceptors/error-notifications.ts
@@ -44,7 +44,11 @@ export class ErrorNotificationsInterceptor implements HttpInterceptor {
   ];
 
   // Array of endpoints that should be silenced in the UI.
-  private readonly _silencedEndpoints = ['providers/gke/validatecredentials', 'presets?name='];
+  private readonly _silencedEndpoints = [
+    'providers/gke/validatecredentials',
+    'presets?name=',
+    'CLUSTER_AUTOSCALING_APP_DEF_NAME',
+  ];
 
   private readonly _errorMap = new Map<string, string>([
     ['"AccessKeyId" is not valid', Errors.InvalidCredentials],

--- a/modules/web/src/app/node-data/style.scss
+++ b/modules/web/src/app/node-data/style.scss
@@ -91,3 +91,11 @@ mat-button-toggle-group[group='operatingSystemGroup'] {
 .quota-widget {
   margin-bottom: 22px !important;
 }
+
+.km-icon-warning {
+  margin-bottom: 10px;
+}
+
+button:has(.km-icon-edit) {
+  width: 220px;
+}

--- a/modules/web/src/app/node-data/template.html
+++ b/modules/web/src/app/node-data/template.html
@@ -243,20 +243,30 @@ limitations under the License.
                         fxLayoutAlign="start center"
                         fxLayoutGap="5px">
           <div>Cluster Autoscaling</div>
-          <i *ngIf="isDialogView()"
+          <i *ngIf="isClusterAutoscalingEnabled()"
              class="km-icon-info km-pointer"
              matTooltip="Autoscaling of machines requires the Cluster Autoscaler application to be installed. NOTE: The addon for cluster-autoscaler has been deprecated in favor of the Application, please make sure to remove the addon from the cluster before enabling this option."></i>
         </mat-card-title>
       </mat-card-header>
 
-      <div fxLayoutAlign="space-between center"
-           *ngIf="!isDialogView()">
+      <div fxLayoutAlign="space-between center">
         <div>
+
+          <div *ngIf="!isClusterAutoscalingEnabled()"
+               class="km-selector-warning"
+               fxLayout="row"
+               fxLayoutAlign="start center">
+            <i class="km-icon-warning km-warning km-pointer"></i>
+            <p fxFlex="95">
+              {{clusterAutoscalerWarningMessage}}
+            </p>
+          </div>
           <mat-checkbox [name]="Controls.EnableClusterAutoscalingApp"
                         [formControlName]="Controls.EnableClusterAutoscalingApp">Enable Cluster Autoscaler Application
           </mat-checkbox>
-          <i class="km-icon-info km-pointer"
-             [matTooltip]="autoscalingTooltipText"></i>
+          <i *ngIf="isClusterAutoscalingEnabled()"
+             class="km-icon-info km-pointer"
+             matTooltip="Autoscaling of machines requires the Cluster Autoscaler application to be installed. Enable this option to install Cluster Autoscaler Application."></i>
         </div>
         <button *ngIf="form.get(Controls.EnableClusterAutoscalingApp).value"
                 mat-flat-button
@@ -274,6 +284,8 @@ limitations under the License.
                          hint="The minimum number of replicas for autoscaling. Minimum value can be 1"
                          [min]="MinReplicasCount"
                          [max]="form.get(Controls.MaxReplicas).value  || MaxReplicasCount"
+                         [required]="form.get(Controls.MaxReplicas).value"
+                         [disabled]="!isClusterAutoscalingEnabled()"
                          [formControlName]="Controls.MinReplicas">
       </km-number-stepper>
 
@@ -282,6 +294,8 @@ limitations under the License.
                          hint="The maximum number of replicas for autoscaling. Maximum value can be 1000."
                          [min]="form.get(Controls.MinReplicas).value || MinReplicasCount"
                          [max]="MaxReplicasCount"
+                         [required]="form.get(Controls.MinReplicas).value"
+                         [disabled]="!isClusterAutoscalingEnabled()"
                          [formControlName]="Controls.MaxReplicas">
       </km-number-stepper>
     </ng-container>


### PR DESCRIPTION
**What this PR does / why we need it**:
disable the min/max options if autoscaler is not available (if user cluster don't have the autoscaler app or if the app is not in the application catalog)

**dialog view:**
<img width="686" height="514" alt="Screenshot from 2025-09-09 09-07-40" src="https://github.com/user-attachments/assets/819ddc95-4c10-446c-95d9-8f555547c429" />

**wizard view:**
<img width="756" height="314" alt="Screenshot from 2025-09-09 08-50-47" src="https://github.com/user-attachments/assets/0ec22dfa-d28d-400c-a292-216059c425a7" />


**Which issue(s) this PR fixes**:
Fixes #7505 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Disable min/max options if cluster autoscaler is not available
```

**Documentation**:
```documentation
NONE
```
