### PR TITLE
Display node labels

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/node-list/template.html
+++ b/modules/web/src/app/cluster/details/cluster/node-list/template.html
@@ -533,6 +533,16 @@ limitations under the License.
             </km-property-boolean>
             <!-- End of boolean properties. -->
 
+            <!-- Provider labels -->
+            <km-property *ngIf="element.spec.labels">
+              <div key>Labels</div>
+              <div value>
+                <km-labels [labels]="element.spec.labels"
+                           emptyMessage="No assigned labels"></km-labels>
+              </div>
+            </km-property>
+            <!-- End of provider labels -->
+
             <div *ngIf="getMetrics(element.name)"
                  fxLayout="row">
               <km-property-usage name="Nodes CPU Usage"


### PR DESCRIPTION
**What this PR does / why we need it**:
Display node labels in the nodes list.

**Node detail:**
<img width="1527" height="342" alt="image" src="https://github.com/user-attachments/assets/529f1df7-c04c-4d61-8e61-045898535415" />

**Which issue(s) this PR fixes**:
Fixes #7553

**What type of PR is this?**
/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Display node labels in the nodes list table
```

**Documentation**:
```documentation
NONE
```
