### PR TITLE
[release/v2.26] Bump KKP dependency and version for KKP patch release 2.26.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.26.12
+KUBERMATIC_VERSION?=v2.26.13
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.26.12
+KUBERMATIC_VERSION?=v2.26.13
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -69,9 +69,9 @@ require (
 	google.golang.org/api v0.197.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.7.3
-	k8c.io/kubermatic/v2 v2.26.12-0.20250813092354-842f307ff061
+	k8c.io/kubermatic/v2 v2.26.13-0.20250915160303-cc5d475a016a
 	k8c.io/machine-controller v1.60.2
-	k8c.io/operating-system-manager v1.6.8
+	k8c.io/operating-system-manager v1.6.9
 	k8c.io/reconciler v0.5.0
 	k8s.io/api v0.32.2
 	k8s.io/apiextensions-apiserver v0.32.2
@@ -177,6 +177,8 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/hashicorp/golang-lru/arc/v2 v2.0.7 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -411,6 +411,10 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.7 h1:QxkVTxwColcduO+LP7eJO56r2hFiG8zEbfAAzRv52KQ=
+github.com/hashicorp/golang-lru/arc/v2 v2.0.7/go.mod h1:Pe7gBlGdc8clY5LJ0LpJXMt5AmgmWNH1g+oFFVUHOEc=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hetznercloud/hcloud-go v1.57.0 h1:aQZZFoJZcq9C1rGX/efZHyyRRmIJxND6tRf98NfIoSc=
@@ -1094,12 +1098,12 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.3 h1:KZ2Q6LQMxoiFf9UQ3ugqjid39NccduhJ50bdbP5tdIU=
 k8c.io/kubeone v1.7.3/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/v2 v2.26.12-0.20250813092354-842f307ff061 h1:JGEayhWglJrHV/+TGeyWsihkdOAmj/zyUlZ+cMZb2Os=
-k8c.io/kubermatic/v2 v2.26.12-0.20250813092354-842f307ff061/go.mod h1:p26RxFCXVEtdCF5fuh4vBN8NzM3JU7bNt55AGwOEkZM=
+k8c.io/kubermatic/v2 v2.26.13-0.20250915160303-cc5d475a016a h1:UUk2CjVezZ9FZdUlIJhvBzL4Ete40izkWoRxhm2hzkc=
+k8c.io/kubermatic/v2 v2.26.13-0.20250915160303-cc5d475a016a/go.mod h1:4JJsNsX3ecM7TJG35+7FVoZ1aEKRd9skPWDuWZq+2cM=
 k8c.io/machine-controller v1.60.2 h1:w5Q1BT5htSCvzRhRhyg7tzvmjLZR3cIGgDZxwl267vg=
 k8c.io/machine-controller v1.60.2/go.mod h1:j9SHRLpzFj5wOMlhdPJL+ub08P8rvVvQOFtg7JaLYb4=
-k8c.io/operating-system-manager v1.6.8 h1:KGDc4Xd3pLJ6/AmmJXgYY5xXnCU8QX6HJ9H/Ok8Ons8=
-k8c.io/operating-system-manager v1.6.8/go.mod h1:Dh9IZp5pb5G3s2r6ZrHUb+gTuHw5AmbIFYuFxIcgU7o=
+k8c.io/operating-system-manager v1.6.9 h1:TdzgPmP/whJ1vxDlgqQd8snNdNyWNJxqyjxsewcDPm0=
+k8c.io/operating-system-manager v1.6.9/go.mod h1:Dh9IZp5pb5G3s2r6ZrHUb+gTuHw5AmbIFYuFxIcgU7o=
 k8c.io/reconciler v0.5.0 h1:BHpelg1UfI/7oBFctqOq8sX6qzflXpl3SlvHe7e8wak=
 k8c.io/reconciler v0.5.0/go.mod h1:pT1+SVcVXJQeBJhpJBXQ5XW64QnKKeYTnVlQf0dGE0k=
 k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.26.12
+KUBERMATIC_VERSION?=v2.26.13
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.26.12",
+  "version": "2.26.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.26.12",
+      "version": "2.26.13",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.26.12",
+  "version": "2.26.13",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump KKP dependency and version for KKP patch release 2.26.13

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
