### PR TITLE
 Fix ClusterTemplate edit when autoscaler application is not enabled

### DIFF
--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -385,16 +385,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
       .get(Controls.EnableClusterAutoscalingApp)
       .valueChanges.pipe(takeUntil(this._unsubscribe))
       .subscribe(enable => {
-        this._filterOutAutoscalerApp();
-        if (enable) {
-          this._applicationService.applications = [
-            ...this._applicationService.applications,
-            this.autoscalerApplication,
-          ];
-        } else {
-          this.form.get(Controls.MaxReplicas).setValue(null);
-          this.form.get(Controls.MinReplicas).setValue(null);
-        }
+        this._updateAutoscalerApplication(enable);
       });
   }
 
@@ -745,6 +736,19 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     };
   }
 
+  private _updateAutoscalerApplication(enable: boolean): void {
+    const hasAutoscalerApp = this._applicationService.applications.some(
+      app => app.spec.applicationRef.name === CLUSTER_AUTOSCALING_APP_DEF_NAME
+    );
+
+    if (enable && !hasAutoscalerApp && this.autoscalerApplication) {
+      this._applicationService.applications = [...this._applicationService.applications, this.autoscalerApplication];
+    } else if (!enable && hasAutoscalerApp) {
+      this._filterOutAutoscalerApp();
+      this.form.get(Controls.MaxReplicas).setValue(null);
+      this.form.get(Controls.MinReplicas).setValue(null);
+    }
+  }
   private _filterOutAutoscalerApp(): void {
     this._applicationService.applications = this._applicationService.applications.filter(
       app => app.spec.applicationRef.name !== CLUSTER_AUTOSCALING_APP_DEF_NAME

--- a/modules/web/src/app/wizard/component.ts
+++ b/modules/web/src/app/wizard/component.ts
@@ -365,12 +365,12 @@ export class WizardComponent implements OnInit, OnDestroy {
         template.nodeDeployment.name = namePrefix;
         this._clusterSpecService.initializeClusterFromClusterTemplate(template);
         this._nodeDataService.initializeNodeDataFromMachineDeployment(template.nodeDeployment);
-        template.applications.forEach(app => {
+        template.applications?.forEach(app => {
           if (app.spec.applicationRef.name === CLUSTER_AUTOSCALING_APP_DEF_NAME) {
             (app.labels ??= {})[ApplicationLabel.ManagedBy] = ApplicationLabelValue.KKP;
           }
         });
-        this._applicationService.applications = template.applications;
+        this._applicationService.applications = template.applications || [];
         this.clusterTemplate = template;
 
         // Re-initialize the form.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where editing cluster templates would fail when the autoscaler application is not enabled or present in the template.

<img width="735" height="246" alt="image" src="https://github.com/user-attachments/assets/b0dda7ac-1475-4ee5-86bb-a9cd9a4e02d3" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
- [Bug: Reference PR](https://github.com/kubermatic/dashboard/pull/7500)

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
  Fix cluster template editing when autoscaler application is not present
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
