### PR TITLE
Fix encryption configuration handling in cluster edit

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -604,9 +604,9 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   private _handleEncryptionConfigurationChanges(patch: ClusterPatch): void {
-    const encryptionEnabled = this.form.get(Controls.EncryptionAtRest).value;
+    const encryptionEnabled = !!this.form.get(Controls.EncryptionAtRest).value;
     const encryptionKey = this.form.get(Controls.EncryptionAtRestKey).value;
-    const wasEnabled = this.cluster.spec.encryptionConfiguration?.enabled;
+    const wasEnabled = !!this.cluster.spec.encryptionConfiguration?.enabled;
 
     if (encryptionEnabled !== wasEnabled || (encryptionEnabled && encryptionKey)) {
       patch.spec.encryptionConfiguration = {
@@ -619,7 +619,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
         }
         patch.annotations[this.ENCRYPTION_KEY_ANNOTATION] = encryptionKey;
       }
-    } else if (this.cluster.spec.encryptionConfiguration) {
+    } else if (wasEnabled) {
       patch.spec.encryptionConfiguration = this.cluster.spec.encryptionConfiguration;
     }
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the encryption configuration handling in the cluster edit  component by adding explicit boolean conversions and removing unnecessary  patch assignment when encryption settings haven't changed.


<img width="719" height="367" alt="image" src="https://github.com/user-attachments/assets/5492eee3-cdad-4fdd-bbf0-222f2851f89d" />

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

- [Bug: Reference PR](https://github.com/kubermatic/dashboard/pull/7599/files#diff-4cde679d28715ceee620ba265cb68ce799fdda1401908486688da58bff1a6416R606)

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
  Fix encryption configuration handling during cluster editing
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
