### PR TITLE
Add optional chaining to prevent undefined cluster access in router reconciliation

### DIFF
--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -78,12 +78,12 @@ import _ from 'lodash';
 import {combineLatest, merge, Subscription} from 'rxjs';
 import {filter, finalize, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {coerce, compare, gte} from 'semver';
+import {WizardMode} from '../../types/wizard-mode';
 import {StepBase} from '../base';
 import {
   CiliumApplicationValuesDialogComponent,
   CiliumApplicationValuesDialogData,
 } from './cilium-application-values-dialog/component';
-import {WizardMode} from '../../types/wizard-mode';
 
 export enum BSLListState {
   Ready = 'Backup Storage Location',
@@ -333,7 +333,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
             this.form.addControl(
               Controls.RouterReconciliation,
               this._builder.control(
-                this._clusterSpecService?.cluster.annotations[
+                this._clusterSpecService?.cluster?.annotations?.[
                   InternalClusterSpecAnnotations.SkipRouterReconciliation
                 ] === 'true'
               )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a potential runtime error in the cluster wizard step component where accessing cluster.annotations for router reconciliation control in Openstack Provider 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
[Reference Link](https://github.com/kubermatic/dashboard/issues/7583#issuecomment-3385012135) 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
