### PR TITLE
Fix Kyverno issues

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/cluster-policies/template.html
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/cluster-policies/template.html
@@ -50,7 +50,7 @@ END OF TERMS AND CONDITIONS
           class="km-header-cell">Category</th>
       <td mat-cell
           *matCellDef="let element">
-        <span>{{element.spec.category}}</span>
+        <span>{{getCategory(element.spec.policyTemplateRef.name)}}</span>
       </td>
     </ng-container>
     <ng-container matColumnDef="namespace">
@@ -66,8 +66,7 @@ END OF TERMS AND CONDITIONS
         </div>
       <td mat-cell
           *matCellDef="let element">
-        <span *ngIf="element.spec.namespacedPolicy">{{policyBindings[element.name]?.namespace}}</span>
-        <span *ngIf="!element.spec.namespacedPolicy">Not Namespaced Policy</span>
+        <span>{{element.spec.kyvernoPolicyNamespace?.name ?? 'Not Namespaced Policy'}}</span>
       </td>
     </ng-container>
     <ng-container matColumnDef="view">
@@ -78,13 +77,16 @@ END OF TERMS AND CONDITIONS
           *matCellDef="let element">
         <div fxLayoutAlign="end"
              class="km-table-actions">
-          <button mat-icon-button
-                  (click)="viewTemplateSpec(element)">
-            <i class="km-icon-mask km-icon-show"></i>
-          </button>
+          <span [matTooltip]="canViewTemplate(element.spec.policyTemplateRef.name) ? 'View Template' : 'Template not available'">
+            <button mat-icon-button
+                    (click)="viewTemplateSpec(element.spec.policyTemplateRef.name)"
+                    [disabled]="!canViewTemplate(element.spec.policyTemplateRef.name)">
+              <i class="km-icon-mask km-icon-show"></i>
+            </button>
+          </span>
           <button mat-icon-button
                   (click)="deletePolicyBinding(element.name)"
-                  [disabled]="!canDeletePolicy(element.spec.enforced)">
+                  [disabled]="!canDeletePolicy(element.spec.policyTemplateRef.name)">
             <i class="km-icon-mask km-icon-delete"></i>
           </button>
         </div>
@@ -96,10 +98,10 @@ END OF TERMS AND CONDITIONS
         *matRowDef="let row; columns: columns;"></tr>
   </table>
   <div class="km-row km-empty-list-msg"
-       *ngIf="!policiesWithBinding.length && !loadingTemplates">No policy templates are available</div>
+       *ngIf="!policyBindings.length && !loadingTemplates">No policy templates are available</div>
 
   <div class="km-row"
-       *ngIf="loadingTemplates && policiesWithBinding.length">
+       *ngIf="loadingTemplates && policyBindings.length">
     <mat-spinner color="accent"
                  class="km-spinner km-with-spacing"
                  [diameter]="25"></mat-spinner>

--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/add-template/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/add-template/component.ts
@@ -34,7 +34,7 @@ import {
 import {Project} from '@app/shared/entity/project';
 import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
 import * as y from 'js-yaml';
-import {Observable, Subject, take} from 'rxjs';
+import {Observable, Subject, take, takeUntil} from 'rxjs';
 
 export interface AddPolicyTemplateDialogConfig {
   mode: PolicyTemplateDialogMode;
@@ -149,6 +149,18 @@ export class AddPolicyTemplateDialogComponent implements OnInit, OnDestroy {
       this.form.get(Controls.Project).disable();
       this.form.get(Controls.Scope).disable();
     }
+
+    this.form
+      .get(Controls.Enforced)
+      .valueChanges.pipe(takeUntil(this._unsubscribe))
+      .subscribe(value => {
+        if (value) {
+          this.form.get(Controls.NamespacedPolicy).setValue(false);
+          this.form.get(Controls.NamespacedPolicy).disable();
+        } else {
+          this.form.get(Controls.NamespacedPolicy).enable();
+        }
+      });
   }
 
   ngOnDestroy(): void {

--- a/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/add-template/template.html
+++ b/modules/web/src/app/dynamic/enterprise/kyverno-policies/policy-template/add-template/template.html
@@ -95,11 +95,13 @@ END OF TERMS AND CONDITIONS
         <i class="km-icon-info km-pointer"
            matTooltip="Enforced policies will be applied to all targeted clusters. Users can't delete them."></i>
       </mat-checkbox>
-      <mat-checkbox [formControlName]="controls.NamespacedPolicy">
-        Namespaced Policy
+      <span>
+        <mat-checkbox [formControlName]="controls.NamespacedPolicy">
+          Namespaced Policy
+        </mat-checkbox>
         <i class="km-icon-info km-pointer"
            matTooltip="Enable to scope the policy down to Namespace instead of the default i.e. Cluster scope."></i>
-      </mat-checkbox>
+      </span>
     </div>
     <km-label-form *ngIf="form.get(controls.Scope).value === scopes.Global"
                    title="Projects Labels Selector"


### PR DESCRIPTION
**What this PR does / why we need it**:

**fix :**
* Policy bindings are not shown in some cases when the user cluster labels are changed and the template selector no longer matches them.

* When Enforce Policy is enabled, the Namespaced Policy option must be disabled.

[Screencast from 2025-10-17 14-37-43.webm](https://github.com/user-attachments/assets/ab9ce08a-7bd9-4267-ab0c-ec3a5e06afd1)

**Which issue(s) this PR fixes**:
Fixes #7649 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix: Kyverno policy bindings disappear when the template selector no longer matches the cluster.
Enforcing Kyverno Policy disables the Namespaced option.
```

**Documentation**:
```documentation
NONE
```
