### PR TITLE
Minor UI improvments

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/share-kubeconfig/template.html
+++ b/modules/web/src/app/cluster/details/cluster/share-kubeconfig/template.html
@@ -66,7 +66,7 @@ limitations under the License.
           On Linux / macOS
           <div class="km-code-block km-copy"
                ngxClipboard
-               [cbContent]="installCommands.linuxInstallCommand"
+               [cbContent]="installCommands.brewInstallCommand"
                matTooltip="Click to copy">
             {{installCommands.brewInstallCommand}}
           </div>

--- a/modules/web/src/app/core/services/cluster.ts
+++ b/modules/web/src/app/core/services/cluster.ts
@@ -254,7 +254,8 @@ export class ClusterService {
   }
 
   getShareKubeconfigURL(projectID: string, clusterID: string, userID: string, oidcKubeLogin = false): string {
-    return `${this._location}${this._restRoot}/kubeconfig?project_id=${projectID}&cluster_id=${clusterID}&user_id=${userID}&oidc_kubelogin_enabled=${oidcKubeLogin}`;
+    const location = this._location.endsWith('/') ? this._location : `${this._location}/`;
+    return `${location}${this._restRoot}/kubeconfig?project_id=${projectID}&cluster_id=${clusterID}&user_id=${userID}&oidc_kubelogin_enabled=${oidcKubeLogin}`;
   }
 
   externalClusterEvents(projectID: string, clusterID: string): Observable<Event[]> {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix copy `brew install kubelogin` command on the share/get kubeconfig dialog
fix displaying two `/` in the share kubeconfig link

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
