### PR TITLE
revert case-sensitive update of immutable user email

### DIFF
--- a/modules/api/pkg/provider/kubernetes/user.go
+++ b/modules/api/pkg/provider/kubernetes/user.go
@@ -132,7 +132,6 @@ func (p *UserProvider) CreateUser(ctx context.Context, name, email string, group
 func (p *UserProvider) UpdateUser(ctx context.Context, user *kubermaticv1.User) (*kubermaticv1.User, error) {
 	// make sure the first patch doesn't override the status
 	status := user.Status.DeepCopy()
-	user.Spec.Email = strings.ToLower(user.Spec.Email)
 	if err := p.runtimeClient.Update(ctx, user); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes a regression bug. Since the field `spec.userEmail` in a user object is immutable the update of that field will return an error. This was introduced to ensure that we do not store the same user with a different email regarding capitalization.

customer ref: 8454

related pr: #7629 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A regression bug was fixed which introduced errors when a user tried to login with a user email containing uppercase letters and the one with only lowercase was already stored.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
