### PR TITLE
add Cluster ID tooltip to cluster and project overview

### DIFF
--- a/modules/web/src/app/cluster/list/cluster/template.html
+++ b/modules/web/src/app/cluster/list/cluster/template.html
@@ -89,7 +89,7 @@ limitations under the License.
             [attr.id]="'km-clusters-' + element.name">
           <div fxLayoutAlign=" center"
                fxLayoutGap="8px">
-            <span>{{element.name}}</span>
+            <span matTooltip="Cluster ID: {{element.id}}">{{element.name}}</span>
             @if (isRestoring(element.id)) {
             <div class="km-update-available-badge">
               Restoring

--- a/modules/web/src/app/project-overview/clusters-overview/template.html
+++ b/modules/web/src/app/project-overview/clusters-overview/template.html
@@ -41,7 +41,7 @@ limitations under the License.
             *matCellDef="let cluster">
           <div fxLayoutAlign=" center"
                fxLayoutGap="8px">
-            {{cluster.name}}
+            <span matTooltip="Cluster ID: {{cluster.id}}">{{cluster.name}}</span>
           </div>
         </td>
       </ng-container>


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds a tooltip to cluster names, showing the Cluster ID in a tooltip on the cluster and project overview pages, so that a user does not need to go into cluster detail view in order to get the Cluster ID.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Adds a Cluster ID tooltip to cluster and project overview.
```

**Documentation**:
```documentation
NONE
```

