### PR TITLE
Show cluster id in cluster list

### DIFF
--- a/modules/web/src/app/cluster/list/cluster/component.ts
+++ b/modules/web/src/app/cluster/list/cluster/component.ts
@@ -52,6 +52,7 @@ import {NodeProvider} from '@app/shared/model/NodeProviderConstants';
 
 enum Column {
   Status = 'status',
+  ID = 'id',
   Name = 'name',
   Provider = 'provider',
   Version = 'version',

--- a/modules/web/src/app/cluster/list/cluster/template.html
+++ b/modules/web/src/app/cluster/list/cluster/template.html
@@ -99,6 +99,22 @@ limitations under the License.
         </td>
       </ng-container>
 
+      <ng-container [matColumnDef]="Column.ID">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-30"
+            mat-sort-header>ID
+        </th>
+        <td mat-cell
+            *matCellDef="let element"
+            [attr.id]="'km-clusters-' + element.id">
+          <div fxLayoutAlign=" center"
+               fxLayoutGap="8px">
+            <span>{{element.id}}</span>
+          </div>
+        </td>
+      </ng-container>
+
       <ng-container [matColumnDef]="Column.Provider">
         <th mat-header-cell
             *matHeaderCellDef

--- a/modules/web/src/app/cluster/list/external-cluster/component.ts
+++ b/modules/web/src/app/cluster/list/external-cluster/component.ts
@@ -44,6 +44,7 @@ import {distinctUntilChanged, map, startWith, switchMap, take, takeUntil, tap} f
 
 enum Column {
   Status = 'status',
+  ID = 'id',
   Name = 'name',
   Provider = 'provider',
   Region = 'region',

--- a/modules/web/src/app/cluster/list/external-cluster/template.html
+++ b/modules/web/src/app/cluster/list/external-cluster/template.html
@@ -85,6 +85,22 @@ limitations under the License.
         </td>
       </ng-container>
 
+      <ng-container [matColumnDef]="Column.ID">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-30"
+            mat-sort-header>ID
+        </th>
+        <td mat-cell
+            *matCellDef="let element"
+            [attr.id]="'km-clusters-' + element.id">
+          <div fxLayoutAlign=" center"
+               fxLayoutGap="8px">
+            <span>{{element.id}}</span>
+          </div>
+        </td>
+      </ng-container>
+
       <ng-container [matColumnDef]="Column.Provider">
         <th mat-header-cell
             *matHeaderCellDef

--- a/modules/web/src/app/cluster/list/kubeone/component.ts
+++ b/modules/web/src/app/cluster/list/kubeone/component.ts
@@ -36,6 +36,7 @@ import {distinctUntilChanged, map, startWith, switchMap, take, takeUntil, tap} f
 
 enum Column {
   Status = 'status',
+  ID = 'id',
   Name = 'name',
   Provider = 'provider',
   Version = 'version',

--- a/modules/web/src/app/cluster/list/kubeone/template.html
+++ b/modules/web/src/app/cluster/list/kubeone/template.html
@@ -73,6 +73,22 @@ limitations under the License.
         </td>
       </ng-container>
 
+      <ng-container [matColumnDef]="Column.ID">
+        <th mat-header-cell
+            *matHeaderCellDef
+            class="km-header-cell p-30"
+            mat-sort-header>ID
+        </th>
+        <td mat-cell
+            *matCellDef="let element"
+            [attr.id]="'km-clusters-' + element.id">
+          <div fxLayoutAlign=" center"
+               fxLayoutGap="8px">
+            <span>{{element.id}}</span>
+          </div>
+        </td>
+      </ng-container>
+
       <ng-container [matColumnDef]="Column.Provider">
         <th mat-header-cell
             *matHeaderCellDef


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the cluster id is only shown on the cluster details page, it would be nice to have it also on the cluster list.

This PR adds a new column that shows the cluster ID.

**Which issue(s) this PR fixes**:

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add cluster id to cluster list view
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
