### PR TITLE
[release/v2.28] Bump KKP version and dependencies for KKP patch release v2.28.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.28.3
+KUBERMATIC_VERSION?=v2.28.4
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.28.3
+KUBERMATIC_VERSION?=v2.28.4
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -73,8 +73,8 @@ require (
 	google.golang.org/api v0.232.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8c.io/kubeone v1.10.0
-	k8c.io/kubermatic/sdk/v2 v2.28.3-0.20250915140301-6a627989824f
-	k8c.io/kubermatic/v2 v2.28.3-0.20250915140301-6a627989824f
+	k8c.io/kubermatic/sdk/v2 v2.28.4-0.20251118073448-3ea08a09d9eb
+	k8c.io/kubermatic/v2 v2.28.4-0.20251118073448-3ea08a09d9eb
 	k8c.io/machine-controller/sdk v1.62.1
 	k8c.io/operating-system-manager v1.7.6
 	k8c.io/reconciler v0.5.0

--- a/modules/api/go.sum
+++ b/modules/api/go.sum
@@ -1563,10 +1563,10 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8c.io/kubeone v1.7.2 h1:uLH19VEp1S5j4f3UwQP4CLHErJ23UiJM2MnbufNWDgI=
 k8c.io/kubeone v1.7.2/go.mod h1:9v2VFz/+l36cW65kd5YufEYHunbKlJ6P8SBakj05xgM=
-k8c.io/kubermatic/sdk/v2 v2.28.3-0.20250915140301-6a627989824f h1:O3D1yj0nwDDaSTOFaNa1pL+6FUXrT1KxB6N01dXPyh8=
-k8c.io/kubermatic/sdk/v2 v2.28.3-0.20250915140301-6a627989824f/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
-k8c.io/kubermatic/v2 v2.28.3-0.20250915140301-6a627989824f h1:zErs/hBh3q40KSkbZsWFUkiI2NHrkTUKTqSf+UCUBdo=
-k8c.io/kubermatic/v2 v2.28.3-0.20250915140301-6a627989824f/go.mod h1:K3+AyV22N7YWZI6T69UQ1l8kZvEKKvvE4PKSgbJZMC4=
+k8c.io/kubermatic/sdk/v2 v2.28.4-0.20251118073448-3ea08a09d9eb h1:KAD59bYj0TUWvBhu+0O3XLfnP7C/hD5ya6Ch/7zT17s=
+k8c.io/kubermatic/sdk/v2 v2.28.4-0.20251118073448-3ea08a09d9eb/go.mod h1:l7qjgKo7qLvJmgfT3FDvAx6ShLNpjdW7ew67v07SyUg=
+k8c.io/kubermatic/v2 v2.28.4-0.20251118073448-3ea08a09d9eb h1:dP6fW3a83Q1hQhXYA4qPLld74qCr+S1kqxiQYqcI8X8=
+k8c.io/kubermatic/v2 v2.28.4-0.20251118073448-3ea08a09d9eb/go.mod h1:K3+AyV22N7YWZI6T69UQ1l8kZvEKKvvE4PKSgbJZMC4=
 k8c.io/machine-controller/sdk v1.62.1 h1:6Q4Qq8W5BwczxeMRrDiYCNMNanAAdV0N2GjkC870Cns=
 k8c.io/machine-controller/sdk v1.62.1/go.mod h1:/5eWTMcfa7mTQUQoqziaalViiHSVzqzy3fXjejT1qLg=
 k8c.io/operating-system-manager v1.7.6 h1:CO7H0U3Ia/Wt6xAT3+fHFb4AXl6aeH6ZAFc8Em7/ALo=

--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
-KUBERMATIC_VERSION?=v2.28.3
+KUBERMATIC_VERSION?=v2.28.4
 CC=npm
 GOOS ?= $(shell go env GOOS)
 export GOOS

--- a/modules/web/package-lock.json
+++ b/modules/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kubermatic-dashboard",
-  "version": "2.28.3",
+  "version": "2.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kubermatic-dashboard",
-      "version": "2.28.3",
+      "version": "2.28.4",
       "hasInstallScript": true,
       "license": "proprietary",
       "dependencies": {

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubermatic-dashboard",
   "description": "Kubermatic Dashboard",
-  "version": "2.28.3",
+  "version": "2.28.4",
   "type": "module",
   "license": "proprietary",
   "repository": "https://github.com/kubermatic/dashboard",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump KKP version and dependencies for KKP patch release v2.28.4.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
