### PR TITLE
 Remove test prefix from quota widget label

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/template.html
+++ b/modules/web/src/app/dynamic/enterprise/quotas/quota-widget/template.html
@@ -194,7 +194,7 @@ END OF TERMS AND CONDITIONS
              fxLayout="row"
              fxLayoutGap="4px"
              fxLayoutAlign="space-between center">
-          <span>KR:{{label}}</span>
+          <span>{{label}}</span>
         </div>
         <mat-progress-bar value
                           class="property-usage-bar"


### PR DESCRIPTION
**What this PR does / why we need it**:

 This PR fixes a small issue where a test prefix "KR:" was accidentally left in the quota widget label template. 
 
Reference PR: https://github.com/kubermatic/dashboard/pull/7675/files#diff-8f5129f8b7d0dc97555097930aed280a413202481140c92d52e2a5e04840d17bR197