### PR TITLE
Display the predefined category tags for vSphere cluster tags

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/vmware-cloud-director/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/vmware-cloud-director/component.ts
@@ -367,7 +367,7 @@ export class VMwareCloudDirectorBasicNodeDataComponent
     const networkControl = this.form.get(Controls.Network);
     const additionalNetworksControl = this.form.get(Controls.AdditionalNetworks);
 
-    additionalNetworksControl.setValue(additionalNetworksControl.value.filter(n => this.networks.includes(n)));
+    additionalNetworksControl.setValue(additionalNetworksControl.value?.filter(n => this.networks.includes(n)));
 
     if (networkControl.value && this.networks.includes(networkControl.value)) {
       return;

--- a/modules/web/src/app/node-data/basic/provider/vmware-cloud-director/template.html
+++ b/modules/web/src/app/node-data/basic/provider/vmware-cloud-director/template.html
@@ -98,9 +98,8 @@ limitations under the License.
     </mat-select>
   </mat-form-field>
 
-
-  <mat-form-field fxFlex
-                  *ngIf="networks.length > 1">
+  @if (networks.length > 1) {
+  <mat-form-field fxFlex>
     <mat-label>Additional Networks</mat-label>
     <mat-select [formControlName]="Controls.AdditionalNetworks"
                 (selectionChange)="onAdditionalNetworkChanged($event.value)"
@@ -112,6 +111,7 @@ limitations under the License.
                   [disabled]="network == form.get(Controls.Network).value"> {{network}} </mat-option>
     </mat-select>
   </mat-form-field>
+  }
 
   <km-combobox #placementPolicyCombobox
                [selected]="selectedPlacementPolicy"

--- a/modules/web/src/app/shared/components/chip-autocomplete/template.html
+++ b/modules/web/src/app/shared/components/chip-autocomplete/template.html
@@ -63,5 +63,13 @@ limitations under the License.
       <span>Values must be <strong>unique</strong>.</span>
     </mat-error>
     }
+
+    @if (form.get(Controls.Tags).hasError('pattern')) {
+    <mat-error>
+      <span [innerHTML]="patternError"></span>
+    </mat-error>
+    }
+
+
   </mat-form-field>
 </form>

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/component.ts
@@ -256,8 +256,6 @@ export class VSphereProviderExtendedComponent extends BaseFormValidator implemen
     this._clusterSpecService.cluster.spec.cloud.vsphere.folder = folder;
   }
 
-  onLoadingTags(): void {}
-
   onTagCategoryChange(tagCategory: string): void {
     this.selectedTagCategory = tagCategory;
     this.predefinedTagList = [];

--- a/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
+++ b/modules/web/src/app/wizard/step/provider-settings/provider/extended/vsphere/template.html
@@ -114,6 +114,8 @@ limitations under the License.
                         placeholder="Add tags..."
                         [disabled]="form.get(Controls.Tags).disabled"
                         [required]="!!form.get(Controls.TagCategory).value"
+                        [patternError]="tagValuesPatternError"
+                        [pattern]="tagValuesPattern"
                         [tags]="predefinedTagList"
                         (onChange)="onTagValuesChange($event)" />
 </form>


### PR DESCRIPTION
**What this PR does / why we need it**:
Show the list of predefined category tags for vSphere cluster tags, and also keep the option to add other tags manually.

**Which issue(s) this PR fixes**:
Fixes #7395 

**What type of PR is this?**
/kind feature


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Show a list of predefined category tags for Vsphere when adding cluster tags.
```

**Documentation**:
```documentation
NONE
```
