### PR TITLE
Advance Machine Type Selector table - Azure

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/azure/machine-type-selector/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/azure/machine-type-selector/component.ts
@@ -1,0 +1,149 @@
+// Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChangeDetectionStrategy, Component, forwardRef, Input, OnChanges, OnInit, SimpleChanges} from '@angular/core';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {AzureSizes} from '@shared/entity/provider/azure';
+import {SizeState} from '../component';
+
+enum Column {
+  Select = 'select',
+  Name = 'name',
+  VCPUs = 'vcpus',
+  MemoryGB = 'memoryGB',
+  GPUs = 'gpus',
+}
+
+enum TabIndex {
+  Standard = 0,
+  GPU = 1,
+}
+
+@Component({
+  selector: 'km-azure-machine-type-selector',
+  templateUrl: './template.html',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => AzureMachineTypeSelectorComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: false,
+})
+export class AzureMachineTypeSelectorComponent implements OnInit, OnChanges, ControlValueAccessor {
+  @Input() options: AzureSizes[] = [];
+  @Input() label = SizeState.Ready;
+  @Input() required = false;
+  @Input() showGpuFilter = true;
+  @Input() isLoading = false;
+  @Input() selectedMachineType = '';
+
+  searchQuery = '';
+  selectedTabIndex = TabIndex.Standard;
+  sizeState = SizeState;
+
+  standardOptions: AzureSizes[] = [];
+  gpuOptions: AzureSizes[] = [];
+  filteredOptions: AzureSizes[] = [];
+  hasGpuTypes = false;
+  displayedColumns: string[] = [];
+
+  private _onChange: (value: string) => void = () => {};
+  private _onTouched: () => void = () => {};
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.options) {
+      this._categorizeOptions();
+    }
+    if (changes.selectedMachineType?.currentValue) {
+      this._onChange(changes.selectedMachineType.currentValue);
+    }
+  }
+
+  ngOnInit(): void {
+    this._categorizeOptions();
+  }
+
+  onTabChange(index: number): void {
+    this.selectedTabIndex = index;
+    this._updateDisplayedColumns();
+    this._applySearchFilter();
+  }
+
+  writeValue(value: string): void {
+    this.selectedMachineType = value || '';
+  }
+
+  registerOnChange(fn: (value: string) => void): void {
+    this._onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  onSearchChange(query: string): void {
+    this.searchQuery = query;
+    this._applySearchFilter();
+  }
+
+  onMachineTypeChange(machineTypeName: string): void {
+    this.selectedMachineType = machineTypeName;
+    this._onChange(machineTypeName);
+    this._onTouched();
+  }
+
+  trackById(_: number, option: AzureSizes): string {
+    return option.name;
+  }
+
+  private _categorizeOptions(): void {
+    const standard: AzureSizes[] = [];
+    const gpu: AzureSizes[] = [];
+
+    for (const option of this.options) {
+      if (option.numberOfGPUs > 0) {
+        gpu.push(option);
+      } else {
+        standard.push(option);
+      }
+    }
+
+    this.standardOptions = standard;
+    this.gpuOptions = gpu;
+    this.hasGpuTypes = gpu.length > 0;
+
+    this._updateDisplayedColumns();
+    this._applySearchFilter();
+  }
+
+  private _applySearchFilter(): void {
+    const sourceOptions = this.selectedTabIndex === TabIndex.GPU ? this.gpuOptions : this.standardOptions;
+
+    if (this.searchQuery) {
+      const query = this.searchQuery.toLowerCase();
+      this.filteredOptions = sourceOptions.filter(size => size.name.toLowerCase().includes(query));
+    } else {
+      this.filteredOptions = [...sourceOptions];
+    }
+  }
+
+  private _updateDisplayedColumns(): void {
+    const baseColumns = [Column.Select, Column.Name, Column.VCPUs, Column.MemoryGB];
+    const optionalColumns = this.selectedTabIndex === TabIndex.GPU ? [Column.GPUs] : [];
+    this.displayedColumns = [...baseColumns, ...optionalColumns];
+  }
+}

--- a/modules/web/src/app/node-data/basic/provider/azure/machine-type-selector/template.html
+++ b/modules/web/src/app/node-data/basic/provider/azure/machine-type-selector/template.html
@@ -1,0 +1,142 @@
+<!--
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div class="km-azure-machine-type-selector"
+     fxLayout="column">
+  <div class="km-text">
+    {{sizeState.Ready}}
+  </div>
+
+  <div class="km-machine-type-selector-panel km-border"
+       fxLayout="column">
+    <div class="km-machine-type-selector-search">
+      <mat-form-field class="km-machine-type-selector-search-field">
+        <mat-label>Search Node Size...</mat-label>
+        <input matInput
+               type="text"
+               [(ngModel)]="searchQuery"
+               (ngModelChange)="onSearchChange($event)"
+               placeholder="Filter by name" />
+        <i matPrefix
+           class="km-icon-mask km-icon-search"></i>
+      </mat-form-field>
+    </div>
+
+    <mat-tab-group class="km-machine-type-selector-tabs"
+                   mat-stretch-tabs="false"
+                   animationDuration="0ms"
+                   [selectedIndex]="selectedTabIndex"
+                   (selectedIndexChange)="onTabChange($event)">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span>Standard</span>
+          <span class="km-machine-type-selector-tab-count">({{standardOptions.length}})</span>
+        </ng-template>
+        <ng-container *ngTemplateOutlet="machineTypeTable" />
+      </mat-tab>
+
+      @if (showGpuFilter && hasGpuTypes) {
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span>GPU Supported</span>
+          <span class="km-machine-type-selector-tab-count">({{gpuOptions.length}})</span>
+        </ng-template>
+        <ng-container *ngTemplateOutlet="machineTypeTable" />
+      </mat-tab>
+      }
+    </mat-tab-group>
+  </div>
+</div>
+
+<ng-template #machineTypeTable>
+  <div class="km-machine-type-selector-table-container">
+    @if (isLoading) {
+    <div class="km-row"
+         fxLayoutAlign="center center">
+      <mat-spinner color="accent"
+                   class="km-spinner"
+                   [diameter]="25" />
+    </div>
+    }
+    @if (!isLoading) {
+    <mat-radio-group [value]="selectedMachineType"
+                     (change)="onMachineTypeChange($event.value)">
+      <table class="km-table km-machine-type-selector-table"
+             mat-table
+             [dataSource]="filteredOptions"
+             [trackBy]="trackById">
+        <ng-container matColumnDef="select">
+          <th mat-header-cell
+              *matHeaderCellDef
+              class="km-header-cell p-5"></th>
+          <td mat-cell
+              *matCellDef="let element">
+            <mat-radio-button [value]="element.name">
+            </mat-radio-button>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell
+              *matHeaderCellDef
+              class="km-header-cell p-35">Name</th>
+          <td mat-cell
+              *matCellDef="let element">
+            {{element.name}}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="vcpus">
+          <th mat-header-cell
+              *matHeaderCellDef
+              class="km-header-cell p-10">vCPU</th>
+          <td mat-cell
+              *matCellDef="let element">{{element.numberOfCores}}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="memoryGB">
+          <th mat-header-cell
+              *matHeaderCellDef
+              class="km-header-cell p-15">Memory</th>
+          <td mat-cell
+              *matCellDef="let element">{{(element.memoryInMB / 1024) | number:'1.0-0'}} GB</td>
+        </ng-container>
+
+        <ng-container matColumnDef="gpus">
+          <th mat-header-cell
+              *matHeaderCellDef
+              class="km-header-cell">GPUs</th>
+          <td mat-cell
+              *matCellDef="let element">{{element.numberOfGPUs || 0}}</td>
+        </ng-container>
+
+        <tr mat-header-row
+            *matHeaderRowDef="displayedColumns; sticky: true"
+            class="km-header-row"></tr>
+        <tr mat-row
+            *matRowDef="let row; columns: displayedColumns;"
+            class="km-mat-row"></tr>
+      </table>
+    </mat-radio-group>
+    }
+
+    @if (filteredOptions.length === 0 && !isLoading) {
+    <div class="km-empty-list-msg">
+      No node sizes found
+    </div>
+    }
+  </div>
+</ng-template>

--- a/modules/web/src/app/node-data/basic/provider/azure/template.html
+++ b/modules/web/src/app/node-data/basic/provider/azure/template.html
@@ -16,18 +16,13 @@ limitations under the License.
 <form [formGroup]="form"
       fxLayout="column"
       fxLayoutGap="8px">
-  <km-combobox [required]="true"
-               [grouped]="false"
-               [selected]="selectedSize"
-               [options]="currentSizes"
-               [formControlName]="Controls.Size"
-               [valueFormatter]="sizeDisplayName.bind(this)"
-               (changed)="onSizeChange($event)"
-               [label]="sizeLabel"
-               inputLabel="Select size..."
-               filterBy="name">
-    <div *option="let size">{{getSizeDisplayName(size)}}</div>
-  </km-combobox>
+  <km-azure-machine-type-selector [options]="currentSizes"
+                                  [label]="sizeLabel"
+                                  [required]="true"
+                                  [isLoading]="sizeLabel === SizeState.Loading"
+                                  [selectedMachineType]="selectedSize"
+                                  [formControlName]="Controls.Size">
+  </km-azure-machine-type-selector>
 
   <km-combobox [required]="false"
                [grouped]="false"

--- a/modules/web/src/app/node-data/module.ts
+++ b/modules/web/src/app/node-data/module.ts
@@ -39,6 +39,7 @@ import {AWSBasicNodeDataComponent} from './basic/provider/aws/component';
 import {AWSMachineTypeSelectorComponent} from './basic/provider/aws/machine-type-selector/component';
 import {GCPMachineTypeSelectorComponent} from './basic/provider/gcp/machine-type-selector/component';
 import {AzureBasicNodeDataComponent} from './basic/provider/azure/component';
+import {AzureMachineTypeSelectorComponent} from './basic/provider/azure/machine-type-selector/component';
 import {BasicNodeDataComponent} from './basic/provider/component';
 import {DigitalOceanBasicNodeDataComponent} from './basic/provider/digitalocean/component';
 import {GCPBasicNodeDataComponent} from './basic/provider/gcp/component';
@@ -74,6 +75,7 @@ const components = [
   HetznerBasicNodeDataComponent,
   HetznerMachineTypeSelectorComponent,
   AzureBasicNodeDataComponent,
+  AzureMachineTypeSelectorComponent,
   AzureExtendedNodeDataComponent,
   VSphereExtendedNodeDataComponent,
   GCPBasicNodeDataComponent,

--- a/modules/web/src/assets/css/global/_machine-type-selector.scss
+++ b/modules/web/src/assets/css/global/_machine-type-selector.scss
@@ -55,6 +55,10 @@
   &-table-container {
     max-height: 500px;
     overflow-y: auto;
+
+    .km-spinner {
+      margin: 24px auto;
+    }
   }
 
   .mat-mdc-form-field {


### PR DESCRIPTION
**What this PR does / why we need it**:
Frontend / UI
* Refactored the Azure machine type selector to use a table-based UI for better readability.
* Introduced tabs to categorize machines into "GPU Supported" and "Standard"

Backend / API
* Updated the sizes endpoint to rely exclusively on the SKU client.

**Which issue(s) this PR fixes**:
Fixes #7755 #7605

**What type of PR is this?**
/kind design


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Introduced a tabbed, searchable table for Azure machines with categorized GPU support and optimized SKU-based data retrieval.
```

**Documentation**:
```documentation
NONE
```
