### PR TITLE
Update base image for dashboard container image to apline:3.23

### DIFF
--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.9.1
+        - image: quay.io/kubermatic/chrome-headless:v1.9.2
           imagePullPolicy: Always
           command:
             - make
@@ -49,7 +49,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.9.1
+        - image: quay.io/kubermatic/chrome-headless:v1.9.2
           imagePullPolicy: Always
           command:
             - make
@@ -77,7 +77,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.9.1
+        - image: quay.io/kubermatic/chrome-headless:v1.9.2
           command:
             - make
             - web-test-headless
@@ -178,7 +178,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.9.1
+        - image: quay.io/kubermatic/chrome-headless:v1.9.2
           imagePullPolicy: Always
           command:
             - make
@@ -232,7 +232,7 @@ presubmits:
       preset-minio: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/chrome-headless:v1.9.1
+        - image: quay.io/kubermatic/chrome-headless:v1.9.2
           imagePullPolicy: Always
           command:
             - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.19
+FROM docker.io/alpine:3.23
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add -U ca-certificates && rm -rf /var/cache/apk/*

--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM docker.io/alpine:3.19
+FROM --platform=$BUILDPLATFORM docker.io/alpine:3.23
 
 ARG BUILDPLATFORM
 ARG TARGETARCH
@@ -20,16 +20,16 @@ ARG TARGETARCH
 LABEL maintainer="support@kubermatic.com"
 
 # Source: https://dl.k8s.io/release/stable-1.32.txt
-ENV KUBECTL_VERSION=v1.32.7
+ENV KUBECTL_VERSION=v1.34.3
 
 # Source: https://github.com/helm/helm/releases
-ENV HELM_VERSION=v3.17.4
+ENV HELM_VERSION=v3.18.5
 
 # Source: https://github.com/k8sgpt-ai/k8sgpt/releases
-ENV K8SGPT_VERSION=v0.4.22
+ENV K8SGPT_VERSION=v0.4.27
 
 # Source: https://github.com/derailed/k9s/releases
-ENV K9S_VERSION=v0.50.9
+ENV K9S_VERSION=v0.50.18
 
 # Source: https://github.com/kubernetes-sigs/krew/releases
 ENV KREW_VERSION=v0.4.5

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 source hack/lib.sh
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.11.0
+VERSION=0.12.0
 SUFFIX=""
 ARCHITECTURES="${ARCHITECTURES:-linux/amd64,linux/arm64/v8}"
 IMAGE="$REPOSITORY:$VERSION$SUFFIX"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a maintenance PR to update base image for dashboard container image to alpine:3.23. Security support for Alpine Linux v3.19 officially ended on November 1, 2025. Hence bumping with current stable release v3.23.
Also update chrome-headless image to v1.9.2 in prow job. 
Update alpine image and other dependencies in web-terminal and bump web-terminal image to version 0.12.0

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Update base image for dashboard container image to apline:3.23
- Update web-terminal image to 0.12.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
