### PR TITLE
Update fubectl and k8sgpt in web-terminal

### DIFF
--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -19,7 +19,7 @@ ARG TARGETARCH
 
 LABEL maintainer="support@kubermatic.com"
 
-# Source: https://dl.k8s.io/release/stable-1.32.txt
+# Source: https://dl.k8s.io/release/stable-1.34.txt
 ENV KUBECTL_VERSION=v1.34.3
 
 # Source: https://github.com/helm/helm/releases
@@ -100,12 +100,20 @@ USER ${USER}
 
 RUN mkdir ${USER_HOME}/bin/
 
-RUN wget https://rawgit.com/kubermatic/fubectl/master/fubectl.source -O ${USER_HOME}/bin/fubectl.source
+RUN wget https://raw.githubusercontent.com/kubermatic/fubectl/refs/heads/main/fubectl.source -O ${USER_HOME}/bin/fubectl.source
 
 USER 0
-RUN curl -LO https://github.com/k8sgpt-ai/k8sgpt/releases/download/${K8SGPT_VERSION}/k8sgpt_${TARGETARCH}.apk
 
-RUN apk add --allow-untrusted k8sgpt_${TARGETARCH}.apk
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        APK_ARCH="x86_64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        APK_ARCH="arm64"; \
+    fi && \
+	curl -LO https://github.com/k8sgpt-ai/k8sgpt/releases/download/${K8SGPT_VERSION}/k8sgpt_Linux_${APK_ARCH}.tar.gz && \
+    tar -xf k8sgpt_Linux_${APK_ARCH}.tar.gz && \
+    mv k8sgpt /usr/bin/k8sgpt && \
+    chmod +x /usr/bin/k8sgpt && \
+    rm k8sgpt_Linux_${APK_ARCH}.tar.gz
 
 USER ${USER}
 COPY .bashrc /tmp/


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is follow-up of https://github.com/kubermatic/dashboard/pull/7777 which bumps the web-terminal to 0.12. 
The web-terminal container image build failed at fubectl download. Fixed the domain URL from (old `rawgit.com` to new `raw.githubusercontent.com` including updating the branch from `master` to `main`) for fubectl.
The k8sgpt installation failed at
```
 => ERROR [linux/amd64->arm64 13/16] RUN apk add --allow-untrusted "k8sgpt_arm64.apk"              0.8s
------
 > [linux/amd64->arm64 13/16] RUN apk add --allow-untrusted "k8sgpt_arm64.apk":
#0 0.808 ERROR: unable to select packages:
#0 0.809   k8sgpt-0.4.27:
#0 0.809     error: uninstallable
#0 0.809     arch: aarch64
#0 0.809     satisfies: world[k8sgpt><Q1Rb9FDgHjWIzxEKPlOt/dLzi2a/U=]
------
Dockerfile:108
--------------------
 107 |
 108 | >>> RUN apk add --allow-untrusted "k8sgpt_${TARGETARCH}.apk"
 109 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apk add --allow-untrusted \"k8sgpt_${TARGETARCH}.apk\"" did not complete successfully: exit code: 1
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
