### PR TITLE
[release/v2.28] Bump Go version to v1.24.12

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
           command:
             - "./hack/ci/run-api-e2e.sh"
           env:
@@ -60,7 +60,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-11
           command:
             - make
           args:
@@ -81,7 +81,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-11
           command:
             - make
             - api-lint
@@ -101,7 +101,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-11
           command:
             - make
             - api-verify
@@ -121,7 +121,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-11
           command:
             - make
             - api-build

--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
           command:
             - ./hack/ci/verify.sh
           resources:

--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -103,7 +103,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
           command:
             - make
             - web-check-dependencies
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-11
           command:
             - make
             - web-lint
@@ -139,7 +139,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
+        - image: quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
           command:
             - make
             - web-check

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -2,7 +2,7 @@ module k8c.io/dashboard/v2
 
 go 1.24.0
 
-toolchain go1.24.7
+toolchain go1.24.12
 
 require (
 	code.cloudfoundry.org/go-pubsub v0.0.0-20250325104231-893079a7322c

--- a/modules/api/hack/gen-api-client.sh
+++ b/modules/api/hack/gen-api-client.sh
@@ -24,7 +24,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./modules/api/hack/gen-api-client.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./modules/api/hack/gen-api-client.sh
 
 cd $API/cmd/kubermatic-api/
 SWAGGER_FILE="swagger.json"

--- a/modules/api/hack/update-swagger.sh
+++ b/modules/api/hack/update-swagger.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./$API/hack/update-swagger.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./$API/hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd $API/cmd/kubermatic-api/

--- a/modules/api/hack/verify-licenses.sh
+++ b/modules/api/hack/verify-licenses.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-9 containerize ./$API/hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.24-node-20-11 containerize ./$API/hack/verify-licenses.sh
 
 cd $API
 go mod vendor

--- a/modules/web/containers/chrome-headless/Dockerfile
+++ b/modules/web/containers/chrome-headless/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
+FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
 
 LABEL maintainer="support@kubermatic.com"
 

--- a/modules/web/containers/chrome-headless/release.sh
+++ b/modules/web/containers/chrome-headless/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v1.8.2
+TAG=v1.8.3
 
 set -euo pipefail
 

--- a/modules/web/containers/custom-dashboard/Dockerfile
+++ b/modules/web/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-9
+FROM quay.io/kubermatic/build:go-1.24-node-20-kind-0.29-11
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to update Go version to 1.24.12 which includes security fixes. Bump chrome-headless to 1.8.2

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Go version to 1.24.12
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
