### PR TITLE
Fix url building logic causing issues with other ingress controller

### DIFF
--- a/modules/web/src/app/core/services/cluster.ts
+++ b/modules/web/src/app/core/services/cluster.ts
@@ -255,7 +255,8 @@ export class ClusterService {
 
   getShareKubeconfigURL(projectID: string, clusterID: string, userID: string, oidcKubeLogin = false): string {
     const location = this._location.endsWith('/') ? this._location : `${this._location}/`;
-    return `${location}${this._restRoot}/kubeconfig?project_id=${projectID}&cluster_id=${clusterID}&user_id=${userID}&oidc_kubelogin_enabled=${oidcKubeLogin}`;
+    const restRoot = this._restRoot.startsWith('/') ? this._restRoot.slice(1) : this._restRoot;
+    return `${location}${restRoot}/kubeconfig?project_id=${projectID}&cluster_id=${clusterID}&user_id=${userID}&oidc_kubelogin_enabled=${oidcKubeLogin}`;
   }
 
   externalClusterEvents(projectID: string, clusterID: string): Observable<Event[]> {

--- a/modules/web/src/environments/environment.e2e.local.ts
+++ b/modules/web/src/environments/environment.e2e.local.ts
@@ -22,7 +22,7 @@ export const environment = {
   configUrl: '../../assets/config/config.json',
   gitVersionUrl: '../../assets/config/version.json',
   refreshTimeBase: 1000,
-  restRoot: 'api/v1',
+  restRoot: '/api/v1',
   newRestRoot: '/api/v2',
   wsRoot: `${wsProtocol}//${host}/api/v1/ws`,
   avoidWebsockets: false,

--- a/modules/web/src/environments/environment.e2e.ts
+++ b/modules/web/src/environments/environment.e2e.ts
@@ -22,7 +22,7 @@ export const environment = {
   configUrl: '../../assets/config/config.json',
   gitVersionUrl: '../../assets/config/version.json',
   refreshTimeBase: 1000,
-  restRoot: 'api/v1',
+  restRoot: '/api/v1',
   newRestRoot: '/api/v2',
   wsRoot: `${wsProtocol}//${host}/api/v1/ws`,
   avoidWebsockets: false,

--- a/modules/web/src/environments/environment.ts
+++ b/modules/web/src/environments/environment.ts
@@ -27,7 +27,7 @@ export const environment = {
   configUrl: '../../assets/config/config.json',
   gitVersionUrl: '../../assets/config/version.json',
   refreshTimeBase: 1000,
-  restRoot: 'api/v1',
+  restRoot: '/api/v1',
   newRestRoot: '/api/v2',
   wsRoot: `${wsProtocol}//${host}/api/v1/ws`,
   avoidWebsockets: false,


### PR DESCRIPTION
**What this PR does / why we need it**:

While migrating our Infrastructure to a new Ingress Controller(in our case traefik) we realized that there is an issue with the download Kubeconfig function. 
The current implementation construct the URL to look like https://kubermatic.example.com//api/v1/kubeconfig?project_id<...> with a double / infront of the path. The nginx controller seems to have merge_slashes active by default which results in a 301 redirect to https://kubermatic.example.com/api/v1/kubeconfig?project_id<...> with one slash and a working process. Other Ingress controllers dont do this, resulting in the browser not setting the csfr_token cookie and after login, failing to download the kubeconfig. 
Thats why we should fix the url generation. This pr does exactly this, by a) unifying the variables across all environments(checked the usages and the option with a leading / should be better) and b) making the crafted url contains one and only one slash.

**Which issue(s) this PR fixes**:


**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

Regarding the near archival of the nginx ingress this bug is rather important.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
- Fixed Kubeconfig download with non nginx ingresses
```

**Documentation**:

```documentation
NONE
```
