### PR TITLE
Option to hide/disable KKP documentation links

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -20,6 +20,7 @@ import {DynamicModule} from '@app/dynamic/module-registry';
 import {BackupStorageLocation} from '@app/shared/entity/backup';
 import {NODEPORTS_IPRANGES_SUPPORTED_PROVIDERS, NodeProvider} from '@app/shared/model/NodeProviderConstants';
 import {BSLListState} from '@app/wizard/step/cluster/component';
+import {BrandingService} from '@core/services/branding';
 import {ClusterService} from '@core/services/cluster';
 import {DatacenterService} from '@core/services/datacenter';
 import {NotificationService} from '@core/services/notification';
@@ -157,7 +158,8 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     private readonly _notificationService: NotificationService,
     private readonly _settingsService: SettingsService,
     private readonly _clusterBackupService: ClusterBackupService,
-    private readonly _cdr: ChangeDetectorRef
+    private readonly _cdr: ChangeDetectorRef,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -144,12 +144,14 @@ limitations under the License.
                     kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">
         <ng-container hint>
           Use commas, space or enter key as the separators. This feature is dependent on cloud provider capabilities.
+          @if (!branding.hideDocumentationLinks) {
           Check the documentation for more information
           <a target="_blank"
              rel="noopener"
              fxLayout="row inline"
              fxLayoutAlign=" center"
              href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/apiserver-policies/#api-server-allowed-source-ip-ranges">here <i class="km-icon-external-link"></i></a>.
+          }
         </ng-container>
       </km-chip-list>
       }

--- a/modules/web/src/app/cluster/details/cluster/share-kubeconfig/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/share-kubeconfig/component.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Component, Input, OnInit} from '@angular/core';
+import {BrandingService} from '@core/services/branding';
 import {Auth} from '@core/services/auth/service';
 import {UserService} from '@core/services/user';
 import {Cluster} from '@shared/entity/cluster';
@@ -55,7 +56,8 @@ export class ShareKubeconfigComponent implements OnInit {
     private readonly _clusterService: ClusterService,
     private readonly _auth: Auth,
     private readonly _userService: UserService,
-    private readonly _matDialogRef: MatDialogRef<ShareKubeconfigComponent>
+    private readonly _matDialogRef: MatDialogRef<ShareKubeconfigComponent>,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {

--- a/modules/web/src/app/cluster/details/cluster/share-kubeconfig/template.html
+++ b/modules/web/src/app/cluster/details/cluster/share-kubeconfig/template.html
@@ -20,6 +20,7 @@ limitations under the License.
     Share <b>{{cluster.name}}</b> cluster with other users by giving them the following link that can be used to authenticate with an OIDC provider and then generate a kubeconfig file.
   </p>
   <p>
+    @if (!branding.hideDocumentationLinks) {
     <strong>
       Please <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/"
          target="_blank"
@@ -28,6 +29,7 @@ limitations under the License.
          rel="noopener">visit our documentation <i class="km-icon-external-link i-18"></i></a>
       for more details.
     </strong>
+    }
   </p>
   }
   <label class="km-radio-group-label">

--- a/modules/web/src/app/core/components/help-panel/component.ts
+++ b/modules/web/src/app/core/components/help-panel/component.ts
@@ -17,6 +17,7 @@ import {MatDialog} from '@angular/material/dialog';
 import {Router} from '@angular/router';
 import {AppConfigService} from '@app/config.service';
 import {AnnouncementsDialogComponent} from '@shared/components/announcements-dialog/component';
+import {BrandingService} from '@core/services/branding';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
 import {slideOut} from '@shared/animations/slide';
@@ -45,7 +46,8 @@ export class HelpPanelComponent implements OnInit, OnDestroy {
     private readonly _userService: UserService,
     private readonly _config: AppConfigService,
     private readonly _router: Router,
-    private readonly _matDialog: MatDialog
+    private readonly _matDialog: MatDialog,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {
@@ -107,7 +109,7 @@ export class HelpPanelComponent implements OnInit, OnDestroy {
 
   shouldShowPanel(): boolean {
     return (
-      !this.adminSettings.disableChangelogPopup ||
+      (!this.adminSettings.disableChangelogPopup && !this.branding.hideDocumentationLinks) ||
       this.adminSettings.displayAPIDocs ||
       this.adminSettings.customLinks.some(link => link.location === CustomLinkLocation.HelpPanel) ||
       !!this.adminSettings.announcements

--- a/modules/web/src/app/core/components/help-panel/template.html
+++ b/modules/web/src/app/core/components/help-panel/template.html
@@ -40,7 +40,7 @@ limitations under the License.
     </div>
     <div class="menu"
          fxLayout="column">
-      @if (!adminSettings?.disableChangelogPopup) {
+      @if (!adminSettings?.disableChangelogPopup && !branding.hideDocumentationLinks) {
       <div class="km-option-hover-bg"
            matRipple
            (click)="openChangelog()"

--- a/modules/web/src/app/core/services/branding.ts
+++ b/modules/web/src/app/core/services/branding.ts
@@ -63,6 +63,10 @@ export class BrandingService {
     return !!this._config.hide_version;
   }
 
+  get hideDocumentationLinks(): boolean {
+    return !!this._config.hide_documentation_links;
+  }
+
   injectCustomCss(): void {
     if (!this._config.custom_css_url) {
       return;

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/upload-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/upload-dialog/component.ts
@@ -29,6 +29,7 @@ import {
   S3Client,
   UploadPartCommand,
 } from '@aws-sdk/client-s3';
+import {BrandingService} from '@core/services/branding';
 import {ClusterBackupService} from '@core/services/cluster-backup';
 import {NotificationService} from '@core/services/notification';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
@@ -96,7 +97,8 @@ export class UploadBackupsDialogComponent implements OnInit, OnDestroy {
     private readonly _builder: FormBuilder,
     private readonly _clusterBackupService: ClusterBackupService,
     private readonly _notificationService: NotificationService,
-    private readonly _matDialog: MatDialog
+    private readonly _matDialog: MatDialog,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/upload-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backups/upload-dialog/template.html
@@ -62,6 +62,7 @@ END OF TERMS AND CONDITIONS
           chosen backup storage location. Backup files will be placed in the {{backupsDirectoryName}} directory,
           and kopia files in the {{kopiaDirectoryName}} directory.
           <br />
+          @if (!branding.hideDocumentationLinks) {
           Please visit the
           <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/cluster-backup/"
              target="_blank"
@@ -70,6 +71,7 @@ END OF TERMS AND CONDITIONS
              fxLayoutAlign=" center">
             documentation <i class="km-icon-external-link i-18"></i>
           </a> to learn more about cluster backups.
+          }
           <br />
           <br />
           <strong>NOTE:</strong> Please keep this window open until all files are uploaded. Closing it prematurely may

--- a/modules/web/src/app/project/component.ts
+++ b/modules/web/src/app/project/component.ts
@@ -37,6 +37,7 @@ import {NotificationService} from '@core/services/notification';
 import {PreviousRouteService} from '@core/services/previous-route';
 import {ProjectService} from '@core/services/project';
 import {SettingsService} from '@core/services/settings';
+import {BrandingService} from '@core/services/branding';
 import {UserService} from '@core/services/user';
 import {AddProjectDialogComponent} from '@shared/components/add-project-dialog/component';
 import {View} from '@shared/entity/common';
@@ -130,7 +131,8 @@ export class ProjectComponent implements OnInit, OnChanges, OnDestroy {
     private readonly _cdr: ChangeDetectorRef,
     private readonly _settingsService: SettingsService,
     @Inject(COOKIE_DI_TOKEN) private readonly _cookie: Cookie,
-    private readonly _dialogModeService: DialogModeService
+    private readonly _dialogModeService: DialogModeService,
+    readonly branding: BrandingService
   ) {
     if (this.isEnterpriseEdition) {
       this._quotaService = GlobalModule.injector.get(QuotaService);

--- a/modules/web/src/app/project/template.html
+++ b/modules/web/src/app/project/template.html
@@ -350,6 +350,7 @@ limitations under the License.
          fxLayoutAlign="center center"
          class="placeholder-text">
       <p>Dive right into your first project.</p>
+      @if (!branding.hideDocumentationLinks) {
       <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/project-and-cluster-management/"
          target="_blank"
          rel="noreferrer noopener"
@@ -357,6 +358,7 @@ limitations under the License.
          fxLayoutAlign=" center">
         Learn more in our documentation <i class="km-icon-external-link"></i>
       </a>
+      }
     </div>
     <ng-container *ngTemplateOutlet="addProjectButton" />
   </div>

--- a/modules/web/src/app/settings/admin/defaults/component.ts
+++ b/modules/web/src/app/settings/admin/defaults/component.ts
@@ -16,6 +16,7 @@ import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
 import {FeatureGateService} from '@app/core/services/feature-gate';
 import {VMwareCloudDirectorIPAllocationMode} from '@app/shared/entity/provider/vmware-cloud-director';
 import {OperatingSystem} from '@app/shared/model/NodeProviderConstants';
+import {BrandingService} from '@core/services/branding';
 import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
@@ -57,7 +58,8 @@ export class DefaultsComponent implements OnInit, OnDestroy {
     private readonly _settingsService: SettingsService,
     private readonly _notificationService: NotificationService,
     private readonly _featureGatesService: FeatureGateService,
-    private readonly _cdr: ChangeDetectorRef
+    private readonly _cdr: ChangeDetectorRef,
+    private readonly _branding: BrandingService
   ) {}
 
   get hiddenAnnotations(): string[] {
@@ -205,6 +207,9 @@ export class DefaultsComponent implements OnInit, OnDestroy {
   }
 
   getDocumentationLink(): string {
+    if (this._branding.hideDocumentationLinks) {
+      return '';
+    }
     return `https://docs.kubermatic.com/kubermatic/${this.editionVersion}/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/`;
   }
 

--- a/modules/web/src/app/settings/admin/defaults/template.html
+++ b/modules/web/src/app/settings/admin/defaults/template.html
@@ -174,7 +174,9 @@ limitations under the License.
                         [disabled]="!isKubernetesDashboardFeatureGatesEnabled()"
                         id="km-enable-kubernetes-dashboard-setting">
             @if (!isKubernetesDashboardFeatureGatesEnabled()) {
-            <mat-hint>This feature requires both OIDC Kubeconfig and OpenID Auth Plugin feature flags to be enabled. Visit the
+            <mat-hint>This feature requires both OIDC Kubeconfig and OpenID Auth Plugin feature flags to be enabled.
+              @if (getDocumentationLink()) {
+              Visit the
               <a [href]="getDocumentationLink()"
                  target="_blank"
                  rel="noopener noreferrer"
@@ -184,6 +186,7 @@ limitations under the License.
                 documentation <i class="km-icon-external-link i-18"></i>
               </a>
               to learn more.
+              }
             </mat-hint>
             }
           </mat-checkbox>
@@ -203,7 +206,9 @@ limitations under the License.
                         (change)="onOIDCKubeconfigSettingsChange()"
                         id="km-enable-oidc-setting">
             @if (!isOIDCKubeCfgEndpointEnabled) {
-            <mat-hint>This feature is disabled. Visit the
+            <mat-hint>This feature is disabled.
+              @if (getDocumentationLink()) {
+              Visit the
               <a [href]="getDocumentationLink()"
                  target="_blank"
                  rel="noopener noreferrer"
@@ -213,6 +218,7 @@ limitations under the License.
                 documentation <i class="km-icon-external-link i-18"></i>
               </a>
               to learn more.
+              }
             </mat-hint>
             }
           </mat-checkbox>
@@ -246,7 +252,9 @@ limitations under the License.
                         (change)="onSettingsChange()"
                         id="km-disabled-admin-kubeconfig-setting">
             @if (!settings.enableOIDCKubeconfig) {
-            <mat-hint>This feature requires the OIDC kubeconfig feature to be enabled. Visit the
+            <mat-hint>This feature requires the OIDC kubeconfig feature to be enabled.
+              @if (getDocumentationLink()) {
+              Visit the
               <a [href]="getDocumentationLink()"
                  target="_blank"
                  rel="noopener noreferrer"
@@ -256,6 +264,7 @@ limitations under the License.
                 documentation <i class="km-icon-external-link i-18"></i>
               </a>
               to learn more.
+              }
             </mat-hint>
             }
           </mat-checkbox>

--- a/modules/web/src/app/settings/user/component.ts
+++ b/modules/web/src/app/settings/user/component.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Component, OnDestroy, OnInit} from '@angular/core';
+import {BrandingService} from '@core/services/branding';
 import {HistoryService} from '@core/services/history';
 import {NotificationService} from '@core/services/notification';
 import {ProjectService} from '@core/services/project';
@@ -52,7 +53,8 @@ export class UserSettingsComponent implements OnInit, OnDestroy {
     private readonly _userService: UserService,
     private readonly _historyService: HistoryService,
     private readonly _notificationService: NotificationService,
-    private readonly _projectService: ProjectService
+    private readonly _projectService: ProjectService,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {

--- a/modules/web/src/app/settings/user/template.html
+++ b/modules/web/src/app/settings/user/template.html
@@ -50,11 +50,13 @@ limitations under the License.
         } @else {
         <div>
           No OIDC groups assigned.
+          @if (!branding.hideDocumentationLinks) {
           <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/architecture/iam-role-based-access-control/groups-support/"
              target="_blank"
              rel="noreferrer noopener"
              fxLayout="row inline"
              fxLayoutAlign=" center">Learn more <i class="km-icon-external-link i-18"></i></a>
+          }
         </div>
         }
       </div>

--- a/modules/web/src/app/shared/components/addon-list/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/component.ts
@@ -22,6 +22,7 @@ import {finalize, take, takeUntil} from 'rxjs/operators';
 import {ConfirmationDialogComponent} from '../confirmation-dialog/component';
 import {EditAddonDialogComponent} from './edit-addon-dialog/component';
 import {InstallAddonDialogComponent} from './install-addon-dialog/component';
+import {BrandingService} from '@core/services/branding';
 import {AddonService} from '@core/services/addon';
 import {getEditionVersion} from '@shared/utils/common';
 import {DialogModeService} from '@app/core/services/dialog-mode';
@@ -55,7 +56,8 @@ export class AddonsListComponent implements OnInit, OnChanges, OnDestroy {
   constructor(
     private readonly _addonService: AddonService,
     private readonly _matDialog: MatDialog,
-    private readonly _dialogModeService: DialogModeService
+    private readonly _dialogModeService: DialogModeService,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {

--- a/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
+++ b/modules/web/src/app/shared/components/addon-list/install-addon-dialog/component.ts
@@ -27,6 +27,7 @@ import {
 } from '@shared/entity/addon';
 import {FormBuilder, FormControl, FormGroup, ValidatorFn, Validators} from '@angular/forms';
 import {MatStepper} from '@angular/material/stepper';
+import {BrandingService} from '@core/services/branding';
 import {getEditionVersion} from '@shared/utils/common';
 import _ from 'lodash';
 
@@ -63,7 +64,8 @@ export class InstallAddonDialogComponent {
   constructor(
     public dialogRef: MatDialogRef<Component>,
     private readonly _builder: FormBuilder,
-    private readonly _sanitizer: DomSanitizer
+    private readonly _sanitizer: DomSanitizer,
+    readonly branding: BrandingService
   ) {}
 
   hasLogo(name: string): boolean {

--- a/modules/web/src/app/shared/components/addon-list/install-addon-dialog/template.html
+++ b/modules/web/src/app/shared/components/addon-list/install-addon-dialog/template.html
@@ -28,6 +28,7 @@ limitations under the License.
     <div class="select-addon-desc">
       <p>
         Addons are extensions provided by Kubermatic to expand cluster capabilities.
+        @if (!branding.hideDocumentationLinks) {
         <br />
         <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/architecture/concept/kkp-concepts/addons/"
            target="_blank"
@@ -36,6 +37,7 @@ limitations under the License.
            fxLayoutAlign=" center">
           Learn more about Addons <i class="km-icon-external-link i-18"></i>.
         </a>
+        }
       </p>
     </div>
     @for (installableAddon of installableAddons; track installableAddon) {

--- a/modules/web/src/app/shared/components/addon-list/template.html
+++ b/modules/web/src/app/shared/components/addon-list/template.html
@@ -19,14 +19,16 @@ limitations under the License.
   <div fxFlex>
     @if (!addons?.length) {
     <p>
-      Addons are extensions provided by Kubermatic to expand cluster capabilities,
+      Addons are extensions provided by Kubermatic to expand cluster capabilities.
+      @if (!branding.hideDocumentationLinks) {
       <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/architecture/concept/kkp-concepts/addons/"
          target="_blank"
          rel="noreferrer noopener"
          fxLayout="row inline"
          fxLayoutAlign=" center">
-        learn more about Addons <i class="km-icon-external-link i-18"></i>.
+        Learn more about Addons <i class="km-icon-external-link i-18"></i>.
       </a>
+      }
     </p>
     }
   </div>

--- a/modules/web/src/app/shared/components/application-list/add-application-dialog/component.ts
+++ b/modules/web/src/app/shared/components/application-list/add-application-dialog/component.ts
@@ -30,6 +30,7 @@ import {
   ApplicationVersion,
   getApplicationVersion,
 } from '@shared/entity/application';
+import {BrandingService} from '@core/services/branding';
 import {getEditionVersion} from '@shared/utils/common';
 import {KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@shared/validators/others';
 import * as y from 'js-yaml';
@@ -84,7 +85,8 @@ export class AddApplicationDialogComponent implements OnInit, OnChanges, OnDestr
   constructor(
     public dialogRef: MatDialogRef<AddApplicationDialogComponent>,
     private readonly _builder: FormBuilder,
-    private readonly _applicationService: ApplicationService
+    private readonly _applicationService: ApplicationService,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {

--- a/modules/web/src/app/shared/components/application-list/add-application-dialog/template.html
+++ b/modules/web/src/app/shared/components/application-list/add-application-dialog/template.html
@@ -28,14 +28,16 @@ limitations under the License.
               fxFlex="100%">
       <div fxLayout="column">
         <p class="application-settings-desc">
-          Install third party Applications into a cluster,
+          Install third party Applications into a cluster.
+          @if (!branding.hideDocumentationLinks) {
           <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/applications/"
              target="_blank"
              rel="noreferrer noopener"
              fxLayout="row inline"
              fxLayoutAlign=" center">
-            learn more about Applications <i class="km-icon-external-link i-18"></i>.
+            Learn more about Applications <i class="km-icon-external-link i-18"></i>.
           </a>
+          }
         </p>
         <div class="applications-search">
           <km-search-field (queryChange)="onSearchQueryChanged($event)" />

--- a/modules/web/src/app/shared/components/application-list/component.ts
+++ b/modules/web/src/app/shared/components/application-list/component.ts
@@ -28,6 +28,7 @@ import {MatSort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
 import {SafeUrl} from '@angular/platform-browser';
 import {DialogModeService} from '@app/core/services/dialog-mode';
+import {BrandingService} from '@core/services/branding';
 import {ApplicationService} from '@core/services/application';
 import {AddApplicationDialogComponent} from '@shared/components/application-list/add-application-dialog/component';
 import {EditApplicationDialogComponent} from '@shared/components/application-list/edit-application-dialog/component';
@@ -131,7 +132,8 @@ export class ApplicationListComponent implements OnInit, OnChanges, OnDestroy {
   constructor(
     private readonly _applicationService: ApplicationService,
     private readonly _matDialog: MatDialog,
-    private readonly _dialogModeService: DialogModeService
+    private readonly _dialogModeService: DialogModeService,
+    readonly branding: BrandingService
   ) {}
 
   ngOnInit(): void {

--- a/modules/web/src/app/shared/components/application-list/template.html
+++ b/modules/web/src/app/shared/components/application-list/template.html
@@ -325,6 +325,7 @@ limitations under the License.
 }
 
 <ng-template #applicationDocsLink>
+  @if (!branding.hideDocumentationLinks) {
   <a href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/applications/"
      target="_blank"
      rel="noreferrer noopener"
@@ -332,6 +333,7 @@ limitations under the License.
      fxLayoutAlign=" center">
     learn more about Applications <i class="km-icon-external-link i-18"></i>.
   </a>
+  }
 </ng-template>
 
 @if (!isClusterReady) {

--- a/modules/web/src/app/shared/model/Config.ts
+++ b/modules/web/src/app/shared/model/Config.ts
@@ -41,6 +41,7 @@ export interface BrandingConfig {
   font_family?: string;
   colors?: BrandingColors;
   hide_version?: boolean;
+  hide_documentation_links?: boolean;
 }
 
 export interface Config {

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -35,6 +35,7 @@ import {
   IPV6_CIDR_PATTERN_VALIDATOR,
   NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR,
 } from '@app/shared/validators/others';
+import {BrandingService} from '@core/services/branding';
 import {ClusterService} from '@core/services/cluster';
 import {ClusterSpecService} from '@core/services/cluster-spec';
 import {DatacenterService} from '@core/services/datacenter';
@@ -236,6 +237,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     private readonly _projectService: ProjectService,
     private readonly _clusterBackupService: ClusterBackupService,
     private readonly _featureGatesService: FeatureGateService,
+    readonly branding: BrandingService,
     wizard: WizardService
   ) {
     super(wizard);

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -136,12 +136,15 @@ limitations under the License.
               </mat-option>
               }
             </mat-select>
-            <mat-hint>Leave empty to use the default value. Check the documentation for more information
+            <mat-hint>Leave empty to use the default value.
+              @if (!branding.hideDocumentationLinks) {
+              Check the documentation for more information
               <a target="_blank"
                  rel="noopener"
                  fxLayout="row inline"
                  fxLayoutAlign=" center"
                  href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/expose-strategies/#configure-the-expose-strategy">here <i class="km-icon-external-link"></i></a>.
+              }
             </mat-hint>
           </mat-form-field>
           @if (isExposeStrategyLoadBalancer()) {
@@ -154,12 +157,15 @@ limitations under the License.
                         kmPatternError="Input has to be a valid IPv4 or IPv6 CIDR">
             <ng-container hint>
               Use commas, space or enter key as the separators. This feature is dependent on cloud provider
-              capabilities. Check the documentation for more information&nbsp;
+              capabilities.
+              @if (!branding.hideDocumentationLinks) {
+              Check the documentation for more information&nbsp;
               <a target="_blank"
                  rel="noopener"
                  fxLayout="row inline"
                  fxLayoutAlign=" center"
                  href="https://docs.kubermatic.com/kubermatic/{{editionVersion}}/tutorials-howtos/networking/apiserver-policies/#api-server-allowed-source-ip-ranges">here <i class="km-icon-external-link"></i></a>.
+              }
             </ng-container>
           </km-chip-list>
           }

--- a/modules/web/src/assets/config/config_branding.json
+++ b/modules/web/src/assets/config/config_branding.json
@@ -17,6 +17,7 @@
     "font_url": "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
     "font_family": "'Inter', helvetica, arial, sans-serif",
     "hide_version": true,
+    "hide_documentation_links": true,
     "colors": {
       "primary": "#0052cc",
       "secondary": "#00b8d9",


### PR DESCRIPTION
**What this PR does / why we need it**:
For whitelabeling, sometimes it's a requirement to not have hyperlinks in your product that point to external products/wesbites. In this PR, we introduce `hide_documentation_links` in branding config to make it configurable without requiring code changes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
Marked the release note and docs as NONE since https://github.com/kubermatic/dashboard/pull/7848 will cover this.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/2085
```
