### PR TITLE
UX Improvement for Kubernetes/OPA Deprecation Warning 

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/component.ts
@@ -82,7 +82,11 @@ import {ShareKubeconfigComponent, ShareKubeconfigDialogMode} from './share-kubec
 import {FeatureGateService} from '@app/core/services/feature-gate';
 import {NodeProvider} from '@app/shared/model/NodeProviderConstants';
 import {Preset} from '@shared/entity/preset';
-import {ANEXIA_DEPRECATED_MESSAGE, KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
+import {
+  ANEXIA_DEPRECATED_MESSAGE,
+  KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE,
+  OPA_DEPRECATED_MESSAGE,
+} from '@app/shared/constants/common';
 
 @Component({
   selector: 'km-cluster-details',
@@ -104,6 +108,7 @@ export class ClusterDetailsComponent implements OnInit, OnDestroy {
   readonly isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   readonly ANEXIA_DEPRECATED_MESSAGE = ANEXIA_DEPRECATED_MESSAGE;
   readonly KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE = KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE;
+  readonly OPA_DEPRECATED_MESSAGE = OPA_DEPRECATED_MESSAGE;
   adminSettings: AdminSettings;
   presetStatus: HealthStatus;
   encryptionStatus: HealthStatus;

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -52,7 +52,7 @@ import {
   generateEncryptionKey,
 } from '@shared/utils/cluster';
 import {getEditionVersion} from '@shared/utils/common';
-import {KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
+import {KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE, OPA_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
 import {AsyncValidators} from '@shared/validators/async.validators';
 import {IPV4_IPV6_CIDR_PATTERN} from '@shared/validators/others';
 import {KmValidators} from '@shared/validators/validators';
@@ -137,6 +137,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   readonly ipv4AndIPv6CidrRegex = IPV4_IPV6_CIDR_PATTERN;
   readonly NodeProvider = NodeProvider;
   readonly KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE = KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE;
+  readonly OPA_DEPRECATED_MESSAGE = OPA_DEPRECATED_MESSAGE;
   private readonly _nameMinLen = 3;
   private readonly ENCRYPTION_KEY_ANNOTATION = 'kubermatic.io/encryption-key';
   private _settings: AdminSettings;

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -243,11 +243,16 @@ limitations under the License.
 
       <mat-checkbox [formControlName]="Controls.OPAIntegration"
                     kmValueChangedIndicator>
-        OPA Integration
-        @if (isEnforced(Controls.OPAIntegration)) {
-        <i class="km-icon-info km-pointer"
-           matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
-        }
+        <div fxLayout="row"
+             fxLayoutAlign=" center">
+          <span>OPA Integration</span>
+          @if (isEnforced(Controls.OPAIntegration)) {
+          <i class="km-icon-info km-pointer"
+             matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
+          }
+          <i class="km-icon-warning km-pointer"
+             [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
+        </div>
       </mat-checkbox>
 
       @if (isEnterpriseEdition) {

--- a/modules/web/src/app/cluster/details/cluster/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/style.scss
@@ -103,7 +103,8 @@ km-button {
 }
 
 .km-dashboard-deprecation-warning {
-  left: 8px;
-  position: relative;
-  top: 10px;
+    left: 5px;
+    margin: auto;
+    position: relative;
+    top: 5px;
 }

--- a/modules/web/src/app/cluster/details/cluster/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/style.scss
@@ -108,3 +108,9 @@ km-button {
     position: relative;
     top: 5px;
 }
+
+.km-opa-deprecation-warning {
+    bottom: 2px;
+    left: 10px;
+    position: relative;
+}

--- a/modules/web/src/app/cluster/details/cluster/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/style.scss
@@ -101,3 +101,9 @@ km-button {
 .event-type {
   margin-bottom: 5px;
 }
+
+.km-dashboard-deprecation-warning {
+  left: 8px;
+  position: relative;
+  top: 10px;
+}

--- a/modules/web/src/app/cluster/details/cluster/style.scss
+++ b/modules/web/src/app/cluster/details/cluster/style.scss
@@ -109,6 +109,10 @@ km-button {
     top: 5px;
 }
 
+.km-opa-warning {
+  margin-left: 10px;
+}
+
 .km-opa-deprecation-warning {
     bottom: 2px;
     left: 10px;

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -36,18 +36,6 @@ limitations under the License.
 </mat-card>
 }
 
-@if (adminSettings.enableDashboard) {
-<mat-card class="warning-card">
-  <mat-card-content>
-    <div fxLayout="row"
-         fxLayoutAlign=" center">
-      <i class="km-icon-warning"></i>
-      <div>{{ KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE }}</div>
-    </div>
-  </mat-card-content>
-</mat-card>
-}
-
 @if (isLoaded()) {
 <div fxLayout="column">
   <div fxFlex
@@ -96,7 +84,10 @@ limitations under the License.
          [matTooltip]="getOpenDashboardTooltip()">
         <i class="km-icon-mask km-icon-external-link"
            matButtonIcon></i>
-        <span>Open Dashboard</span>
+        <span>Open Dashboard
+          <i class="km-icon-warning km-pointer km-dashboard-deprecation-warning"
+             [matTooltip]="KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE"></i>
+        </span>
       </a>
       }
       @if (adminSettings.enableOIDCKubeconfig && isWebTerminalEnabled()) {

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -611,6 +611,11 @@ limitations under the License.
     </km-tab>
     @if (cluster.spec.opaIntegration?.enabled) {
     <km-tab label="OPA Constraints">
+      <ng-template #tabLabel>
+        OPA Constraints
+        <i class="km-icon-warning km-pointer-warning km-opa-warning"
+           [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
+      </ng-template>
       <km-constraint-list [constraints]="constraints"
                           [cluster]="cluster"
                           [projectID]="projectID"
@@ -619,6 +624,11 @@ limitations under the License.
     }
     @if (cluster.spec.opaIntegration?.enabled) {
     <km-tab label="OPA Gatekeeper Config">
+      <ng-template #tabLabel>
+        OPA Gatekeeper Config
+        <i class="km-icon-warning km-pointer km-opa-warning"
+           [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
+      </ng-template>
       <km-gatekeeper-config [gatekeeperConfig]="gatekeeperConfig"
                             [cluster]="cluster"
                             [projectID]="projectID"

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -14,24 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-@if (cluster?.spec?.opaIntegration?.enabled || nodeDc?.spec?.provider === nodeProvider.ANEXIA) {
+@if (nodeDc?.spec?.provider === nodeProvider.ANEXIA) {
 <mat-card class="warning-card">
   <mat-card-content>
-    @if (cluster?.spec?.opaIntegration?.enabled) {
-    <div fxLayout="row"
-         fxLayoutAlign=" center">
-      <i class="km-icon-warning"></i>
-      <div>OPA (Open Policy Agent) has been deprecated in KKP 2.28 and will be <strong>removed in the future</strong>, Kyverno has replaced it as an Enterprise Edition feature for policy management.</div>
-    </div>
-    }
-
-    @if (nodeDc?.spec?.provider === nodeProvider.ANEXIA) {
     <div fxLayout="row"
          fxLayoutAlign=" center">
       <i class="km-icon-warning"></i>
       <div>{{ ANEXIA_DEPRECATED_MESSAGE }}</div>
     </div>
-    }
   </mat-card-content>
 </mat-card>
 }
@@ -404,7 +394,14 @@ limitations under the License.
           <div fxFlex="33"
                class="container-spacing">
             <div fxLayout="row"
-                 class="section-header">OPA</div>
+                 fxLayoutAlign=" center"
+                 class="section-header">
+              <span>OPA</span>
+              @if (cluster?.spec?.opaIntegration?.enabled) {
+              <i class="km-icon-warning km-pointer km-opa-deprecation-warning"
+                 [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
+              }
+            </div>
             @if (!cluster?.spec?.opaIntegration?.enabled) {
             <km-property-boolean label="Policy Control"
                                  [value]="cluster?.spec?.opaIntegration?.enabled" />

--- a/modules/web/src/app/settings/admin/opa/component.ts
+++ b/modules/web/src/app/settings/admin/opa/component.ts
@@ -16,6 +16,7 @@ import {ChangeDetectionStrategy, Component, OnDestroy} from '@angular/core';
 import {Context} from '@shared/components/tab-card/component';
 import {DynamicTabComponent} from '@shared/components/tab-card/dynamic-tab/component';
 import {DynamicTab} from '@shared/model/dynamic-tab';
+import {OPA_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 
@@ -29,6 +30,7 @@ import {takeUntil} from 'rxjs/operators';
 export class AdminSettingsOPAComponent implements OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
   readonly Context = Context;
+  readonly OPA_DEPRECATED_MESSAGE = OPA_DEPRECATED_MESSAGE;
   private _dynamicTabs = new Set<DynamicTabComponent>();
 
   get dynamicTabs(): DynamicTabComponent[] {

--- a/modules/web/src/app/settings/admin/opa/template.html
+++ b/modules/web/src/app/settings/admin/opa/template.html
@@ -13,16 +13,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<mat-card>
+
+<mat-card class="warning-container">
   <mat-card-content>
     <div fxLayout="row"
-         fxLayoutAlign=" center"
-         class="warning-container">
+         fxLayoutAlign=" center">
       <i class="km-icon-warning"></i>
-      <div>OPA (Open Policy Agent) has been deprecated in KKP 2.28 and will be removed in the future, Kyverno has replaced it as an Enterprise Edition feature for policy management.</div>
+      <div>{{ OPA_DEPRECATED_MESSAGE }}</div>
     </div>
   </mat-card-content>
 </mat-card>
+
 <km-tab-card id="km-admin-opa-card"
              [dynamicTabs]="dynamicTabs">
   <km-tab label="Constraint Templates">

--- a/modules/web/src/app/shared/components/tab-card/tab/component.ts
+++ b/modules/web/src/app/shared/components/tab-card/tab/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, TemplateRef, ViewChild} from '@angular/core';
+import {Component, Input, TemplateRef, ViewChild, ContentChild} from '@angular/core';
 
 @Component({
   selector: 'km-tab',
@@ -22,4 +22,5 @@ import {Component, Input, TemplateRef, ViewChild} from '@angular/core';
 export class TabComponent {
   @Input() label: string;
   @ViewChild(TemplateRef) template: TemplateRef<any>;
+  @ContentChild('tabLabel') labelTemplate: TemplateRef<any>;
 }

--- a/modules/web/src/app/shared/components/tab-card/template.html
+++ b/modules/web/src/app/shared/components/tab-card/template.html
@@ -20,6 +20,11 @@ limitations under the License.
                  dynamicHeight>
     @for (tab of tabs; track tab; let i = $index) {
     <mat-tab [label]="tab.label">
+      @if (tab.labelTemplate) {
+      <ng-template mat-tab-label>
+        <ng-container *ngTemplateOutlet="tab.labelTemplate" />
+      </ng-template>
+      }
       <div class="tab-content">
         <mat-card appearance="outlined">
           <ng-container *ngTemplateOutlet="tab.template" />

--- a/modules/web/src/app/shared/constants/common.ts
+++ b/modules/web/src/app/shared/constants/common.ts
@@ -20,3 +20,6 @@ export const ANEXIA_DEPRECATED_MESSAGE =
 
 export const KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE =
   'Kubernetes Dashboard is no longer maintained. This feature is deprecated and may be removed in a future release.';
+
+export const OPA_DEPRECATED_MESSAGE =
+  'OPA (Open Policy Agent) has been deprecated in KKP 2.28 and will be removed in a future release. Kyverno has replaced it as an Enterprise Edition feature for policy management.';

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -75,7 +75,7 @@ import {
   generateEncryptionKey,
 } from '@shared/utils/cluster';
 import {getEditionVersion} from '@shared/utils/common';
-import {KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
+import {KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE, OPA_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
 import {AsyncValidators} from '@shared/validators/async.validators';
 import {KmValidators} from '@shared/validators/validators';
 import * as y from 'js-yaml';
@@ -208,6 +208,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   readonly IPFamily = IPFamily;
   readonly NodeProvider = NodeProvider;
   readonly KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE = KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE;
+  readonly OPA_DEPRECATED_MESSAGE = OPA_DEPRECATED_MESSAGE;
   private _datacenterSpec: Datacenter;
   private _seedSettings: SeedSettings;
   private _settings: AdminSettings;

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -605,7 +605,7 @@ limitations under the License.
                    matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
                 }
                 <i class="km-icon-warning km-pointer"
-                   matTooltip="OPA (Open Policy Agent) has been deprecated in KKP 2.28 and will be removed in the future, Kyverno has replaced it as an Enterprise Edition feature for policy management.."></i>
+                   [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
               </div>
             </mat-checkbox>
             @if (isEnterpriseEdition) {

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -589,7 +589,6 @@ limitations under the License.
                    fxLayoutAlign=" center">
                 <span>Kubernetes Dashboard</span>
                 <i class="km-icon-warning km-pointer"
-                   style="margin: 0 10px"
                    [matTooltip]="KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE"></i>
               </div>
             </mat-checkbox>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR remove sticky warning-card banner for Kubernetes Dashboard from top of cluster details page instead add warning icon deprecation tooltip on hover.

### Kubernetes Banner (Removed)

Before:
<img width="1310" height="330" alt="image" src="https://github.com/user-attachments/assets/472f1d55-04cf-4da0-adb5-4ffadebeeb4e" />


After (Warning Icon Added):
<img width="1301" height="273" alt="Screenshot 2026-02-19 at 7 39 58 PM" src="https://github.com/user-attachments/assets/051d74e1-dfe7-42f2-9c8c-dc5bfc44109d" />

### OPA Banner (Removed)

Before:
<img width="1292" height="569" alt="image" src="https://github.com/user-attachments/assets/f79dcf7a-be0d-40c3-a0f0-5dcd866c698a" />


After (Icon Added in cluster details expansion panel)
<img width="1275" height="308" alt="image" src="https://github.com/user-attachments/assets/3d7765ac-2757-4b41-afce-e3fda9019943" />


OPA Tabs
<img width="1289" height="175" alt="image" src="https://github.com/user-attachments/assets/fc425f11-1869-47c8-a363-57b69200e915" />



- [Internal Discussion](https://kubermatic.slack.com/archives/C08PNJ0R8F3/p1771261259643719)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref #7810

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
