### PR TITLE
Add Anexia deprecation warning to remaining views

### DIFF
--- a/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
@@ -28,6 +28,7 @@ import * as y from 'js-yaml';
 import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
 import {take, takeUntil} from 'rxjs/operators';
+import {ANEXIA_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
 
 export interface DatacenterDataDialogConfig {
   title: string;
@@ -73,6 +74,7 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
   readonly domainRegex = '^(?!-)[A-Za-z0-9-]+([\\-.][a-z0-9]+)*\\.[A-Za-z]{2,6}$';
   readonly countryCodes: string[] = countryCodeLookup.countries.map(country => country.iso2);
   readonly providers = INTERNAL_NODE_PROVIDERS;
+  readonly ANEXIA_DEPRECATED_MESSAGE = ANEXIA_DEPRECATED_MESSAGE;
   seeds: string[] = [];
   form: FormGroup;
   requiredEmails: string[] = [];

--- a/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/template.html
@@ -21,8 +21,9 @@ limitations under the License.
 
   <form [formGroup]="form"
         fxLayout="column"
-        fxLayoutGap="8px">
-    <mat-form-field fxFlex>
+        fxLayoutGap="20px">
+    <mat-form-field fxFlex
+                    subscriptSizing="dynamic">
       <mat-label>Name</mat-label>
       <input required
              matInput
@@ -44,7 +45,8 @@ limitations under the License.
       }
     </mat-form-field>
 
-    <mat-form-field fxFlex>
+    <mat-form-field fxFlex
+                    subscriptSizing="dynamic">
       <mat-label>Provider</mat-label>
       <mat-select required
                   disableOptionCentering
@@ -60,6 +62,15 @@ limitations under the License.
         </mat-option>
         }
       </mat-select>
+      @if (form.get(controls.Provider).value === 'anexia') {
+      <mat-hint>
+        <div fxLayout="row"
+             fxLayoutAlign=" center">
+          <i class="km-icon-warning"></i>
+          <div>{{ ANEXIA_DEPRECATED_MESSAGE }}</div>
+        </div>
+      </mat-hint>
+      }
       @if (form.get(controls.Provider).hasError('required')) {
       <mat-error>
         <strong>Required</strong>
@@ -67,7 +78,8 @@ limitations under the License.
       }
     </mat-form-field>
 
-    <mat-form-field fxFlex>
+    <mat-form-field fxFlex
+                    subscriptSizing="dynamic">
       <mat-label>Seed</mat-label>
       <mat-select required
                   disableOptionCentering
@@ -87,7 +99,8 @@ limitations under the License.
       }
     </mat-form-field>
 
-    <mat-form-field fxFlex>
+    <mat-form-field fxFlex
+                    subscriptSizing="dynamic">
       <mat-label>Country</mat-label>
       <mat-select required
                   disableOptionCentering
@@ -121,7 +134,8 @@ limitations under the License.
       }
     </mat-form-field>
 
-    <mat-form-field fxFlex>
+    <mat-form-field fxFlex
+                    subscriptSizing="dynamic">
       <mat-label>Location</mat-label>
       <input required
              matInput

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/component.ts
@@ -16,6 +16,7 @@ import {Component, forwardRef, Input, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, NG_VALIDATORS, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Mode} from '@app/settings/admin/presets/dialog/component';
 import {PresetDialogService} from '@app/settings/admin/presets/dialog/steps/service';
+import {ANEXIA_DEPRECATED_MESSAGE} from '@app/shared/constants/common';
 import {DatacenterService} from '@core/services/datacenter';
 import {AutocompleteControls, AutocompleteInitialState} from '@shared/components/autocomplete/component';
 import {Datacenter} from '@shared/entity/datacenter';
@@ -59,6 +60,7 @@ export class PresetSettingsStepComponent extends BaseFormValidator implements On
   readonly Providers = NodeProvider;
   readonly Controls = Controls;
   readonly Mode = Mode;
+  readonly ANEXIA_DEPRECATED_MESSAGE = ANEXIA_DEPRECATED_MESSAGE;
 
   constructor(
     private readonly _builder: FormBuilder,

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/template.html
@@ -110,4 +110,11 @@ limitations under the License.
     </div>
     }
   </form>
+  @if (provider === Providers.ANEXIA) {
+  <div fxLayout="row"
+       fxLayoutAlign=" center">
+    <i class="km-icon-warning"></i>
+    <div>{{ ANEXIA_DEPRECATED_MESSAGE }}</div>
+  </div>
+  }
 </div>

--- a/modules/web/src/app/settings/admin/seed-configurations/seed-configurations-details/style.scss
+++ b/modules/web/src/app/settings/admin/seed-configurations/seed-configurations-details/style.scss
@@ -48,6 +48,10 @@
           padding: 10px 30px;
         }
       }
+
+      .km-icon-warning {
+        background-color: unset;
+      }
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Anexia deprecation warning to :

* **add datacenter dialog:**
<img width="688" height="789" alt="image" src="https://github.com/user-attachments/assets/72bb8898-e9fa-44c0-9329-2bfc71bdbc79" />

* **create/edit preset settings step:**
<img width="619" height="658" alt="image" src="https://github.com/user-attachments/assets/23923a32-e019-4526-9143-553382fa598b" />

* **fix the warning icon background in the seed page:**
<img width="577" height="299" alt="image" src="https://github.com/user-attachments/assets/67dbc97f-4328-48b0-b5a9-15e575b288c1" />

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref #https://github.com/kubermatic/dashboard/issues/7858

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
