### PR TITLE
Fix Rest-API Page Authentication Bearer Token Issue 

### DIFF
--- a/modules/web/src/app/pages/api-docs/component.ts
+++ b/modules/web/src/app/pages/api-docs/component.ts
@@ -44,13 +44,20 @@ export class ApiDocsComponent implements OnInit {
         requestSnippetsEnabled: true,
         url: `${this._document.location.origin}/api/swagger.json`,
         requestInterceptor: req => {
-          const hasAuthorizationHeader = !!(req.headers['Authorization'] || req.headers['authorization']);
-          if (!hasAuthorizationHeader) {
+          const authHeader = req.headers['Authorization'] || req.headers['authorization'];
+          const bearerPrefix = 'Bearer ';
+
+          // Add Bearer prefix to raw tokens from Swagger UI Authorize dialog
+          if (authHeader && !authHeader.startsWith(bearerPrefix)) {
+            req.headers['Authorization'] = `${bearerPrefix}${authHeader}`;
+          } else if (!authHeader) {
+            // Fall back to logged-in user's session token
             const token = this._auth.getBearerToken();
             if (token) {
-              req.headers['Authorization'] = 'Bearer ' + token;
+              req.headers['Authorization'] = `${bearerPrefix}${token}`;
             }
           }
+
           return req;
         },
       });


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes authorization header handling in the Swagger request  interceptor to properly support REST API tokens provided through the  Swagger UI Authorize dialog while maintaining backward compatibility with session tokens.   

<img width="1497" height="343" alt="Screenshot 2026-02-21 at 4 02 44 AM" src="https://github.com/user-attachments/assets/fc05c972-0e62-4d1f-8b8c-f6157751d5d0" />

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7752 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

#### Session Token CURL

```
curl -X 'GET' \
  'https://localhost:8000/api/v1/projects/rzbqvk6qwc/clusters' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjYzMWE3ZDUwMjFiZWZjNzcyZTNmYmY0YWVmZWY1NjYyYTczZWFkZDAifQ.eyJpc3MiOiJod
  <SESSION_TOKEN>
v6pLUb85KA4c9xyZPT8Vefq-DyOsqz0xqnFLfeGG_7Zs68qMXRDL4urw46wofR1gcwUGMw'
```

#### Service Account Token CURL

```
curl -X 'GET' \
  'https://dev.kubermatic.io/api/v1/projects/rzbqvk6qwc/clusters' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InNlcnZpY2VhY2NvdW50LXAycTlsajR0YmNAZGV2Lmt1YmVybWF0aWMuaW8iLCJleHAi
<SERVICE__ACCOUNT__TOKEN>'
2VuX2lkIjoiOGZzNG5zczZoNyJ9.VMs-xv4XixH2l0DlkGJJd6nFFuWRKe1CJc_hlWEleR0'
```

SA: Token Can be created:
<img width="1310" height="487" alt="Screenshot 2026-02-23 at 7 55 55 PM" src="https://github.com/user-attachments/assets/c47468bd-b111-42a6-b262-150b853ef8f9" />



**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
REST API tokens can now be properly authenticated through the Swagger UI without being overwritten by session tokens.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
