### PR TITLE
Add Missing Network fields to VMware Cloud Director In Cluster Summary Page

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/machine-deployment-details/template.html
+++ b/modules/web/src/app/cluster/details/cluster/machine-deployment-details/template.html
@@ -167,74 +167,12 @@ limitations under the License.
         }
         }
         @if (machineDeployment.spec.template.cloud.vmwareclouddirector; as vmwareclouddirector) {
-        <km-property>
-          <div key>CPUs</div>
-          <div value>{{vmwareclouddirector.cpus}}</div>
-        </km-property>
-        <km-property>
-          <div key>Cores per CPU</div>
-          <div value>{{vmwareclouddirector.cpuCores}}</div>
-        </km-property>
-        <km-property>
-          <div key>Memory</div>
-          <div value>{{vmwareclouddirector.memoryMB}} MB</div>
-        </km-property>
-        <km-property>
-          <div key>Disk Size</div>
-          <div value>{{vmwareclouddirector.diskSizeGB}} GB</div>
-        </km-property>
-        @if (vmwareclouddirector.diskIOPS) {
-        <km-property>
-          <div key>Disk IOPS</div>
-          <div value>{{vmwareclouddirector.diskIOPS}}</div>
-        </km-property>
-        }
-        <km-property>
-          <div key>Storage Profile</div>
-          <div value>{{vmwareclouddirector.storageProfile}}</div>
-        </km-property>
-        @if (vmwareclouddirector.placementPolicy) {
-        <km-property>
-          <div key>Placement Policy</div>
-          <div value>{{vmwareclouddirector.placementPolicy}}</div>
-        </km-property>
-        }
-        @if (vmwareclouddirector.sizingPolicy) {
-        <km-property>
-          <div key>Sizing Policy</div>
-          <div value>{{vmwareclouddirector.sizingPolicy}}</div>
-        </km-property>
-        }
-        <km-property>
-          <div key>IP Allocation Mode</div>
-          <div value>{{vmwareclouddirector.ipAllocationMode}}</div>
-        </km-property>
-        @if (vmwareclouddirector.network) {
-        <km-property>
-          <div key>Network</div>
-          <div value>{{vmwareclouddirector.network}}</div>
-        </km-property>
-        }
-        @if (vmwareclouddirector.additionalNetworks?.length) {
-        <km-property>
-          <div key>Additional Networks</div>
-          <div value>{{vmwareclouddirector.additionalNetworks.join(', ')}}</div>
-        </km-property>
-        }
         @if (vmwareclouddirector.vapp) {
         <km-property>
           <div key>VApp</div>
           <div value>{{vmwareclouddirector.vapp}}</div>
         </km-property>
         }
-        <km-property>
-          <div key>Catalog</div>
-          <div value>{{vmwareclouddirector.catalog}}</div>
-        </km-property>
-        <km-property>
-          <div key>Template</div>
-          <div value>{{vmwareclouddirector.template}}</div>
-        </km-property>
         }
         <km-property>
           <div key>Created</div>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR Add Network and Additional Networks properties to the VMware Cloud Director machine deployment section of the cluster summary component. 

Reference: Found While Testing Following [Ticket](https://github.com/kubermatic/dashboard/issues/7813)

## Cluster Summary Page

#### BEFORE:
<img width="629" height="251" alt="Screenshot 2026-02-28 at 12 12 39 AM" src="https://github.com/user-attachments/assets/61d66e0e-8376-4c1e-88a9-b9028992a41e" />

<img width="656" height="390" alt="Screenshot 2026-02-28 at 12 12 31 AM" src="https://github.com/user-attachments/assets/f48a390f-9f63-45e5-9642-2fd7e6b6c376" />

#### AFTER:
<img width="687" height="269" alt="image" src="https://github.com/user-attachments/assets/6af8a5e1-3564-46e4-9cd5-d10a694c51be" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref: #7452

**What type of PR is this?**
/kind design
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed VMware Cloud Director cluster summary not displaying Network and Additional Networks fields
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
