### PR TITLE
Hide native spinners in number input for better UX across browsers

### DIFF
--- a/modules/web/src/app/shared/components/number-stepper/style.scss
+++ b/modules/web/src/app/shared/components/number-stepper/style.scss
@@ -19,9 +19,11 @@
 }
 
 input[type='number'] {
+  appearance: textfield; // Hides native spinners in Firefox
+
   &::-webkit-inner-spin-button,
   &::-webkit-outer-spin-button {
-    appearance: none;
+    appearance: none; // Hides native spinners in WebKit browsers (Chrome, Safari, Edge)
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 This PR fixes the number-stepper component to hide native browser spinners in Firefox browser


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7885 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

## Before:
<img width="645" height="231" alt="Screenshot 2026-03-03 at 11 37 24 PM" src="https://github.com/user-attachments/assets/d7e36fd3-563f-4e18-b7de-2b54df2657cb" />


## After
<img width="677" height="292" alt="Screenshot 2026-03-03 at 11 36 30 PM" src="https://github.com/user-attachments/assets/8c7de95f-a934-4600-9a19-655e548c8b56" />



**Special notes for your reviewer**:

- Brower: Firefox

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed number-stepper input to hide native spinners in Firefox for a consistent UI across all browsers.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
