### PR TITLE
Add GPU resource warning to project quotas

### DIFF
--- a/modules/web/src/app/dynamic/enterprise/quotas/style.scss
+++ b/modules/web/src/app/dynamic/enterprise/quotas/style.scss
@@ -43,6 +43,15 @@
   margin-top: 30px;
 }
 
+.warning-container {
+  margin-bottom: 10px;
+  margin-left: 30px;
+
+  i {
+    font-size: 18px;
+  }
+}
+
 km-search-field {
   font-size: variables.$font-size-subhead;
 

--- a/modules/web/src/app/dynamic/enterprise/quotas/template.html
+++ b/modules/web/src/app/dynamic/enterprise/quotas/template.html
@@ -52,6 +52,13 @@ END OF TERMS AND CONDITIONS
     </div>
   </mat-card-header>
   <mat-card-content>
+    <div fxLayout="row"
+         fxLayoutAlign=" center"
+         fxLayoutGap="8px"
+         class="warning-container">
+      <i class="km-icon-warning"></i>
+      <span>GPU resources are not included in quota calculations.</span>
+    </div>
     <table id="quotas-table"
            class="km-table"
            mat-table


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a warning message to the project quotas page in the admin settings stating that GPU resources are excluded from quota calculations.

<img width="1183" height="647" alt="image" src="https://github.com/user-attachments/assets/288aaab7-a451-44fb-8c15-95443860fd0f" />


**Which issue(s) this PR fixes**:
Fixes #7903

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
