### PR TITLE
Fix enforce event rate in edit cluster dialog

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -110,7 +110,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   annotations: Record<string, string>;
   podNodeSelectorAdmissionPluginConfig: Record<string, string>;
   eventRateLimitConfig: EventRateLimitConfig;
-  isEnforcedByAdmin = false;
+  isEventRateLimitEnforcedByAdmin = false;
   admissionPlugins: string[] = [];
   providerSettingsPatch: ProviderSettingsPatch = {
     isValid: true,
@@ -177,7 +177,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .getAdmissionPluginsConfiguration()
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(config => {
-        this.isEnforcedByAdmin = !!config?.eventRateLimit?.enforced;
+        this.isEventRateLimitEnforcedByAdmin = !!config?.eventRateLimit?.enforced;
       });
     this.eventRateLimitConfig = _.cloneDeep(this.cluster.spec.eventRateLimitConfig);
     this.apiServerAllowedIPRanges = this.cluster.spec.apiServerAllowedIPRanges?.cidrBlocks;
@@ -477,6 +477,17 @@ export class EditClusterComponent implements OnInit, OnDestroy {
 
   isPodSecurityPolicyEnforced(): boolean {
     return AdmissionPluginUtils.isPodSecurityPolicyEnforced(this.datacenter);
+  }
+
+  isAdmissionPluginEnforced(admissionPlugin: AdmissionPlugin): boolean {
+    switch (admissionPlugin) {
+      case AdmissionPlugin.EventRateLimit:
+        return this.isEventRateLimitEnforcedByAdmin;
+      case AdmissionPlugin.PodSecurityPolicy:
+        return this.isPodSecurityPolicyEnforced();
+      default:
+        return false;
+    }
   }
 
   isEnforced(control: Controls): boolean {

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -68,7 +68,7 @@ limitations under the License.
                       disableOptionCentering>
             @for (admissionPlugin of admissionPlugins; track admissionPlugin) {
             <mat-option [value]="admissionPlugin"
-                        [disabled]="admissionPlugin === admissionPlugin.PodSecurityPolicy && !!isPodSecurityPolicyEnforced()">
+                        [disabled]="isAdmissionPluginEnforced(admissionPlugin)">
               {{getPluginName(admissionPlugin)}}
               @if (admissionPlugin === admissionPlugin.PodSecurityPolicy) {
               <i class="km-icon-info km-pointer"
@@ -119,7 +119,7 @@ limitations under the License.
         @if (isPluginEnabled(admissionPlugin.EventRateLimit)) {
         <div>
           <km-wizard-cluster-event-rate-limit [formControl]="form.get(Controls.EventRateLimitConfig)"
-                                              [isEnforcedByAdmin]="isEnforcedByAdmin" />
+                                              [isEnforcedByAdmin]="isEventRateLimitEnforcedByAdmin" />
         </div>
         }
       </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable the Event Rate Limit plugin option from the plugins dropdown list when it's enforced by admin, to prevent the user from unchecking it.

**Before:**
<img width="693" height="215" alt="image" src="https://github.com/user-attachments/assets/61bdc5e4-8b77-4621-a9ca-cd703ac99804" />


**After:**
<img width="693" height="215" alt="image" src="https://github.com/user-attachments/assets/67da0ef1-3775-460c-8f29-193530ef6b3e" />


**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
