### PR TITLE
Handle country code lookup errors gracefully in dynamic datacenters

### DIFF
--- a/modules/web/src/app/settings/admin/dynamic-datacenters/component.ts
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/component.ts
@@ -110,8 +110,12 @@ export class DynamicDatacentersComponent implements OnInit, OnDestroy, OnChanges
       return '';
     }
 
-    const country = countryCodeLookup.byIso(code);
-    return country ? country.country : code;
+    try {
+      const country = countryCodeLookup.byIso(code);
+      return country ? country.country : code;
+    } catch {
+      return code;
+    }
   }
 
   private _setCountries(datacenters: Datacenter[]) {

--- a/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
+++ b/modules/web/src/app/settings/admin/dynamic-datacenters/datacenter-data-dialog/component.ts
@@ -204,8 +204,12 @@ export class DatacenterDataDialogComponent implements OnInit, OnDestroy {
       return '';
     }
 
-    const country = countryCodeLookup.byIso(code);
-    return country ? country.country : code;
+    try {
+      const country = countryCodeLookup.byIso(code);
+      return country ? country.country : code;
+    } catch {
+      return code;
+    }
   }
 
   getObservable(): Observable<Datacenter> | void {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a crash in the dynamic datacenters admin settings when countryCodeLookup.byIso() throws an error for  invalid or unrecognized ISO country codes, by wrapping the call in a try-catch and falling back to the raw code.

**BEFORE:**
<img width="1074" height="394" alt="image" src="https://github.com/user-attachments/assets/751b8432-d7db-49bc-8307-e08d493ac8b9" />


**AFTER**

<img width="992" height="229" alt="image" src="https://github.com/user-attachments/assets/48b2cbcf-6ab8-43b4-b324-77554a027bd3" />


<img width="324" height="340" alt="Screenshot 2026-03-10 at 2 14 10 AM" src="https://github.com/user-attachments/assets/a22c1172-69b0-468a-8099-1029309582af" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7904 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix crash in dynamic datacenters admin page when encountering invalid ISO country codes.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
