### PR TITLE
Prevent conflicting network configuration and fix field assignment for VSphere

### DIFF
--- a/modules/api/pkg/resources/machine/common.go
+++ b/modules/api/pkg/resources/machine/common.go
@@ -218,15 +218,10 @@ func GetVSphereProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 		datastore = defaultIfEmpty(c.Spec.Cloud.VSphere.Datastore, dc.Spec.VSphere.DefaultDatastore)
 	}
 
-	// Determine network configuration - prefer Networks array over deprecated VMNetName
-	vmNetName := ""
-	if len(c.Spec.Cloud.VSphere.Networks) > 0 {
-		vmNetName = c.Spec.Cloud.VSphere.Networks[0]
-	}
-
 	config := &vsphere.RawConfig{
-		TemplateVMName:   providerconfig.ConfigVarString{Value: nodeSpec.Cloud.VSphere.Template},
-		VMNetName:        providerconfig.ConfigVarString{Value: vmNetName},
+		TemplateVMName: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.VSphere.Template},
+		//nolint:staticcheck
+		VMNetName:        providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.VMNetName},
 		CPUs:             int32(nodeSpec.Cloud.VSphere.CPUs),
 		MemoryMB:         int64(nodeSpec.Cloud.VSphere.Memory),
 		DiskSizeGB:       nodeSpec.Cloud.VSphere.DiskSizeGB,
@@ -242,6 +237,10 @@ func GetVSphereProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, 
 	}
 
 	if len(c.Spec.Cloud.VSphere.Networks) > 0 {
+		//nolint:staticcheck
+		if c.Spec.Cloud.VSphere.VMNetName != "" {
+			return nil, errors.New("both vmNetName and networks are set in the cluster spec, please use only networks and remove the deprecated vmNetName field")
+		}
 		config.Networks = make([]providerconfig.ConfigVarString, len(c.Spec.Cloud.VSphere.Networks))
 		for i, network := range c.Spec.Cloud.VSphere.Networks {
 			config.Networks[i].Value = network


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses a bug in the vSphere provider configuration where network settings were being incorrectly assigned. It also adds validation to users from assigning both `networks` and the deprecated field `VMNetName`.

**Which issue(s) this PR fixes**:
Fixes #7923 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fixed a bug in vSphere provider configuration where networks were incorrectly assigned. Added validation to prevent using both the deprecated `vmNetName` and the `networks` field at the same time.
```

**Documentation**:
```documentation
NONE
```
