### PR TITLE
fix: Improved layout alignment for the cluster template quota widget and updated license year to 2026.    

### DIFF
--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -36,7 +36,7 @@
     "fix:ts": "gts fix",
     "fix:scss": "stylelint \"src/**/*.scss\" --fix",
     "fix:html": "html-beautify --replace -f \"src/**/*.html\"",
-    "fix:license": "license-check-and-add add -r 2025",
+    "fix:license": "license-check-and-add add -r 2026",
     "clean": "gts clean",
     "vi": "node version.js",
     "postinstall": "npm run vi",

--- a/modules/web/src/app/cluster-template/style.scss
+++ b/modules/web/src/app/cluster-template/style.scss
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+.km-cluster-template-quota {
+  margin-right: 10px;
+}
+
 .mat-column-provider {
   width: 160px;
 }

--- a/modules/web/src/app/cluster-template/template.html
+++ b/modules/web/src/app/cluster-template/template.html
@@ -23,23 +23,22 @@ limitations under the License.
        fxLayoutAlign=" center"
        class="header">
     <km-search-field (queryChange)="onSearch($event)" />
-    <div fxFlex
-         fxLayoutAlign="end center">
-      <div>
-        <router-outlet name="quota-widget"
-                       (activate)="onActivate($event)" />
-      </div>
-      <span [matTooltip]="!can(Permission.Create) ? projectViewOnlyToolTip : ''">
-        <button mat-flat-button
-                type="button"
-                (click)="create()"
-                [disabled]="!can(Permission.Create) || isGroupConfigLoading">
-          <i class="km-icon-mask km-icon-add"
-             matButtonIcon></i>
-          <span>Create Cluster Template</span>
-        </button>
-      </span>
+    <div fxFlex></div>
+    <div fxLayoutAlign="center center"
+         class="km-cluster-template-quota">
+      <router-outlet name="quota-widget"
+                     (activate)="onActivate($event)" />
     </div>
+    <span [matTooltip]="!can(Permission.Create) ? projectViewOnlyToolTip : ''">
+      <button mat-flat-button
+              type="button"
+              (click)="create()"
+              [disabled]="!can(Permission.Create) || isGroupConfigLoading">
+        <i class="km-icon-mask km-icon-add"
+           matButtonIcon></i>
+        <span>Create Cluster Template</span>
+      </button>
+    </span>
   </div>
 
   <mat-card-content>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the license year in package.json to 2026 and improves the layout  alignment for the cluster template quota widget in the header. 


### Margin Fix
<img width="1260" height="139" alt="image" src="https://github.com/user-attachments/assets/8c59f90d-0cb7-447d-96a4-4e8a9465bfa8" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # NONE

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE	
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
