### PR TITLE
Fix project allowed operating systems not initialized on creation

### DIFF
--- a/modules/web/src/app/shared/components/add-project-dialog/component.spec.ts
+++ b/modules/web/src/app/shared/components/add-project-dialog/component.spec.ts
@@ -51,11 +51,11 @@ describe('AddProjectDialogComponent', () => {
     fixture.detectChanges();
   }));
 
-  it('should create the component', waitForAsync(() => {
+  it('should create the add project dialog component', waitForAsync(() => {
     expect(component).toBeTruthy();
   }));
 
-  it('should initialize projectAllowedOperatingSystems from admin defaults', () => {
+  it('should initialize project allowed operating systems with only enabled entries from admin defaults', () => {
     const expected: Record<string, boolean> = {};
     Object.keys(DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems)
       .filter(os => DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems[os])
@@ -64,7 +64,7 @@ describe('AddProjectDialogComponent', () => {
     expect(component.projectAllowedOperatingSystems).toEqual(expected);
   });
 
-  it('should call createProject method with allowedOperatingSystems', fakeAsync(() => {
+  it('should pass the selected operating systems in the project spec when creating a project', fakeAsync(() => {
     const spy = jest.spyOn(fixture.debugElement.injector.get(ProjectService) as any, 'create');
 
     const expected: Record<string, boolean> = {};
@@ -87,7 +87,7 @@ describe('AddProjectDialogComponent', () => {
     );
   }));
 
-  it('should only include enabled operating systems from admin settings', () => {
+  it('should exclude disabled operating systems and only include enabled ones from admin settings', () => {
     component.adminAllowedOperatingSystems = {
       ubuntu: true,
       flatcar: true,

--- a/modules/web/src/app/shared/components/add-project-dialog/component.spec.ts
+++ b/modules/web/src/app/shared/components/add-project-dialog/component.spec.ts
@@ -55,8 +55,22 @@ describe('AddProjectDialogComponent', () => {
     expect(component).toBeTruthy();
   }));
 
-  it('should call createProject method', fakeAsync(() => {
+  it('should initialize projectAllowedOperatingSystems from admin defaults', () => {
+    const expected: Record<string, boolean> = {};
+    Object.keys(DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems)
+      .filter(os => DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems[os])
+      .forEach(os => (expected[os] = true));
+
+    expect(component.projectAllowedOperatingSystems).toEqual(expected);
+  });
+
+  it('should call createProject method with allowedOperatingSystems', fakeAsync(() => {
     const spy = jest.spyOn(fixture.debugElement.injector.get(ProjectService) as any, 'create');
+
+    const expected: Record<string, boolean> = {};
+    Object.keys(DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems)
+      .filter(os => DEFAULT_ADMIN_SETTINGS.allowedOperatingSystems[os])
+      .forEach(os => (expected[os] = true));
 
     component.form.controls.name.patchValue('test');
     component.getObservable().subscribe();
@@ -64,6 +78,34 @@ describe('AddProjectDialogComponent', () => {
     tick();
     flush();
 
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({
+          allowedOperatingSystems: expected,
+        }),
+      })
+    );
   }));
+
+  it('should only include enabled operating systems from admin settings', () => {
+    component.adminAllowedOperatingSystems = {
+      ubuntu: true,
+      flatcar: true,
+      amzn2: true,
+      rhel: false,
+      rockylinux: false,
+    };
+    component.ngOnInit();
+
+    const expected: Record<string, boolean> = {};
+    Object.keys(component.adminAllowedOperatingSystems)
+      .filter(os => component.adminAllowedOperatingSystems[os])
+      .forEach(os => (expected[os] = true));
+
+    expect(component.projectAllowedOperatingSystems).toEqual(expected);
+
+    // Also verify disabled OS are NOT present
+    expect(component.projectAllowedOperatingSystems).not.toHaveProperty('rhel');
+    expect(component.projectAllowedOperatingSystems).not.toHaveProperty('rockylinux');
+  });
 });

--- a/modules/web/src/app/shared/components/add-project-dialog/component.ts
+++ b/modules/web/src/app/shared/components/add-project-dialog/component.ts
@@ -54,13 +54,17 @@ export class AddProjectDialogComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    const enabledOperatingSystems = Object.keys(this.adminAllowedOperatingSystems).filter(
+      os => this.adminAllowedOperatingSystems[os]
+    );
+
     this.form = new FormGroup({
       [Controls.Name]: new FormControl('', [Validators.required]),
       [Controls.Labels]: new FormControl(''),
-      [Controls.AllowedOperatingSystems]: new FormControl(
-        Object.keys(this.adminAllowedOperatingSystems).filter(os => this.adminAllowedOperatingSystems[os])
-      ),
+      [Controls.AllowedOperatingSystems]: new FormControl(enabledOperatingSystems),
     });
+
+    this.onOperatingSystemChange(enabledOperatingSystems);
   }
 
   onOperatingSystemChange(operatingSystems: string[]): void {


### PR DESCRIPTION
**What this PR does / why we need it**:
  This PR fixes the project creation dialog not properly initializing the allowed operating systems, causing newly created projects to have no OS restrictions applied from admin defaults.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7955 7955

### Before:

- Add:
<img width="643" height="489" alt="Screenshot 2026-03-27 at 4 41 12 PM" src="https://github.com/user-attachments/assets/c649ae0d-a66c-4ac5-ad51-01a35b578c5c" />


- Edit:
<img width="1696" height="1208" alt="Screenshot" src="https://github.com/user-attachments/assets/deeb3a55-f70b-4ace-9247-d89c7b8e59f3" />



### After

- Add:

<img width="643" height="509" alt="Screenshot 2026-03-27 at 4 43 52 PM" src="https://github.com/user-attachments/assets/17e6a2d2-e6bc-49ed-9bfc-cd7194ff75ef" />

- Edit:
<img width="633" height="552" alt="Screenshot 2026-03-27 at 4 43 58 PM" src="https://github.com/user-attachments/assets/cc5de58c-eea6-406e-bbfa-c97722f91c0f" />


**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed project creation dialog not applying admin-configured allowed operating systems to new projects.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
