### PR TITLE
BackupStorageLocation UX improvements

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.spec.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.spec.ts
@@ -14,7 +14,7 @@
 
 import {EventEmitter} from '@angular/core';
 import {ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync} from '@angular/core/testing';
-import {MatDialogRef} from '@angular/material/dialog';
+import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {BrowserModule} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {Router} from '@angular/router';
@@ -42,7 +42,7 @@ import {ProjectMockService} from '@test/services/project-mock';
 import {RouterStub} from '@test/services/router-stubs';
 import {SettingsMockService} from '@test/services/settings-mock';
 import {UserMockService} from '@test/services/user-mock';
-import {Subject} from 'rxjs';
+import {of, Subject} from 'rxjs';
 import {AlibabaProviderSettingsComponent} from '../edit-provider-settings/alibaba-provider-settings/component';
 import {AWSProviderSettingsComponent} from '../edit-provider-settings/aws-provider-settings/component';
 import {AzureProviderSettingsComponent} from '../edit-provider-settings/azure-provider-settings/component';
@@ -89,6 +89,7 @@ describe('EditClusterComponent', () => {
       ],
       providers: [
         {provide: DatacenterService, useClass: DatacenterMockService},
+        {provide: MatDialog, useValue: {open: jest.fn().mockReturnValue({afterClosed: () => of(undefined)})}},
         {provide: MatDialogRef, useClass: MatDialogRefMock},
         {provide: ClusterService, useValue: clusterServiceMock},
         {provide: AppConfigService, useClass: AppConfigMockService},

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -568,10 +568,15 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(cbslList => {
         this.backupStorageLocationsList = cbslList.filter(bsl => this._isBackupStorageLocationAvailable(bsl));
-        this.backupStorageLocationLabel = this.backupStorageLocationsList.length ? BSLListState.Ready : BSLListState.Empty;
+        this.backupStorageLocationLabel = this.backupStorageLocationsList.length
+          ? BSLListState.Ready
+          : BSLListState.Empty;
 
         const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
-        if (backupStorageLocationControl && !this.backupStorageLocationsList.some(bsl => bsl.name === backupStorageLocationControl.value)) {
+        if (
+          backupStorageLocationControl &&
+          !this.backupStorageLocationsList.some(bsl => bsl.name === backupStorageLocationControl.value)
+        ) {
           backupStorageLocationControl.reset();
         }
       });

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -14,9 +14,11 @@
 
 import {ChangeDetectorRef, Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
-import {MatDialogRef} from '@angular/material/dialog';
+import {MatDialog, MatDialogRef} from '@angular/material/dialog';
+import {MatSelectChange} from '@angular/material/select';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {UserClusterConfigService} from '@app/core/services/user-cluster-config';
+import {AddBackupStorageLocationDialogComponent} from '@app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component';
 import {DynamicModule} from '@app/dynamic/module-registry';
 import {BackupStorageLocation} from '@app/shared/entity/backup';
 import {NODEPORTS_IPRANGES_SUPPORTED_PROVIDERS, NodeProvider} from '@app/shared/model/NodeProviderConstants';
@@ -66,7 +68,7 @@ import {HTTP_PROXY_URL_PATTERN_VALIDATOR, IPV4_IPV6_CIDR_PATTERN, NO_PROXY_PATTE
 import {KmValidators} from '@shared/validators/validators';
 import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
-import {map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
+import {filter, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
 enum Controls {
   Name = 'name',
@@ -138,6 +140,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   isAuditWebhookBackendHidden = false;
   backupStorageLocationsList: BackupStorageLocation[];
   backupStorageLocationLabel: BSLListState = BSLListState.Ready;
+  readonly createBackupStorageLocationOptionValue = '__create_backup_storage_location__';
   isAllowedIPRangeSupported: boolean;
   readonly isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   readonly CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE = CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE;
@@ -174,6 +177,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     private readonly _builder: FormBuilder,
     private readonly _clusterService: ClusterService,
     private readonly _datacenterService: DatacenterService,
+    private readonly _matDialog: MatDialog,
     private readonly _matDialogRef: MatDialogRef<EditClusterComponent>,
     private readonly _notificationService: NotificationService,
     private readonly _settingsService: SettingsService,
@@ -563,9 +567,37 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .listBackupStorageLocation(projectID)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(cbslList => {
-        this.backupStorageLocationsList = cbslList;
-        this.backupStorageLocationLabel = cbslList.length ? BSLListState.Ready : BSLListState.Empty;
+        this.backupStorageLocationsList = cbslList.filter(bsl => this._isBackupStorageLocationAvailable(bsl));
+        this.backupStorageLocationLabel = this.backupStorageLocationsList.length ? BSLListState.Ready : BSLListState.Empty;
+
+        const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
+        if (backupStorageLocationControl && !this.backupStorageLocationsList.some(bsl => bsl.name === backupStorageLocationControl.value)) {
+          backupStorageLocationControl.reset();
+        }
       });
+  }
+
+  onBackupStorageLocationSelectionChange(event: MatSelectChange<string>): void {
+    if (event.value !== this.createBackupStorageLocationOptionValue) {
+      return;
+    }
+
+    const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
+    const previousValue = this.cluster.spec?.backupConfig?.backupStorageLocation?.name ?? '';
+    backupStorageLocationControl.setValue(previousValue, {emitEvent: false});
+
+    this._matDialog
+      .open(AddBackupStorageLocationDialogComponent, {
+        data: {projectID: this.projectID},
+      })
+      .afterClosed()
+      .pipe(take(1), filter(Boolean))
+      .subscribe(() => this._getCBSL(this.projectID));
+  }
+
+  private _isBackupStorageLocationAvailable(bsl: BackupStorageLocation): boolean {
+    const status = bsl.status?.phase || bsl.spec?.status || '';
+    return status.toLowerCase() === 'available';
   }
 
   getObservable(): Observable<Cluster> {

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -18,7 +18,6 @@ import {MatDialog, MatDialogRef} from '@angular/material/dialog';
 import {MatSelectChange} from '@angular/material/select';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {UserClusterConfigService} from '@app/core/services/user-cluster-config';
-import {AddBackupStorageLocationDialogComponent} from '@app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component';
 import {DynamicModule} from '@app/dynamic/module-registry';
 import {BackupStorageLocation} from '@app/shared/entity/backup';
 import {NODEPORTS_IPRANGES_SUPPORTED_PROVIDERS, NodeProvider} from '@app/shared/model/NodeProviderConstants';
@@ -582,7 +581,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       });
   }
 
-  onBackupStorageLocationSelectionChange(event: MatSelectChange<string>): void {
+  async onBackupStorageLocationSelectionChange(event: MatSelectChange<string>): Promise<void> {
     if (event.value !== this.createBackupStorageLocationOptionValue) {
       return;
     }
@@ -591,6 +590,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     const previousValue = this.cluster.spec?.backupConfig?.backupStorageLocation?.name ?? '';
     backupStorageLocationControl.setValue(previousValue, {emitEvent: false});
 
+    const AddBackupStorageLocationDialogComponent = await DynamicModule.AddBackupStorageLocationDialogComponent;
+    if (!AddBackupStorageLocationDialogComponent) {
+      return;
+    }
     this._matDialog
       .open(AddBackupStorageLocationDialogComponent, {
         data: {projectID: this.projectID},

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -14,8 +14,7 @@
 
 import {ChangeDetectorRef, Component, Input, OnDestroy, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
-import {MatDialog, MatDialogRef} from '@angular/material/dialog';
-import {MatSelectChange} from '@angular/material/select';
+import {MatDialogRef} from '@angular/material/dialog';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {UserClusterConfigService} from '@app/core/services/user-cluster-config';
 import {DynamicModule} from '@app/dynamic/module-registry';
@@ -47,6 +46,7 @@ import {Datacenter, SeedSettings} from '@shared/entity/datacenter';
 import {AdminSettings, StaticLabel} from '@shared/entity/settings';
 import {KeyValueEntry} from '@shared/types/common';
 import {AdmissionPlugin, AdmissionPluginUtils} from '@shared/utils/admission-plugin';
+import {isBackupStorageLocationAvailable} from '@shared/utils/backup';
 import {
   CLUSTER_DEFAULT_NODE_SELECTOR_HINT,
   CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE,
@@ -67,7 +67,7 @@ import {HTTP_PROXY_URL_PATTERN_VALIDATOR, IPV4_IPV6_CIDR_PATTERN, NO_PROXY_PATTE
 import {KmValidators} from '@shared/validators/validators';
 import _ from 'lodash';
 import {Observable, Subject} from 'rxjs';
-import {filter, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
+import {map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
 enum Controls {
   Name = 'name',
@@ -139,7 +139,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   isAuditWebhookBackendHidden = false;
   backupStorageLocationsList: BackupStorageLocation[];
   backupStorageLocationLabel: BSLListState = BSLListState.Ready;
-  readonly createBackupStorageLocationOptionValue = '__create_backup_storage_location__';
   isAllowedIPRangeSupported: boolean;
   readonly isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   readonly CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE = CLUSTER_DEFAULT_NODE_SELECTOR_NAMESPACE;
@@ -176,7 +175,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     private readonly _builder: FormBuilder,
     private readonly _clusterService: ClusterService,
     private readonly _datacenterService: DatacenterService,
-    private readonly _matDialog: MatDialog,
     private readonly _matDialogRef: MatDialogRef<EditClusterComponent>,
     private readonly _notificationService: NotificationService,
     private readonly _settingsService: SettingsService,
@@ -566,7 +564,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       .listBackupStorageLocation(projectID)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(cbslList => {
-        this.backupStorageLocationsList = cbslList.filter(bsl => this._isBackupStorageLocationAvailable(bsl));
+        this.backupStorageLocationsList = cbslList.filter(bsl => isBackupStorageLocationAvailable(bsl));
         this.backupStorageLocationLabel = this.backupStorageLocationsList.length
           ? BSLListState.Ready
           : BSLListState.Empty;
@@ -579,33 +577,6 @@ export class EditClusterComponent implements OnInit, OnDestroy {
           backupStorageLocationControl.reset();
         }
       });
-  }
-
-  async onBackupStorageLocationSelectionChange(event: MatSelectChange<string>): Promise<void> {
-    if (event.value !== this.createBackupStorageLocationOptionValue) {
-      return;
-    }
-
-    const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
-    const previousValue = this.cluster.spec?.backupConfig?.backupStorageLocation?.name ?? '';
-    backupStorageLocationControl.setValue(previousValue, {emitEvent: false});
-
-    const AddBackupStorageLocationDialogComponent = await DynamicModule.AddBackupStorageLocationDialogComponent;
-    if (!AddBackupStorageLocationDialogComponent) {
-      return;
-    }
-    this._matDialog
-      .open(AddBackupStorageLocationDialogComponent, {
-        data: {projectID: this.projectID},
-      })
-      .afterClosed()
-      .pipe(take(1), filter(Boolean))
-      .subscribe(() => this._getCBSL(this.projectID));
-  }
-
-  private _isBackupStorageLocationAvailable(bsl: BackupStorageLocation): boolean {
-    const status = bsl.status?.phase || bsl.spec?.status || '';
-    return status.toLowerCase() === 'available';
   }
 
   getObservable(): Observable<Cluster> {

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -391,12 +391,14 @@ limitations under the License.
       <mat-form-field class="bsl-field">
         <mat-label>{{backupStorageLocationLabel}}</mat-label>
         <mat-select [formControlName]="Controls.BackupStorageLocation"
+                    (selectionChange)="onBackupStorageLocationSelectionChange($event)"
                     disableOptionCentering
                     kmValueChangedIndicator>
           @for (bsl of backupStorageLocationsList; track bsl) {
           <mat-option [value]="bsl.name">{{bsl.displayName}}
           </mat-option>
           }
+          <mat-option [value]="createBackupStorageLocationOptionValue">+ Create Backup Storage Location</mat-option>
         </mat-select>
         @if (form.get(Controls.BackupStorageLocation).hasError('required')) {
         <mat-error>

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -405,6 +405,13 @@ limitations under the License.
         }
       </mat-form-field>
       }
+      @if (datacenter?.spec?.provider === NodeProvider.OPENSTACK) {
+      <mat-checkbox [formControlName]="Controls.RouterReconciliation"
+                    kmValueChangedIndicator>
+        Skip Router Reconciliation
+      </mat-checkbox>
+      }
+
       <div class="km-proxy-settings">
         <div class="km-proxy-settings-title">Node Egress Proxy<i class="km-icon-info km-pointer"
              [matTooltip]="NODE_EGRESS_PROXY_TOOLTIP"></i></div>
@@ -433,12 +440,6 @@ limitations under the License.
           </ng-container>
         </km-chip-list>
       </div>
-
-      @if (datacenter?.spec?.provider === NodeProvider.OPENSTACK) {
-      <mat-checkbox [formControlName]="Controls.RouterReconciliation">
-        Skip Router Reconciliation
-      </mat-checkbox>
-      }
 
       <km-label-form title="Labels"
                      (labelsChange)="onLabelsChange($event)"

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -391,14 +391,12 @@ limitations under the License.
       <mat-form-field class="bsl-field">
         <mat-label>{{backupStorageLocationLabel}}</mat-label>
         <mat-select [formControlName]="Controls.BackupStorageLocation"
-                    (selectionChange)="onBackupStorageLocationSelectionChange($event)"
                     disableOptionCentering
                     kmValueChangedIndicator>
           @for (bsl of backupStorageLocationsList; track bsl) {
           <mat-option [value]="bsl.name">{{bsl.displayName}}
           </mat-option>
           }
-          <mat-option [value]="createBackupStorageLocationOptionValue">+ Create Backup Storage Location</mat-option>
         </mat-select>
         @if (form.get(Controls.BackupStorageLocation).hasError('required')) {
         <mat-error>

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -387,12 +387,6 @@ limitations under the License.
       </mat-checkbox>
       }
 
-      @if (datacenter?.spec?.provider === NodeProvider.OPENSTACK) {
-      <mat-checkbox [formControlName]="Controls.RouterReconciliation">
-        Skip Router Reconciliation
-      </mat-checkbox>
-      }
-
       @if (!!form.get(Controls.ClusterBackup).value && isclusterBackupEnabled) {
       <mat-form-field class="bsl-field">
         <mat-label>{{backupStorageLocationLabel}}</mat-label>
@@ -439,6 +433,12 @@ limitations under the License.
           </ng-container>
         </km-chip-list>
       </div>
+
+      @if (datacenter?.spec?.provider === NodeProvider.OPENSTACK) {
+      <mat-checkbox [formControlName]="Controls.RouterReconciliation">
+        Skip Router Reconciliation
+      </mat-checkbox>
+      }
 
       <km-label-form title="Labels"
                      (labelsChange)="onLabelsChange($event)"

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -19,7 +19,7 @@
 // END OF TERMS AND CONDITIONS
 
 import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {NotificationService} from '@app/core/services/notification';
@@ -64,6 +64,7 @@ enum Controls {
 })
 export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
+  private readonly _dnsLabelRegex = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
   readonly Controls = Controls;
   readonly veleroChecksumAlgorithms = Object.values(VeleroChecksumAlgorithm);
   form: FormGroup;
@@ -108,8 +109,14 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
         this._config.bslObject?.spec.backupSyncPeriod ?? '0',
         CBSL_SYNC_PERIOD
       ),
-      [Controls.Region]: this._builder.control(this._config.bslObject?.spec.config?.region ?? ''),
-      [Controls.Endpoints]: this._builder.control(this._config.bslObject?.spec.config?.s3Url ?? ''),
+      [Controls.Region]: this._builder.control(this._config.bslObject?.spec.config?.region ?? '', [
+        Validators.required,
+        this._dnsNameValidator(),
+      ]),
+      [Controls.Endpoints]: this._builder.control(this._config.bslObject?.spec.config?.s3Url ?? '', [
+        Validators.required,
+        this._endpointURLValidator(),
+      ]),
       [Controls.ChecksumAlgorithm]: this._builder.control(this._config.bslObject?.spec.config?.checksumAlgorithm ?? ''),
       [Controls.AddCustomConfig]: this._builder.control(false),
     });
@@ -196,7 +203,7 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
           this.form.get(Controls.BackupSyncPeriod).value === '' ? null : this.form.get(Controls.BackupSyncPeriod).value,
         config: {
           region: this.form.get(Controls.Region).value,
-          s3Url: this.form.get(Controls.Endpoints).value,
+          s3Url: this.form.get(Controls.Endpoints).value?.trim(),
           checksumAlgorithm: this.form.get(Controls.ChecksumAlgorithm).value || '',
         },
         provider: SupportedBSLProviders.AWS,
@@ -216,5 +223,46 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
       }
     }
     return bsl;
+  }
+
+  private _dnsNameValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const value = control.value?.trim();
+      if (!value) {
+        return null;
+      }
+
+      const labels = value.split('.');
+      return labels.every(label => this._dnsLabelRegex.test(label)) ? null : {invalidDnsName: true};
+    };
+  }
+
+  private _endpointURLValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const value = control.value?.trim();
+      if (!value) {
+        return null;
+      }
+
+      if (!/^https?:\/\//i.test(value)) {
+        return {invalidEndpointUrl: true};
+      }
+
+      try {
+        const url = new URL(value);
+        if (!['http:', 'https:'].includes(url.protocol)) {
+          return {invalidEndpointUrl: true};
+        }
+
+        if (!url.hostname) {
+          return {invalidEndpointUrl: true};
+        }
+
+        const labels = url.hostname.split('.');
+        return labels.every(label => this._dnsLabelRegex.test(label)) ? null : {invalidEndpointUrl: true};
+      } catch {
+        return {invalidEndpointUrl: true};
+      }
+    };
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -110,16 +110,16 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
         CBSL_SYNC_PERIOD
       ),
       [Controls.Region]: this._builder.control(this._config.bslObject?.spec.config?.region ?? '', [
-        Validators.required,
         this._dnsNameValidator(),
       ]),
       [Controls.Endpoints]: this._builder.control(this._config.bslObject?.spec.config?.s3Url ?? '', [
-        Validators.required,
         this._endpointURLValidator(),
       ]),
       [Controls.ChecksumAlgorithm]: this._builder.control(this._config.bslObject?.spec.config?.checksumAlgorithm ?? ''),
       [Controls.AddCustomConfig]: this._builder.control(false),
     });
+
+    this._updateRegionAndEndpointValidators(this.form.get(Controls.AddCustomConfig).value);
 
     if (this._config.bslObject) {
       this.form.get(Controls.Name).disable();
@@ -139,6 +139,7 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
       .get(Controls.AddCustomConfig)
       .valueChanges.pipe(takeUntil(this._unsubscribe))
       .subscribe((value: boolean) => {
+        this._updateRegionAndEndpointValidators(value);
         let config: BackupStorageLocationConfig;
         if (this._config.bslObject?.name) {
           config = this._config.bslObject.spec.config;
@@ -264,5 +265,24 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
         return {invalidEndpointUrl: true};
       }
     };
+  }
+
+  private _updateRegionAndEndpointValidators(addCustomConfig: boolean): void {
+    const regionControl = this.form.get(Controls.Region);
+    const endpointControl = this.form.get(Controls.Endpoints);
+
+    const regionValidators = [this._dnsNameValidator()];
+    const endpointValidators = [this._endpointURLValidator()];
+
+    if (!addCustomConfig) {
+      regionValidators.unshift(Validators.required);
+      endpointValidators.unshift(Validators.required);
+    }
+
+    regionControl.setValidators(regionValidators);
+    endpointControl.setValidators(endpointValidators);
+
+    regionControl.updateValueAndValidity({emitEvent: false});
+    endpointControl.updateValueAndValidity({emitEvent: false});
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -38,6 +38,7 @@ import {
   endpointUrlValidator,
   KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
 } from '@app/shared/validators/others';
+import {ENDPOINT_URL_ERROR_MESSAGE, REGION_ERROR_MESSAGE} from '@app/shared/constants/common';
 import {SettingsService} from '@core/services/settings';
 import * as y from 'js-yaml';
 import {Observable, Subject, takeUntil} from 'rxjs';
@@ -61,9 +62,6 @@ enum Controls {
   AddCustomConfig = 'addCustomConfig',
 }
 
-const REGION_ERROR_MESSAGE = 'Region must be a valid DNS name.';
-const ENDPOINT_URL_ERROR_MESSAGE = 'Endpoint URL must start with http:// or https:// and contain a valid DNS host.';
-
 @Component({
   selector: 'km-add-backup-storage-location-dialog',
   templateUrl: './template.html',
@@ -74,8 +72,8 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
   private readonly _unsubscribe = new Subject<void>();
   readonly Controls = Controls;
   readonly veleroChecksumAlgorithms = Object.values(VeleroChecksumAlgorithm);
-  readonly regionErrorMessage = REGION_ERROR_MESSAGE;
-  readonly endpointUrlErrorMessage = ENDPOINT_URL_ERROR_MESSAGE;
+  readonly REGION_ERROR_MESSAGE = REGION_ERROR_MESSAGE;
+  readonly ENDPOINT_URL_ERROR_MESSAGE = ENDPOINT_URL_ERROR_MESSAGE;
   form: FormGroup;
   valuesConfig = '';
   isYamlEditorValid = true;

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -19,7 +19,7 @@
 // END OF TERMS AND CONDITIONS
 
 import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
-import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {NotificationService} from '@app/core/services/notification';
@@ -61,6 +61,9 @@ enum Controls {
   AddCustomConfig = 'addCustomConfig',
 }
 
+const REGION_ERROR_MESSAGE = 'Region must be a valid DNS name.';
+const ENDPOINT_URL_ERROR_MESSAGE = 'Endpoint URL must start with http:// or https:// and contain a valid DNS host.';
+
 @Component({
   selector: 'km-add-backup-storage-location-dialog',
   templateUrl: './template.html',
@@ -71,9 +74,12 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
   private readonly _unsubscribe = new Subject<void>();
   readonly Controls = Controls;
   readonly veleroChecksumAlgorithms = Object.values(VeleroChecksumAlgorithm);
+  readonly regionErrorMessage = REGION_ERROR_MESSAGE;
+  readonly endpointUrlErrorMessage = ENDPOINT_URL_ERROR_MESSAGE;
   form: FormGroup;
   valuesConfig = '';
   isYamlEditorValid = true;
+  customConfigError = '';
 
   get label(): string {
     return this._config.bslObject ? 'Save Changes' : 'Create';
@@ -149,8 +155,13 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
         } catch (error) {
           this.isYamlEditorValid = false;
         }
+
+        // Validate either the YAML editor or the config fields, never both.
+        this._toggleConfigControls(!value);
+
         if (!value) {
           this.isYamlEditorValid = true;
+          this.customConfigError = '';
         }
       });
   }
@@ -182,7 +193,39 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
   }
 
   isValidYaml(valid: boolean): void {
-    this.isYamlEditorValid = valid;
+    this.customConfigError = '';
+    this.isYamlEditorValid = valid && this._isCustomConfigValid();
+  }
+
+  private _toggleConfigControls(enable: boolean): void {
+    [Controls.Region, Controls.Endpoints, Controls.ChecksumAlgorithm].forEach(control => {
+      if (enable) {
+        this.form.get(control).enable({emitEvent: false});
+      } else {
+        this.form.get(control).disable({emitEvent: false});
+      }
+    });
+  }
+
+  private _isCustomConfigValid(): boolean {
+    let config: BackupStorageLocationConfig;
+    try {
+      config = (y.load(this.valuesConfig) as {config: BackupStorageLocationConfig})?.config;
+    } catch (error) {
+      return false;
+    }
+
+    if (config?.region && DNS_NAME_PATTERN_VALIDATOR(new FormControl(config.region))) {
+      this.customConfigError = REGION_ERROR_MESSAGE;
+      return false;
+    }
+
+    if (config?.s3Url && endpointUrlValidator()(new FormControl(config.s3Url))) {
+      this.customConfigError = ENDPOINT_URL_ERROR_MESSAGE;
+      return false;
+    }
+
+    return true;
   }
 
   private _getBackupStorageLocation(): CreateBackupStorageLocation {

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -123,8 +123,6 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
       [Controls.AddCustomConfig]: this._builder.control(false),
     });
 
-    this._updateRegionAndEndpointValidators(this.form.get(Controls.AddCustomConfig).value);
-
     if (this._config.bslObject) {
       this.form.get(Controls.Name).disable();
     } else {
@@ -143,17 +141,9 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
       .get(Controls.AddCustomConfig)
       .valueChanges.pipe(takeUntil(this._unsubscribe))
       .subscribe((value: boolean) => {
-        this._updateRegionAndEndpointValidators(value);
-        let config: BackupStorageLocationConfig;
-        if (this._config.bslObject?.name) {
-          config = this._config.bslObject.spec.config;
-        } else {
-          config = {
-            region: this.form.get(Controls.Region).value,
-            s3Url: this.form.get(Controls.Endpoints).value?.trim(),
-            checksumAlgorithm: this.form.get(Controls.ChecksumAlgorithm).value,
-          };
-        }
+        const config: BackupStorageLocationConfig = this._config.bslObject?.name
+          ? this._config.bslObject.spec.config
+          : this._getConfig();
         try {
           this.valuesConfig = y.dump({config: config});
         } catch (error) {
@@ -206,11 +196,7 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
         },
         backupSyncPeriod:
           this.form.get(Controls.BackupSyncPeriod).value === '' ? null : this.form.get(Controls.BackupSyncPeriod).value,
-        config: {
-          region: this.form.get(Controls.Region).value,
-          s3Url: this.form.get(Controls.Endpoints).value?.trim(),
-          checksumAlgorithm: this.form.get(Controls.ChecksumAlgorithm).value || '',
-        },
+        config: this._getConfig(),
         provider: SupportedBSLProviders.AWS,
       } as BackupStorageLocationSpec,
       credentials: {
@@ -230,22 +216,22 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
     return bsl;
   }
 
-  private _updateRegionAndEndpointValidators(addCustomConfig: boolean): void {
-    const regionControl = this.form.get(Controls.Region);
-    const endpointControl = this.form.get(Controls.Endpoints);
+  // https://github.com/velero-io/velero-plugin-for-aws/blob/main/backupstoragelocation.md
+  private _getConfig(): BackupStorageLocationConfig {
+    const config: BackupStorageLocationConfig = {};
+    const region = this.form.get(Controls.Region).value?.trim();
+    const s3Url = this.form.get(Controls.Endpoints).value?.trim();
+    const checksumAlgorithm = this.form.get(Controls.ChecksumAlgorithm).value;
 
-    const regionValidators = [DNS_NAME_PATTERN_VALIDATOR];
-    const endpointValidators = [endpointUrlValidator()];
-
-    if (!addCustomConfig) {
-      regionValidators.unshift(Validators.required);
-      endpointValidators.unshift(Validators.required);
+    if (region) {
+      config.region = region;
     }
-
-    regionControl.setValidators(regionValidators);
-    endpointControl.setValidators(endpointValidators);
-
-    regionControl.updateValueAndValidity({emitEvent: false});
-    endpointControl.updateValueAndValidity({emitEvent: false});
+    if (s3Url) {
+      config.s3Url = s3Url;
+    }
+    if (checksumAlgorithm) {
+      config.checksumAlgorithm = checksumAlgorithm;
+    }
+    return config;
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component.ts
@@ -19,7 +19,7 @@
 // END OF TERMS AND CONDITIONS
 
 import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
-import {AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators} from '@angular/forms';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {NotificationService} from '@app/core/services/notification';
@@ -32,7 +32,12 @@ import {
   SupportedBSLProviders,
   VeleroChecksumAlgorithm,
 } from '@app/shared/entity/backup';
-import {CBSL_SYNC_PERIOD, KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR} from '@app/shared/validators/others';
+import {
+  CBSL_SYNC_PERIOD,
+  DNS_NAME_PATTERN_VALIDATOR,
+  endpointUrlValidator,
+  KUBERNETES_RESOURCE_NAME_PATTERN_VALIDATOR,
+} from '@app/shared/validators/others';
 import {SettingsService} from '@core/services/settings';
 import * as y from 'js-yaml';
 import {Observable, Subject, takeUntil} from 'rxjs';
@@ -64,7 +69,6 @@ enum Controls {
 })
 export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
-  private readonly _dnsLabelRegex = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
   readonly Controls = Controls;
   readonly veleroChecksumAlgorithms = Object.values(VeleroChecksumAlgorithm);
   form: FormGroup;
@@ -110,10 +114,10 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
         CBSL_SYNC_PERIOD
       ),
       [Controls.Region]: this._builder.control(this._config.bslObject?.spec.config?.region ?? '', [
-        this._dnsNameValidator(),
+        DNS_NAME_PATTERN_VALIDATOR,
       ]),
       [Controls.Endpoints]: this._builder.control(this._config.bslObject?.spec.config?.s3Url ?? '', [
-        this._endpointURLValidator(),
+        endpointUrlValidator(),
       ]),
       [Controls.ChecksumAlgorithm]: this._builder.control(this._config.bslObject?.spec.config?.checksumAlgorithm ?? ''),
       [Controls.AddCustomConfig]: this._builder.control(false),
@@ -226,53 +230,12 @@ export class AddBackupStorageLocationDialogComponent implements OnInit, OnDestro
     return bsl;
   }
 
-  private _dnsNameValidator(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      const value = control.value?.trim();
-      if (!value) {
-        return null;
-      }
-
-      const labels = value.split('.');
-      return labels.every(label => this._dnsLabelRegex.test(label)) ? null : {invalidDnsName: true};
-    };
-  }
-
-  private _endpointURLValidator(): ValidatorFn {
-    return (control: AbstractControl): ValidationErrors | null => {
-      const value = control.value?.trim();
-      if (!value) {
-        return null;
-      }
-
-      if (!/^https?:\/\//i.test(value)) {
-        return {invalidEndpointUrl: true};
-      }
-
-      try {
-        const url = new URL(value);
-        if (!['http:', 'https:'].includes(url.protocol)) {
-          return {invalidEndpointUrl: true};
-        }
-
-        if (!url.hostname) {
-          return {invalidEndpointUrl: true};
-        }
-
-        const labels = url.hostname.split('.');
-        return labels.every(label => this._dnsLabelRegex.test(label)) ? null : {invalidEndpointUrl: true};
-      } catch {
-        return {invalidEndpointUrl: true};
-      }
-    };
-  }
-
   private _updateRegionAndEndpointValidators(addCustomConfig: boolean): void {
     const regionControl = this.form.get(Controls.Region);
     const endpointControl = this.form.get(Controls.Endpoints);
 
-    const regionValidators = [this._dnsNameValidator()];
-    const endpointValidators = [this._endpointURLValidator()];
+    const regionValidators = [DNS_NAME_PATTERN_VALIDATOR];
+    const endpointValidators = [endpointUrlValidator()];
 
     if (!addCustomConfig) {
       regionValidators.unshift(Validators.required);

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
@@ -46,7 +46,7 @@ END OF TERMS AND CONDITIONS
              matInput
              required>
       <mat-hint>The bucket in which to store backups.</mat-hint>
-      @if (form.get(Controls.Name).hasError('required')) {
+      @if (form.get(Controls.Bucket).hasError('required')) {
       <mat-error>
         <strong>Required</strong>
       </mat-error>
@@ -69,12 +69,14 @@ END OF TERMS AND CONDITIONS
       <input [formControlName]="Controls.AccessKeyId"
              matInput
              kmInputPassword>
+      <mat-hint>Optional. Leave empty for anonymous S3 access.</mat-hint>
     </mat-form-field>
     <mat-form-field>
       <mat-label>Secret Access Key</mat-label>
       <input [formControlName]="Controls.SecretAccessKey"
              matInput
              kmInputPassword>
+      <mat-hint>Optional. Leave empty for anonymous S3 access.</mat-hint>
     </mat-form-field>
     <mat-form-field subscriptSizing="dynamic">
       <mat-label>Backup Sync Period</mat-label>
@@ -103,12 +105,32 @@ END OF TERMS AND CONDITIONS
       <input [formControlName]="Controls.Region"
              matInput>
       <mat-hint>The AWS region where the bucket is located.</mat-hint>
+      @if (form.get(Controls.Region).hasError('required')) {
+      <mat-error>
+        <strong>Required</strong>
+      </mat-error>
+      }
+      @if (form.get(Controls.Region).hasError('invalidDnsName')) {
+      <mat-error>
+        Region must be a valid DNS name.
+      </mat-error>
+      }
     </mat-form-field>
     <mat-form-field>
-      <mat-label>Endpoints</mat-label>
+      <mat-label>Endpoint URL</mat-label>
       <input [formControlName]="Controls.Endpoints"
              matInput>
       <mat-hint>Specify the AWS S3 URL here.</mat-hint>
+      @if (form.get(Controls.Endpoints).hasError('required')) {
+      <mat-error>
+        <strong>Required</strong>
+      </mat-error>
+      }
+      @if (form.get(Controls.Endpoints).hasError('invalidEndpointUrl')) {
+      <mat-error>
+        Endpoint URL must start with http:// or https:// and contain a valid DNS host.
+      </mat-error>
+      }
     </mat-form-field>
     <mat-form-field>
       <mat-label>Default Checksum Algorithm</mat-label>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
@@ -69,14 +69,12 @@ END OF TERMS AND CONDITIONS
       <input [formControlName]="Controls.AccessKeyId"
              matInput
              kmInputPassword>
-      <mat-hint>Optional. Leave empty for anonymous S3 access.</mat-hint>
     </mat-form-field>
     <mat-form-field>
       <mat-label>Secret Access Key</mat-label>
       <input [formControlName]="Controls.SecretAccessKey"
              matInput
              kmInputPassword>
-      <mat-hint>Optional. Leave empty for anonymous S3 access.</mat-hint>
     </mat-form-field>
     <mat-form-field subscriptSizing="dynamic">
       <mat-label>Backup Sync Period</mat-label>
@@ -98,28 +96,27 @@ END OF TERMS AND CONDITIONS
     <km-validate-json-or-yaml [data]="valuesConfig"
                               [isOnlyYAML]="true"
                               (dataValid)="isValidYaml($event)" />
+    @if (customConfigError) {
+    <mat-error>{{customConfigError}}</mat-error>
+    }
     }
     @if (!form.get(Controls.AddCustomConfig).value) {
     <mat-form-field class="region-field">
       <mat-label>Region</mat-label>
       <input [formControlName]="Controls.Region"
              matInput>
-      <mat-hint>Optional. The AWS region where the bucket is located.</mat-hint>
+      <mat-hint>The AWS region where the bucket is located.</mat-hint>
       @if (form.get(Controls.Region).hasError('pattern')) {
-      <mat-error>
-        Region must be a valid DNS name.
-      </mat-error>
+      <mat-error>{{regionErrorMessage}}</mat-error>
       }
     </mat-form-field>
     <mat-form-field>
       <mat-label>Endpoint URL</mat-label>
       <input [formControlName]="Controls.Endpoints"
              matInput>
-      <mat-hint>Optional. Specify the AWS S3 URL here.</mat-hint>
+      <mat-hint>Specify the AWS S3 URL here.</mat-hint>
       @if (form.get(Controls.Endpoints).hasError('invalidEndpointUrl')) {
-      <mat-error>
-        Endpoint URL must start with http:// or https:// and contain a valid DNS host.
-      </mat-error>
+      <mat-error>{{endpointUrlErrorMessage}}</mat-error>
       }
     </mat-form-field>
     <mat-form-field>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
@@ -104,12 +104,7 @@ END OF TERMS AND CONDITIONS
       <mat-label>Region</mat-label>
       <input [formControlName]="Controls.Region"
              matInput>
-      <mat-hint>The AWS region where the bucket is located.</mat-hint>
-      @if (form.get(Controls.Region).hasError('required')) {
-      <mat-error>
-        <strong>Required</strong>
-      </mat-error>
-      }
+      <mat-hint>Optional. The AWS region where the bucket is located.</mat-hint>
       @if (form.get(Controls.Region).hasError('pattern')) {
       <mat-error>
         Region must be a valid DNS name.
@@ -120,12 +115,7 @@ END OF TERMS AND CONDITIONS
       <mat-label>Endpoint URL</mat-label>
       <input [formControlName]="Controls.Endpoints"
              matInput>
-      <mat-hint>Specify the AWS S3 URL here.</mat-hint>
-      @if (form.get(Controls.Endpoints).hasError('required')) {
-      <mat-error>
-        <strong>Required</strong>
-      </mat-error>
-      }
+      <mat-hint>Optional. Specify the AWS S3 URL here.</mat-hint>
       @if (form.get(Controls.Endpoints).hasError('invalidEndpointUrl')) {
       <mat-error>
         Endpoint URL must start with http:// or https:// and contain a valid DNS host.

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
@@ -110,7 +110,7 @@ END OF TERMS AND CONDITIONS
         <strong>Required</strong>
       </mat-error>
       }
-      @if (form.get(Controls.Region).hasError('invalidDnsName')) {
+      @if (form.get(Controls.Region).hasError('pattern')) {
       <mat-error>
         Region must be a valid DNS name.
       </mat-error>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/template.html
@@ -107,7 +107,7 @@ END OF TERMS AND CONDITIONS
              matInput>
       <mat-hint>The AWS region where the bucket is located.</mat-hint>
       @if (form.get(Controls.Region).hasError('pattern')) {
-      <mat-error>{{regionErrorMessage}}</mat-error>
+      <mat-error>{{REGION_ERROR_MESSAGE}}</mat-error>
       }
     </mat-form-field>
     <mat-form-field>
@@ -116,7 +116,7 @@ END OF TERMS AND CONDITIONS
              matInput>
       <mat-hint>Specify the AWS S3 URL here.</mat-hint>
       @if (form.get(Controls.Endpoints).hasError('invalidEndpointUrl')) {
-      <mat-error>{{endpointUrlErrorMessage}}</mat-error>
+      <mat-error>{{ENDPOINT_URL_ERROR_MESSAGE}}</mat-error>
       }
     </mat-form-field>
     <mat-form-field>

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/component.ts
@@ -23,6 +23,7 @@ import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {MatPaginator} from '@angular/material/paginator';
 import {MatSort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
+import {MatTooltip} from '@angular/material/tooltip';
 import {ProjectService} from '@app/core/services/project';
 import {BackupStorageLocation, BackupType} from '@app/shared/entity/backup';
 import {Project} from '@app/shared/entity/project';
@@ -46,6 +47,7 @@ import {DISABLED_TOOLTIP_MESSAGE} from '@app/shared/constants/common';
 })
 export class BackupStorageLocationsListComponent implements OnInit, OnDestroy {
   private readonly _unsubscribe = new Subject<void>();
+  private readonly _copiedStatusMessageByBSL = new Map<string, boolean>();
   private _selectedProject: Project;
   private _user: Member;
   private _currentGroupConfig: GroupConfig;
@@ -107,6 +109,25 @@ export class BackupStorageLocationsListComponent implements OnInit, OnDestroy {
 
   getStatusIcon(phase: string): StatusIcon {
     return getClusterBackupHealthStatus(phase).icon;
+  }
+
+  getStatusTooltip(bsl: BackupStorageLocation): string {
+    return this._copiedStatusMessageByBSL.get(bsl.name) ? 'Error message copied' : bsl.status?.message;
+  }
+
+  canCopyStatusMessage(bsl: BackupStorageLocation): boolean {
+    return !this._isBSLAvailable(bsl) && !!bsl.status?.message;
+  }
+
+  copyStatusMessage(bsl: BackupStorageLocation, tooltip: MatTooltip): void {
+    if (!this.canCopyStatusMessage(bsl)) {
+      return;
+    }
+
+    navigator.clipboard.writeText(bsl.status.message);
+    this._copiedStatusMessageByBSL.set(bsl.name, true);
+    tooltip.message = 'Error message copied';
+    tooltip.show(0);
   }
 
   addBackupStorageLocation(): void {
@@ -172,5 +193,10 @@ export class BackupStorageLocationsListComponent implements OnInit, OnDestroy {
         this.backupStorageLocations = data;
         this.dataSource.data = this.backupStorageLocations;
       });
+  }
+
+  private _isBSLAvailable(bsl: BackupStorageLocation): boolean {
+    const phase = bsl.status?.phase || '';
+    return phase.toLowerCase() === 'available';
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/component.ts
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/component.ts
@@ -38,6 +38,7 @@ import {GroupConfig} from '@app/shared/model/Config';
 import {DeleteBackupDialogComponent} from '../backups/delete-dialog/component';
 import {NotificationService} from '@app/core/services/notification';
 import {StatusIcon, getClusterBackupHealthStatus} from '@app/shared/utils/health-status';
+import {isBackupStorageLocationAvailable} from '@app/shared/utils/backup';
 import {DISABLED_TOOLTIP_MESSAGE} from '@app/shared/constants/common';
 
 @Component({
@@ -116,7 +117,7 @@ export class BackupStorageLocationsListComponent implements OnInit, OnDestroy {
   }
 
   canCopyStatusMessage(bsl: BackupStorageLocation): boolean {
-    return !this._isBSLAvailable(bsl) && !!bsl.status?.message;
+    return !isBackupStorageLocationAvailable(bsl) && !!bsl.status?.message;
   }
 
   copyStatusMessage(bsl: BackupStorageLocation, tooltip: MatTooltip): void {
@@ -193,10 +194,5 @@ export class BackupStorageLocationsListComponent implements OnInit, OnDestroy {
         this.backupStorageLocations = data;
         this.dataSource.data = this.backupStorageLocations;
       });
-  }
-
-  private _isBSLAvailable(bsl: BackupStorageLocation): boolean {
-    const phase = bsl.status?.phase || '';
-    return phase.toLowerCase() === 'available';
   }
 }

--- a/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/template.html
+++ b/modules/web/src/app/dynamic/enterprise/cluster-backups/list/backup-storage-location/template.html
@@ -48,8 +48,11 @@ END OF TERMS AND CONDITIONS
             class="km-header-cell"></th>
         <td mat-cell
             *matCellDef="let element">
-          <i [matTooltip]="element.status?.message"
+          <i [matTooltip]="getStatusTooltip(element)"
+             #statusTooltip="matTooltip"
              [ngClass]="getStatusIcon(element.status?.phase)"
+             [class.km-pointer]="canCopyStatusMessage(element)"
+             (click)="copyStatusMessage(element, statusTooltip)"
              class="km-vertical-center"></i>
         </td>
       </ng-container>

--- a/modules/web/src/app/dynamic/module-registry.ce.ts
+++ b/modules/web/src/app/dynamic/module-registry.ce.ts
@@ -23,6 +23,7 @@ export namespace DynamicModule {
   export const Quotas = import('./community/quotas/module').then(module => module.QuotasModule);
   export const Group = import('./community/group/module').then(module => module.GroupModule);
   export const ClusterBackups = import('./community/cluster-backups/module').then(module => module.ClusterBackupsModule);
+  export const AddBackupStorageLocationDialogComponent = Promise.resolve(null);
   export const KyvernoPolicies = import('./community/kyverno-policies/module').then(module => module.KyvernoPoliciesModule);
   export const isEnterpriseEdition = false;
 }

--- a/modules/web/src/app/dynamic/module-registry.ts
+++ b/modules/web/src/app/dynamic/module-registry.ts
@@ -28,6 +28,10 @@ export namespace DynamicModule {
   export const ClusterBackups = import('./enterprise/cluster-backups/module').then(
     module => module.ClusterBackupsModule
   );
+  export const AddBackupStorageLocationDialogComponent =
+    import('./enterprise/cluster-backups/list/backup-storage-location/add-dialog/component').then(
+      module => module.AddBackupStorageLocationDialogComponent
+    );
   export const KyvernoPolicies = import('./enterprise/kyverno-policies/module').then(
     module => module.KyvernoPoliciesModule
   );

--- a/modules/web/src/app/shared/constants/common.ts
+++ b/modules/web/src/app/shared/constants/common.ts
@@ -113,6 +113,11 @@ export const CLUSTER_OPTION_TOOLTIPS = {
     'Enable to deploy User SSH Key Agent to the cluster. It cannot be changed once the cluster is created.',
 } as const;
 
+// Backup storage location validation messages
+export const REGION_ERROR_MESSAGE = 'Region must be a valid DNS name.';
+export const ENDPOINT_URL_ERROR_MESSAGE =
+  'Endpoint URL must start with http:// or https:// and contain a valid DNS host.';
+
 // Per-cluster proxy tooltips
 export const PROXY_MODE_HINT = 'kube-proxy mode for in-cluster service routing.';
 export const NODE_EGRESS_PROXY_TOOLTIP =

--- a/modules/web/src/app/shared/utils/backup.ts
+++ b/modules/web/src/app/shared/utils/backup.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {BackupStorageLocation} from '@shared/entity/backup';
+
+export function isBackupStorageLocationAvailable(bsl: BackupStorageLocation): boolean {
+  return bsl.status?.phase?.toLowerCase() === 'available';
+}

--- a/modules/web/src/app/shared/validators/others.ts
+++ b/modules/web/src/app/shared/validators/others.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Validators} from '@angular/forms';
+import {AbstractControl, ValidationErrors, ValidatorFn, Validators} from '@angular/forms';
 
 export const IPV4_CIDR_PATTERN_VALIDATOR = Validators.pattern(/^((\d{1,3}\.){3}\d{1,3}\/([0-9]|[1-2][0-9]|3[0-2]))$/);
 export const IPV6_CIDR_PATTERN_VALIDATOR = Validators.pattern(
@@ -59,3 +59,25 @@ export const KUBERNETES_ANNOTATION_VALUE_PATTERN_VALIDATOR = Validators.pattern(
 
 export const NON_SPECIAL_CHARACTERS_PATTERN = /^[^|"<>[\]{}`\\';&]+$/;
 export const NON_SPECIAL_CHARACTERS_PATTERN_VALIDATOR = Validators.pattern(NON_SPECIAL_CHARACTERS_PATTERN);
+
+export const DNS_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i;
+export const DNS_NAME_PATTERN_VALIDATOR = Validators.pattern(DNS_NAME_PATTERN);
+
+export function endpointUrlValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value?.trim();
+    if (!value) {
+      return null;
+    }
+
+    try {
+      const url = new URL(value);
+      if (!['http:', 'https:'].includes(url.protocol) || !url.hostname) {
+        return {invalidEndpointUrl: true};
+      }
+      return DNS_NAME_PATTERN.test(url.hostname) ? null : {invalidEndpointUrl: true};
+    } catch {
+      return {invalidEndpointUrl: true};
+    }
+  };
+}

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -312,14 +312,12 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.updateValueAndValidity();
     });
 
-    this._projectService.selectedProject
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(project => {
-        this._selectedProjectID = project.id;
-        if (this.isEnterpriseEdition) {
-          this._getCBSL(project.id);
-        }
-      });
+    this._projectService.selectedProject.pipe(takeUntil(this._unsubscribe)).subscribe(project => {
+      this._selectedProjectID = project.id;
+      if (this.isEnterpriseEdition) {
+        this._getCBSL(project.id);
+      }
+    });
 
     this._fetchCNIPlugins();
 
@@ -1277,10 +1275,15 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(cbslList => {
         this.backupStorageLocationsList = cbslList.filter(bsl => this._isBackupStorageLocationAvailable(bsl));
-        this.backupStorageLocationLabel = this.backupStorageLocationsList.length ? BSLListState.Ready : BSLListState.Empty;
+        this.backupStorageLocationLabel = this.backupStorageLocationsList.length
+          ? BSLListState.Ready
+          : BSLListState.Empty;
 
         const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
-        if (backupStorageLocationControl && !this.backupStorageLocationsList.some(bsl => bsl.name === backupStorageLocationControl.value)) {
+        if (
+          backupStorageLocationControl &&
+          !this.backupStorageLocationsList.some(bsl => bsl.name === backupStorageLocationControl.value)
+        ) {
           backupStorageLocationControl.reset();
         }
       });

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -28,7 +28,6 @@ import {ApplicationService} from '@app/core/services/application';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {FeatureGateService} from '@app/core/services/feature-gate';
 import {ProjectService} from '@app/core/services/project';
-import {AddBackupStorageLocationDialogComponent} from '@app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component';
 import {DynamicModule} from '@app/dynamic/module-registry';
 import {BackupStorageLocation} from '@app/shared/entity/backup';
 import {
@@ -1289,7 +1288,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       });
   }
 
-  onBackupStorageLocationSelectionChange(event: MatSelectChange): void {
+  async onBackupStorageLocationSelectionChange(event: MatSelectChange): Promise<void> {
     if (event.value !== this.createBackupStorageLocationOptionValue) {
       return;
     }
@@ -1298,6 +1297,10 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     const previousValue = this._clusterSpecService.cluster?.spec?.backupConfig?.backupStorageLocation?.name ?? '';
     backupStorageLocationControl.setValue(previousValue, {emitEvent: false});
 
+    const AddBackupStorageLocationDialogComponent = await DynamicModule.AddBackupStorageLocationDialogComponent;
+    if (!AddBackupStorageLocationDialogComponent) {
+      return;
+    }
     this._matDialog
       .open(AddBackupStorageLocationDialogComponent, {
         data: {projectID: this._selectedProjectID},

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -23,7 +23,6 @@ import {
   Validators,
 } from '@angular/forms';
 import {MatDialog} from '@angular/material/dialog';
-import {MatSelectChange} from '@angular/material/select';
 import {ApplicationService} from '@app/core/services/application';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {FeatureGateService} from '@app/core/services/feature-gate';
@@ -78,6 +77,7 @@ import {
   CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP,
   generateEncryptionKey,
 } from '@shared/utils/cluster';
+import {isBackupStorageLocationAvailable} from '@shared/utils/backup';
 import {getEditionVersion, tooltipWithAdminNote} from '@shared/utils/common';
 import {
   ADMIN_ENFORCED_IN_DATACENTER_NOTE,
@@ -93,7 +93,7 @@ import {AsyncValidators} from '@shared/validators/async.validators';
 import {KmValidators} from '@shared/validators/validators';
 import * as y from 'js-yaml';
 import _ from 'lodash';
-import {combineLatest, merge, Subscription} from 'rxjs';
+import {combineLatest, from, merge, Subscription} from 'rxjs';
 import {debounceTime, filter, finalize, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {coerce, compare, gte} from 'semver';
 import {WizardMode} from '../../types/wizard-mode';
@@ -182,7 +182,6 @@ enum Controls {
   standalone: false,
 })
 export class ClusterStepComponent extends StepBase implements OnInit, ControlValueAccessor, Validator, OnDestroy {
-  readonly createBackupStorageLocationOptionValue = '__create_backup_storage_location__';
   containerRuntime = ContainerRuntime;
   admissionPlugin = AdmissionPlugin;
   masterVersions: MasterVersion[] = [];
@@ -1273,7 +1272,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       .listBackupStorageLocation(projectID)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(cbslList => {
-        this.backupStorageLocationsList = cbslList.filter(bsl => this._isBackupStorageLocationAvailable(bsl));
+        this.backupStorageLocationsList = cbslList.filter(bsl => isBackupStorageLocationAvailable(bsl));
         this.backupStorageLocationLabel = this.backupStorageLocationsList.length
           ? BSLListState.Ready
           : BSLListState.Empty;
@@ -1288,32 +1287,21 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       });
   }
 
-  async onBackupStorageLocationSelectionChange(event: MatSelectChange): Promise<void> {
-    if (event.value !== this.createBackupStorageLocationOptionValue) {
-      return;
-    }
-
-    const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
-    const previousValue = this._clusterSpecService.cluster?.spec?.backupConfig?.backupStorageLocation?.name ?? '';
-    backupStorageLocationControl.setValue(previousValue, {emitEvent: false});
-
-    const AddBackupStorageLocationDialogComponent = await DynamicModule.AddBackupStorageLocationDialogComponent;
-    if (!AddBackupStorageLocationDialogComponent) {
-      return;
-    }
-    this._matDialog
-      .open(AddBackupStorageLocationDialogComponent, {
-        data: {projectID: this._selectedProjectID},
-      })
-      .afterClosed()
-      .pipe(take(1))
-      .pipe(filter(Boolean))
+  addBackupStorageLocationDialog(): void {
+    from(DynamicModule.AddBackupStorageLocationDialogComponent)
+      .pipe(
+        filter(Boolean),
+        switchMap(component =>
+          this._matDialog
+            .open(component, {
+              data: {projectID: this._selectedProjectID},
+            })
+            .afterClosed()
+        ),
+        take(1),
+        filter(Boolean)
+      )
       .subscribe(() => this._getCBSL(this._selectedProjectID));
-  }
-
-  private _isBackupStorageLocationAvailable(bsl: BackupStorageLocation): boolean {
-    const status = bsl.status?.phase || bsl.spec?.status || '';
-    return status.toLowerCase() === 'available';
   }
 
   private _handleClusterBackupChange(): void {

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -23,10 +23,12 @@ import {
   Validators,
 } from '@angular/forms';
 import {MatDialog} from '@angular/material/dialog';
+import {MatSelectChange} from '@angular/material/select';
 import {ApplicationService} from '@app/core/services/application';
 import {ClusterBackupService} from '@app/core/services/cluster-backup';
 import {FeatureGateService} from '@app/core/services/feature-gate';
 import {ProjectService} from '@app/core/services/project';
+import {AddBackupStorageLocationDialogComponent} from '@app/dynamic/enterprise/cluster-backups/list/backup-storage-location/add-dialog/component';
 import {DynamicModule} from '@app/dynamic/module-registry';
 import {BackupStorageLocation} from '@app/shared/entity/backup';
 import {
@@ -181,6 +183,7 @@ enum Controls {
   standalone: false,
 })
 export class ClusterStepComponent extends StepBase implements OnInit, ControlValueAccessor, Validator, OnDestroy {
+  readonly createBackupStorageLocationOptionValue = '__create_backup_storage_location__';
   containerRuntime = ContainerRuntime;
   admissionPlugin = AdmissionPlugin;
   masterVersions: MasterVersion[] = [];
@@ -236,6 +239,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   private _datacenterSpec: Datacenter;
   private _seedSettings: SeedSettings;
   private _settings: AdminSettings;
+  private _selectedProjectID: string;
   private _auditWebhookBackendChangesSubscription: Subscription;
   private readonly _minNameLength = 5;
   private readonly _canalDualStackMinimumSupportedVersion = '3.22.0';
@@ -308,11 +312,14 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.updateValueAndValidity();
     });
 
-    if (this.isEnterpriseEdition) {
-      this._projectService.selectedProject
-        .pipe(takeUntil(this._unsubscribe))
-        .subscribe(project => this._getCBSL(project.id));
-    }
+    this._projectService.selectedProject
+      .pipe(takeUntil(this._unsubscribe))
+      .subscribe(project => {
+        this._selectedProjectID = project.id;
+        if (this.isEnterpriseEdition) {
+          this._getCBSL(project.id);
+        }
+      });
 
     this._fetchCNIPlugins();
 
@@ -1269,9 +1276,38 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       .listBackupStorageLocation(projectID)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(cbslList => {
-        this.backupStorageLocationsList = cbslList;
-        this.backupStorageLocationLabel = cbslList.length ? BSLListState.Ready : BSLListState.Empty;
+        this.backupStorageLocationsList = cbslList.filter(bsl => this._isBackupStorageLocationAvailable(bsl));
+        this.backupStorageLocationLabel = this.backupStorageLocationsList.length ? BSLListState.Ready : BSLListState.Empty;
+
+        const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
+        if (backupStorageLocationControl && !this.backupStorageLocationsList.some(bsl => bsl.name === backupStorageLocationControl.value)) {
+          backupStorageLocationControl.reset();
+        }
       });
+  }
+
+  onBackupStorageLocationSelectionChange(event: MatSelectChange): void {
+    if (event.value !== this.createBackupStorageLocationOptionValue) {
+      return;
+    }
+
+    const backupStorageLocationControl = this.form.get(Controls.BackupStorageLocation);
+    const previousValue = this._clusterSpecService.cluster?.spec?.backupConfig?.backupStorageLocation?.name ?? '';
+    backupStorageLocationControl.setValue(previousValue, {emitEvent: false});
+
+    this._matDialog
+      .open(AddBackupStorageLocationDialogComponent, {
+        data: {projectID: this._selectedProjectID},
+      })
+      .afterClosed()
+      .pipe(take(1))
+      .pipe(filter(Boolean))
+      .subscribe(() => this._getCBSL(this._selectedProjectID));
+  }
+
+  private _isBackupStorageLocationAvailable(bsl: BackupStorageLocation): boolean {
+    const status = bsl.status?.phase || bsl.spec?.status || '';
+    return status.toLowerCase() === 'available';
   }
 
   private _handleClusterBackupChange(): void {

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -535,11 +535,13 @@ limitations under the License.
             <mat-form-field>
               <mat-label>{{backupStorageLocationLabel}}</mat-label>
               <mat-select [formControlName]="Controls.BackupStorageLocation"
+                          (selectionChange)="onBackupStorageLocationSelectionChange($event)"
                           disableOptionCentering>
                 @for (bsl of backupStorageLocationsList; track bsl) {
                 <mat-option [value]="bsl.name">{{bsl.displayName}}
                 </mat-option>
                 }
+                <mat-option [value]="createBackupStorageLocationOptionValue">+ Create Backup Storage Location</mat-option>
               </mat-select>
               @if (form.get(Controls.BackupStorageLocation).hasError('required')) {
               <mat-error>

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -525,23 +525,33 @@ limitations under the License.
             }
             }
             @if (isclusterBackupEnabled) {
-            <mat-checkbox [formControlName]="Controls.ClusterBackup">
-              Cluster Backup
-              <i class="km-icon-info km-pointer"
-                 [matTooltip]="Tooltips.clusterBackup"></i>
-            </mat-checkbox>
+            <div fxLayoutAlign="space-between center">
+              <mat-checkbox [formControlName]="Controls.ClusterBackup">
+                Cluster Backup
+                <i class="km-icon-info km-pointer"
+                   [matTooltip]="Tooltips.clusterBackup"></i>
+              </mat-checkbox>
+              @if (!!controlValue(Controls.ClusterBackup)) {
+              <button (click)="addBackupStorageLocationDialog()"
+                      type="button"
+                      mat-flat-button
+                      color="quaternary">
+                <i class="km-icon-mask km-icon-add"
+                   matButtonIcon></i>
+                <span>Add Backup Storage Location</span>
+              </button>
+              }
+            </div>
             }
             @if (!!controlValue(Controls.ClusterBackup) && isclusterBackupEnabled) {
             <mat-form-field>
               <mat-label>{{backupStorageLocationLabel}}</mat-label>
               <mat-select [formControlName]="Controls.BackupStorageLocation"
-                          (selectionChange)="onBackupStorageLocationSelectionChange($event)"
                           disableOptionCentering>
                 @for (bsl of backupStorageLocationsList; track bsl) {
                 <mat-option [value]="bsl.name">{{bsl.displayName}}
                 </mat-option>
                 }
-                <mat-option [value]="createBackupStorageLocationOptionValue">+ Create Backup Storage Location</mat-option>
               </mat-select>
               @if (form.get(Controls.BackupStorageLocation).hasError('required')) {
               <mat-error>


### PR DESCRIPTION
**What this PR does / why we need it**:

This introduces a few UX improvements on the handling of `BackupStorageLocations` (BSLs) for the UC Backup feature. These apply to both, the Cluster Creation Wizard and "Edit cluster" dialogue.

 - New  "Create Backup Storage Location' button on clicking "Cluster Backup" checkbox

**Image Update**

KR: FYI
- This option is availaible for Create Cluster Wizard not for (Edit Cluster) to open a new dialog over a dialog

<img width="629" height="308" alt="Screenshot 2026-07-29 at 3 41 09 PM" src="https://github.com/user-attachments/assets/056b1a32-4292-4a7e-8142-2e88123225ce" />

- Add field validations on the BSL form(s):
  - Basic regexp validation for DNS on 'Region' and 'Endpoint URL' (+ `http(s)` for the latter).
  
<img width="1264" height="690" alt="Screenshot 2026-07-29 at 3 42 04 PM" src="https://github.com/user-attachments/assets/8d253e07-73b0-4b68-83d2-0b331e2faac6" />


- Mandatory 'Endpoint' & 'Region' unless using 'custom config' (see behavior in gif below).

<img width="526" height="557" alt="Screenshot 2026-07-29 at 3 43 50 PM" src="https://github.com/user-attachments/assets/85d2adb7-9a03-44de-b1af-f577b17d18c5" />


- Allow to copy BSL error messages on click from the BackupStorageLocation list view

<div align="center">
   <img src="https://github.com/user-attachments/assets/d2a7b1c1-f19b-4668-8799-0d5b9913ab21" />
</div>

- Fix: reorder BSL selector & Skip router reconciliation on the 'Edit cluster' modal: the checkbox to enable UC Backup and the BSL dropdown were split by the new 'Skip router reconciliation' on OpenStack DCs

<img width="530" height="553" alt="image" src="https://github.com/user-attachments/assets/61e7b883-ec80-407a-a28f-d73607dc3767" />

**Which issue(s) this PR fixes**: N/A 

**What type of PR is this?**
/kind design

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Cluster Creation/Edition: Improve BackupStorageLocation UX: display only available BSLs and allow to create new ones.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```