### PR TITLE
Add missing groups scope to OIDC kubelogin kubeconfig

### DIFF
--- a/modules/api/pkg/handler/common/kubeconfig.go
+++ b/modules/api/pkg/handler/common/kubeconfig.go
@@ -361,6 +361,7 @@ func CreateOIDCKubeconfigEndpoint(
 						"--oidc-client-id=" + oidcIssuerVerifier.OIDCConfig().ClientID,
 						"--oidc-client-secret=" + oidcIssuerVerifier.OIDCConfig().ClientSecret,
 						"--oidc-extra-scope=email",
+						"--oidc-extra-scope=groups",
 					},
 					InteractiveMode:    clientcmdapi.NeverExecInteractiveMode,
 					ProvideClusterInfo: false,


### PR DESCRIPTION

**What this PR does / why we need it**:

The exec-based kubeconfig (kubectl oidc-login) only requested the
email scope from the OIDC provider, but not groups. This meant that
RBAC ClusterRoleBindings based on OIDC group membership did not work
when using the kubelogin plugin, while the same setup worked fine via
the Kubernetes Dashboard (which uses the server-side token exchange
that already includes groups in its scopes).

This aligns the kubelogin exec args with the server-side OIDC flow
at line 407 which correctly requests ["openid", "email", "groups"].

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix missing OIDC group scope for kubelogin kubeconfig to fix group mapping for KKP user clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```

