### PR TITLE
Fix KubeLB option precedence enforced over enabled

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -511,15 +511,15 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   private _isKubeLBEnabled(datacenter: Datacenter, seedSettings: SeedSettings): boolean {
-    // If enabled is explicitly false at datacenter level, hide regardless of enforced
+    if (datacenter.spec.kubelb?.enforced) {
+      return true;
+    }
     if (datacenter.spec.kubelb?.enabled === false) {
       return false;
     }
-    // If enforced or enabled at datacenter level, show
-    if (datacenter.spec.kubelb?.enforced || datacenter.spec.kubelb?.enabled) {
+    if (datacenter.spec.kubelb?.enabled) {
       return true;
     }
-    // Fall back to seed-level setting
     return !!seedSettings?.kubelb?.enableForAllDatacenters;
   }
 

--- a/modules/web/src/app/shared/components/cluster-summary/component.ts
+++ b/modules/web/src/app/shared/components/cluster-summary/component.ts
@@ -90,14 +90,14 @@ export class ClusterSummaryComponent implements OnInit {
   }
 
   get kubeLBAssignPublicIPWarning(): boolean {
-    // Check all sources: cluster spec, datacenter enforced/enabled, and seed-level setting
-    // Respect explicit datacenter disable (enabled === false)
     const dcKubeLB = this.datacenter?.spec?.kubelb;
     let isKubeLBActive = !!this.cluster?.spec?.kubelb?.enabled;
     if (!isKubeLBActive) {
-      if (dcKubeLB?.enabled === false) {
+      if (dcKubeLB?.enforced) {
+        isKubeLBActive = true;
+      } else if (dcKubeLB?.enabled === false) {
         isKubeLBActive = false;
-      } else if (dcKubeLB?.enforced || dcKubeLB?.enabled) {
+      } else if (dcKubeLB?.enabled) {
         isKubeLBActive = true;
       } else {
         isKubeLBActive = !!this.seedSettings?.kubelb?.enableForAllDatacenters;

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -1367,15 +1367,15 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   private _isKubeLBEnabled(datacenter: Datacenter, seedSettings: SeedSettings): boolean {
-    // If enabled is explicitly false at datacenter level, hide regardless of enforced
+    if (datacenter.spec.kubelb?.enforced) {
+      return true;
+    }
     if (datacenter.spec.kubelb?.enabled === false) {
       return false;
     }
-    // If enforced or enabled at datacenter level, show
-    if (datacenter.spec.kubelb?.enforced || datacenter.spec.kubelb?.enabled) {
+    if (datacenter.spec.kubelb?.enabled) {
       return true;
     }
-    // Fall back to seed-level setting
     return !!seedSettings?.kubelb?.enableForAllDatacenters;
   }
 }

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -1368,15 +1368,15 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   private _isKubeLBEnabled(datacenter: Datacenter, seedSettings: SeedSettings): boolean {
-    // If enabled is explicitly false at datacenter level, hide regardless of enforced
+    if (datacenter.spec.kubelb?.enforced) {
+      return true;
+    }
     if (datacenter.spec.kubelb?.enabled === false) {
       return false;
     }
-    // If enforced or enabled at datacenter level, show
-    if (datacenter.spec.kubelb?.enforced || datacenter.spec.kubelb?.enabled) {
+    if (datacenter.spec.kubelb?.enabled) {
       return true;
     }
-    // Fall back to seed-level setting
     return !!seedSettings?.kubelb?.enableForAllDatacenters;
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes KubeLB option visibility so that enforced takes precedence over the enabled flag


#### Behaviour Matrix

| enforced | enabled | enableForAllDatacenters | Result | Rationale |
|----------|---------|-------------------------|--------|-----------|
| true | any | any | show + locked | enforced wins |
| false / undef | true | any | show | enabled wins |
| false / undef | false | any | hide | explicit per-DC disable |
| false / undef | undef | true | show | seed fallback |
| false / undef | undef | false / undef | hide | no signal to show |

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/dashboard/issues/7902

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes KubeLB option precedence so enforced datacenters always show the option regardless of the enabled flag.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
