### PR TITLE
KubeVirt: standard instancetypes leak through when DisableDefaultInstanceTypes is enabled 

### DIFF
--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -264,7 +264,11 @@ func kubeVirtInstancetypes(ctx context.Context, client ctrlruntimeclient.Client,
 	// only cluster-wide custom and kubermatic standard instancetypes were
 	// returned, and listing all namespaces would leak cross-tenant data.
 	if datacenter.Spec.Kubevirt != nil && datacenter.Spec.Kubevirt.NamespacedMode != nil && datacenter.Spec.Kubevirt.NamespacedMode.Enabled {
-		if err := client.List(ctx, &namespaceInstancetypes, ctrlruntimeclient.InNamespace(datacenter.Spec.Kubevirt.NamespacedMode.Namespace)); err != nil {
+		namespace := datacenter.Spec.Kubevirt.NamespacedMode.Namespace
+		if namespace == "" {
+			return instancetypes, fmt.Errorf("namespaced mode enabled but no namespace configured")
+		}
+		if err := client.List(ctx, &namespaceInstancetypes, ctrlruntimeclient.InNamespace(namespace)); err != nil {
 			return instancetypes, err
 		}
 	}

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -244,18 +244,27 @@ func kubeVirtInstancetypes(ctx context.Context, client ctrlruntimeclient.Client,
 	if err := client.List(ctx, &clusterInstancetypes); err != nil {
 		return instancetypes, err
 	}
-	// "standard" (namespaced)
-	if datacenter.Spec.Kubevirt != nil && !datacenter.Spec.Kubevirt.DisableDefaultInstanceTypes {
-		standardInstancetypes.Items = kubevirt.GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
+	// Always fetch the full set of kubermatic standard instancetypes once.
+	// We need the names to filter lingering instances from the namespace even
+	// when defaults are disabled, so a single call covers both use-cases.
+	allStandardItems := kubevirt.GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
+	allStandardNames := sets.New[string]()
+	for _, si := range allStandardItems {
+		allStandardNames.Insert(si.Name)
 	}
 
-	// "custom" (namespaced)
+	// Only expose standard instancetypes when not disabled.
+	if datacenter.Spec.Kubevirt != nil && !datacenter.Spec.Kubevirt.DisableDefaultInstanceTypes {
+		standardInstancetypes.Items = allStandardItems
+	}
+
+	// "custom" (namespaced) — only in namespaced mode, list user-created
+	// instancetypes from the configured namespace.  In non-namespaced mode
+	// we skip this entirely: before the namespaced-mode feature was added
+	// only cluster-wide custom and kubermatic standard instancetypes were
+	// returned, and listing all namespaces would leak cross-tenant data.
 	if datacenter.Spec.Kubevirt != nil && datacenter.Spec.Kubevirt.NamespacedMode != nil && datacenter.Spec.Kubevirt.NamespacedMode.Enabled {
 		if err := client.List(ctx, &namespaceInstancetypes, ctrlruntimeclient.InNamespace(datacenter.Spec.Kubevirt.NamespacedMode.Namespace)); err != nil {
-			return instancetypes, err
-		}
-	} else {
-		if err := client.List(ctx, &namespaceInstancetypes); err != nil {
 			return instancetypes, err
 		}
 	}
@@ -268,18 +277,17 @@ func kubeVirtInstancetypes(ctx context.Context, client ctrlruntimeclient.Client,
 		instancetypes.items = append(instancetypes.items, &w)
 	}
 
-	standardNames := sets.New[string]()
 	for i := range standardInstancetypes.Items {
-		standardNames.Insert(standardInstancetypes.Items[i].Name)
 		w := standardInstancetypeWrapper{&standardInstancetypes.Items[i]}
 		instancetypes.items = append(instancetypes.items, &w)
 	}
 	for i := range namespaceInstancetypes.Items {
-		// Skip if already added from standard instancetypes to avoid duplicates
-		if standardNames.Has(namespaceInstancetypes.Items[i].Name) {
+		// Skip kubermatic standard instancetypes (already added above, or
+		// disabled but still lingering in the namespace from prior reconciliation).
+		if allStandardNames.Has(namespaceInstancetypes.Items[i].Name) {
 			continue
 		}
-		w := standardInstancetypeWrapper{&namespaceInstancetypes.Items[i]}
+		w := customNamespacedInstancetypeWrapper{&namespaceInstancetypes.Items[i]}
 		instancetypes.items = append(instancetypes.items, &w)
 	}
 
@@ -578,6 +586,20 @@ func (it *standardInstancetypeWrapper) Category() apiv2.VirtualMachineInstancety
 }
 
 func (it *standardInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
+	return it.VirtualMachineInstancetype.Spec
+}
+
+// customNamespacedInstancetypeWrapper wraps a namespaced VirtualMachineInstancetype
+// that was created by the user (not by the kubermatic reconciler).
+type customNamespacedInstancetypeWrapper struct {
+	*kvinstancetypev1alpha1.VirtualMachineInstancetype
+}
+
+func (it *customNamespacedInstancetypeWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
+	return apiv2.InstancetypeCustom
+}
+
+func (it *customNamespacedInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
 	return it.VirtualMachineInstancetype.Spec
 }
 

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -26,6 +26,8 @@ import (
 	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
 
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
+	"k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt"
+	kvmanifests "k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt/manifests"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -170,7 +172,7 @@ func newInstancetype(category apiv2.VirtualMachineInstancetypeCategory, cpu uint
 	case apiv2.InstancetypeCustom:
 		instancetype := &kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "small-1",
+				Name: instancetypeName(cpu, memory),
 			},
 			Spec: getInstancetypeSpec(cpu, memory),
 		}
@@ -198,20 +200,53 @@ func getInstancetypeSpec(cpu uint32, memory string) kvinstancetypev1alpha1.Virtu
 
 // newFakeClient builds a controller-runtime fake client with the KubeVirt
 // instancetype scheme registered and the given objects pre-created.
-func newFakeClient(objs ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
+func newFakeClient(t *testing.T, objs ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
+	t.Helper()
 	scheme := runtime.NewScheme()
-	_ = kvinstancetypev1alpha1.AddToScheme(scheme)
+	if err := kvinstancetypev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register KubeVirt instancetype scheme: %v", err)
+	}
 	return fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(objs...).
 		Build()
 }
 
+// standardNamesFromManifests derives the set of kubermatic standard instancetype
+// names from the actual embedded manifests, so tests stay correct when manifests
+// are added or renamed without any code changes.
+func standardNamesFromManifests(t *testing.T) []string {
+	t.Helper()
+	client := newFakeClient(t)
+	items := kubevirt.GetKubermaticStandardInstancetypes(client, &kvmanifests.StandardInstancetypeGetter{})
+	names := make([]string, 0, len(items))
+	for _, it := range items {
+		names = append(names, it.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 func Test_kubeVirtInstancetypes(t *testing.T) {
 	ctx := context.Background()
 
-	// Standard instancetype names that ship via embedded manifests.
-	standardNames := []string{"standard-2", "standard-4", "standard-8"}
+	// Derive standard names from the actual embedded manifests so the test
+	// stays correct even when manifests are added or renamed.
+	standardNames := standardNamesFromManifests(t)
+
+	// staleStandardsInstanceTypes returns namespace-scoped VirtualMachineInstancetype objects
+	// whose names match the standard set — simulating instancetypes that were
+	// previously reconciled into a namespace and still exist there.
+	staleStandardsInstanceTypes := func(namespace string) []ctrlruntimeclient.Object {
+		objs := make([]ctrlruntimeclient.Object, 0, len(standardNames))
+		for _, name := range standardNames {
+			objs = append(objs, &kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec:       getInstancetypeSpec(2, "8Gi"),
+			})
+		}
+		return objs
+	}
 
 	tests := []struct {
 		name      string
@@ -282,7 +317,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			},
 		},
 		{
-			name: "namespaced mode: lingering standard instancetypes are filtered out from custom list",
+			name: "namespaced mode: existing standard instancetypes are filtered out from custom list",
 			dc: &kubermaticv1.Datacenter{
 				Spec: kubermaticv1.DatacenterSpec{
 					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
@@ -293,22 +328,13 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 					},
 				},
 			},
-			objects: []ctrlruntimeclient.Object{
-				// Previously reconciled standard instancetypes still live in the namespace.
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-2", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(2, "8Gi"),
-				},
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-4", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(4, "16Gi"),
-				},
+			objects: append(staleStandardsInstanceTypes("infra-ns"),
 				// Plus a real user-created one.
 				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "my-flavor", Namespace: "infra-ns"},
 					Spec:       getInstancetypeSpec(8, "32Gi"),
 				},
-			},
+			),
 			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
 				// standard-2 and standard-4 must appear under Kubermatic (from manifests),
 				// NOT duplicated under Custom from the namespace listing.
@@ -317,7 +343,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			},
 		},
 		{
-			name: "defaults disabled: standard instancetypes not returned, lingering ones in namespace filtered",
+			name: "defaults disabled: standard instancetypes not returned, existing ones in namespace filtered",
 			dc: &kubermaticv1.Datacenter{
 				Spec: kubermaticv1.DatacenterSpec{
 					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
@@ -329,26 +355,13 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 					},
 				},
 			},
-			objects: []ctrlruntimeclient.Object{
-				// These linger from before defaults were disabled.
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-2", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(2, "8Gi"),
-				},
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-4", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(4, "16Gi"),
-				},
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-8", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(8, "32Gi"),
-				},
+			objects: append(staleStandardsInstanceTypes("infra-ns"),
 				// A real user-created instancetype.
 				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "my-custom", Namespace: "infra-ns"},
 					Spec:       getInstancetypeSpec(16, "64Gi"),
 				},
-			},
+			),
 			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
 				// No Kubermatic standards should appear at all (disabled).
 				// Lingering standard-2/4/8 must NOT leak through as Custom.
@@ -356,7 +369,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			},
 		},
 		{
-			name: "defaults disabled, namespaced mode, only lingering standards: empty result",
+			name: "defaults disabled, namespaced mode, only existing standards: empty result",
 			dc: &kubermaticv1.Datacenter{
 				Spec: kubermaticv1.DatacenterSpec{
 					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
@@ -368,23 +381,10 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 					},
 				},
 			},
-			objects: []ctrlruntimeclient.Object{
-				// Only previously-reconciled standard instancetypes linger in the
-				// namespace — no user-created custom ones exist.  With defaults
-				// disabled these must all be filtered out, yielding an empty result.
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-2", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(2, "8Gi"),
-				},
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-4", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(4, "16Gi"),
-				},
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
-					ObjectMeta: metav1.ObjectMeta{Name: "standard-8", Namespace: "infra-ns"},
-					Spec:       getInstancetypeSpec(8, "32Gi"),
-				},
-			},
+			// Only previously-reconciled standard instancetypes exist in the
+			// namespace — no user-created custom ones exist.  With defaults
+			// disabled these must all be filtered out, yielding an empty result.
+			objects:   staleStandardsInstanceTypes("infra-ns"),
 			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{},
 		},
 		{
@@ -403,50 +403,28 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := newFakeClient(tt.objects...)
+			client := newFakeClient(t, tt.objects...)
 			got, err := kubeVirtInstancetypes(ctx, client, tt.dc)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("kubeVirtInstancetypes() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			if !reflect.DeepEqual(sortedCategoryNames(got.items), normalizeCategoryNames(tt.wantNames)) {
-				t.Errorf("kubeVirtInstancetypes() names =\n  %v\nwant:\n  %v", sortedCategoryNames(got.items), normalizeCategoryNames(tt.wantNames))
+			if gotNames := sortedCategoryNames(got.items); !reflect.DeepEqual(gotNames, tt.wantNames) {
+				t.Errorf("kubeVirtInstancetypes() names =\n  %v\nwant:\n  %v", gotNames, tt.wantNames)
 			}
 		})
 	}
 }
 
-// sortedCategoryNames groups instancetype items by category, sorts each name
-// slice, and drops empty categories — ready for reflect.DeepEqual.
+// sortedCategoryNames groups instancetype items by category and sorts each
+// name slice, producing a map ready for reflect.DeepEqual against tt.wantNames.
 func sortedCategoryNames(items []instancetypeWrapper) map[apiv2.VirtualMachineInstancetypeCategory][]string {
 	m := make(map[apiv2.VirtualMachineInstancetypeCategory][]string)
 	for _, item := range items {
-		cat := item.Category()
-		m[cat] = append(m[cat], item.GetObjectMeta().GetName())
+		m[item.Category()] = append(m[item.Category()], item.GetObjectMeta().GetName())
 	}
-	for cat, names := range m {
-		if len(names) == 0 {
-			delete(m, cat)
-		} else {
-			sort.Strings(names)
-			m[cat] = names
-		}
-	}
-	return m
-}
-
-// normalizeCategoryNames sorts each name slice and drops empty categories,
-// producing a map comparable with the output of sortedCategoryNames.
-func normalizeCategoryNames(wantNames map[apiv2.VirtualMachineInstancetypeCategory][]string) map[apiv2.VirtualMachineInstancetypeCategory][]string {
-	m := make(map[apiv2.VirtualMachineInstancetypeCategory][]string)
-	for cat, names := range wantNames {
-		if len(names) == 0 {
-			continue
-		}
-		sorted := make([]string, len(names))
-		copy(sorted, names)
-		sort.Strings(sorted)
-		m[cat] = sorted
+	for cat := range m {
+		sort.Strings(m[cat])
 	}
 	return m
 }

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package provider
 
 import (
+	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
@@ -28,6 +30,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_filterInstancetypes(t *testing.T) {
@@ -188,5 +193,271 @@ func getInstancetypeSpec(cpu uint32, memory string) kvinstancetypev1alpha1.Virtu
 		Memory: kvinstancetypev1alpha1.MemoryInstancetype{
 			Guest: resource.MustParse(memory),
 		},
+	}
+}
+
+// newFakeClient builds a controller-runtime fake client with the KubeVirt
+// instancetype scheme registered and the given objects pre-created.
+func newFakeClient(objs ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
+	scheme := runtime.NewScheme()
+	_ = kvinstancetypev1alpha1.AddToScheme(scheme)
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+}
+
+func Test_kubeVirtInstancetypes(t *testing.T) {
+	ctx := context.Background()
+
+	// Standard instancetype names that ship via embedded manifests.
+	standardNames := []string{"standard-2", "standard-4", "standard-8"}
+
+	tests := []struct {
+		name      string
+		dc        *kubermaticv1.Datacenter
+		objects   []ctrlruntimeclient.Object // pre-existing objects in the fake cluster
+		wantNames map[apiv2.VirtualMachineInstancetypeCategory][]string
+		wantErr   bool
+	}{
+		{
+			name: "non-namespaced mode: only cluster-wide custom + kubermatic standards",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster-custom-1"},
+					Spec:       getInstancetypeSpec(4, "8Gi"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
+				apiv2.InstancetypeCustom:     {"cluster-custom-1"},
+				apiv2.InstancetypeKubermatic: standardNames,
+			},
+		},
+		{
+			name: "non-namespaced mode: does NOT list namespaced instancetypes (cross-tenant leak fix)",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+						// NamespacedMode is nil → non-namespaced mode
+					},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				// Namespaced instancetype in some tenant namespace — must NOT appear.
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "tenant-it", Namespace: "tenant-ns-1"},
+					Spec:       getInstancetypeSpec(2, "4Gi"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
+				apiv2.InstancetypeKubermatic: standardNames,
+			},
+		},
+		{
+			name: "namespaced mode: user-created instancetype categorized as custom",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+						NamespacedMode: &kubermaticv1.NamespacedMode{
+							Enabled:   true,
+							Namespace: "infra-ns",
+						},
+					},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "user-created", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(4, "16Gi"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
+				apiv2.InstancetypeCustom:     {"user-created"},
+				apiv2.InstancetypeKubermatic: standardNames,
+			},
+		},
+		{
+			name: "namespaced mode: lingering standard instancetypes are filtered out from custom list",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+						NamespacedMode: &kubermaticv1.NamespacedMode{
+							Enabled:   true,
+							Namespace: "infra-ns",
+						},
+					},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				// Previously reconciled standard instancetypes still live in the namespace.
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-2", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(2, "8Gi"),
+				},
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-4", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(4, "16Gi"),
+				},
+				// Plus a real user-created one.
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-flavor", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(8, "32Gi"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
+				// standard-2 and standard-4 must appear under Kubermatic (from manifests),
+				// NOT duplicated under Custom from the namespace listing.
+				apiv2.InstancetypeCustom:     {"my-flavor"},
+				apiv2.InstancetypeKubermatic: standardNames,
+			},
+		},
+		{
+			name: "defaults disabled: standard instancetypes not returned, lingering ones in namespace filtered",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+						DisableDefaultInstanceTypes: true,
+						NamespacedMode: &kubermaticv1.NamespacedMode{
+							Enabled:   true,
+							Namespace: "infra-ns",
+						},
+					},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				// These linger from before defaults were disabled.
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-2", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(2, "8Gi"),
+				},
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-4", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(4, "16Gi"),
+				},
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-8", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(8, "32Gi"),
+				},
+				// A real user-created instancetype.
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "my-custom", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(16, "64Gi"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
+				// No Kubermatic standards should appear at all (disabled).
+				// Lingering standard-2/4/8 must NOT leak through as Custom.
+				apiv2.InstancetypeCustom: {"my-custom"},
+			},
+		},
+		{
+			name: "defaults disabled, namespaced mode, only lingering standards: empty result",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+						DisableDefaultInstanceTypes: true,
+						NamespacedMode: &kubermaticv1.NamespacedMode{
+							Enabled:   true,
+							Namespace: "infra-ns",
+						},
+					},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				// Only previously-reconciled standard instancetypes linger in the
+				// namespace — no user-created custom ones exist.  With defaults
+				// disabled these must all be filtered out, yielding an empty result.
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-2", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(2, "8Gi"),
+				},
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-4", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(4, "16Gi"),
+				},
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-8", Namespace: "infra-ns"},
+					Spec:       getInstancetypeSpec(8, "32Gi"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{},
+		},
+		{
+			name: "defaults disabled, no namespaced mode: empty result",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+						DisableDefaultInstanceTypes: true,
+					},
+				},
+			},
+			objects:   []ctrlruntimeclient.Object{},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newFakeClient(tt.objects...)
+			got, err := kubeVirtInstancetypes(ctx, client, tt.dc)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("kubeVirtInstancetypes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			gotNames := make(map[apiv2.VirtualMachineInstancetypeCategory][]string)
+			for _, item := range got.items {
+				cat := item.Category()
+				gotNames[cat] = append(gotNames[cat], item.GetObjectMeta().GetName())
+			}
+
+			// Sort for deterministic comparison.
+			for cat := range gotNames {
+				sort.Strings(gotNames[cat])
+			}
+			for cat := range tt.wantNames {
+				sort.Strings(tt.wantNames[cat])
+			}
+
+			// Remove empty slices for clean comparison.
+			for cat, names := range gotNames {
+				if len(names) == 0 {
+					delete(gotNames, cat)
+				}
+			}
+			for cat, names := range tt.wantNames {
+				if len(names) == 0 {
+					delete(tt.wantNames, cat)
+				}
+			}
+
+			if !reflect.DeepEqual(gotNames, tt.wantNames) {
+				t.Errorf("kubeVirtInstancetypes() names =\n  %v\nwant:\n  %v", gotNames, tt.wantNames)
+			}
+
+			// Additionally verify wrapper types / categories.
+			for _, item := range got.items {
+				switch item.(type) {
+				case *customInstancetypeWrapper:
+					if item.Category() != apiv2.InstancetypeCustom {
+						t.Errorf("customInstancetypeWrapper should have category Custom, got %v", item.Category())
+					}
+				case *standardInstancetypeWrapper:
+					if item.Category() != apiv2.InstancetypeKubermatic {
+						t.Errorf("standardInstancetypeWrapper should have category Kubermatic, got %v", item.Category())
+					}
+				case *customNamespacedInstancetypeWrapper:
+					if item.Category() != apiv2.InstancetypeCustom {
+						t.Errorf("customNamespacedInstancetypeWrapper should have category Custom, got %v", item.Category())
+					}
+				default:
+					t.Errorf("unexpected wrapper type %T for %s", item, item.GetObjectMeta().GetName())
+				}
+			}
+		})
 	}
 }

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -234,10 +234,10 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 	// stays correct even when manifests are added or renamed.
 	standardNames := standardNamesFromManifests(t)
 
-	// staleStandardsInstanceTypes returns namespace-scoped VirtualMachineInstancetype objects
+	// staleStandardInstanceTypes returns namespace-scoped VirtualMachineInstancetype objects
 	// whose names match the standard set — simulating instancetypes that were
 	// previously reconciled into a namespace and still exist there.
-	staleStandardsInstanceTypes := func(namespace string) []ctrlruntimeclient.Object {
+	staleStandardInstanceTypes := func(namespace string) []ctrlruntimeclient.Object {
 		objs := make([]ctrlruntimeclient.Object, 0, len(standardNames))
 		for _, name := range standardNames {
 			objs = append(objs, &kvinstancetypev1alpha1.VirtualMachineInstancetype{
@@ -328,7 +328,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 					},
 				},
 			},
-			objects: append(staleStandardsInstanceTypes("infra-ns"),
+			objects: append(staleStandardInstanceTypes("infra-ns"),
 				// Plus a real user-created one.
 				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "my-flavor", Namespace: "infra-ns"},
@@ -355,7 +355,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 					},
 				},
 			},
-			objects: append(staleStandardsInstanceTypes("infra-ns"),
+			objects: append(staleStandardInstanceTypes("infra-ns"),
 				// A real user-created instancetype.
 				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "my-custom", Namespace: "infra-ns"},
@@ -384,7 +384,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			// Only previously-reconciled standard instancetypes exist in the
 			// namespace — no user-created custom ones exist.  With defaults
 			// disabled these must all be filtered out, yielding an empty result.
-			objects:   staleStandardsInstanceTypes("infra-ns"),
+			objects:   staleStandardInstanceTypes("infra-ns"),
 			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{},
 		},
 		{

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -409,55 +409,44 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 				t.Fatalf("kubeVirtInstancetypes() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			gotNames := make(map[apiv2.VirtualMachineInstancetypeCategory][]string)
-			for _, item := range got.items {
-				cat := item.Category()
-				gotNames[cat] = append(gotNames[cat], item.GetObjectMeta().GetName())
-			}
-
-			// Sort for deterministic comparison.
-			for cat := range gotNames {
-				sort.Strings(gotNames[cat])
-			}
-			for cat := range tt.wantNames {
-				sort.Strings(tt.wantNames[cat])
-			}
-
-			// Remove empty slices for clean comparison.
-			for cat, names := range gotNames {
-				if len(names) == 0 {
-					delete(gotNames, cat)
-				}
-			}
-			for cat, names := range tt.wantNames {
-				if len(names) == 0 {
-					delete(tt.wantNames, cat)
-				}
-			}
-
-			if !reflect.DeepEqual(gotNames, tt.wantNames) {
-				t.Errorf("kubeVirtInstancetypes() names =\n  %v\nwant:\n  %v", gotNames, tt.wantNames)
-			}
-
-			// Additionally verify wrapper types / categories.
-			for _, item := range got.items {
-				switch item.(type) {
-				case *customInstancetypeWrapper:
-					if item.Category() != apiv2.InstancetypeCustom {
-						t.Errorf("customInstancetypeWrapper should have category Custom, got %v", item.Category())
-					}
-				case *standardInstancetypeWrapper:
-					if item.Category() != apiv2.InstancetypeKubermatic {
-						t.Errorf("standardInstancetypeWrapper should have category Kubermatic, got %v", item.Category())
-					}
-				case *customNamespacedInstancetypeWrapper:
-					if item.Category() != apiv2.InstancetypeCustom {
-						t.Errorf("customNamespacedInstancetypeWrapper should have category Custom, got %v", item.Category())
-					}
-				default:
-					t.Errorf("unexpected wrapper type %T for %s", item, item.GetObjectMeta().GetName())
-				}
+			if !reflect.DeepEqual(sortedCategoryNames(got.items), normalizeCategoryNames(tt.wantNames)) {
+				t.Errorf("kubeVirtInstancetypes() names =\n  %v\nwant:\n  %v", sortedCategoryNames(got.items), normalizeCategoryNames(tt.wantNames))
 			}
 		})
 	}
+}
+
+// sortedCategoryNames groups instancetype items by category, sorts each name
+// slice, and drops empty categories — ready for reflect.DeepEqual.
+func sortedCategoryNames(items []instancetypeWrapper) map[apiv2.VirtualMachineInstancetypeCategory][]string {
+	m := make(map[apiv2.VirtualMachineInstancetypeCategory][]string)
+	for _, item := range items {
+		cat := item.Category()
+		m[cat] = append(m[cat], item.GetObjectMeta().GetName())
+	}
+	for cat, names := range m {
+		if len(names) == 0 {
+			delete(m, cat)
+		} else {
+			sort.Strings(names)
+			m[cat] = names
+		}
+	}
+	return m
+}
+
+// normalizeCategoryNames sorts each name slice and drops empty categories,
+// producing a map comparable with the output of sortedCategoryNames.
+func normalizeCategoryNames(wantNames map[apiv2.VirtualMachineInstancetypeCategory][]string) map[apiv2.VirtualMachineInstancetypeCategory][]string {
+	m := make(map[apiv2.VirtualMachineInstancetypeCategory][]string)
+	for cat, names := range wantNames {
+		if len(names) == 0 {
+			continue
+		}
+		sorted := make([]string, len(names))
+		copy(sorted, names)
+		sort.Strings(sorted)
+		m[cat] = sorted
+	}
+	return m
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

 When `DisableDefaultInstanceTypes` is set to `true` on a KubeVirt datacenter with `NamespacedMode` enabled, Kubermatic standard instancetypes that were previously reconciled into the configured namespace are still returned by the API — regardless of the configured setting. They appear under the Kubermatic category, identical to the behaviour when the setting is `false`.
                                                                                                                                                                                                                                                              
### Root cause:                                               

There are two compounding bugs in `kubeVirtInstancetypes()` in `modules/api/pkg/handler/common/provider/kubevirt.go`:                                                                                                                                          

#### The standard name blocklist is blind when defaults are disabled
  
To avoid listing standard instancetypes twice (once from the embedded manifests, once from the namespace listing), the code built a standardNames set to filter them out of the namespace results:                                                          

```
  standardNames := sets.New[string]()                                                                                                                                                                                                                         
  for i := range standardInstancetypes.Items {              
      standardNames.Insert(standardInstancetypes.Items[i].Name)
      ...
  }
  for i := range namespaceInstancetypes.Items {
      if standardNames.Has(namespaceInstancetypes.Items[i].Name) {                                                                                                                                                                                            
          continue  // skip duplicates
      }                                                                                                                                                                                                                                                       
      ...                                                   
  }
```

`standardInstancetypes.Items` is only populated when `DisableDefaultInstanceTypes` is `false`. When it is `true`, the list is empty, `standardNames` contains nothing, and the `Has()` check never matches — so every instancetype found in the namespace passes through, including any standard ones still lingering there from before the setting was changed.
                                                                                                                                                                                                                                                              
#### Namespaced instancetypes are wrapped with the wrong type  

Instancetypes that passed the filter were wrapped as `standardInstancetypeWrapper`, which has `Category() = InstancetypeKubermatic`. This means lingering standard instancetypes not only appear in the response, but are indistinguishable from legitimately loaded Kubermatic standard types. User-created namespaced instancetypes were equally misclassified as Kubermatic instead of Custom.
                                                                                                                                                                                                                                                              
  Steps to reproduce:                                       

  - Create a KubeVirt datacenter with `NamespacedMode` enabled and `DisableDefaultInstanceTypes: false`
  - Wait for the standard instancetypes (`standard-2`, `standard-4`, `standard-8`) to be reconciled into the configured namespace or apply them manually by 
      - `kubectl apply -n kkp-dev -f ./pkg/provider/cloud/kubevirt/manifests/instancetypes/ `
  - Set `DisableDefaultInstanceTypes: true`                                                                                                                                                                                                                     
  - Query the instancetypes endpoint for that datacenter
                                                                                                                                                                                                                                                              
#### Expected behavior:                                        

  No Kubermatic standard instancetypes are returned. User-created instancetypes in the namespace appear under the Custom category.                                                                                                                            
  
#### Actual behavior:                                                                                                                                                                                                                                            
                                                            
  Previously reconciled standard instancetypes still appear under the Kubermatic category, as if the setting had no effect. User-created namespaced instancetypes are also incorrectly categorized as Kubermatic.                                             
  
#### Fix:                                                                                                                                                                                                                                                        
                                                            
  Two changes in `kubeVirtInstancetypes()`:

  - Build the standard name blocklist unconditionally from the embedded manifests (allStandardNames) rather than from the currently loaded items list. This ensures lingering instancetypes in the namespace are always filtered out regardless of whether    
  defaults are enabled.
  - Introduce a dedicated customNamespacedInstancetypeWrapper with Category() = InstancetypeCustom for user-created namespaced instancetypes, replacing the incorrectly used standardInstancetypeWrapper.                                                     
                                                                                                                                                                                                                     

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
a regression bug has been fixed where default kkp kubevirt instancetypes were displayed regardless of disabling them
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
