### PR TITLE
Add -oidc-authflow-redirect-uri flag to fix redirect URI behind ingress

### DIFF
--- a/modules/api/cmd/kubermatic-api/main.go
+++ b/modules/api/cmd/kubermatic-api/main.go
@@ -615,6 +615,7 @@ func createAPIHandler(
 		PrivilegedOperatingSystemProfileProviderGetter: prov.privilegedOperatingSystemProfileProviderGetter,
 		OIDCIssuerVerifierProviderGetter:               prov.oidcIssuerVerifierProviderGetter,
 		OIDCIssuerVerifier:                             prov.oidcIssuerVerifier,
+		AuthflowRedirectURI:                            options.oidcAuthflowRedirectURI,
 		StateStore:                                     auth.NewInMemoryStateStore(auth.DefaultStateTTL, auth.DefaultStateCleanupInterval),
 		Versions:                                       options.versions,
 		CABundle:                                       options.caBundle.CertPool(),

--- a/modules/api/cmd/kubermatic-api/options.go
+++ b/modules/api/cmd/kubermatic-api/options.go
@@ -63,6 +63,7 @@ type serverRunOptions struct {
 	oidcIssuerClientID             string
 	oidcIssuerClientSecret         string
 	oidcIssuerRedirectURI          string
+	oidcAuthflowRedirectURI        string
 	oidcIssuerCookieHashKey        string
 	oidcIssuerCookieSecureMode     bool
 	oidcSkipTLSVerify              bool
@@ -99,6 +100,7 @@ func newServerRunOptions() (serverRunOptions, error) {
 	flag.StringVar(&s.oidcIssuerClientID, "oidc-issuer-client-id", "", "Issuer client ID")
 	flag.StringVar(&s.oidcIssuerClientSecret, "oidc-issuer-client-secret", "", "OpenID client secret")
 	flag.StringVar(&s.oidcIssuerRedirectURI, "oidc-issuer-redirect-uri", "", "Callback URL for OpenID responses.")
+	flag.StringVar(&s.oidcAuthflowRedirectURI, "oidc-authflow-redirect-uri", "", "Redirect URI for the dashboard OAuth authorization code flow. Defaults to https://<request-host>/api/v2/auth/callback.")
 	flag.StringVar(&s.oidcIssuerCookieHashKey, "oidc-issuer-cookie-hash-key", "", "Hash key authenticates the cookie value using HMAC. It is recommended to use a key with 32 or 64 bytes.")
 	flag.BoolVar(&s.oidcIssuerCookieSecureMode, "oidc-issuer-cookie-secure-mode", true, "When true cookie received only with HTTPS. Set false for local deployment with HTTP")
 	flag.BoolVar(&s.oidcIssuerOfflineAccessAsScope, "oidc-issuer-offline-access-as-scope", true, "Set it to false if OIDC provider requires to set \"access_type=offline\" query param when accessing the refresh token")

--- a/modules/api/hack/run-api.sh
+++ b/modules/api/hack/run-api.sh
@@ -57,6 +57,7 @@ API_EXTRA_ARGS="$API_EXTRA_ARGS -oidc-issuer-client-id=$OIDC_ISSUER_CLIENT_ID"
 API_EXTRA_ARGS="$API_EXTRA_ARGS -oidc-issuer-client-secret=$OIDC_ISSUER_CLIENT_SECRET"
 API_EXTRA_ARGS="$API_EXTRA_ARGS -oidc-issuer-redirect-uri=$OIDC_ISSUER_REDIRECT_URI"
 API_EXTRA_ARGS="$API_EXTRA_ARGS -oidc-issuer-cookie-hash-key=$OIDC_ISSUER_COOKIE_HASH_KEY"
+API_EXTRA_ARGS="$API_EXTRA_ARGS -oidc-authflow-redirect-uri=http://127.0.0.1:8080/api/v2/auth/callback"
 
 echodate "Starting API..."
 set -x

--- a/modules/api/pkg/handler/routing.go
+++ b/modules/api/pkg/handler/routing.go
@@ -235,6 +235,7 @@ type RoutingParams struct {
 	PrivilegedOperatingSystemProfileProviderGetter provider.PrivilegedOperatingSystemProfileProviderGetter
 	OIDCIssuerVerifierProviderGetter               provider.OIDCIssuerVerifierGetter
 	OIDCIssuerVerifier                             authtypes.OIDCIssuerVerifier
+	AuthflowRedirectURI                            string
 	StateStore                                     authtypes.StateStore
 	Versions                                       kubermatic.Versions
 	CABundle                                       *x509.CertPool

--- a/modules/api/pkg/handler/v2/authflow/handler.go
+++ b/modules/api/pkg/handler/v2/authflow/handler.go
@@ -43,13 +43,14 @@ func appendPKCEParams(authURL, codeChallenge string) string {
 	return authURL + "&code_challenge=" + url.QueryEscape(codeChallenge) + "&code_challenge_method=S256"
 }
 
-// buildRedirectURI constructs the callback URL from the incoming request's host.
-func buildRedirectURI(r *http.Request) string {
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
+// buildRedirectURI returns the configured redirect URI if set, otherwise
+// defaults to https://<host>/api/v2/auth/callback.
+func (a *authHandler) buildRedirectURI(r *http.Request) string {
+	if a.redirectURI != "" {
+		return a.redirectURI
 	}
-	return fmt.Sprintf("%s://%s%s", scheme, r.Host, callbackPath)
+
+	return fmt.Sprintf("https://%s%s", r.Host, callbackPath)
 }
 
 func (a *authHandler) loginHandler() http.Handler {
@@ -72,7 +73,7 @@ func (a *authHandler) loginHandler() http.Handler {
 			scopes = append(scopes, "offline_access")
 		}
 
-		redirectURI := buildRedirectURI(r)
+		redirectURI := a.buildRedirectURI(r)
 		authURL := a.oidcIssuerVerifier.AuthCodeURL(state, oidcConfig.OfflineAccessAsScope, redirectURI, scopes...)
 		authURL = appendPKCEParams(authURL, oauth2.S256ChallengeFromVerifier(codeVerifier))
 
@@ -144,7 +145,7 @@ func (a *authHandler) callbackHandler() http.Handler {
 		}
 
 		// 4. Exchange authorization code for tokens with PKCE code_verifier.
-		redirectURI := buildRedirectURI(r)
+		redirectURI := a.buildRedirectURI(r)
 		oidcTokens, err := a.oidcIssuerVerifier.Exchange(r.Context(), code, redirectURI, authState.CodeVerifier)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to exchange code for tokens: %v", err), http.StatusInternalServerError)

--- a/modules/api/pkg/handler/v2/authflow/routing.go
+++ b/modules/api/pkg/handler/v2/authflow/routing.go
@@ -32,6 +32,7 @@ type authHandler struct {
 	tokenExtractor           authtypes.TokenExtractor
 	userProvider             provider.UserProvider
 	kubermaticConfigProvider provider.KubermaticConfigurationGetter
+	redirectURI              string
 }
 
 func (a *authHandler) Install(router *mux.Router) {
@@ -57,7 +58,7 @@ func (a *authHandler) Install(router *mux.Router) {
 }
 
 // NewAuthHandler creates a new Handler for KKP dashboard authentication.
-func NewAuthHandler(stateStore authtypes.StateStore, oidcIssuerVerifier authtypes.OIDCIssuerVerifier, userProvider provider.UserProvider, kubermaticConfigProvider provider.KubermaticConfigurationGetter) *authHandler {
+func NewAuthHandler(stateStore authtypes.StateStore, oidcIssuerVerifier authtypes.OIDCIssuerVerifier, userProvider provider.UserProvider, kubermaticConfigProvider provider.KubermaticConfigurationGetter, redirectURI string) *authHandler {
 	return &authHandler{
 		stateStore:         stateStore,
 		oidcIssuerVerifier: oidcIssuerVerifier,
@@ -67,5 +68,6 @@ func NewAuthHandler(stateStore authtypes.StateStore, oidcIssuerVerifier authtype
 		),
 		userProvider:             userProvider,
 		kubermaticConfigProvider: kubermaticConfigProvider,
+		redirectURI:              redirectURI,
 	}
 }

--- a/modules/api/pkg/handler/v2/routes_v2.go
+++ b/modules/api/pkg/handler/v2/routes_v2.go
@@ -1136,7 +1136,7 @@ func (r Routing) RegisterV2(mux *mux.Router, oidcKubeConfEndpoint bool) {
 		Handler(r.listVMwareCloudDirectorComputePoliciesNoCredentials())
 
 	authflow.
-		NewAuthHandler(r.stateStore, r.oidcIssuerVerifier, r.userProvider, r.kubermaticConfigGetter).
+		NewAuthHandler(r.stateStore, r.oidcIssuerVerifier, r.userProvider, r.kubermaticConfigGetter, r.authflowRedirectURI).
 		Install(mux)
 
 	kubernetesdashboard.

--- a/modules/api/pkg/handler/v2/routing.go
+++ b/modules/api/pkg/handler/v2/routing.go
@@ -103,6 +103,7 @@ type Routing struct {
 	oidcIssuerVerifierProviderGetter               provider.OIDCIssuerVerifierGetter
 	oidcIssuerVerifier                             authtypes.OIDCIssuerVerifier
 	stateStore                                     authtypes.StateStore
+	authflowRedirectURI                            string
 	versions                                       kubermatic.Versions
 	caBundle                                       *x509.CertPool
 	features                                       features.FeatureGate
@@ -174,6 +175,7 @@ func NewV2Routing(routingParams handler.RoutingParams) Routing {
 		oidcIssuerVerifierProviderGetter:               routingParams.OIDCIssuerVerifierProviderGetter,
 		oidcIssuerVerifier:                             routingParams.OIDCIssuerVerifier,
 		stateStore:                                     routingParams.StateStore,
+		authflowRedirectURI:                            routingParams.AuthflowRedirectURI,
 		versions:                                       routingParams.Versions,
 		caBundle:                                       routingParams.CABundle,
 		features:                                       routingParams.Features,


### PR DESCRIPTION
**What this PR does / why we need it**:

The authflow login and callback handlers use `buildRedirectURI` to construct the redirect URI sent to Dex. This function checks `r.TLS` to decide the scheme - if TLS is nil, it uses `http://`. When the API runs behind a TLS-terminating ingress, `r.TLS` is always nil, so the redirect URI becomes `http://<host>/api/v2/auth/callback`. Dex rejects this because it doesn't match the registered `https://` redirect URI.

This PR adds a `-oidc-authflow-redirect-uri` flag that lets operators explicitly set the redirect URI. When the flag is empty (the default), `buildRedirectURI` uses `https://` unconditionally instead of checking `r.TLS`. This is the correct behavior for production where the API sits behind an ingress.

For local development, the flag can be set to `http://127.0.0.1:8080/api/v2/auth/callback` (already added to `run-api.sh`).

**Which issue(s) this PR fixes**:
Fixes the redirect URI mismatch error that occurs when logging into the dashboard behind an ingress.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

The existing `-oidc-issuer-redirect-uri` flag serves a different OAuth client (`kubermaticIssuer` for kubeconfig flows) and cannot be reused here. This new flag is specific to the dashboard auth authorization code flow.


Ref: https://github.com/kubermatic/dashboard/pull/7960

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
> Its NONE because the feature itself is not released yet.

**Documentation**:
```documentation
TBD
```

> We should document this and allow KKP to configure this field.

**Test issue**:
```test-issue
NONE
```
