### PR TITLE
Fix 'background-repeat' for multi-line menu-item icons

### DIFF
--- a/modules/web/src/app/core/components/sidenav/style.scss
+++ b/modules/web/src/app/core/components/sidenav/style.scss
@@ -50,7 +50,10 @@
       i {
         @include mixins.size(24px);
 
+        background-position: center;
+        background-repeat: no-repeat;
         background-size: contain;
+        flex-shrink: 0;
 
         &.km-icon-arrow-left {
           @include mixins.size(16px);


### PR DESCRIPTION
**What this PR does / why we need it**:
We're recently added a new entry to our `customLinks` that rendered in two lines. We picked the `docs.svg` icon for it, and realised that, under 125% of Zoom, the icon was repeating itself: 

![](https://github.com/user-attachments/assets/311b597f-b12a-4d1a-b15b-92c3c48b9593)

The global `.km-sidenav` styles give `<i>` a `size` and `background-size: contain`, **but never set `background-repeat`**.

The initial value for `background-repeat` is `repeat`. When the `customLinks[n].label` wraps, the flex row gets taller and so does the icon column. The browser then tiles the image on the Y axis to fill in the space.

Icons that use the `km-icon-mask` get `mask-repeat: no-repeat`, but `custom-link` icons use `background-image`, so they didn’t get that protection. This patch aims to fix this, even at the smallest levels of zoom.

**What type of PR is this?**
/kind bug
/kind flake

**Special notes for your reviewer**:
> [!NOTE]  
> Does not reproduce with all the icon classes. We actually never noticed for `external-link.svg`. But it reproduces with `docs.svg`.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fix background-repeat for multi-line 'menu-item' icons on low zoom.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
