### PR TITLE
Fix km-tab label regression introduced by #8049

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -611,7 +611,7 @@ limitations under the License.
     </km-tab>
     @if (cluster.spec.opaIntegration?.enabled) {
     <km-tab label="OPA Constraints">
-      <ng-template>
+      <ng-template kmTabLabel>
         OPA Constraints
         <i class="km-icon-warning km-pointer-warning km-opa-warning"
            [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
@@ -624,7 +624,7 @@ limitations under the License.
     }
     @if (cluster.spec.opaIntegration?.enabled) {
     <km-tab label="OPA Gatekeeper Config">
-      <ng-template>
+      <ng-template kmTabLabel>
         OPA Gatekeeper Config
         <i class="km-icon-warning km-pointer km-opa-warning"
            [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>

--- a/modules/web/src/app/shared/components/tab-card/tab/label.directive.ts
+++ b/modules/web/src/app/shared/components/tab-card/tab/label.directive.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+// Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,20 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, TemplateRef, ViewChild, ContentChild} from '@angular/core';
-import {TabLabelDirective} from './label.directive';
+import {Directive, TemplateRef} from '@angular/core';
 
-@Component({
-  selector: 'km-tab',
-  templateUrl: 'template.html',
+@Directive({
+  selector: '[kmTabLabel]',
   standalone: false,
 })
-export class TabComponent {
-  @Input() label: string;
-  @ViewChild(TemplateRef) template: TemplateRef<any>;
-  @ContentChild(TabLabelDirective) private _labelDirective?: TabLabelDirective;
-
-  get labelTemplate(): TemplateRef<unknown> | undefined {
-    return this._labelDirective?.templateRef;
-  }
+export class TabLabelDirective {
+  constructor(public templateRef: TemplateRef<unknown>) {}
 }

--- a/modules/web/src/app/shared/module.ts
+++ b/modules/web/src/app/shared/module.ts
@@ -91,6 +91,7 @@ import {SideNavExpansionMenuComponent} from '@shared/components/side-nav-field/c
 import {TabCardComponent} from '@shared/components/tab-card/component';
 import {DynamicTabComponent} from '@shared/components/tab-card/dynamic-tab/component';
 import {TabComponent} from '@shared/components/tab-card/tab/component';
+import {TabLabelDirective} from '@shared/components/tab-card/tab/label.directive';
 import {TerminalComponent} from '@shared/components/terminal/component';
 import {TerminalStatusBarComponent} from '@shared/components/terminal/terminal-status-bar/component';
 import {TerminalToolBarComponent} from '@shared/components/terminal/terminal-toolbar/component';
@@ -284,6 +285,7 @@ const directives = [
   OptionDirective,
   InputPasswordDirective,
   ValueChangedIndicatorDirective,
+  TabLabelDirective,
 ];
 
 @NgModule({


### PR DESCRIPTION
**What this PR does / why we need it**:
 This PR fixes the regression introduced by #8049 that broke the Clusters Overview page by causing the <km-tab> label-template content  query to capture unrelated TemplateRef instances produced by structural directives inside the tab body (e.g. *matHeaderCellDef from  mat-table).        

<img width="870" height="252" alt="image" src="https://github.com/user-attachments/assets/819c8fb8-8e08-424d-8dc8-a9b693083ec8" />


#### Why It Broke
@ContentChild(TemplateRef) matches the first TemplateRef instance in projected content. Angular structural directives such as    `*matHeaderCellDef, *matCellDef, *matRowDef, *ngIf,` etc. desugar to <ng-template> and produce TemplateRef instances. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug                                                 
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
