### PR TITLE
Return empty metrics for unavailable BYO CNI cluster

### DIFF
--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -798,6 +798,13 @@ func GetMetricsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGet
 	if err := dynamicClient.List(ctx, allNodeMetricsList); err != nil {
 		// Happens during cluster creation when the CRD is not setup yet
 		if !meta.IsNoMatchError(err) {
+			if apierrors.IsServiceUnavailable(err) && cluster.Spec.CNIPlugin != nil && cluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeNone {
+				// Return empty metrics with 200 status code if the cluster is using BYO CNI and the metrics endpoint is unavailable.
+				// This is because cluster unavailability is expected as long as the user cluster admins didn't set up CNI themselves.
+				// Meanwhile we don't want to bother KKP admins with alerts about an error that is not actionable for them.
+				kubermaticlog.Logger.With("cluster", cluster.Name).Warn("returning empty cluster metrics for BYO CNI user cluster since it is unavailable")
+				return &apiv1.ClusterMetrics{Name: cluster.Name}, nil
+			}
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 	}

--- a/modules/api/pkg/handler/common/cluster.go
+++ b/modules/api/pkg/handler/common/cluster.go
@@ -802,7 +802,7 @@ func GetMetricsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGet
 				// Return empty metrics with 200 status code if the cluster is using BYO CNI and the metrics endpoint is unavailable.
 				// This is because cluster unavailability is expected as long as the user cluster admins didn't set up CNI themselves.
 				// Meanwhile we don't want to bother KKP admins with alerts about an error that is not actionable for them.
-				kubermaticlog.Logger.With("cluster", cluster.Name).Warn("returning empty cluster metrics for BYO CNI user cluster since it is unavailable")
+				kubermaticlog.Logger.With("cluster", cluster.Name, "error", err).Warn("returning empty cluster metrics for BYO CNI user cluster since it is unavailable")
 				return &apiv1.ClusterMetrics{Name: cluster.Name}, nil
 			}
 			return nil, common.KubernetesErrorToHTTPError(err)

--- a/modules/api/pkg/handler/common/cluster_test.go
+++ b/modules/api/pkg/handler/common/cluster_test.go
@@ -17,15 +17,26 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
+	"k8c.io/dashboard/v2/pkg/handler/middleware"
+	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/sdk/v2/semver"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestExternalCCMMigration(t *testing.T) {
@@ -216,4 +227,115 @@ func TestExternalCCMMigration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetMetricsEndpointBYOCNIUnavailableReturnsEmptyMetrics(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+
+	cluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+		Spec: kubermaticv1.ClusterSpec{
+			CNIPlugin: &kubermaticv1.CNIPluginSettings{Type: kubermaticv1.CNIPluginTypeNone},
+		},
+	}
+
+	project := &kubermaticv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project-1"}}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+
+	baseClient := ctrlruntimefake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		Build()
+
+	seedClient := ctrlruntimefake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	clusterProvider := &fakeClusterProvider{
+		adminClient: &fakeFailingNodeMetricsClient{
+			Client: baseClient,
+			err:    apierrors.NewServiceUnavailable("the server is currently unable to handle the request"),
+		},
+	}
+
+	ctx := context.WithValue(t.Context(), middleware.ClusterProviderContextKey, clusterProvider)
+	ctx = context.WithValue(ctx, middleware.PrivilegedClusterProviderContextKey, &fakePrivilegedClusterProvider{
+		cluster:    cluster,
+		seedClient: seedClient,
+	})
+
+	resp, err := GetMetricsEndpoint(
+		ctx,
+		adminUserInfoGetter,
+		project.Name,
+		cluster.Name,
+		&fakeProjectProvider{},
+		&fakePrivilegedProjectProvider{project: project},
+	)
+	require.NoError(t, err)
+
+	metrics, ok := resp.(*apiv1.ClusterMetrics)
+	require.Truef(t, ok, "expected *apiv1.ClusterMetrics, got %T", resp)
+	require.Equal(t, cluster.Name, metrics.Name, "returned metrics name should equal cluster name")
+}
+
+type fakeFailingNodeMetricsClient struct {
+	ctrlruntimeclient.Client
+	err error
+}
+
+func (c *fakeFailingNodeMetricsClient) List(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+	if _, ok := list.(*v1beta1.NodeMetricsList); ok {
+		return c.err
+	}
+
+	return c.Client.List(ctx, list, opts...)
+}
+
+type fakeClusterProvider struct {
+	provider.ClusterProvider
+	adminClient ctrlruntimeclient.Client
+}
+
+func (p *fakeClusterProvider) GetAdminClientForUserCluster(_ context.Context, _ *kubermaticv1.Cluster) (ctrlruntimeclient.Client, error) {
+	return p.adminClient, nil
+}
+
+type fakePrivilegedClusterProvider struct {
+	provider.PrivilegedClusterProvider
+	cluster    *kubermaticv1.Cluster
+	seedClient ctrlruntimeclient.Client
+}
+
+func (p *fakePrivilegedClusterProvider) GetUnsecured(_ context.Context, _ *kubermaticv1.Project, _ string, _ *provider.ClusterGetOptions) (*kubermaticv1.Cluster, error) {
+	return p.cluster, nil
+}
+
+func (p *fakePrivilegedClusterProvider) GetSeedClusterAdminRuntimeClient() ctrlruntimeclient.Client {
+	return p.seedClient
+}
+
+type fakeProjectProvider struct {
+	provider.ProjectProvider
+}
+
+type fakePrivilegedProjectProvider struct {
+	provider.PrivilegedProjectProvider
+	project *kubermaticv1.Project
+}
+
+func (p *fakePrivilegedProjectProvider) GetUnsecured(_ context.Context, _ string, _ *provider.ProjectGetOptions) (*kubermaticv1.Project, error) {
+	return p.project, nil
+}
+
+func adminUserInfoGetter(_ context.Context, _ string) (*provider.UserInfo, error) {
+	return &provider.UserInfo{
+		IsAdmin: true,
+		Email:   "admin@example.com",
+		Groups:  []string{"admins"},
+	}, nil
 }

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -37,12 +37,14 @@ import (
 	"k8c.io/dashboard/v2/pkg/provider"
 	"k8c.io/dashboard/v2/pkg/resources/machine"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
 	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
 	"k8c.io/machine-controller/sdk/bootstrap"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -455,6 +457,13 @@ func ListMachineDeploymentMetrics(ctx context.Context, userInfoGetter provider.U
 	if err := dynamicClient.List(ctx, allNodeMetricsList); err != nil {
 		// Happens during cluster creation when the CRD is not setup yet
 		if !meta.IsNoMatchError(err) {
+			if apierrors.IsServiceUnavailable(err) && cluster.Spec.CNIPlugin != nil && cluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeNone {
+				// Return empty metrics with 200 status code if the cluster is using BYO CNI and the metrics endpoint is unavailable.
+				// This is because cluster unavailability is expected as long as the user cluster admins didn't set up CNI themselves.
+				// Meanwhile we don't want to bother KKP admins with alerts about an error that is not actionable for them.
+				kubermaticlog.Logger.With("cluster", cluster.Name).Warn("returning empty node metrics for BYO CNI user cluster since it is unavailable")
+				return make([]apiv1.NodeMetric, 0), nil
+			}
 			return nil, common.KubernetesErrorToHTTPError(err)
 		}
 	}

--- a/modules/api/pkg/handler/common/machine.go
+++ b/modules/api/pkg/handler/common/machine.go
@@ -461,7 +461,7 @@ func ListMachineDeploymentMetrics(ctx context.Context, userInfoGetter provider.U
 				// Return empty metrics with 200 status code if the cluster is using BYO CNI and the metrics endpoint is unavailable.
 				// This is because cluster unavailability is expected as long as the user cluster admins didn't set up CNI themselves.
 				// Meanwhile we don't want to bother KKP admins with alerts about an error that is not actionable for them.
-				kubermaticlog.Logger.With("cluster", cluster.Name).Warn("returning empty node metrics for BYO CNI user cluster since it is unavailable")
+				kubermaticlog.Logger.With("cluster", cluster.Name).With("error", err).Warn("returning empty node metrics for BYO CNI user cluster since it is unavailable")
 				return make([]apiv1.NodeMetric, 0), nil
 			}
 			return nil, common.KubernetesErrorToHTTPError(err)

--- a/modules/api/pkg/handler/common/machine_test.go
+++ b/modules/api/pkg/handler/common/machine_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
+	"k8c.io/dashboard/v2/pkg/handler/middleware"
+	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestListMachineDeploymentMetricsBYOCNIUnavailableReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+	utilruntime.Must(clusterv1alpha1.AddToScheme(scheme))
+
+	project := &kubermaticv1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project-1"}}
+	cluster := &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+		Spec: kubermaticv1.ClusterSpec{
+			CNIPlugin: &kubermaticv1.CNIPluginSettings{Type: kubermaticv1.CNIPluginTypeNone},
+		},
+	}
+
+	md := &clusterv1alpha1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "md-1", Namespace: metav1.NamespaceSystem},
+		Spec: clusterv1alpha1.MachineDeploymentSpec{
+			Template: clusterv1alpha1.MachineTemplateSpec{},
+			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"md-id": "md-1"}},
+		},
+	}
+	machine := &clusterv1alpha1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1", Namespace: metav1.NamespaceSystem, Labels: map[string]string{"md-id": "md-1"}},
+	}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+
+	baseClient := ctrlruntimefake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(md, machine, node).
+		Build()
+
+	clusterProvider := &fakeClusterProvider{
+		adminClient: &fakeFailingNodeMetricsClient{
+			Client: baseClient,
+			err:    apierrors.NewServiceUnavailable("the server is currently unable to handle the request"),
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), middleware.ClusterProviderContextKey, clusterProvider)
+	ctx = context.WithValue(ctx, middleware.PrivilegedClusterProviderContextKey, &fakePrivilegedClusterProvider{cluster: cluster})
+
+	resp, err := ListMachineDeploymentMetrics(
+		ctx,
+		adminUserInfoGetter,
+		&fakeProjectProvider{},
+		&fakePrivilegedProjectProvider{project: project},
+		project.Name,
+		cluster.Name,
+		md.Name,
+	)
+	require.NoError(t, err)
+
+	metrics, ok := resp.([]apiv1.NodeMetric)
+	require.Truef(t, ok, "expected []apiv1.NodeMetric, got %T", resp)
+	require.Equal(t, 0, len(metrics), "expected empty metrics list")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Let the API return empty node/cluster metrics when the corresponding user cluster is unavailable and configured to use a custom CNI provider.
This is to avoid bothering KKP admins with alerts that are not actionable for them since user cluster admins need to set up CNI themselves if they disabled managed CNI for their user cluster.

In case of an unavailable user cluster that has the `none` CNI plugin configured the metrics endpoints behave as follows:
* The Cluster metrics endpoint returns an object with the cluster name but no metrics (the `0` default value).
* The MachineDeployment metrics endpoint returns an empty array, not even listing the available Machines each with their metrics.

Also, the metrics endpoints don't log an error for every request anymore in that case but a warning.

**Behaviour without this fix**
Without this fix the Dashboard API server continuously logs errors like this as soon as there is a user cluster with CNI set to `none` and somebody browsing the detail view of that cluster within the KKP Dashboard:
<details>
<summary>KKP Dashboard API server error log</summary>
```
$ kubectl -n kubermatic logs kubermatic-api-86dd4c47dd-5fgxm | grep "the server is currently unable to handle the request"
{"level":"error","time":"2026-05-07T14:50:44.661Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/e2e-j9f44/clusters/k8c-fba7bc-412b0b-1-35-2/machinedeployments/k8c-fba7bc-4-e3af0284/nodes/metrics"}
{"level":"error","time":"2026-05-07T14:50:59.642Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/e2e-j9f44/clusters/k8c-fba7bc-412b0b-1-35-2/metrics"}
{"level":"error","time":"2026-05-07T14:51:09.599Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/e2e-j9f44/clusters/k8c-fba7bc-412b0b-1-35-2/metrics"}
{"level":"error","time":"2026-05-07T14:51:29.831Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/v79gv9jx5s/metrics"}
{"level":"error","time":"2026-05-07T14:51:35.626Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/e2e-j9f44/clusters/k8c-fba7bc-412b0b-1-35-2/metrics"}
{"level":"error","time":"2026-05-07T14:51:39.720Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/e2e-j9f44/clusters/k8c-fba7bc-412b0b-1-35-2/metrics"}
{"level":"error","time":"2026-05-07T14:51:49.926Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/e2e-j9f44/clusters/k8c-fba7bc-412b0b-1-35-2/metrics"}
{"level":"error","time":"2026-05-08T07:57:07.800Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:57:22.986Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:58:03.505Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:58:16.844Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:58:23.055Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:58:34.974Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:58:51.464Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:59:06.994Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:59:37.974Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T07:59:50.537Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T08:00:23.350Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
{"level":"error","time":"2026-05-08T08:00:54.005Z","caller":"handler/routing.go:152","msg":"the server is currently unable to handle the request","request":"/api/v2/projects/qtwrpljtkm/clusters/gscmldh9c2/metrics"}
```
</details>

Correspondingly, there is an error notification shown within the Dashboard UI periodically:
<img width="422" height="132" alt="grafik" src="https://github.com/user-attachments/assets/c6f82e5e-42ae-4bdd-bc8c-d1a3fb6603ff" />

As a consequence of the Dashboard API server's request errors, the kubermatic-api error rate exceeds the 0.1 threshold eventually (I had to create 3 of those BYO CNI clusters and have a dashboard UI tab for each open in parallel to get there), triggering the [KubermaticAPITooManyErrors](https://github.com/mgoltzsche/kubermatic/blob/d969847a31361de981195d745e0fd44c8355486b/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml#L29) alert:
<img width="1036" height="797" alt="grafik" src="https://github.com/user-attachments/assets/d7bd476b-4c18-4f38-bcda-20f3b7e83ece" />
<img width="703" height="297" alt="grafik" src="https://github.com/user-attachments/assets/5069f389-462e-4f0c-82c7-b51cf5071c44" />

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/15801

Relates to #7643

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cluster/machine metrics endpoints return an empty result for unavailable BYO CNI user clusters to avoid triggering KubermaticAPITooManyErrors alerts
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/dashboard/issues/8063
```
