### PR TITLE
Remove Kyverno package from dashboard

### DIFF
--- a/modules/api/cmd/kubermatic-api/main.go
+++ b/modules/api/cmd/kubermatic-api/main.go
@@ -56,7 +56,6 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
-	kyvernov1 "github.com/kyverno/kyverno/api/kyverno/v1"
 	gatekeeperconfigv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
 	prometheusapi "github.com/prometheus/client_golang/api"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -140,10 +139,6 @@ func main() {
 
 	if err := velerov1.AddToScheme(scheme.Scheme); err != nil {
 		log.Fatalw("failed to register scheme", zap.Stringer("api", velerov1.SchemeGroupVersion), zap.Error(err))
-	}
-
-	if err := kyvernov1.Install(scheme.Scheme); err != nil {
-		log.Fatalw("failed to register scheme", zap.Stringer("api", kyvernov1.SchemeGroupVersion), zap.Error(err))
 	}
 
 	if err := kubeovnv1.AddToScheme(scheme.Scheme); err != nil {

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hetznercloud/hcloud-go v1.59.2
 	github.com/kubeovn/kube-ovn v1.13.11
-	github.com/kyverno/kyverno v1.15.3
 	github.com/minio/minio-go/v7 v7.0.94
 	github.com/onsi/ginkgo v1.16.5
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20250429231206-7a3c70aae2a1 // v0.9.0+
@@ -282,6 +281,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/kyverno/kyverno v1.15.3 // indirect
 	github.com/kyverno/kyverno-json v0.0.4-0.20240730143747-aade3d42fc0e // indirect
 	github.com/lestrrat-go/blackmagic v1.0.4 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
The `github.com/kyverno/kyverno` package was imported solely to register its scheme in `main.go`.
However, the dashboard's kyverno feature only performs CRUD operations on KKP's own `PolicyTemplate` and `PolicyBinding` wrapper types — it never uses the kyverno engine or interacts with kyverno CRDs directly.
The scheme registration was likely added during initial feature development and became redundant once the implementation settled on KKP's wrapper types via `k8c.io/kubermatic/v2`.

**What type of PR is this?**
/kind cleanup


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
