### PR TITLE
Fix trailing grey artifact on Material chips after Angular v21 upgrade

### DIFF
--- a/modules/web/src/assets/css/theme/_main.scss
+++ b/modules/web/src/assets/css/theme/_main.scss
@@ -30,7 +30,7 @@ $my-typography: mat.m2-define-typography-config(
 
 // Restores overflow:visible on chip cells (removed as a default in Angular Material v21 via
 // angular/components#31679 and now only re-applied through this mixin). 
-@include mat.strong-focus-indicators();
+@include mat.strong-focus-indicators;
 
 @mixin theme($theme, $colors) {
   $palette-background: map.get($theme, background);

--- a/modules/web/src/assets/css/theme/_main.scss
+++ b/modules/web/src/assets/css/theme/_main.scss
@@ -28,6 +28,10 @@ $my-typography: mat.m2-define-typography-config(
 @include mat.elevation-classes;
 @include mat.app-background;
 
+// Restores overflow:visible on chip cells (removed as a default in Angular Material v21 via
+// angular/components#31679 and now only re-applied through this mixin). 
+@include mat.strong-focus-indicators();
+
 @mixin theme($theme, $colors) {
   $palette-background: map.get($theme, background);
   $palette-foreground: map.get($theme, foreground);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a visual regression where labels and annotations rendered with `mat-chip` show a residual grey artifact at the chip's trailing edge after the Angular Material v21 upgrade.


#### Dev
<img width="1364" height="232" alt="Screenshot 2026-05-21 at 5 30 15 PM" src="https://github.com/user-attachments/assets/05738a39-bb1f-49e6-9d93-a73dc433f3cf" />

<img width="564" height="206" alt="Screenshot 2026-05-21 at 5 29 52 PM" src="https://github.com/user-attachments/assets/f6c53118-fbaa-4b4c-b3cb-410968f20914" />


#### PR:
<img width="1361" height="208" alt="Screenshot 2026-05-21 at 5 30 12 PM" src="https://github.com/user-attachments/assets/c7d4f892-95b6-4a81-9bd1-a20ef635fe0b" />

<img width="539" height="185" alt="Screenshot 2026-05-21 at 5 30 02 PM" src="https://github.com/user-attachments/assets/2470cd0d-7130-46db-804f-48338244ffa9" />

Caused by 
Dep Update: [PR #8052 (Angular v21 upgrade) bumped @angular/material 20.2.12 → 21.2.9 →](https://github.com/kubermatic/dashboard/pull/8052/changes#diff-763208310a7d99bd77033d3f53879c572d99f4ab5350b82cd5d2142e7ab4c12bL68)
Lib Updated: https://github.com/angular/components/pull/31679

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
NONE

**What type of PR is this?**
/kind bug
/kind regression

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Fix the trailing grey visual artifact from label and annotation chips introduced by Angular Material v21.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
