### PR TITLE
[release/v2.29] Fix incorrect memory/storage values shown after saving project quota

### DIFF
--- a/modules/api/pkg/api/v2/convert.go
+++ b/modules/api/pkg/api/v2/convert.go
@@ -64,7 +64,7 @@ func ConvertToCRDQuota(quota Quota) (kubermaticv1.ResourceDetails, error) {
 	}
 
 	if quota.Memory != nil {
-		mem, err = resource.ParseQuantity(fmt.Sprintf("%fG", *quota.Memory))
+		mem, err = resource.ParseQuantity(fmt.Sprintf("%fGi", *quota.Memory))
 		if err != nil {
 			return kubermaticv1.ResourceDetails{}, fmt.Errorf("error parsing quota Memory %w", err)
 		}
@@ -72,7 +72,7 @@ func ConvertToCRDQuota(quota Quota) (kubermaticv1.ResourceDetails, error) {
 	}
 
 	if quota.Storage != nil {
-		storage, err = resource.ParseQuantity(fmt.Sprintf("%fG", *quota.Storage))
+		storage, err = resource.ParseQuantity(fmt.Sprintf("%fGi", *quota.Storage))
 		if err != nil {
 			return kubermaticv1.ResourceDetails{}, fmt.Errorf("error parsing quota Memory %w", err)
 		}


### PR DESCRIPTION
Manual cherry pick of https://github.com/kubermatic/dashboard/pull/8076

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed Project Resource Quota dialog showing incorrect Memory and Storage values after save.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
