### PR TITLE
Fix user cluster event count and occurrence

### DIFF
--- a/modules/api/pkg/handler/test/helper.go
+++ b/modules/api/pkg/handler/test/helper.go
@@ -1289,6 +1289,27 @@ func GenDefaultExpiry() (apiv1.Time, error) {
 	return apiv1.NewTime(claim.Expiry.Time()), nil
 }
 
+func GenLegacyTestEvent(eventName, eventType, eventReason, eventMessage, kind, uid, involvedObjectName string) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      eventName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		InvolvedObject: corev1.ObjectReference{
+			UID:       types.UID(uid),
+			Name:      involvedObjectName,
+			Namespace: metav1.NamespaceSystem,
+			Kind:      kind,
+		},
+		Reason:        eventReason,
+		Message:       eventMessage,
+		Source:        corev1.EventSource{Component: "eventTest"},
+		LastTimestamp: metav1.NewTime(time.Date(2026, time.May, 28, 8, 0, 0, 0, time.UTC)),
+		Count:         1,
+		Type:          eventType,
+	}
+}
+
 func GenTestEvent(eventName, eventType, eventReason, eventMessage, kind, uid, involvedObjectName string) *corev1.Event {
 	return &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1301,11 +1322,13 @@ func GenTestEvent(eventName, eventType, eventReason, eventMessage, kind, uid, in
 			Namespace: metav1.NamespaceSystem,
 			Kind:      kind,
 		},
-		Reason:  eventReason,
-		Message: eventMessage,
-		Source:  corev1.EventSource{Component: "eventTest"},
-		Count:   1,
-		Type:    eventType,
+		Reason:    eventReason,
+		Message:   eventMessage,
+		Type:      eventType,
+		EventTime: metav1.NewMicroTime(time.Date(2026, time.May, 29, 9, 0, 0, 0, time.UTC)),
+		Series: &corev1.EventSeries{
+			Count: 2,
+		},
 	}
 }
 

--- a/modules/api/pkg/handler/v1/cluster/cluster_test.go
+++ b/modules/api/pkg/handler/v1/cluster/cluster_test.go
@@ -2146,10 +2146,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 2
 		{
@@ -2164,10 +2164,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 3
 		{
@@ -2182,10 +2182,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 4
 		{
@@ -2200,10 +2200,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 5
 		{
@@ -2218,10 +2218,43 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
 			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
+		},
+		// scenario 6
+		{
+			Name:            "scenario 6: list events with series count and event time",
+			HTTPStatus:      http.StatusOK,
+			ClusterIDToSync: test.GenDefaultCluster().Name,
+			ProjectIDToSync: test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			ExistingEvents: []*corev1.Event{
+				test.GenTestEvent("event-3", corev1.EventTypeWarning, "Failed", "failed to reconcile cluster", "Cluster", test.GenDefaultCluster().Name, test.GenDefaultCluster().Name),
+			},
+			ExpectedResult: `[{"name":"event-3","creationTimestamp":"0001-01-01T00:00:00Z","message":"failed to reconcile cluster","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-29T09:00:00Z","count":2}]`,
+		},
+		// scenario 7
+		{
+			Name:            "scenario 7: list mixed legacy and series events",
+			HTTPStatus:      http.StatusOK,
+			ClusterIDToSync: test.GenDefaultCluster().Name,
+			ProjectIDToSync: test.GenDefaultProject().Name,
+			ExistingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			ExistingAPIUser: test.GenDefaultAPIUser(),
+			ExistingEvents: []*corev1.Event{
+				test.GenLegacyTestEvent("event-4", corev1.EventTypeNormal, "Started", "legacy event", "Cluster", test.GenDefaultCluster().Name, test.GenDefaultCluster().Name),
+				test.GenTestEvent("event-5", corev1.EventTypeNormal, "Scaling", "series event", "Cluster", test.GenDefaultCluster().Name, test.GenDefaultCluster().Name),
+			},
+			ExpectedResult: `[{"name":"event-4","creationTimestamp":"0001-01-01T00:00:00Z","message":"legacy event","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-5","creationTimestamp":"0001-01-01T00:00:00Z","message":"series event","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-29T09:00:00Z","count":2}]`,
 		},
 	}
 

--- a/modules/api/pkg/handler/v1/common/conversion.go
+++ b/modules/api/pkg/handler/v1/common/conversion.go
@@ -22,6 +22,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ConvertInternalSSHKeysToExternal(internalKeys []*kubermaticv1.UserSSHKey) []*apiv1.SSHKey {
@@ -74,9 +75,39 @@ func ConvertInternalEventToExternal(event corev1.Event) apiv1.Event {
 			Namespace: event.InvolvedObject.Namespace,
 			Type:      event.InvolvedObject.Kind,
 		},
-		LastTimestamp: apiv1.NewTime(event.LastTimestamp.Time),
-		Count:         event.Count,
+		LastTimestamp: apiv1.NewTime(resolveEventLastTimestamp(event).Time),
+		Count:         resolveEventCount(event),
 	}
+}
+
+func resolveEventCount(event corev1.Event) int32 {
+	if event.Count > 0 {
+		return event.Count
+	}
+
+	if event.Series != nil {
+		if event.Series.Count > 0 {
+			return event.Series.Count
+		}
+
+		// If a series exists but count is unset, treat it as at least one occurrence.
+		return 1
+	}
+
+	// Any emitted event should have at least one occurrence.
+	return 1
+}
+
+func resolveEventLastTimestamp(event corev1.Event) metav1.Time {
+	if !event.LastTimestamp.IsZero() {
+		return event.LastTimestamp
+	}
+
+	if !event.EventTime.IsZero() {
+		return metav1.NewTime(event.EventTime.Time)
+	}
+
+	return event.CreationTimestamp
 }
 
 func ConvertInternalProjectToExternal(kubermaticProject *kubermaticv1.Project, projectOwners []apiv1.User, clustersNumber int) *apiv1.Project {

--- a/modules/api/pkg/handler/v1/node/node_test.go
+++ b/modules/api/pkg/handler/v1/node/node_test.go
@@ -858,10 +858,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 2
 		{
@@ -883,10 +883,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 3
 		{
@@ -908,10 +908,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 4
 		{
@@ -933,10 +933,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 5
 		{
@@ -958,8 +958,8 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
 			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},

--- a/modules/api/pkg/handler/v2/cluster/cluster_test.go
+++ b/modules/api/pkg/handler/v2/cluster/cluster_test.go
@@ -1141,10 +1141,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 2
 		{
@@ -1159,10 +1159,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 3
 		{
@@ -1177,10 +1177,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 4
 		{
@@ -1195,10 +1195,10 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Cluster","namespace":"kube-system","name":"defClusterID"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 5
 		{
@@ -1213,8 +1213,8 @@ func TestGetClusterEventsEndpoint(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Cluster", "venus-1-machine", test.GenDefaultCluster().Name),
 			},
 			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},

--- a/modules/api/pkg/handler/v2/external_cluster/external_cluster_test.go
+++ b/modules/api/pkg/handler/v2/external_cluster/external_cluster_test.go
@@ -744,7 +744,7 @@ func TestGetClusterEvents(t *testing.T) {
 		// scenario 1
 		{
 			Name:             "scenario 1: gets all cluster events",
-			ExpectedResponse: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResponse: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 			ClusterToGet:     "clusterAbcID",
 			HTTPStatus:       http.StatusOK,
 			ExistingNodes: []*corev1.Node{
@@ -754,15 +754,15 @@ func TestGetClusterEvents(t *testing.T) {
 				test.GenExternalCluster(test.GenDefaultProject().Name, "clusterAbcID"),
 			),
 			ExistingNodeEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
 			},
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 		// scenario 2
 		{
 			Name:             "scenario 2: gets only warning events",
-			ExpectedResponse: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResponse: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 			QueryParams:      "?type=warning",
 			ClusterToGet:     "clusterAbcID",
 			HTTPStatus:       http.StatusOK,
@@ -773,15 +773,15 @@ func TestGetClusterEvents(t *testing.T) {
 				test.GenExternalCluster(test.GenDefaultProject().Name, "clusterAbcID"),
 			),
 			ExistingNodeEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
 			},
 			ExistingAPIUser: test.GenDefaultAPIUser(),
 		},
 		// scenario 3
 		{
 			Name:             "scenario 3: the admin John can get any cluster events",
-			ExpectedResponse: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResponse: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"testMachine"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 			ClusterToGet:     "clusterAbcID",
 			HTTPStatus:       http.StatusOK,
 			ExistingNodes: []*corev1.Node{
@@ -795,8 +795,8 @@ func TestGetClusterEvents(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			ExistingNodeEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
 			},
 		},
 		// scenario 4
@@ -815,8 +815,8 @@ func TestGetClusterEvents(t *testing.T) {
 			),
 			ExistingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 			ExistingNodeEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Node", "venus-1-machine", "testMachine"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Node", "venus-1-machine", "testMachine"),
 			},
 		},
 	}

--- a/modules/api/pkg/handler/v2/machine/machine_test.go
+++ b/modules/api/pkg/handler/v2/machine/machine_test.go
@@ -1832,10 +1832,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 2
 		{
@@ -1857,10 +1857,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 3
 		{
@@ -1882,10 +1882,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 4
 		{
@@ -1907,10 +1907,10 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
-			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"0001-01-01T00:00:00Z","count":1}]`,
+			ExpectedResult: `[{"name":"event-1","creationTimestamp":"0001-01-01T00:00:00Z","message":"message started","type":"Normal","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1},{"name":"event-2","creationTimestamp":"0001-01-01T00:00:00Z","message":"message killed","type":"Warning","involvedObject":{"type":"Node","namespace":"kube-system","name":"venus-1"},"lastTimestamp":"2026-05-28T08:00:00Z","count":1}]`,
 		},
 		// scenario 5
 		{
@@ -1932,8 +1932,8 @@ func TestListNodeDeploymentNodesEvents(t *testing.T) {
 				genTestMachine("venus-1", `{"cloudProvider":"digitalocean","cloudProviderSpec":{"token":"dummy-token","region":"fra1","size":"2GB"},"operatingSystem":"ubuntu","containerRuntimeInfo":{"name":"docker","version":"1.13"},"operatingSystemSpec":{"distUpgradeOnBoot":true}}`, map[string]string{"md-id": "123", "some-other": "xyz"}, nil),
 			},
 			ExistingEvents: []*corev1.Event{
-				test.GenTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
-				test.GenTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-1", corev1.EventTypeNormal, "Started", "message started", "Machine", "venus-1-machine", "venus-1"),
+				test.GenLegacyTestEvent("event-2", corev1.EventTypeWarning, "Killed", "message killed", "Machine", "venus-1-machine", "venus-1"),
 			},
 			ExpectedResult: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
 		},

--- a/modules/web/src/app/shared/components/event-list/component.spec.ts
+++ b/modules/web/src/app/shared/components/event-list/component.spec.ts
@@ -55,4 +55,24 @@ describe('EventListComponent', () => {
   it('should return false when there are no events', () => {
     expect(component.hasEvents()).toBeFalsy();
   });
+
+  it('should group duplicate events with undefined count as numeric values', () => {
+    const duplicatedWarningA = {
+      message: 'failed to get tenant',
+      type: 'Warning',
+      involvedObject: {name: 'defClusterID', namespace: 'kubermatic', type: 'Cluster'},
+    } as Event;
+
+    const duplicatedWarningB = {
+      message: 'failed to get tenant',
+      type: 'Warning',
+      involvedObject: {name: 'defClusterID', namespace: 'kubermatic', type: 'Cluster'},
+    } as Event;
+
+    component.events = [duplicatedWarningA, duplicatedWarningB];
+    component.ngOnChanges();
+
+    expect(component.dataSource.data.length).toBe(1);
+    expect(component.dataSource.data[0].count).toBe(component.events.length);
+  });
 });

--- a/modules/web/src/app/shared/components/event-list/component.ts
+++ b/modules/web/src/app/shared/components/event-list/component.ts
@@ -121,12 +121,18 @@ export class EventListComponent implements OnInit, OnChanges, OnDestroy {
 
     events.forEach(event => {
       const hash = this._hash(event);
+      const currentCount = Number.isFinite(event.count) ? event.count : 1;
+
       if (map.has(hash)) {
         const ev = event;
-        ev.count += map.get(hash).count;
+        const existing = map.get(hash);
+        const existingCount = Number.isFinite(existing?.count) ? existing.count : 1;
+        ev.count = currentCount + existingCount;
         map.set(hash, ev);
+        return;
       }
 
+      event.count = currentCount;
       map.set(hash, event);
     });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the user cluster event count and last occurrence date by falling back to
* using `eventTime` instead of `lastTimestamp`
* using `series.count` instead of `count`.

Also, ensures that the frontend can handle `undefined` and `NaN` values.

Previously:
<img width="1652" height="343" alt="Bildschirmfoto vom 2026-05-29 18-35-30" src="https://github.com/user-attachments/assets/fe28b88b-e46f-4d54-bc9c-054f09054695" />
With the fix this PR provides:
<img width="1652" height="343" alt="Bildschirmfoto vom 2026-05-29 18-35-44" src="https://github.com/user-attachments/assets/5824c37d-653c-4a9b-be9d-59b83af21256" />

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/15654

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes the user cluster event count and last occurrence date.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
https://github.com/kubermatic/dashboard/issues/8103
```
