### PR TITLE
Pass correct KubeVirt instancetype kind to providerSpec

### DIFF
--- a/modules/api/cmd/kubermatic-api/swagger.json
+++ b/modules/api/cmd/kubermatic-api/swagger.json
@@ -42466,6 +42466,11 @@
       "description": "VirtualMachineInstanctype represents a KubeVirt VirtualMachineInstanctype",
       "type": "object",
       "properties": {
+        "kind": {
+          "description": "Kind is the KubeVirt resource kind: \"VirtualMachineInstancetype\" (namespaced) or\n\"VirtualMachineClusterInstancetype\" (cluster-scoped). The dashboard must use this\nvalue verbatim when constructing the machine providerSpec instancetype reference.",
+          "type": "string",
+          "x-go-name": "Kind"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"

--- a/modules/api/pkg/api/v2/types.go
+++ b/modules/api/pkg/api/v2/types.go
@@ -1737,6 +1737,10 @@ const (
 // swagger:model VirtualMachineInstancetype
 type VirtualMachineInstancetype struct {
 	Name string `json:"name,omitempty"`
+	// Kind is the KubeVirt resource kind: "VirtualMachineInstancetype" (namespaced) or
+	// "VirtualMachineClusterInstancetype" (cluster-scoped). The dashboard must use this
+	// value verbatim when constructing the machine providerSpec instancetype reference.
+	Kind string `json:"kind,omitempty"`
 	// Spec contains the kvinstancetypealpha1v1.VirtualMachineInstanctype.Spec object marshalled
 	// Required by UI to not embed the whole kubevirt.io API object, but a marshalled spec.
 	Spec string `json:"spec,omitempty"`

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -306,6 +306,7 @@ func newAPIInstancetype(w instancetypeWrapper) (*apiv2.VirtualMachineInstancetyp
 
 	return &apiv2.VirtualMachineInstancetype{
 		Name: w.GetObjectMeta().GetName(),
+		Kind: w.Kind(),
 		Spec: string(spec),
 	}, nil
 }
@@ -566,6 +567,7 @@ func filterInstancetypes(instancetypes *apiv2.VirtualMachineInstancetypeList, ma
 type instancetypeWrapper interface {
 	Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec
 	Category() apiv2.VirtualMachineInstancetypeCategory
+	Kind() string
 	GetObjectMeta() metav1.Object
 }
 
@@ -575,6 +577,10 @@ type customInstancetypeWrapper struct {
 
 func (it *customInstancetypeWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
 	return apiv2.InstancetypeCustom
+}
+
+func (it *customInstancetypeWrapper) Kind() string {
+	return "VirtualMachineClusterInstancetype"
 }
 
 func (it *customInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
@@ -589,6 +595,10 @@ func (it *standardInstancetypeWrapper) Category() apiv2.VirtualMachineInstancety
 	return apiv2.InstancetypeKubermatic
 }
 
+func (it *standardInstancetypeWrapper) Kind() string {
+	return "VirtualMachineInstancetype"
+}
+
 func (it *standardInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
 	return it.VirtualMachineInstancetype.Spec
 }
@@ -601,6 +611,10 @@ type customNamespacedInstancetypeWrapper struct {
 
 func (it *customNamespacedInstancetypeWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
 	return apiv2.InstancetypeCustom
+}
+
+func (it *customNamespacedInstancetypeWrapper) Kind() string {
+	return "VirtualMachineInstancetype"
 }
 
 func (it *customNamespacedInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -44,6 +44,11 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	kindVirtualMachineInstancetype        = "VirtualMachineInstancetype"
+	kindVirtualMachineClusterInstancetype = "VirtualMachineClusterInstancetype"
+)
+
 var NewKubeVirtClient = kubevirt.NewClient
 
 func getKvKubeConfigFromCredentials(ctx context.Context, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider,
@@ -580,7 +585,7 @@ func (it *customInstancetypeWrapper) Category() apiv2.VirtualMachineInstancetype
 }
 
 func (it *customInstancetypeWrapper) Kind() string {
-	return "VirtualMachineClusterInstancetype"
+	return kindVirtualMachineClusterInstancetype
 }
 
 func (it *customInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
@@ -596,7 +601,7 @@ func (it *standardInstancetypeWrapper) Category() apiv2.VirtualMachineInstancety
 }
 
 func (it *standardInstancetypeWrapper) Kind() string {
-	return "VirtualMachineInstancetype"
+	return kindVirtualMachineInstancetype
 }
 
 func (it *standardInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
@@ -614,7 +619,7 @@ func (it *customNamespacedInstancetypeWrapper) Category() apiv2.VirtualMachineIn
 }
 
 func (it *customNamespacedInstancetypeWrapper) Kind() string {
-	return "VirtualMachineInstancetype"
+	return kindVirtualMachineInstancetype
 }
 
 func (it *customNamespacedInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -416,6 +416,28 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 	}
 }
 
+func Test_instancetypeWrapperKind(t *testing.T) {
+	namespaced := &kvinstancetypev1alpha1.VirtualMachineInstancetype{}
+	cluster := &kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{}
+
+	tests := []struct {
+		name    string
+		wrapper instancetypeWrapper
+		want    string
+	}{
+		{name: "cluster-scoped custom", wrapper: &customInstancetypeWrapper{cluster}, want: kindVirtualMachineClusterInstancetype},
+		{name: "kubermatic standard", wrapper: &standardInstancetypeWrapper{namespaced}, want: kindVirtualMachineInstancetype},
+		{name: "namespaced custom", wrapper: &customNamespacedInstancetypeWrapper{namespaced}, want: kindVirtualMachineInstancetype},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.wrapper.Kind(); got != tt.want {
+				t.Errorf("Kind() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // sortedCategoryNames groups instancetype items by category and sorts each
 // name slice, producing a map ready for reflect.DeepEqual against tt.wantNames.
 func sortedCategoryNames(items []instancetypeWrapper) map[apiv2.VirtualMachineInstancetypeCategory][]string {

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -18,11 +18,13 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
 	"testing"
 
+	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
 
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
@@ -122,6 +124,29 @@ func Test_filterInstancetypes(t *testing.T) {
 				addInstanceType(apiv2.InstancetypeKubermatic, 4, "4295M"). // ok
 				toApiWithoutError(),
 		},
+		{
+			name: "gpu instancetype passes cpu/ram filter",
+			instancetypes: &apiv2.VirtualMachineInstancetypeList{
+				Instancetypes: map[apiv2.VirtualMachineInstancetypeCategory][]apiv2.VirtualMachineInstancetype{
+					apiv2.InstancetypeCustom: {
+						mustMarshalInstancetype("standard-gpu-2", getGPUInstancetypeSpec(2, "8Gi", "A100", "nv-a100-standard")),
+					},
+				},
+			},
+			quota: kubermaticv1.MachineFlavorFilter{
+				MinCPU: 1,
+				MaxCPU: 4,
+				MinRAM: 4,
+				MaxRAM: 16,
+			},
+			want: &apiv2.VirtualMachineInstancetypeList{
+				Instancetypes: map[apiv2.VirtualMachineInstancetypeCategory][]apiv2.VirtualMachineInstancetype{
+					apiv2.InstancetypeCustom: {
+						mustMarshalInstancetype("standard-gpu-2", mustScaleMemory(getGPUInstancetypeSpec(2, "8Gi", "A100", "nv-a100-standard"))),
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -196,6 +221,39 @@ func getInstancetypeSpec(cpu uint32, memory string) kvinstancetypev1alpha1.Virtu
 			Guest: resource.MustParse(memory),
 		},
 	}
+}
+
+func getGPUInstancetypeSpec(cpu uint32, memory, gpuName, deviceName string) kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
+	return kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+		CPU: kvinstancetypev1alpha1.CPUInstancetype{
+			Guest: cpu,
+		},
+		Memory: kvinstancetypev1alpha1.MemoryInstancetype{
+			Guest: resource.MustParse(memory),
+		},
+		GPUs: []kubevirtcorev1.GPU{
+			{
+				Name:       gpuName,
+				DeviceName: deviceName,
+			},
+		},
+	}
+}
+
+// mustMarshalInstancetype builds an apiv2.VirtualMachineInstancetype with the spec JSON-marshalled.
+func mustMarshalInstancetype(name string, spec kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec) apiv2.VirtualMachineInstancetype {
+	b, err := json.Marshal(spec)
+	if err != nil {
+		panic(err)
+	}
+	return apiv2.VirtualMachineInstancetype{Name: name, Spec: string(b)}
+}
+
+// mustScaleMemory returns a copy of spec with Memory.Guest converted from BinarySI to
+// DecimalSI (Mega), matching what filterInstancetypes does before returning.
+func mustScaleMemory(spec kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec) kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
+	spec.Memory.Guest = *resource.NewScaledQuantity(spec.Memory.Guest.ScaledValue(resource.Mega), resource.Mega)
+	return spec
 }
 
 // newFakeClient builds a controller-runtime fake client with the KubeVirt
@@ -399,6 +457,47 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			objects:   []ctrlruntimeclient.Object{},
 			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{},
 		},
+		{
+			name: "non-namespaced mode: gpu cluster instancetype returned as custom",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-gpu-2"},
+					Spec:       getGPUInstancetypeSpec(2, "8Gi", "A100", "nv-a100-standard"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
+				apiv2.InstancetypeCustom:     {"standard-gpu-2"},
+				apiv2.InstancetypeKubermatic: standardNames,
+			},
+		},
+		{
+			name: "namespaced mode: gpu instancetype deployed in infra namespace returned as custom",
+			dc: &kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
+						NamespacedMode: &kubermaticv1.NamespacedMode{
+							Enabled:   true,
+							Namespace: "infra-ns",
+						},
+					},
+				},
+			},
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "standard-gpu-2", Namespace: "infra-ns"},
+					Spec:       getGPUInstancetypeSpec(2, "8Gi", "A100", "nv-a100-standard"),
+				},
+			},
+			wantNames: map[apiv2.VirtualMachineInstancetypeCategory][]string{
+				apiv2.InstancetypeCustom:     {"standard-gpu-2"},
+				apiv2.InstancetypeKubermatic: standardNames,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -417,22 +516,31 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 }
 
 func Test_instancetypeWrapperKind(t *testing.T) {
-	namespaced := &kvinstancetypev1alpha1.VirtualMachineInstancetype{}
-	cluster := &kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{}
+	spec := getInstancetypeSpec(4, "8Gi")
+
+	namespaced := &kvinstancetypev1alpha1.VirtualMachineInstancetype{Spec: spec}
+	cluster := &kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{Spec: spec}
 
 	tests := []struct {
-		name    string
-		wrapper instancetypeWrapper
-		want    string
+		name         string
+		wrapper      instancetypeWrapper
+		wantKind     string
+		wantCategory apiv2.VirtualMachineInstancetypeCategory
 	}{
-		{name: "cluster-scoped custom", wrapper: &customInstancetypeWrapper{cluster}, want: kindVirtualMachineClusterInstancetype},
-		{name: "kubermatic standard", wrapper: &standardInstancetypeWrapper{namespaced}, want: kindVirtualMachineInstancetype},
-		{name: "namespaced custom", wrapper: &customNamespacedInstancetypeWrapper{namespaced}, want: kindVirtualMachineInstancetype},
+		{name: "cluster-scoped custom", wrapper: &customInstancetypeWrapper{cluster}, wantKind: kindVirtualMachineClusterInstancetype, wantCategory: apiv2.InstancetypeCustom},
+		{name: "kubermatic standard", wrapper: &standardInstancetypeWrapper{namespaced}, wantKind: kindVirtualMachineInstancetype, wantCategory: apiv2.InstancetypeKubermatic},
+		{name: "namespaced custom", wrapper: &customNamespacedInstancetypeWrapper{namespaced}, wantKind: kindVirtualMachineInstancetype, wantCategory: apiv2.InstancetypeCustom},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.wrapper.Kind(); got != tt.want {
-				t.Errorf("Kind() = %q, want %q", got, tt.want)
+			if got := tt.wrapper.Kind(); got != tt.wantKind {
+				t.Errorf("Kind() = %q, want %q", got, tt.wantKind)
+			}
+			if got := tt.wrapper.Category(); got != tt.wantCategory {
+				t.Errorf("Category() = %q, want %q", got, tt.wantCategory)
+			}
+			if got := tt.wrapper.Spec(); got.CPU.Guest != spec.CPU.Guest || got.Memory.Guest != spec.Memory.Guest {
+				t.Errorf("Spec() = %+v, want CPU=%d memory=%s", got, spec.CPU.Guest, spec.Memory.Guest.String())
 			}
 		})
 	}

--- a/modules/api/pkg/handler/v2/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/v2/provider/kubevirt_test.go
@@ -112,13 +112,13 @@ var (
 
 	instancetypeListResponse = "{\"instancetypes\":" +
 		"{\"custom\":[" +
-		"{\"name\":\"cpu-2-memory-4Gi\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":2},\\\"memory\\\":{\\\"guest\\\":\\\"4295M\\\"}}\"}," +
-		"{\"name\":\"cpu-4-memory-8Gi\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":4},\\\"memory\\\":{\\\"guest\\\":\\\"8590M\\\"}}\"}" +
+		"{\"name\":\"cpu-2-memory-4Gi\",\"kind\":\"VirtualMachineClusterInstancetype\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":2},\\\"memory\\\":{\\\"guest\\\":\\\"4295M\\\"}}\"}," +
+		"{\"name\":\"cpu-4-memory-8Gi\",\"kind\":\"VirtualMachineClusterInstancetype\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":4},\\\"memory\\\":{\\\"guest\\\":\\\"8590M\\\"}}\"}" +
 		"]," +
 		"\"kubermatic\":[" +
-		"{\"name\":\"standard-2\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":2},\\\"memory\\\":{\\\"guest\\\":\\\"8590M\\\"}}\"}," +
-		"{\"name\":\"standard-4\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":4},\\\"memory\\\":{\\\"guest\\\":\\\"17180M\\\"}}\"}," +
-		"{\"name\":\"standard-8\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":8},\\\"memory\\\":{\\\"guest\\\":\\\"34360M\\\"}}\"}]}}"
+		"{\"name\":\"standard-2\",\"kind\":\"VirtualMachineInstancetype\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":2},\\\"memory\\\":{\\\"guest\\\":\\\"8590M\\\"}}\"}," +
+		"{\"name\":\"standard-4\",\"kind\":\"VirtualMachineInstancetype\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":4},\\\"memory\\\":{\\\"guest\\\":\\\"17180M\\\"}}\"}," +
+		"{\"name\":\"standard-8\",\"kind\":\"VirtualMachineInstancetype\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":8},\\\"memory\\\":{\\\"guest\\\":\\\"34360M\\\"}}\"}]}}"
 )
 
 func newClusterInstancetype(cpu uint32, memory string) *kvinstancetypev1alpha1.VirtualMachineClusterInstancetype {

--- a/modules/api/pkg/test/e2e/utils/apiclient/models/virtual_machine_instancetype.go
+++ b/modules/api/pkg/test/e2e/utils/apiclient/models/virtual_machine_instancetype.go
@@ -17,6 +17,11 @@ import (
 // swagger:model VirtualMachineInstancetype
 type VirtualMachineInstancetype struct {
 
+	// Kind is the KubeVirt resource kind: "VirtualMachineInstancetype" (namespaced) or
+	// "VirtualMachineClusterInstancetype" (cluster-scoped). The dashboard must use this
+	// value verbatim when constructing the machine providerSpec instancetype reference.
+	Kind string `json:"kind,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -770,11 +770,19 @@ export class KubeVirtBasicNodeDataComponent
     const sep = this._instanceTypeIDSeparator;
     if (this._instanceTypes?.instancetypes) {
       if (instanceType.kind) {
-        // kind present: unambiguous match by name+kind
+        // kind present: try exact name+kind match first
         for (const [cat, items] of Object.entries(this._instanceTypes.instancetypes)) {
           const found = items.find(it => it.name === instanceType.name && it.kind === instanceType.kind);
           if (found) {
             return `${cat}${sep}${found.kind}${sep}${instanceType.name}`;
+          }
+        }
+        // No exact match — saved kind may be stale (e.g. namespaced custom previously stored
+        // as VirtualMachineClusterInstancetype). Fall back to name-only to recover gracefully.
+        for (const [cat, items] of Object.entries(this._instanceTypes.instancetypes)) {
+          const found = items.find(it => it.name === instanceType.name);
+          if (found) {
+            return `${cat}${sep}${found.kind ?? ''}${sep}${instanceType.name}`;
           }
         }
       } else {

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -36,6 +36,7 @@ import {
   KubeVirtAffinityPreset,
   KubeVirtInstanceType,
   KubeVirtInstanceTypeCategory,
+  KubeVirtInstanceTypeKind,
   KubeVirtInstanceTypeList,
   KubeVirtNodeInstanceType,
   KubeVirtNodePreference,
@@ -402,7 +403,7 @@ export class KubeVirtBasicNodeDataComponent
       const existingKind = existingInstancetype?.name === name ? existingInstancetype?.kind : undefined;
       this._nodeDataService.nodeData.spec.cloud.kubevirt.instancetype = {
         name,
-        kind: this.selectedInstanceType?.kind ?? existingKind,
+        kind: this.selectedInstanceType?.kind ?? existingKind ?? (kind as KubeVirtInstanceTypeKind || undefined),
       };
       this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
 
@@ -761,6 +762,10 @@ export class KubeVirtBasicNodeDataComponent
     }
   }
 
+  // Builds the 3-part selector ID "{category}:{kind}:{name}" used by the form control and
+  // machine-type-selector. Prefers a live lookup in the loaded instancetype list so the ID
+  // always reflects the actual API kind. Falls back to getCategory only when the name is not
+  // present in the list (e.g. before the list loads or after the type is deleted).
   private _getSelectedInstanceTypeId(instanceType: KubeVirtNodeInstanceType): string {
     const sep = this._instanceTypeIDSeparator;
     if (this._instanceTypes?.instancetypes) {
@@ -773,19 +778,25 @@ export class KubeVirtBasicNodeDataComponent
           }
         }
       } else {
-        // kind absent (saved before kind was added to the API): only use name-only match
-        // when exactly one category contains the name — avoids order-dependent results when
-        // the same name exists in multiple categories.
+        // kind absent (saved before kind was added to the API): resolve by name from the
+        // loaded list. When exactly one category contains the name the result is unambiguous.
+        // When multiple categories share the name, prefer custom — ambiguous but consistent
+        // with existing behaviour and anchored to real API data rather than getCategory.
         const matches = Object.entries(this._instanceTypes.instancetypes).filter(([, items]) =>
           items.some(it => it.name === instanceType.name)
         );
         if (matches.length === 1) {
           const found = matches[0][1].find(it => it.name === instanceType.name);
           return `${matches[0][0]}${sep}${found?.kind ?? ''}${sep}${instanceType.name}`;
+        } else if (matches.length > 1) {
+          const preferred =
+            matches.find(([cat]) => cat === KubeVirtInstanceTypeCategory.Custom) ?? matches[0];
+          const found = preferred[1].find(it => it.name === instanceType.name);
+          return `${preferred[0]}${sep}${found?.kind ?? ''}${sep}${instanceType.name}`;
         }
       }
     }
-    // Final fallback: guard against absent kind so getCategory cannot produce an invalid id.
+    // Final fallback: _instanceTypes not loaded or name absent from every category.
     const category = KubeVirtNodeInstanceType.getCategory(instanceType) ?? KubeVirtInstanceTypeCategory.Custom;
     return `${category}${sep}${instanceType.kind ?? ''}${sep}${instanceType.name}`;
   }

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -393,13 +393,16 @@ export class KubeVirtBasicNodeDataComponent
     } else if (this._instanceTypes) {
       const tokens = instanceTypeId.split(this._instanceTypeIDSeparator);
       const category = tokens.shift();
+      const kind = tokens.shift();
       const name = tokens.join(this._instanceTypeIDSeparator);
       this.selectedInstanceType = this._instanceTypes?.instancetypes?.[category]?.find(
-        instanceType => instanceType.name === name
+        instanceType => instanceType.name === name && (!kind || instanceType.kind === kind)
       );
+      const existingInstancetype = this._nodeDataService.nodeData.spec.cloud.kubevirt.instancetype;
+      const existingKind = existingInstancetype?.name === name ? existingInstancetype?.kind : undefined;
       this._nodeDataService.nodeData.spec.cloud.kubevirt.instancetype = {
         name,
-        kind: this.selectedInstanceType?.kind,
+        kind: this.selectedInstanceType?.kind ?? existingKind,
       };
       this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
 
@@ -759,12 +762,14 @@ export class KubeVirtBasicNodeDataComponent
   }
 
   private _getSelectedInstanceTypeId(instanceType: KubeVirtNodeInstanceType): string {
+    const sep = this._instanceTypeIDSeparator;
     if (this._instanceTypes?.instancetypes) {
       if (instanceType.kind) {
         // kind present: unambiguous match by name+kind
         for (const [cat, items] of Object.entries(this._instanceTypes.instancetypes)) {
-          if (items.some(it => it.name === instanceType.name && it.kind === instanceType.kind)) {
-            return `${cat}${this._instanceTypeIDSeparator}${instanceType.name}`;
+          const found = items.find(it => it.name === instanceType.name && it.kind === instanceType.kind);
+          if (found) {
+            return `${cat}${sep}${found.kind}${sep}${instanceType.name}`;
           }
         }
       } else {
@@ -775,13 +780,14 @@ export class KubeVirtBasicNodeDataComponent
           items.some(it => it.name === instanceType.name)
         );
         if (matches.length === 1) {
-          return `${matches[0][0]}${this._instanceTypeIDSeparator}${instanceType.name}`;
+          const found = matches[0][1].find(it => it.name === instanceType.name);
+          return `${matches[0][0]}${sep}${found?.kind ?? ''}${sep}${instanceType.name}`;
         }
       }
     }
     // Final fallback: guard against absent kind so getCategory cannot produce an invalid id.
     const category = KubeVirtNodeInstanceType.getCategory(instanceType) ?? KubeVirtInstanceTypeCategory.Custom;
-    return `${category}${this._instanceTypeIDSeparator}${instanceType.name}`;
+    return `${category}${sep}${instanceType.kind ?? ''}${sep}${instanceType.name}`;
   }
 
   private _getSelectedPreferenceId(preference: KubeVirtNodePreference): string {

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -36,7 +36,6 @@ import {
   KubeVirtAffinityPreset,
   KubeVirtInstanceType,
   KubeVirtInstanceTypeCategory,
-  KubeVirtInstanceTypeKind,
   KubeVirtInstanceTypeList,
   KubeVirtNodeInstanceType,
   KubeVirtNodePreference,
@@ -395,21 +394,12 @@ export class KubeVirtBasicNodeDataComponent
       const tokens = instanceTypeId.split(this._instanceTypeIDSeparator);
       const category = tokens.shift();
       const name = tokens.join(this._instanceTypeIDSeparator);
-      let kind;
-      switch (category) {
-        case KubeVirtInstanceTypeCategory.Kubermatic:
-          kind = KubeVirtInstanceTypeKind.VirtualMachineInstancetype;
-          break;
-        case KubeVirtInstanceTypeCategory.Custom:
-          kind = KubeVirtInstanceTypeKind.VirtualMachineClusterInstancetype;
-          break;
-      }
       this.selectedInstanceType = this._instanceTypes?.instancetypes?.[category]?.find(
         instanceType => instanceType.name === name
       );
       this._nodeDataService.nodeData.spec.cloud.kubevirt.instancetype = {
         name,
-        kind,
+        kind: this.selectedInstanceType?.kind,
       };
       this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
 
@@ -769,6 +759,20 @@ export class KubeVirtBasicNodeDataComponent
   }
 
   private _getSelectedInstanceTypeId(instanceType: KubeVirtNodeInstanceType): string {
+    // Find the actual category by searching the loaded list — kind alone is ambiguous for
+    // namespaced VirtualMachineInstancetype (kubermatic standard vs user-deployed custom).
+    // When kind is absent (specs saved before kind was added to the API), fall back to
+    // name-only matching so the correct kind is sourced from the API response on next save.
+    if (this._instanceTypes?.instancetypes) {
+      for (const [cat, items] of Object.entries(this._instanceTypes.instancetypes)) {
+        const match = instanceType.kind
+          ? items.some(it => it.name === instanceType.name && it.kind === instanceType.kind)
+          : items.some(it => it.name === instanceType.name);
+        if (match) {
+          return `${cat}${this._instanceTypeIDSeparator}${instanceType.name}`;
+        }
+      }
+    }
     const category = KubeVirtNodeInstanceType.getCategory(instanceType);
     return `${category}${this._instanceTypeIDSeparator}${instanceType.name}`;
   }

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -403,7 +403,7 @@ export class KubeVirtBasicNodeDataComponent
       const existingKind = existingInstancetype?.name === name ? existingInstancetype?.kind : undefined;
       this._nodeDataService.nodeData.spec.cloud.kubevirt.instancetype = {
         name,
-        kind: this.selectedInstanceType?.kind ?? existingKind ?? (kind as KubeVirtInstanceTypeKind || undefined),
+        kind: this.selectedInstanceType?.kind ?? existingKind ?? ((kind as KubeVirtInstanceTypeKind) || undefined),
       };
       this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
 
@@ -789,8 +789,7 @@ export class KubeVirtBasicNodeDataComponent
           const found = matches[0][1].find(it => it.name === instanceType.name);
           return `${matches[0][0]}${sep}${found?.kind ?? ''}${sep}${instanceType.name}`;
         } else if (matches.length > 1) {
-          const preferred =
-            matches.find(([cat]) => cat === KubeVirtInstanceTypeCategory.Custom) ?? matches[0];
+          const preferred = matches.find(([cat]) => cat === KubeVirtInstanceTypeCategory.Custom) ?? matches[0];
           const found = preferred[1].find(it => it.name === instanceType.name);
           return `${preferred[0]}${sep}${found?.kind ?? ''}${sep}${instanceType.name}`;
         }

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -759,21 +759,29 @@ export class KubeVirtBasicNodeDataComponent
   }
 
   private _getSelectedInstanceTypeId(instanceType: KubeVirtNodeInstanceType): string {
-    // Find the actual category by searching the loaded list — kind alone is ambiguous for
-    // namespaced VirtualMachineInstancetype (kubermatic standard vs user-deployed custom).
-    // When kind is absent (specs saved before kind was added to the API), fall back to
-    // name-only matching so the correct kind is sourced from the API response on next save.
     if (this._instanceTypes?.instancetypes) {
-      for (const [cat, items] of Object.entries(this._instanceTypes.instancetypes)) {
-        const match = instanceType.kind
-          ? items.some(it => it.name === instanceType.name && it.kind === instanceType.kind)
-          : items.some(it => it.name === instanceType.name);
-        if (match) {
-          return `${cat}${this._instanceTypeIDSeparator}${instanceType.name}`;
+      if (instanceType.kind) {
+        // kind present: unambiguous match by name+kind
+        for (const [cat, items] of Object.entries(this._instanceTypes.instancetypes)) {
+          if (items.some(it => it.name === instanceType.name && it.kind === instanceType.kind)) {
+            return `${cat}${this._instanceTypeIDSeparator}${instanceType.name}`;
+          }
+        }
+      } else {
+        // kind absent (saved before kind was added to the API): only use name-only match
+        // when exactly one category contains the name — avoids order-dependent results when
+        // the same name exists in multiple categories.
+        const matches = Object.entries(this._instanceTypes.instancetypes).filter(([, items]) =>
+          items.some(it => it.name === instanceType.name)
+        );
+        if (matches.length === 1) {
+          return `${matches[0][0]}${this._instanceTypeIDSeparator}${instanceType.name}`;
         }
       }
     }
-    const category = KubeVirtNodeInstanceType.getCategory(instanceType);
+    // Final fallback: guard against absent kind so getCategory cannot produce an invalid id.
+    const category =
+      KubeVirtNodeInstanceType.getCategory(instanceType) ?? KubeVirtInstanceTypeCategory.Custom;
     return `${category}${this._instanceTypeIDSeparator}${instanceType.name}`;
   }
 

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -780,8 +780,7 @@ export class KubeVirtBasicNodeDataComponent
       }
     }
     // Final fallback: guard against absent kind so getCategory cannot produce an invalid id.
-    const category =
-      KubeVirtNodeInstanceType.getCategory(instanceType) ?? KubeVirtInstanceTypeCategory.Custom;
+    const category = KubeVirtNodeInstanceType.getCategory(instanceType) ?? KubeVirtInstanceTypeCategory.Custom;
     return `${category}${this._instanceTypeIDSeparator}${instanceType.name}`;
   }
 

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -401,9 +401,12 @@ export class KubeVirtBasicNodeDataComponent
       );
       const existingInstancetype = this._nodeDataService.nodeData.spec.cloud.kubevirt.instancetype;
       const existingKind = existingInstancetype?.name === name ? existingInstancetype?.kind : undefined;
+      const kindFromToken = Object.values(KubeVirtInstanceTypeKind).includes(kind as KubeVirtInstanceTypeKind)
+        ? (kind as KubeVirtInstanceTypeKind)
+        : undefined;
       this._nodeDataService.nodeData.spec.cloud.kubevirt.instancetype = {
         name,
-        kind: this.selectedInstanceType?.kind ?? existingKind ?? ((kind as KubeVirtInstanceTypeKind) || undefined),
+        kind: this.selectedInstanceType?.kind ?? existingKind ?? kindFromToken,
       };
       this._nodeDataService.nodeDataChanges.next(this._nodeDataService.nodeData);
 

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/machine-type-selector/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/machine-type-selector/component.ts
@@ -201,7 +201,7 @@ export class KubeVirtMachineTypeSelectorComponent implements OnInit, OnChanges, 
 
   /** Parses instance type spec JSON and enriches with computed properties. */
   private _parseInstanceTypeSpec(instanceType: KubeVirtInstanceType, category: string): ParsedInstanceType {
-    const id = `${category}${this._instanceTypeIDSeparator}${instanceType.name}`;
+    const id = `${category}${this._instanceTypeIDSeparator}${instanceType.kind ?? ''}${this._instanceTypeIDSeparator}${instanceType.name}`;
     let cpuValue: number | undefined;
     let memoryValue: string | undefined;
     let gpuCount = 0;

--- a/modules/web/src/app/shared/entity/provider/kubevirt.spec.ts
+++ b/modules/web/src/app/shared/entity/provider/kubevirt.spec.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  KubeVirtInstanceType,
+  KubeVirtInstanceTypeCategory,
+  KubeVirtInstanceTypeKind,
+  KubeVirtNodeInstanceType,
+  KubeVirtNodePreference,
+  KubeVirtPreferenceKind,
+} from './kubevirt';
+
+describe('KubeVirtInstanceType', () => {
+  it('should allow kind to be optional', () => {
+    const it = new KubeVirtInstanceType();
+    it.name = 'standard-2';
+    it.spec = '{}';
+    expect(it.kind).toBeUndefined();
+
+    it.kind = KubeVirtInstanceTypeKind.VirtualMachineInstancetype;
+    expect(it.kind).toBe(KubeVirtInstanceTypeKind.VirtualMachineInstancetype);
+  });
+});
+
+describe('KubeVirtNodeInstanceType.getCategory', () => {
+  it('should return Kubermatic for VirtualMachineInstancetype', () => {
+    const it = new KubeVirtNodeInstanceType();
+    it.kind = KubeVirtInstanceTypeKind.VirtualMachineInstancetype;
+    expect(KubeVirtNodeInstanceType.getCategory(it)).toBe(KubeVirtInstanceTypeCategory.Kubermatic);
+  });
+
+  it('should return Custom for VirtualMachineClusterInstancetype', () => {
+    const it = new KubeVirtNodeInstanceType();
+    it.kind = KubeVirtInstanceTypeKind.VirtualMachineClusterInstancetype;
+    expect(KubeVirtNodeInstanceType.getCategory(it)).toBe(KubeVirtInstanceTypeCategory.Custom);
+  });
+});
+
+describe('KubeVirtNodePreference.getCategory', () => {
+  it('should return Kubermatic for VirtualMachinePreference', () => {
+    const pref = new KubeVirtNodePreference();
+    pref.kind = KubeVirtPreferenceKind.VirtualMachinePreference;
+    expect(KubeVirtNodePreference.getCategory(pref)).toBe(KubeVirtInstanceTypeCategory.Kubermatic);
+  });
+
+  it('should return Custom for VirtualMachineClusterPreference', () => {
+    const pref = new KubeVirtNodePreference();
+    pref.kind = KubeVirtPreferenceKind.VirtualMachineClusterPreference;
+    expect(KubeVirtNodePreference.getCategory(pref)).toBe(KubeVirtInstanceTypeCategory.Custom);
+  });
+});

--- a/modules/web/src/app/shared/entity/provider/kubevirt.spec.ts
+++ b/modules/web/src/app/shared/entity/provider/kubevirt.spec.ts
@@ -23,27 +23,27 @@ import {
 
 describe('KubeVirtInstanceType', () => {
   it('should allow kind to be optional', () => {
-    const it = new KubeVirtInstanceType();
-    it.name = 'standard-2';
-    it.spec = '{}';
-    expect(it.kind).toBeUndefined();
+    const instanceType = new KubeVirtInstanceType();
+    instanceType.name = 'standard-2';
+    instanceType.spec = '{}';
+    expect(instanceType.kind).toBeUndefined();
 
-    it.kind = KubeVirtInstanceTypeKind.VirtualMachineInstancetype;
-    expect(it.kind).toBe(KubeVirtInstanceTypeKind.VirtualMachineInstancetype);
+    instanceType.kind = KubeVirtInstanceTypeKind.VirtualMachineInstancetype;
+    expect(instanceType.kind).toBe(KubeVirtInstanceTypeKind.VirtualMachineInstancetype);
   });
 });
 
 describe('KubeVirtNodeInstanceType.getCategory', () => {
   it('should return Kubermatic for VirtualMachineInstancetype', () => {
-    const it = new KubeVirtNodeInstanceType();
-    it.kind = KubeVirtInstanceTypeKind.VirtualMachineInstancetype;
-    expect(KubeVirtNodeInstanceType.getCategory(it)).toBe(KubeVirtInstanceTypeCategory.Kubermatic);
+    const instanceType = new KubeVirtNodeInstanceType();
+    instanceType.kind = KubeVirtInstanceTypeKind.VirtualMachineInstancetype;
+    expect(KubeVirtNodeInstanceType.getCategory(instanceType)).toBe(KubeVirtInstanceTypeCategory.Kubermatic);
   });
 
   it('should return Custom for VirtualMachineClusterInstancetype', () => {
-    const it = new KubeVirtNodeInstanceType();
-    it.kind = KubeVirtInstanceTypeKind.VirtualMachineClusterInstancetype;
-    expect(KubeVirtNodeInstanceType.getCategory(it)).toBe(KubeVirtInstanceTypeCategory.Custom);
+    const instanceType = new KubeVirtNodeInstanceType();
+    instanceType.kind = KubeVirtInstanceTypeKind.VirtualMachineClusterInstancetype;
+    expect(KubeVirtNodeInstanceType.getCategory(instanceType)).toBe(KubeVirtInstanceTypeCategory.Custom);
   });
 });
 

--- a/modules/web/src/app/shared/entity/provider/kubevirt.ts
+++ b/modules/web/src/app/shared/entity/provider/kubevirt.ts
@@ -21,6 +21,7 @@ export class KubeVirtInstanceTypeList {
 export class KubeVirtInstanceType {
   _id?: string; // unique identifier for dropdown options
   name: string;
+  kind: KubeVirtInstanceTypeKind;
   spec: string;
 }
 

--- a/modules/web/src/app/shared/entity/provider/kubevirt.ts
+++ b/modules/web/src/app/shared/entity/provider/kubevirt.ts
@@ -21,7 +21,7 @@ export class KubeVirtInstanceTypeList {
 export class KubeVirtInstanceType {
   _id?: string; // unique identifier for dropdown options
   name: string;
-  kind: KubeVirtInstanceTypeKind;
+  kind?: KubeVirtInstanceTypeKind;
   spec: string;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The KubeVirt instancetype API response did not include a kind field, so the frontend derived it from the category with a hardcoded mapping: Custom →  VirtualMachineClusterInstancetype. This was wrong for user-deployed namespaced VirtualMachineInstancetype resources, which are also listed under the custom category. The machine providerSpec was created with the wrong kind, causing kkp ee resource quota validation in the kkp admission webhook to fail with  "instancetype not found".

this pr:
  - adds kind to the API response for each instancetype (correct per wrapper type)
  - removes the hardcoded category→kind switch in the frontend; uses kind from the API directly
  - fixes MachineDeployment edit/pre-selection to search the loaded list by name+kind to find the correct display category, with a name-only fallback for specs saved before this fix

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind regression

**Special notes for your reviewer**:

Depends on the [companion kubermatic pr](https://github.com/kubermatic/kubermatic/pull/15958) that fixes the ee webhook to handle user-deployed namespaced instancetypes. The kubermatic pr must be deployed first without the kind field in the api response, `selectedInstanceType?.kind` is undefined, which omits the field from the providerSpec and KubeVirt defaults back to VirtualMachineClusterInstancetype.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
none
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
tbd
```
