### PR TITLE
Fix chip list iterator error when form control receives wrapped tags object

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -637,7 +637,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     if (this.form.get(Controls.NodePortsAllowedIPRanges)?.value) {
       patch.spec.cloud[this._provider] = {
         nodePortsAllowedIPRanges: {
-          cidrBlocks: this.form.get(Controls.NodePortsAllowedIPRanges).value.tags,
+          cidrBlocks: this.form.get(Controls.NodePortsAllowedIPRanges).value,
         },
       };
     }
@@ -690,7 +690,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
     if (!this.isExposeStrategyLoadBalancer()) {
       return null;
     }
-    const apiServerAllowedIPRange = this.form.get(Controls.APIServerAllowedIPRanges).value?.tags;
+    const apiServerAllowedIPRange = this.form.get(Controls.APIServerAllowedIPRanges).value;
     return !apiServerAllowedIPRange ? {cidrBlocks: []} : {cidrBlocks: apiServerAllowedIPRange};
   }
 

--- a/modules/web/src/app/node-data/component.ts
+++ b/modules/web/src/app/node-data/component.ts
@@ -659,7 +659,7 @@ export class NodeDataComponent extends BaseFormValidator implements OnInit, OnDe
     return {
       cidr: this.form.get(Controls.StaticNetworkCIDR).value,
       dns: {
-        servers: this.form.get(Controls.StaticNetworkDNSServers).value?.tags,
+        servers: this.form.get(Controls.StaticNetworkDNSServers).value,
       },
       gateway: this.form.get(Controls.StaticNetworkGateway).value,
     };

--- a/modules/web/src/app/settings/admin/defaults/static-labels-form/component.ts
+++ b/modules/web/src/app/settings/admin/defaults/static-labels-form/component.ts
@@ -110,7 +110,7 @@ export class StaticLabelsFormComponent implements OnInit, OnChanges, OnDestroy {
 
   private _addLabelIfNeeded(): void {
     const lastLabel = this.staticLabelArray.at(this.staticLabelArray.length - 1)?.value;
-    if (lastLabel?.key && lastLabel?.values?.tags?.length) {
+    if (lastLabel?.key && lastLabel?.values?.length) {
       this._addStaticLabel();
     }
   }
@@ -158,7 +158,7 @@ export class StaticLabelsFormComponent implements OnInit, OnChanges, OnDestroy {
       .map(raw => {
         return {
           key: raw.key,
-          values: raw.values.length ? raw.values : raw.values?.tags,
+          values: raw.values,
           protected: raw.protected,
           default: raw.default,
         };

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vmware-cloud-director/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vmware-cloud-director/component.ts
@@ -124,7 +124,7 @@ export class VMwareCloudDirectorSettingsComponent extends BaseFormValidator impl
       apiToken: this.form.get(Controls.APIToken).value,
       organization: this.form.get(Controls.Organization).value,
       vdc: this.form.get(Controls.Vdc).value,
-      ovdcNetworks: this.form.get(Controls.OvdcNetworks).value?.tags,
+      ovdcNetworks: this.form.get(Controls.OvdcNetworks).value,
     } as VMwareCloudDirectorPresetSpec;
   }
 }

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/vsphere/component.ts
@@ -95,7 +95,7 @@ export class VSphereSettingsComponent extends BaseFormValidator implements OnIni
     this._presetDialogService.preset.spec.vsphere = {
       username: this.form.get(Controls.Username).value,
       password: this.form.get(Controls.Password).value,
-      networks: this.form.get(Controls.Networks).value?.tags,
+      networks: this.form.get(Controls.Networks).value,
       datastore: this.form.get(Controls.Datastore).value,
       datastoreCluster: this.form.get(Controls.DatastoreCluster).value,
       resourcePool: this.form.get(Controls.ResourcePool).value,

--- a/modules/web/src/app/shared/components/chip-list/component.spec.ts
+++ b/modules/web/src/app/shared/components/chip-list/component.spec.ts
@@ -13,13 +13,20 @@
 // limitations under the License.
 
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {MatChipInputEvent} from '@angular/material/chips';
 import {BrowserModule} from '@angular/platform-browser';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 import {SharedModule} from '@shared/module';
 import {ChipListComponent} from './component';
 
-describe('TagListComponent', () => {
+const TAGS_CONTROL = 'tags';
+
+function chipInputEvent(value: string): MatChipInputEvent {
+  return {value, chipInput: {clear: jest.fn()}} as unknown as MatChipInputEvent;
+}
+
+describe('ChipListComponent', () => {
   let fixture: ComponentFixture<ChipListComponent>;
   let component: ChipListComponent;
 
@@ -33,9 +40,104 @@ describe('TagListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ChipListComponent);
     component = fixture.componentInstance;
+    component.tags = [];
+    fixture.detectChanges(); // triggers ngOnInit -> builds the form
   });
 
   it('should initialize', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('addTag', () => {
+    it('should add a single trimmed tag and emit it', () => {
+      const spy = jest.spyOn(component.onChange, 'emit');
+
+      component.addTag(chipInputEvent('prod'));
+
+      expect(component.tags).toEqual(['prod']);
+      expect(spy).toHaveBeenCalledWith(['prod']);
+    });
+
+    it('should split multiple values separated by comma or space', () => {
+      component.addTag(chipInputEvent('a, b c'));
+
+      expect(component.tags).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should ignore empty or whitespace-only input', () => {
+      const spy = jest.spyOn(component.onChange, 'emit');
+
+      component.addTag(chipInputEvent('   '));
+
+      expect(component.tags).toEqual([]);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeTag', () => {
+    it('should remove an existing tag and emit the remainder', () => {
+      component.tags = ['a', 'b'];
+      const spy = jest.spyOn(component.onChange, 'emit');
+
+      component.removeTag('a');
+
+      expect(component.tags).toEqual(['b']);
+      expect(spy).toHaveBeenCalledWith(['b']);
+    });
+
+    it('should leave tags unchanged when the tag is absent', () => {
+      component.tags = ['a'];
+
+      component.removeTag('missing');
+
+      expect(component.tags).toEqual(['a']);
+    });
+  });
+
+  describe('writeValue', () => {
+    it('should set the form control and tags for a non-empty array', () => {
+      component.writeValue(['x', 'y']);
+
+      expect(component.tags).toEqual(['x', 'y']);
+      expect(component.form.get(TAGS_CONTROL).value).toEqual(['x', 'y']);
+    });
+
+    it('should ignore an empty array and keep the current value', () => {
+      component.form.get(TAGS_CONTROL).setValue(['keep']);
+
+      component.writeValue([]);
+
+      expect(component.form.get(TAGS_CONTROL).value).toEqual(['keep']);
+    });
+  });
+
+  describe('registerOnChange', () => {
+    it('should propagate the raw tags array, not the wrapped group value', () => {
+      const fn = jest.fn();
+      component.registerOnChange(fn);
+
+      component.form.get(TAGS_CONTROL).setValue(['a', 'b']);
+
+      expect(fn).toHaveBeenCalledWith(['a', 'b']);
+      expect(fn).not.toHaveBeenCalledWith({[TAGS_CONTROL]: ['a', 'b']});
+    });
+  });
+
+  describe('validate', () => {
+    it('should return null when the control is valid', () => {
+      component.writeValue(['ok']);
+
+      expect(component.validate(null)).toBeNull();
+    });
+
+    it('should return errors when required and empty', () => {
+      const requiredFixture = TestBed.createComponent(ChipListComponent);
+      const requiredComponent = requiredFixture.componentInstance;
+      requiredComponent.required = true;
+      requiredComponent.tags = [];
+      requiredFixture.detectChanges();
+
+      expect(requiredComponent.validate(null)).toBeTruthy();
+    });
   });
 });

--- a/modules/web/src/app/shared/components/chip-list/component.ts
+++ b/modules/web/src/app/shared/components/chip-list/component.ts
@@ -29,7 +29,7 @@ import {MatChipInputEvent} from '@angular/material/chips';
 import {KmValidators} from '@shared/validators/validators';
 import _ from 'lodash';
 import {Subject} from 'rxjs';
-import {takeUntil} from 'rxjs/operators';
+import {map, takeUntil} from 'rxjs/operators';
 import {Validators} from '@angular/forms';
 import {LabelFormValidators} from '@app/shared/validators/label-form.validators';
 
@@ -136,19 +136,16 @@ export class ChipListComponent implements OnChanges, OnDestroy, ControlValueAcce
     this.onChange.emit(this.tags);
   }
 
-  writeValue(value: string[] | {tags: string[]}): void {
-    // The form control bound via ControlValueAccessor may receive either a raw
-    // string[] or the wrapped {tags: string[]} emitted by registerOnChange.
-
-    const tags = Array.isArray(value) ? value : value?.tags;
-    if (!_.isEmpty(tags)) {
-      this.form.get(Controls.Tags).setValue(tags, {emitEvent: false});
-      this.tags = tags;
+  writeValue(value: string[]): void {
+    if (!_.isEmpty(value)) {
+      this.form.get(Controls.Tags).setValue(value, {emitEvent: false});
+      this.tags = value;
     }
   }
 
   registerOnChange(fn: any): void {
-    this.form.valueChanges.pipe(takeUntil(this._unsubscribe)).subscribe(fn);
+    // Emit the raw tags array, not the wrapped {tags: string[]} group value.
+    this.form.valueChanges.pipe(map(value => value[Controls.Tags]), takeUntil(this._unsubscribe)).subscribe(fn);
   }
 
   registerOnTouched(_: any): void {}

--- a/modules/web/src/app/shared/components/chip-list/component.ts
+++ b/modules/web/src/app/shared/components/chip-list/component.ts
@@ -136,7 +136,11 @@ export class ChipListComponent implements OnChanges, OnDestroy, ControlValueAcce
     this.onChange.emit(this.tags);
   }
 
-  writeValue(tags: string[]): void {
+  writeValue(value: string[] | {tags: string[]}): void {
+    // The form control bound via ControlValueAccessor may receive either a raw
+    // string[] or the wrapped {tags: string[]} emitted by registerOnChange.
+
+    const tags = Array.isArray(value) ? value : value?.tags;
     if (!_.isEmpty(tags)) {
       this.form.get(Controls.Tags).setValue(tags, {emitEvent: false});
       this.tags = tags;

--- a/modules/web/src/app/shared/components/chip-list/component.ts
+++ b/modules/web/src/app/shared/components/chip-list/component.ts
@@ -145,7 +145,12 @@ export class ChipListComponent implements OnChanges, OnDestroy, ControlValueAcce
 
   registerOnChange(fn: any): void {
     // Emit the raw tags array, not the wrapped {tags: string[]} group value.
-    this.form.valueChanges.pipe(map(value => value[Controls.Tags]), takeUntil(this._unsubscribe)).subscribe(fn);
+    this.form.valueChanges
+      .pipe(
+        map(value => value[Controls.Tags]),
+        takeUntil(this._unsubscribe)
+      )
+      .subscribe(fn);
   }
 
   registerOnTouched(_: any): void {}

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -512,7 +512,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     merge(this.control(Controls.IPFamily).valueChanges, this.control(Controls.NodePortsAllowedIPRanges).valueChanges)
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => {
-        const nodePortsAllowedIPRanges = this.controlValue(Controls.NodePortsAllowedIPRanges)?.tags;
+        const nodePortsAllowedIPRanges = this.controlValue(Controls.NodePortsAllowedIPRanges);
         this._getExtraCloudSpecOptions().nodePortsAllowedIPRanges = {
           cidrBlocks: nodePortsAllowedIPRanges ? nodePortsAllowedIPRanges : [],
         };
@@ -1204,7 +1204,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
     if (this.controlValue(Controls.ExposeStrategy) !== ExposeStrategy.loadbalancer) {
       return apiServerAllowedIPRange;
     }
-    apiServerAllowedIPRange = this.controlValue(Controls.APIServerAllowedIPRanges)?.tags;
+    apiServerAllowedIPRange = this.controlValue(Controls.APIServerAllowedIPRanges);
     return {
       cidrBlocks: apiServerAllowedIPRange ? apiServerAllowedIPRange : [],
     };


### PR DESCRIPTION
**What this PR does / why we need it**:
This mismatch caused an iterator error. This PR fixes the chip list error by accepting both shapes and normalizing to the underlying tags array.

**Cause:**
The writeValue method in the chip list component only accepted a raw string[], but the form control bound via ControlValueAccessor can also receive the wrapped {tags: string[]} object emitted by registerOnChange. 


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #8104 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
