### PR TITLE
Admin settings not loaded after authentication

### DIFF
--- a/modules/web/src/app/core/services/settings.ts
+++ b/modules/web/src/app/core/services/settings.ts
@@ -51,9 +51,9 @@ export class SettingsService {
   get adminSettings(): Observable<AdminSettings> {
     if (!this._adminSettingsWatch$) {
       this._adminSettingsWatch$ = iif(
-        () => this._auth.authenticated(),
-        environment.avoidWebsockets ? this._getAdminSettings() : this._getAdminSettingsWebSocket(),
-        of(DEFAULT_ADMIN_SETTINGS)
+        () => environment.avoidWebsockets,
+        this._getAdminSettings(),
+        this._getAdminSettingsWebSocket()
       );
       this._adminSettingsWatch$.subscribe(settings => this._adminSettings$.next(this._defaultAdminSettings(settings)));
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
The `adminSettings()` getter always returns the default admin settings because the authentication check happens before the `/status` endpoint responds. As a result, `this._auth.authenticated()` is `false` on the initial call, causing `_adminSettingsWatch$` to be initialized with the default settings.

Since both the WebSocket and HTTP approaches for fetching the settings are already protected by authentication, I don't think this additional check is necessary.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
