### PR TITLE
Add Additional tools Webterminal

### DIFF
--- a/hack/images/web-terminal/.bashrc
+++ b/hack/images/web-terminal/.bashrc
@@ -18,3 +18,12 @@ source <(helm completion bash)
 #### krew
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
+### cilium
+source <(cilium completion bash)
+
+### hubble
+source <(hubble completion bash)
+
+### velero
+source <(velero completion bash)
+

--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -93,6 +93,22 @@ RUN curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KRE
   ./krew-linux_${TARGETARCH} install krew && \
   echo "export PATH=${KREW_ROOT:-$HOME/.krew}/bin:$PATH" >> /root/.bashrc
 
+
+# Install Cilium CLI
+RUN curl -L --fail https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${TARGETARCH}.tar.gz | tar -xzO cilium > /usr/local/bin/cilium && \
+  chmod +x /usr/local/bin/cilium && \
+  cilium version --client
+
+# Install Hubble
+RUN curl -L --fail https://github.com/cilium/hubble/releases/download/${HUBBLE_VERSION}/hubble-linux-${TARGETARCH}.tar.gz | tar -xzO hubble > /usr/local/bin/hubble && \
+  chmod +x /usr/local/bin/hubble && \
+  hubble version
+
+# Install Velero CLI
+RUN curl -L --fail https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-${TARGETARCH}.tar.gz | tar -xzO velero-${VELERO_VERSION}-linux-${TARGETARCH}/velero > /usr/local/bin/velero && \
+  chmod +x /usr/local/bin/velero && \
+  velero version --client-only
+
 ENV PATH="/root/.krew/bin:$PATH"
 
 # Krew plugins
@@ -102,8 +118,8 @@ RUN PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH" && \
   kubectl krew install ctx && \
   kubectl krew install ns
 
-RUN mkdir -p /home/webshell/.local/state && \
-    chown -R webshell:webshell /home/webshell/.local
+RUN mkdir -p ${USER_HOME}/.local/state && \
+    chown -R ${USER}:${GROUP} ${USER_HOME}/.local
 
 USER ${USER}
 
@@ -123,21 +139,6 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     mv k8sgpt /usr/bin/k8sgpt && \
     chmod +x /usr/bin/k8sgpt && \
     rm k8sgpt_Linux_${APK_ARCH}.tar.gz
-
-# Install Cilium CLI
-RUN curl -L --fail https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${TARGETARCH}.tar.gz | tar -xzO cilium > /usr/local/bin/cilium && \
-  chmod +x /usr/local/bin/cilium && \
-  cilium version --client
-
-# Install Hubble
-RUN curl -L --fail https://github.com/cilium/hubble/releases/download/${HUBBLE_VERSION}/hubble-linux-${TARGETARCH}.tar.gz | tar -xzO hubble > /usr/local/bin/hubble && \
-  chmod +x /usr/local/bin/hubble && \
-  hubble version
-
-# Install Velero CLI
-RUN curl -L --fail https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-${TARGETARCH}.tar.gz | tar -xzO velero-${VELERO_VERSION}-linux-${TARGETARCH}/velero > /usr/local/bin/velero && \
-  chmod +x /usr/local/bin/velero && \
-  velero version --client-only
 
 USER ${USER}
 COPY .bashrc /tmp/

--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -34,6 +34,15 @@ ENV K9S_VERSION=v0.50.18
 # Source: https://github.com/kubernetes-sigs/krew/releases
 ENV KREW_VERSION=v0.4.5
 
+# Source: https://github.com/cilium/cilium-cli/releases
+ENV CILIUM_CLI_VERSION=v0.19.4
+
+# Source: https://github.com/cilium/hubble/releases
+ENV HUBBLE_VERSION=v1.19.4
+
+# Source: https://github.com/vmware-tanzu/velero/releases
+ENV VELERO_VERSION=v1.18.1
+
 ENV USER=webshell
 ENV GROUP=webshell
 ENV UID=12345
@@ -114,6 +123,21 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     mv k8sgpt /usr/bin/k8sgpt && \
     chmod +x /usr/bin/k8sgpt && \
     rm k8sgpt_Linux_${APK_ARCH}.tar.gz
+
+# Install Cilium CLI
+RUN curl -L --fail https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${TARGETARCH}.tar.gz | tar -xzO cilium > /usr/local/bin/cilium && \
+  chmod +x /usr/local/bin/cilium && \
+  cilium version --client
+
+# Install Hubble
+RUN curl -L --fail https://github.com/cilium/hubble/releases/download/${HUBBLE_VERSION}/hubble-linux-${TARGETARCH}.tar.gz | tar -xzO hubble > /usr/local/bin/hubble && \
+  chmod +x /usr/local/bin/hubble && \
+  hubble version
+
+# Install Velero CLI
+RUN curl -L --fail https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-${TARGETARCH}.tar.gz | tar -xzO velero-${VELERO_VERSION}-linux-${TARGETARCH}/velero > /usr/local/bin/velero && \
+  chmod +x /usr/local/bin/velero && \
+  velero version --client-only
 
 USER ${USER}
 COPY .bashrc /tmp/

--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -40,7 +40,7 @@ ENV CILIUM_CLI_VERSION=v0.19.4
 # Source: https://github.com/cilium/hubble/releases
 ENV HUBBLE_VERSION=v1.19.4
 
-# Source: https://github.com/vmware-tanzu/velero/releases
+# Source: https://github.com/velero-io/velero/releases
 ENV VELERO_VERSION=v1.18.1
 
 ENV USER=webshell
@@ -105,7 +105,7 @@ RUN curl -L --fail https://github.com/cilium/hubble/releases/download/${HUBBLE_V
   hubble version
 
 # Install Velero CLI
-RUN curl -L --fail https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-${TARGETARCH}.tar.gz | tar -xzO velero-${VELERO_VERSION}-linux-${TARGETARCH}/velero > /usr/local/bin/velero && \
+RUN curl -L --fail https://github.com/velero-io/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-${TARGETARCH}.tar.gz | tar -xzO velero-${VELERO_VERSION}-linux-${TARGETARCH}/velero > /usr/local/bin/velero && \
   chmod +x /usr/local/bin/velero && \
   velero version --client-only
 

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 source hack/lib.sh
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.12.0
+VERSION=0.13.0
 SUFFIX=""
 ARCHITECTURES="${ARCHITECTURES:-linux/amd64,linux/arm64/v8}"
 IMAGE="$REPOSITORY:$VERSION$SUFFIX"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7512

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

<img width="1094" height="507" alt="image" src="https://github.com/user-attachments/assets/da74312c-5f13-4062-93d7-eb0036b6b17f" />


## Testing Steps Followed

```
docker run --rm web-terminal:test bash -lc '
kubectl version --client
helm version --short
k9s version
k8sgpt version
kubectl krew version
cilium version --client
hubble version
velero version --client-only
'

Checking Binaries

docker run --rm web-terminal:test bash -lc 'for cmd in cilium hubble velero; do command -v "$cmd" || echo "MISSING: $cmd"; done'
```


#### Velero Backup (Created Backup for exising cluster)

- Setup a new cluster
- Created Backup 
- Checked by getting backup list from Docker Image

<img width="1235" height="65" alt="image" src="https://github.com/user-attachments/assets/07904be1-0b7b-473f-95a3-d29ab8135623" />

UI Backup
<img width="1701" height="322" alt="image" src="https://github.com/user-attachments/assets/4f9e2103-540d-481a-85b9-f759ffb046ee" />


#### Cilium

I have MOUNTED to User Cluster Kubeconfig while running Docker Image Locally (After Build)

- kubectl get pods -n kube-system | grep cilium
-   cilium connectivity test -n kube-system


<img width="1172" height="447" alt="Screenshot 2026-06-16 at 12 35 48 PM" src="https://github.com/user-attachments/assets/f6b24b6f-ee41-4e45-9fa1-3f62cbad8c46" />

<img width="1128" height="842" alt="image" src="https://github.com/user-attachments/assets/d8901e8f-1a80-49d7-9a58-e069ce644170" />

Hubble Only Version Test (Not Sure to Test UI) 

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for cilium. hubble, velero tools support in web-terminal
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
