### PR TITLE
Bump Go version to 1.26.4

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - "./hack/ci/run-api-e2e.sh"
           env:
@@ -60,7 +60,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - make
           args:
@@ -81,7 +81,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - make
             - api-lint
@@ -101,7 +101,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - make
             - api-verify
@@ -121,7 +121,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - make
             - api-build

--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - ./hack/ci/verify.sh
           resources:

--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -103,7 +103,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - make
             - web-check-dependencies
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-1
           command:
             - make
             - web-lint
@@ -139,7 +139,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
           command:
             - make
             - web-check

--- a/Development.md
+++ b/Development.md
@@ -8,7 +8,7 @@ This approach assumes that you have all required dependencies available on your 
 
 - Node >= v22.0.0
 - NPM >= v10.0.0
-- Go v1.24+ (required only by the production build)
+- Go v1.26+ (required only by the production build)
 
 ## Preparation
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/modules/api/.golangci.yml
+++ b/modules/api/.golangci.yml
@@ -37,7 +37,6 @@ linters:
     - errcheck
     - errname
     - errorlint
-    - goconst
     - gocritic
     - gocyclo
     - godot
@@ -105,6 +104,9 @@ linters:
         - '-ST1005'
         # very opinionated naming conventions
         - '-ST1003'
+    gocritic:
+      disabled-checks:
+        - deprecatedComment
   exclusions:
     generated: lax
     presets:
@@ -113,6 +115,9 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      - path: _test\.go
+        linters:
+          - noctx
       # NOTE: Do not use commas in the exclude patterns, or else the regex will be
       # split and you will be sad: https://github.com/golangci/golangci-lint/issues/665
       # gocyclo

--- a/modules/api/go.mod
+++ b/modules/api/go.mod
@@ -1,6 +1,6 @@
 module k8c.io/dashboard/v2
 
-go 1.25.7
+go 1.26.4
 
 require (
 	code.cloudfoundry.org/go-pubsub v0.0.0-20250325104231-893079a7322c

--- a/modules/api/hack/gen-api-client.sh
+++ b/modules/api/hack/gen-api-client.sh
@@ -24,7 +24,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./modules/api/hack/gen-api-client.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./modules/api/hack/gen-api-client.sh
 
 cd $API/cmd/kubermatic-api/
 SWAGGER_FILE="swagger.json"

--- a/modules/api/hack/update-swagger.sh
+++ b/modules/api/hack/update-swagger.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./$API/hack/update-swagger.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./$API/hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd $API/cmd/kubermatic-api/

--- a/modules/api/hack/verify-licenses.sh
+++ b/modules/api/hack/verify-licenses.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.25-node-22-8 containerize ./$API/hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-1 containerize ./$API/hack/verify-licenses.sh
 
 cd $API
 go mod vendor

--- a/modules/api/pkg/handler/v2/kubernetes-dashboard/director.go
+++ b/modules/api/pkg/handler/v2/kubernetes-dashboard/director.go
@@ -19,6 +19,7 @@ package kubernetesdashboard
 import (
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"strings"
 )
@@ -30,15 +31,15 @@ type dashboardProxyDirector struct {
 	originalRequest *http.Request
 }
 
-func (director *dashboardProxyDirector) director() func(*http.Request) {
-	return func(req *http.Request) {
-		req.URL.Scheme = director.proxyURL.Scheme
-		req.URL.Host = director.proxyURL.Host
-		req.Host = director.proxyURL.Host
-		req.URL.Path = director.getBasePath(director.originalRequest.URL.Path)
+func (director *dashboardProxyDirector) rewrite() func(*httputil.ProxyRequest) {
+	return func(preq *httputil.ProxyRequest) {
+		preq.Out.URL.Scheme = director.proxyURL.Scheme
+		preq.Out.URL.Host = director.proxyURL.Host
+		preq.Out.Host = director.proxyURL.Host
+		preq.Out.URL.Path = director.getBasePath(director.originalRequest.URL.Path)
 
-		req.Header.Set("Authorization", director.getAuthorizationHeader())
-		req.Header.Set("X-Forwarded-Host", director.originalRequest.Header.Get("Host"))
+		preq.Out.Header.Set("Authorization", director.getAuthorizationHeader())
+		preq.Out.Header.Set("X-Forwarded-Host", director.originalRequest.Header.Get("Host"))
 	}
 }
 

--- a/modules/api/pkg/handler/v2/kubernetes-dashboard/proxy.go
+++ b/modules/api/pkg/handler/v2/kubernetes-dashboard/proxy.go
@@ -200,7 +200,7 @@ func (h *proxyHandler) proxy(w http.ResponseWriter, request *http.Request) endpo
 
 		// Proxy the request
 		proxy := httputil.NewSingleHostReverseProxy(proxyURL)
-		proxy.Director = newDashboardProxyDirector(proxyURL, token, request).director()
+		proxy.Rewrite = newDashboardProxyDirector(proxyURL, token, request).rewrite()
 		proxy.ServeHTTP(w, request)
 
 		return nil, nil

--- a/modules/web/containers/custom-dashboard/Dockerfile
+++ b/modules/web/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+FROM quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci

--- a/modules/web/go.mod
+++ b/modules/web/go.mod
@@ -1,8 +1,6 @@
 module k8c.io/dashboard/web
 
-go 1.24.0
-
-toolchain go1.24.13
+go 1.26.4
 
 require (
 	github.com/prometheus/client_golang v1.20.5


### PR DESCRIPTION
**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #8120

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

The `chrome-headless` Cypress image is intentionally left on its current tag. It runs only Node/Chrome workloads (no Go), and the Node version is unchanged, so there is no reason to rebuild it for a Go-only bump.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Go version to 1.26.4.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
