### PR TITLE
Fix dashboard reporting "Development" as version on GA releases

### DIFF
--- a/modules/web/Makefile
+++ b/modules/web/Makefile
@@ -46,8 +46,8 @@ LDFLAGS += -extldflags '-static' \
   -X k8c.io/kubermatic/v2/pkg/version/kubermatic.gitVersion=$(GIT_VERSION) \
   -X k8c.io/kubermatic/v2/pkg/version/kubermatic.kubermaticDockerTag=$(KUBERMATICDOCKERTAG) \
   -X k8c.io/kubermatic/v2/pkg/version/kubermatic.uiDockerTag=$(UIDOCKERTAG) \
-  -X cmd/dashboard/main.Edition=${KUBERMATIC_EDITION} \
-  -X cmd/dashboard/main.Version=${HUMAN_VERSION}
+  -X main.Edition=${KUBERMATIC_EDITION} \
+  -X main.Version=${HUMAN_VERSION}
 
 LDFLAGS_EXTRA=-w
 BUILD_DEST ?= _build

--- a/modules/web/cmd/dashboard/main.go
+++ b/modules/web/cmd/dashboard/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Those values will be overridden during the build.
-const (
+var (
 	Version = "Development"
 	Edition = "N/A"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the dashboard logging its version as "Development" on tagged GA releases, which made deployed releases look like accidental dev builds.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7988

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

Tested Locally By Verifying 

**Command:**

```shell
cd modules/web
go build -tags ee -ldflags "-X main.Edition=ee -X main.Version=v2.30.0-TESTING" -o /tmp/d-ee ./cmd/dashboard
timeout 2 /tmp/d-ee 2>&1 | head -1
```

**Output:**

<img width="910" height="131" alt="image" src="https://github.com/user-attachments/assets/d7cd805a-d478-46ef-a0c4-eb465cdf0944" />


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The dashboard now reports its real version and edition at startup instead of always logging "Development".
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
