### PR TITLE
Mount ca-bundle into web terminal pod to fix TLS error

### DIFF
--- a/modules/api/pkg/handler/websocket/terminal.go
+++ b/modules/api/pkg/handler/websocket/terminal.go
@@ -74,6 +74,10 @@ const (
 
 	webTerminalImage                   = resources.WEBTerminalImage
 	webTerminalContainerKubeconfigPath = "/etc/kubernetes/kubeconfig/kubeconfig"
+
+	webTerminalCABundleVolume = "ca-bundle"
+	webTerminalCABundleDir    = "/etc/kubermatic/certs"
+	webTerminalCABundlePath   = webTerminalCABundleDir + "/" + resources.CABundleConfigMapKey
 )
 
 type TerminalConnStatus string
@@ -638,6 +642,10 @@ func genWebTerminalPod(userAppName, userEmailID string, options *kubermaticv1.We
 			Name:  "PS1",
 			Value: "\\s-\\v \\w \\$ ",
 		},
+		{
+			Name:  "SSL_CERT_FILE",
+			Value: webTerminalCABundlePath,
+		},
 	}
 
 	if options != nil && options.AdditionalEnvironmentVariables != nil {
@@ -773,6 +781,22 @@ func getVolumes(userEmailID, userAppName string) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: webTerminalCABundleVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: resources.CABundleConfigMapName,
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  resources.CABundleConfigMapKey,
+							Path: resources.CABundleConfigMapKey,
+						},
+					},
+				},
+			},
+		},
 	}
 	return vs
 }
@@ -816,6 +840,11 @@ func getVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      webTerminalConfigVolume,
 			MountPath: "/etc/config",
+		},
+		{
+			Name:      webTerminalCABundleVolume,
+			MountPath: webTerminalCABundleDir,
+			ReadOnly:  true,
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Mount the `ca-bundle` ConfigMap, and set `SSL_CERT_FILE` so `kubectl` trusts it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7993 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed the web terminal failing with a TLS "unknown authority" error
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
