### PR TITLE
[release/v2.28] - Add vim to web terminal Dockerfile dependencies (#8134)

### DIFF
--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -52,6 +52,7 @@ RUN apk add --no-cache -U \
   openssh-client \
   unzip \
   tar \
+  vim \
   wget
 
 RUN curl -Lo /usr/bin/kubectl https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl && \


### PR DESCRIPTION
**What this PR does / why we need it**:
 This is a manual cherry-pick of #8134

**Special notes for your reviewer**:

- Automated cherrypick didn’t work, as seen [here](https://github.com/kubermatic/dashboard/pull/8134#issuecomment-4777869423):
 
/assign @ahmadhamzh 

```release-note
vim is now pre-installed in the web-terminal image
```

