### PR TITLE
switch dashboard api-e2e cluster-create test from Hetzner to AWS

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -22,6 +22,7 @@ presubmits:
       preset-hetzner: "true"
       preset-openstack: "true"
       preset-azure: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"

--- a/hack/ci/run-api-e2e.sh
+++ b/hack/ci/run-api-e2e.sh
@@ -80,6 +80,20 @@ spec:
 EOF
 retry 2 kubectl apply -f preset-hetzner.yaml
 
+echodate "Creating AWS preset..."
+cat << EOF > preset-aws.yaml
+apiVersion: kubermatic.k8c.io/v1
+kind: Preset
+metadata:
+  name: e2e-aws
+  namespace: kubermatic
+spec:
+  aws:
+    accessKeyID: ${AWS_E2E_TESTS_KEY_ID}
+    secretAccessKey: ${AWS_E2E_TESTS_SECRET}
+EOF
+retry 2 kubectl apply -f preset-aws.yaml
+
 echodate "Creating DigitalOcean preset..."
 cat << EOF > preset-digitalocean.yaml
 apiVersion: kubermatic.k8c.io/v1

--- a/modules/api/pkg/test/e2e/api/aws_test.go
+++ b/modules/api/pkg/test/e2e/api/aws_test.go
@@ -1,7 +1,7 @@
-//go:build hetzner_e2e
+//go:build create
 
 /*
-Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,14 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-func TestCreateUpdateHetznerCluster(t *testing.T) {
+func TestCreateUpdateAWSCluster(t *testing.T) {
 	tests := []createCluster{
 		{
-			name:       "create cluster on Hetzner",
+			name:       "create cluster on AWS",
 			dc:         "kubermatic",
-			location:   "hetzner-hel1",
+			location:   "aws-eu-central-1a",
 			version:    utils.KubernetesVersion(),
-			credential: "e2e-hetzner",
+			credential: "e2e-aws",
 			replicas:   1,
 			patch: utils.PatchCluster{
 				Name:   "newName",
@@ -66,14 +66,14 @@ func TestCreateUpdateHetznerCluster(t *testing.T) {
 			}
 
 			testClient := utils.NewTestClient(masterToken, t)
-			project, cluster := createProjectWithCluster(t, testClient, tc.dc, tc.credential, tc.version, tc.location, tc.replicas)
+			project, cluster := createProjectWithAWSCluster(t, testClient, tc.dc, tc.credential, tc.version, tc.location, tc.replicas)
 			defer cleanupProject(t, project.ID)
 			testCluster(ctx, masterToken, project, cluster, testClient, tc, t)
 		})
 	}
 }
 
-func TestDeleteClusterBeforeIsUp(t *testing.T) {
+func TestDeleteAWSClusterBeforeIsUp(t *testing.T) {
 	tests := []struct {
 		name       string
 		dc         string
@@ -85,9 +85,9 @@ func TestDeleteClusterBeforeIsUp(t *testing.T) {
 		{
 			name:       "delete cluster before is up",
 			dc:         "kubermatic",
-			location:   "hetzner-hel1",
+			location:   "aws-eu-central-1a",
 			version:    utils.KubernetesVersion(),
-			credential: "e2e-hetzner",
+			credential: "e2e-aws",
 			replicas:   0,
 		},
 	}
@@ -108,7 +108,7 @@ func TestDeleteClusterBeforeIsUp(t *testing.T) {
 			}
 			defer cleanupProject(t, project.ID)
 
-			cluster, err := testClient.CreateHetznerCluster(project.ID, tc.dc, rand.String(10), tc.credential, tc.version, tc.location, tc.replicas)
+			cluster, err := testClient.CreateAWSCluster(project.ID, tc.dc, rand.String(10), tc.credential, tc.version, tc.location, tc.replicas)
 			if err != nil {
 				t.Fatalf("failed to create cluster: %v", err)
 			}
@@ -126,13 +126,13 @@ func TestDeleteClusterBeforeIsUp(t *testing.T) {
 	}
 }
 
-func createProjectWithCluster(t *testing.T, testClient *utils.TestClient, dc, credential, version, location string, replicas int32) (*apiv1.Project, *apiv1.Cluster) {
+func createProjectWithAWSCluster(t *testing.T, testClient *utils.TestClient, dc, credential, version, location string, replicas int32) (*apiv1.Project, *apiv1.Cluster) {
 	project, err := testClient.CreateProject(rand.String(10))
 	if err != nil {
 		t.Fatalf("failed to create project %v", err)
 	}
 
-	cluster, err := testClient.CreateHetznerCluster(project.ID, dc, rand.String(10), credential, version, location, replicas)
+	cluster, err := testClient.CreateAWSCluster(project.ID, dc, rand.String(10), credential, version, location, replicas)
 	if err != nil {
 		t.Fatalf("failed to create cluster: %v", err)
 	}

--- a/modules/api/pkg/test/e2e/utils/client.go
+++ b/modules/api/pkg/test/e2e/utils/client.go
@@ -432,6 +432,69 @@ func (r *TestClient) ListCredentials(providerName, datacenter string) ([]string,
 	return names, nil
 }
 
+// CreateAWSCluster creates cluster for AWS provider. Credentials are injected
+// via the named preset, so the cloud spec is left empty.
+func (r *TestClient) CreateAWSCluster(projectID, dc, name, credential, version, location string, replicas int32) (*apiv1.Cluster, error) {
+	_, err := semverlib.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
+	}
+
+	clusterSpec := &models.CreateClusterSpec{}
+	clusterSpec.Cluster = &models.Cluster{
+		Type:       "kubernetes",
+		Name:       name,
+		Credential: credential,
+		Spec: &models.ClusterSpec{
+			Cloud: &models.CloudSpec{
+				DatacenterName: location,
+				Aws:            &models.AWSCloudSpec{},
+			},
+			Version: models.Semver(version),
+		},
+	}
+
+	if replicas > 0 {
+		instanceType := "t3.small"
+		volumeSize := int32(25)
+		volumeType := "gp2"
+
+		clusterSpec.NodeDeployment = &models.NodeDeployment{
+			Spec: &models.NodeDeploymentSpec{
+				Replicas: &replicas,
+				Template: &models.NodeSpec{
+					Cloud: &models.NodeCloudSpec{
+						Aws: &models.AWSNodeSpec{
+							InstanceType: &instanceType,
+							VolumeSize:   &volumeSize,
+							VolumeType:   &volumeType,
+						},
+					},
+					OperatingSystem: &models.OperatingSystemSpec{
+						Ubuntu: &models.UbuntuSpec{
+							DistUpgradeOnBoot: false,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	r.test.Logf("Creating AWS cluster %q (%s, %d nodes)...", name, version, replicas)
+
+	params := &project.CreateClusterParams{ProjectID: projectID, DC: dc, Body: clusterSpec}
+	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+
+	clusterResponse, err := r.client.Project.CreateCluster(params, r.bearerToken)
+	if err != nil {
+		return nil, err
+	}
+
+	r.test.Log("Cluster created successfully.")
+
+	return convertCluster(clusterResponse.Payload)
+}
+
 // CreateKubevirtCluster creates cluster for Kubevirt provider.
 func (r *TestClient) CreateKubevirtCluster(projectID, dc, name, credential, version, location string, replicas int32) (*apiv1.Cluster, error) {
 	_, err := semverlib.NewVersion(version)
@@ -549,69 +612,6 @@ func (r *TestClient) CreateHetznerCluster(projectID, dc, name, credential, versi
 	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
 
 	r.test.Logf("Creating Hetzner cluster %q (%s, %d nodes)...", name, version, replicas)
-
-	clusterResponse, err := r.client.Project.CreateCluster(params, r.bearerToken)
-	if err != nil {
-		return nil, err
-	}
-
-	r.test.Log("Cluster created successfully.")
-
-	return convertCluster(clusterResponse.Payload)
-}
-
-// CreateAWSCluster creates cluster for AWS provider. Credentials are injected
-// via the named preset, so the cloud spec is left empty.
-func (r *TestClient) CreateAWSCluster(projectID, dc, name, credential, version, location string, replicas int32) (*apiv1.Cluster, error) {
-	_, err := semverlib.NewVersion(version)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
-	}
-
-	clusterSpec := &models.CreateClusterSpec{}
-	clusterSpec.Cluster = &models.Cluster{
-		Type:       "kubernetes",
-		Name:       name,
-		Credential: credential,
-		Spec: &models.ClusterSpec{
-			Cloud: &models.CloudSpec{
-				DatacenterName: location,
-				Aws:            &models.AWSCloudSpec{},
-			},
-			Version: models.Semver(version),
-		},
-	}
-
-	if replicas > 0 {
-		instanceType := "t3.small"
-		volumeSize := int32(25)
-		volumeType := "gp2"
-
-		clusterSpec.NodeDeployment = &models.NodeDeployment{
-			Spec: &models.NodeDeploymentSpec{
-				Replicas: &replicas,
-				Template: &models.NodeSpec{
-					Cloud: &models.NodeCloudSpec{
-						Aws: &models.AWSNodeSpec{
-							InstanceType: &instanceType,
-							VolumeSize:   &volumeSize,
-							VolumeType:   &volumeType,
-						},
-					},
-					OperatingSystem: &models.OperatingSystemSpec{
-						Ubuntu: &models.UbuntuSpec{
-							DistUpgradeOnBoot: false,
-						},
-					},
-				},
-			},
-		}
-	}
-
-	params := &project.CreateClusterParams{ProjectID: projectID, DC: dc, Body: clusterSpec}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
-
-	r.test.Logf("Creating AWS cluster %q (%s, %d nodes)...", name, version, replicas)
 
 	clusterResponse, err := r.client.Project.CreateCluster(params, r.bearerToken)
 	if err != nil {

--- a/modules/api/pkg/test/e2e/utils/client.go
+++ b/modules/api/pkg/test/e2e/utils/client.go
@@ -432,81 +432,6 @@ func (r *TestClient) ListCredentials(providerName, datacenter string) ([]string,
 	return names, nil
 }
 
-// CreateAWSCluster creates cluster for AWS provider.
-func (r *TestClient) CreateAWSCluster(projectID, dc, name, secretAccessKey, accessKeyID, version, location, availabilityZone, proxyMode string, replicas int32, konnectivityEnabled bool, cniSettings *models.CNIPluginSettings) (*apiv1.Cluster, error) {
-	_, err := semverlib.NewVersion(version)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
-	}
-
-	clusterSpec := &models.CreateClusterSpec{}
-	clusterSpec.Cluster = &models.Cluster{
-		Type: "kubernetes",
-		Name: name,
-		Spec: &models.ClusterSpec{
-			Cloud: &models.CloudSpec{
-				DatacenterName: location,
-				Aws: &models.AWSCloudSpec{
-					SecretAccessKey: secretAccessKey,
-					AccessKeyID:     accessKeyID,
-				},
-			},
-			Version:   models.Semver(version),
-			CniPlugin: cniSettings,
-			ClusterNetwork: &models.ClusterNetworkingConfig{
-				ProxyMode: proxyMode,
-			},
-		},
-	}
-
-	if konnectivityEnabled {
-		clusterSpec.Cluster.Spec.ClusterNetwork = &models.ClusterNetworkingConfig{
-			KonnectivityEnabled: true,
-		}
-	}
-
-	if replicas > 0 {
-		instanceType := "t3.small"
-		volumeSize := int32(25)
-		volumeType := "standard"
-
-		clusterSpec.NodeDeployment = &models.NodeDeployment{
-			Spec: &models.NodeDeploymentSpec{
-				Replicas: &replicas,
-				Template: &models.NodeSpec{
-					Cloud: &models.NodeCloudSpec{
-						Aws: &models.AWSNodeSpec{
-							AvailabilityZone: availabilityZone,
-							InstanceType:     &instanceType,
-							VolumeSize:       &volumeSize,
-							VolumeType:       &volumeType,
-						},
-					},
-					OperatingSystem: &models.OperatingSystemSpec{
-						Ubuntu: &models.UbuntuSpec{
-							DistUpgradeOnBoot: false,
-						},
-					},
-				},
-			},
-		}
-	}
-
-	r.test.Logf("Creating AWS cluster %q (%s, %d nodes)...", name, version, replicas)
-
-	params := &project.CreateClusterParams{ProjectID: projectID, DC: dc, Body: clusterSpec}
-	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
-
-	clusterResponse, err := r.client.Project.CreateCluster(params, r.bearerToken)
-	if err != nil {
-		return nil, err
-	}
-
-	r.test.Log("Cluster created successfully.")
-
-	return convertCluster(clusterResponse.Payload)
-}
-
 // CreateKubevirtCluster creates cluster for Kubevirt provider.
 func (r *TestClient) CreateKubevirtCluster(projectID, dc, name, credential, version, location string, replicas int32) (*apiv1.Cluster, error) {
 	_, err := semverlib.NewVersion(version)
@@ -624,6 +549,69 @@ func (r *TestClient) CreateHetznerCluster(projectID, dc, name, credential, versi
 	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
 
 	r.test.Logf("Creating Hetzner cluster %q (%s, %d nodes)...", name, version, replicas)
+
+	clusterResponse, err := r.client.Project.CreateCluster(params, r.bearerToken)
+	if err != nil {
+		return nil, err
+	}
+
+	r.test.Log("Cluster created successfully.")
+
+	return convertCluster(clusterResponse.Payload)
+}
+
+// CreateAWSCluster creates cluster for AWS provider. Credentials are injected
+// via the named preset, so the cloud spec is left empty.
+func (r *TestClient) CreateAWSCluster(projectID, dc, name, credential, version, location string, replicas int32) (*apiv1.Cluster, error) {
+	_, err := semverlib.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %s: %w", version, err)
+	}
+
+	clusterSpec := &models.CreateClusterSpec{}
+	clusterSpec.Cluster = &models.Cluster{
+		Type:       "kubernetes",
+		Name:       name,
+		Credential: credential,
+		Spec: &models.ClusterSpec{
+			Cloud: &models.CloudSpec{
+				DatacenterName: location,
+				Aws:            &models.AWSCloudSpec{},
+			},
+			Version: models.Semver(version),
+		},
+	}
+
+	if replicas > 0 {
+		instanceType := "t3.small"
+		volumeSize := int32(25)
+		volumeType := "gp2"
+
+		clusterSpec.NodeDeployment = &models.NodeDeployment{
+			Spec: &models.NodeDeploymentSpec{
+				Replicas: &replicas,
+				Template: &models.NodeSpec{
+					Cloud: &models.NodeCloudSpec{
+						Aws: &models.AWSNodeSpec{
+							InstanceType: &instanceType,
+							VolumeSize:   &volumeSize,
+							VolumeType:   &volumeType,
+						},
+					},
+					OperatingSystem: &models.OperatingSystemSpec{
+						Ubuntu: &models.UbuntuSpec{
+							DistUpgradeOnBoot: false,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	params := &project.CreateClusterParams{ProjectID: projectID, DC: dc, Body: clusterSpec}
+	SetupParams(r.test, params, 1*time.Second, 3*time.Minute)
+
+	r.test.Logf("Creating AWS cluster %q (%s, %d nodes)...", name, version, replicas)
 
 	clusterResponse, err := r.client.Project.CreateCluster(params, r.bearerToken)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `pre-dashboard-api-e2e` prow job is failing on every dashboard PR (8161, 8163, 8166, …) with the same error: `TestCreateUpdateHetznerCluster` creates a Hetzner cluster whose control plane becomes healthy, but the worker node never reaches `Ready` within the 15m timeout (`hetzner_test.go:145`, `NodeDeployment has not reached 1 ready replicas`). The failure is environmental to the shared Hetzner e2e setup, not a regression in any individual PR.

This switches the cluster-create e2e test to AWS so the job can pass, while keeping the Hetzner test code on disk for later re-enablement.

Changes:
- `hetzner_test.go`: retag `//go:build create` → `//go:build hetzner_e2e` to disable both Hetzner tests in CI (file + helpers preserved; mirrors the existing `kubevirt_test.go` exclusion convention).
- `aws_test.go` (new, tag `create`): `TestCreateUpdateAWSCluster` + `TestDeleteAWSClusterBeforeIsUp` targeting `dc=kubermatic`, `location=aws-eu-central-1a`, `credential=e2e-aws`, reusing the shared `createCluster`/`testCluster`/`cleanupProject` helpers.
- `utils/client.go`: add a preset-based `CreateAWSCluster(projectID, dc, name, credential, version, location, replicas)`; remove the prior unused inline-credential `CreateAWSCluster` (no callers) it conflicts with.
- `run-api-e2e.sh`: add an `e2e-aws` Preset heredoc reading `AWS_E2E_TESTS_KEY_ID`/`AWS_E2E_TESTS_SECRET` (e2e-hetzner kept so `credentials_test.go` still passes).
- `.prow/api.yaml`: attach `preset-aws-e2e-kkp: "true"` to the `pre-dashboard-api-e2e` job.

AWS credentials (`preset-aws-e2e-kkp` / secret `e2e-aws-kkp`) and the `aws-eu-central-1a` datacenter already exist, so no new secrets or seed changes are required.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

WIP — the local build/vet/gofmt/boilerplate checks pass, but this needs a real CI run to confirm the AWS cluster comes up in `aws-eu-central-1a`. Re-enabling Hetzner later is a one-line build-tag flip back to `create`.

The larger `client.go` diff is because the pre-existing `CreateAWSCluster` (12-arg inline-credential signature, no callers) had to be removed to avoid a duplicate-method compile error; the new method matches the Hetzner preset pattern.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

```test-issue
NONE
```
