### PR TITLE
[release/v2.29] - Fix KubeLB option precedence enforced over enabled (#7999)

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -485,11 +485,16 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   private _isKubeLBEnabled(datacenter: Datacenter, seedSettings: SeedSettings): boolean {
-    return !!(
-      datacenter.spec.kubelb?.enforced ||
-      datacenter.spec.kubelb?.enabled ||
-      seedSettings?.kubelb?.enableForAllDatacenters
-    );
+    if (datacenter.spec.kubelb?.enforced) {
+      return true;
+    }
+    if (datacenter.spec.kubelb?.enabled === false) {
+      return false;
+    }
+    if (datacenter.spec.kubelb?.enabled) {
+      return true;
+    }
+    return !!seedSettings?.kubelb?.enableForAllDatacenters;
   }
 
   private _getCBSL(projectID: string): void {

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -1270,10 +1270,15 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   private _isKubeLBEnabled(datacenter: Datacenter, seedSettings: SeedSettings): boolean {
-    return !!(
-      datacenter.spec.kubelb?.enforced ||
-      datacenter.spec.kubelb?.enabled ||
-      seedSettings?.kubelb?.enableForAllDatacenters
-    );
+    if (datacenter.spec.kubelb?.enforced) {
+      return true;
+    }
+    if (datacenter.spec.kubelb?.enabled === false) {
+      return false;
+    }
+    if (datacenter.spec.kubelb?.enabled) {
+      return true;
+    }
+    return !!seedSettings?.kubelb?.enableForAllDatacenters;
   }
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubermatic/dashboard/pull/7999

FYI: Automated cherrypick didn’t work, as seen https://github.com/kubermatic/dashboard/pull/7999#issuecomment-4901878509

```release-note
Fixes KubeLB option precedence so enforced datacenters always show the option regardless of the enabled flag.
```

/assign KhizerRehan