### PR TITLE
Automate web-terminal image releases

### DIFF
--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -31,3 +31,17 @@ presubmits:
           env:
             - name: KUBERMATIC_EDITION
               value: ee
+
+  - name: pre-dashboard-web-terminal-tag
+    run_if_changed: "^hack/images/web-terminal/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
+          command:
+            - ./hack/verify-web-terminal-tag.sh
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m

--- a/hack/images/web-terminal/metadata.yaml
+++ b/hack/images/web-terminal/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Source of truth for the web-terminal image release. Bump the tag to cut a new
+# release; a postsubmit job rebuilds and pushes when this file changes and the
+# tag does not yet exist in the registry.
+# After the release is published, bump WEBTerminalImage in
+# kubermatic/pkg/resources/resources.go so user clusters pick up the new image.
+tag: "0.13.0"

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -20,11 +20,29 @@ cd $(dirname $0)/../../..
 source hack/lib.sh
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.13.0
+# read the tag from metadata.yaml so it has a single source of truth;
+# the path is relative to the repo root because of the cd above
+METADATA_FILE=hack/images/web-terminal/metadata.yaml
+# take the value after the first "tag:" and strip whitespace and quotes
+VERSION="$(grep -E '^tag:' "$METADATA_FILE" | head -n1 | cut -d: -f2- | tr -d ' \t"')"
+
+if [ -z "$VERSION" ]; then
+  echodate "No tag found in $METADATA_FILE"
+  exit 1
+fi
+
 SUFFIX=""
 ARCHITECTURES="${ARCHITECTURES:-linux/amd64,linux/arm64/v8}"
 IMAGE="$REPOSITORY:$VERSION$SUFFIX"
 MANIFEST="${MANIFEST:-$IMAGE}"
+
+# skip if the tag already exists in the registry; makes the postsubmit
+# idempotent so re-runs or re-merges of the same tag do not rebuild
+# retry so a transient registry error is not read as "tag missing"
+if retry 3 docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+  echodate "Image $IMAGE already exists in the registry, skipping build."
+  exit 0
+fi
 
 # build multi-arch images
 #  start_docker_daemon_ci
@@ -36,4 +54,4 @@ docker buildx build ./hack/images/web-terminal \
   --push \
   --tag "$IMAGE"
 
-echodate "Successfully build and pushed image for all architectures."
+echodate "Successfully built and pushed image for all architectures."

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -39,7 +39,7 @@ MANIFEST="${MANIFEST:-$IMAGE}"
 # skip if the tag already exists in the registry; makes the postsubmit
 # idempotent so re-runs or re-merges of the same tag do not rebuild
 # retry so a transient registry error is not read as "tag missing"
-if retry 3 docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+if retry 3 docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
   echodate "Image $IMAGE already exists in the registry, skipping build."
   exit 0
 fi

--- a/hack/verify-web-terminal-tag.sh
+++ b/hack/verify-web-terminal-tag.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Changes under hack/images/web-terminal/ only reach users through a new image
+# release, so any change there must come with an unpublished tag in
+# metadata.yaml. The presubmit runs this script only when files in that
+# directory change.
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+source hack/lib.sh
+
+METADATA_FILE=hack/images/web-terminal/metadata.yaml
+TAG="$(grep -E '^tag:' "$METADATA_FILE" | head -n1 | cut -d: -f2- | tr -d ' \t"')"
+
+if [ -z "$TAG" ]; then
+  echodate "No tag found in $METADATA_FILE"
+  exit 1
+fi
+
+# quay's public API needs no credentials for public repositories
+COUNT="$(retry 3 curl --fail --silent \
+  "https://quay.io/api/v1/repository/kubermatic/web-terminal/tag/?specificTag=${TAG}&onlyActiveTags=true" \
+  | jq '.tags | length')"
+
+if [ "$COUNT" != "0" ]; then
+  echodate "Tag ${TAG} is already published at quay.io/kubermatic/web-terminal."
+  echodate "Files under hack/images/web-terminal/ changed; bump tag in $METADATA_FILE to release them."
+  exit 1
+fi
+
+echodate "Tag ${TAG} is not published yet; a merge will release it."

--- a/hack/verify-web-terminal-tag.sh
+++ b/hack/verify-web-terminal-tag.sh
@@ -34,8 +34,8 @@ fi
 
 # quay's public API needs no credentials for public repositories
 COUNT="$(retry 3 curl --fail --silent \
-  "https://quay.io/api/v1/repository/kubermatic/web-terminal/tag/?specificTag=${TAG}&onlyActiveTags=true" \
-  | jq '.tags | length')"
+  "https://quay.io/api/v1/repository/kubermatic/web-terminal/tag/?specificTag=${TAG}&onlyActiveTags=true" |
+  jq '.tags | length')"
 
 if [ "$COUNT" != "0" ]; then
   echodate "Tag ${TAG} is already published at quay.io/kubermatic/web-terminal."


### PR DESCRIPTION
**What this PR does / why we need it**:

Releasing the web-terminal image currently means running `hack/images/web-terminal/release.sh` by hand with quay credentials. This PR makes `hack/images/web-terminal/metadata.yaml` the source of truth for the release tag, lets `release.sh` skip tags that already exist in the registry, and adds a presubmit that fails when files under `hack/images/web-terminal/` change without an unpublished tag. A postsubmit in kubermatic/infra builds and pushes the image on merge.

**Which issue(s) this PR fixes**:
Part of #8136

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

The first automated release will be 0.13.0, which ships the CLIs added in #8118. After it is published, `WEBTerminalImage` in kubermatic needs a bump to 0.13.0.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
