### PR TITLE
Raise hardcoded KubeVirt node defaults

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/component.ts
@@ -156,7 +156,7 @@ export class KubeVirtBasicNodeDataComponent
   selectedConfigurationMode = ConfigurationMode.CustomResources;
   private readonly _instanceTypeIDSeparator = ':';
   private readonly _defaultCPUs = 2;
-  private readonly _defaultMemory = 2000;
+  private readonly _defaultMemory = 4000;
   private readonly _initialData = _.cloneDeep(this._nodeDataService.nodeData.spec.cloud.kubevirt);
   private _quotaCalculationService: QuotaCalculationService;
   private _initialQuotaCalculationPayload: ResourceQuotaCalculationPayload;
@@ -209,7 +209,7 @@ export class KubeVirtBasicNodeDataComponent
       [Controls.Memory]: this._builder.control(this._defaultMemory, Validators.required),
       [Controls.PrimaryDiskOSImage]: this._builder.control('', Validators.required),
       [Controls.PrimaryDiskStorageClassName]: this._builder.control('', Validators.required),
-      [Controls.PrimaryDiskSize]: this._builder.control('10G', Validators.required),
+      [Controls.PrimaryDiskSize]: this._builder.control('25G', Validators.required),
       [Controls.NodeAffinityPreset]: this._builder.control(''),
       [Controls.NodeAffinityPresetKey]: this._builder.control('', Validators.required),
       [Controls.NodeAffinityPresetValues]: this._builder.control(''),

--- a/modules/web/src/app/shared/entity/node.ts
+++ b/modules/web/src/app/shared/entity/node.ts
@@ -404,7 +404,7 @@ export function getDefaultNodeProviderSpec(provider: string): object {
       } as AnexiaNodeSpec;
     case NodeProvider.KUBEVIRT:
       return {
-        primaryDiskSize: '10',
+        primaryDiskSize: '25',
       } as KubeVirtNodeSpec;
     case NodeProvider.NUTANIX:
       return {


### PR DESCRIPTION
**What this PR does / why we need it**:

The KubeVirt worker-node defaults pre-filled in the dashboard's Custom Configuration path are too small for real workloads (disk 10G, CPU 2, memory 2000 MB). This raises them to sensible baselines:

- Disk: 10G -> 25G (matches the suggested minimum in the Ubuntu Server system requirements guide)
- Memory: 2000 -> 4000 MB (~4G, in the decimal-MB unit the field emits)
- CPU: 2 (unchanged)

Touched locations:
- `modules/web/src/app/shared/entity/node.ts` — default `KubeVirtNodeSpec.primaryDiskSize`: `'10'` -> `'25'`.
- `modules/web/src/app/node-data/basic/provider/kubevirt/component.ts` — `_defaultMemory`: `2000` -> `4000`; primary disk form control: `'10G'` -> `'25G'`. The constant is also consumed by the custom-mode re-apply and the existing-node load fallback, both of which pick up the new value by reference.

These defaults apply only on the Custom Configuration path. Instance-type selection continues to take CPU/memory from the instance type and is unaffected.

**Which issue(s) this PR fixes**:
Fixes #8179

**What type of PR is this?**:
/kind feature

**Special notes for your reviewer**:
- Memory is an integer in MB; the build path appends a capital `M` (`${memory}M`), so the literal must stay a number. `4000M` is the decimal-megabyte interpretation of the issue's "4G" (~3.73 GiB). machine-controller treats memory as an opaque k8s quantity string (`resource.ParseQuantity`) and enforces no minimum, so 4000 is safe.
- This is the first half of #8179. The second half (admin-configurable per-datacenter defaults, with these values becoming the fallback) is tracked separately.
- No backend, API, or machine-controller changes. No existing unit test asserts these literals.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The KubeVirt node defaults shown in the Custom Configuration path have been raised: primary disk 10G -> 25G, memory 2000 MB -> 4000 MB. CPU default is unchanged at 2.
```

**Documentation**:
NONE