### PR TITLE
Fix project selector dropdown not closing

### DIFF
--- a/modules/web/src/app/core/components/navigation/project/component.ts
+++ b/modules/web/src/app/core/components/navigation/project/component.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Input, OnDestroy, OnInit} from '@angular/core';
-import {MatSelect, MatSelectChange} from '@angular/material/select';
+import {Component, Input, OnDestroy, OnInit, ViewEncapsulation} from '@angular/core';
+import {MatSelectChange} from '@angular/material/select';
 import {ProjectService} from '@core/services/project';
 import {UserService} from '@core/services/user';
 import {Project} from '@shared/entity/project';
@@ -25,6 +25,7 @@ import {switchMap, takeUntil, tap} from 'rxjs/operators';
   selector: 'km-project-selector',
   templateUrl: './template.html',
   styleUrls: ['./style.scss'],
+  encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
 export class ProjectSelectorComponent implements OnInit, OnDestroy {
@@ -64,10 +65,6 @@ export class ProjectSelectorComponent implements OnInit, OnDestroy {
         this._selectProject(project);
       }
     });
-  }
-
-  openDropdown(matSelect: MatSelect): void {
-    matSelect.open();
   }
 
   areProjectsEqual(a: Project, b: Project): boolean {

--- a/modules/web/src/app/core/components/navigation/project/style.scss
+++ b/modules/web/src/app/core/components/navigation/project/style.scss
@@ -12,19 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@use 'variables';
+@use 'mixins';
 
-.project-selector {
-  height: variables.$toolbar-height - 2px;
-}
+.project-selector-control {
+  max-width: 220px;
 
-.projects-container {
-  border-radius: variables.$border-radius;
-  margin: 0 20px;
-  padding: 10px 15px;
+  .mat-mdc-select-trigger {
+    padding: 10px 15px;
+  }
 
-  .km-projects-icon {
+  .mat-mdc-select-arrow {
+    @include mixins.mask-image('/assets/images/icons/arrow-down.svg', 12px);
+
     margin-left: 14px;
-    pointer-events: none;
   }
 }

--- a/modules/web/src/app/core/components/navigation/project/template.html
+++ b/modules/web/src/app/core/components/navigation/project/template.html
@@ -13,45 +13,37 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<mat-list-item class="project-selector"
-               (click)="openDropdown(select)">
-  <div class="projects-container"
-       fxFlex
-       fxLayout="row"
-       fxLayoutAlign=" center">
-    <mat-select #select
-                placeholder="None"
-                panelClass="project-selector-dropdown"
-                (selectionChange)="onSelectionChange($event)"
-                [(value)]="selectedProject"
-                [compareWith]="areProjectsEqual"
-                disableOptionCentering>
-      @if (myProjects) {
-      <mat-optgroup label="My Projects">
-        @for (project of myProjects; track trackByProject($index, project)) {
-        <mat-option [value]="project"
-                    [disabled]="project.status !== 'Active'"
-                    [matTooltip]="project.status !== 'Active' ? project.status + ' Project' : ''">
-          {{project.name}}
-        </mat-option>
-        }
-      </mat-optgroup>
-      }
-      @if (externalProjects.length) {
-      <mat-divider class="km-option-divider" />
-      }
-      @if (externalProjects.length > 0) {
-      <mat-optgroup label="External Projects">
-        @for (project of externalProjects; track trackByProject($index, project)) {
-        <mat-option [value]="project"
-                    [disabled]="project.status !== 'Active'"
-                    [matTooltip]="project.status !== 'Active' ? project.status + ' Project' : ''">
-          {{project.name}}
-        </mat-option>
-        }
-      </mat-optgroup>
-      }
-    </mat-select>
-    <i class="km-projects-icon km-icon-arrow-down"></i>
-  </div>
-</mat-list-item>
+
+<mat-select class="project-selector-control"
+            placeholder="None"
+            panelClass="project-selector-dropdown"
+            (selectionChange)="onSelectionChange($event)"
+            [(value)]="selectedProject"
+            [compareWith]="areProjectsEqual"
+            disableOptionCentering>
+  @if (myProjects) {
+  <mat-optgroup label="My Projects">
+    @for (project of myProjects; track trackByProject($index, project)) {
+    <mat-option [value]="project"
+                [disabled]="project.status !== 'Active'"
+                [matTooltip]="project.status !== 'Active' ? project.status + ' Project' : ''">
+      {{project.name}}
+    </mat-option>
+    }
+  </mat-optgroup>
+  }
+  @if (externalProjects.length) {
+  <mat-divider class="km-option-divider" />
+  }
+  @if (externalProjects.length > 0) {
+  <mat-optgroup label="External Projects">
+    @for (project of externalProjects; track trackByProject($index, project)) {
+    <mat-option [value]="project"
+                [disabled]="project.status !== 'Active'"
+                [matTooltip]="project.status !== 'Active' ? project.status + ' Project' : ''">
+      {{project.name}}
+    </mat-option>
+    }
+  </mat-optgroup>
+  }
+</mat-select>

--- a/modules/web/src/app/core/components/navigation/project/theme.scss
+++ b/modules/web/src/app/core/components/navigation/project/theme.scss
@@ -14,15 +14,12 @@
 
 @use 'sass:map';
 @use 'km-var' as *;
+@use 'variables';
 
 @mixin theme-project-selector-component($colors) {
-  .projects-container {
-    i {
-      background-color: km-var($colors, text);
-    }
-
-    &:hover {
-      background-color: km-var($colors, project-selector-hover);
-    }
+  .project-selector-control:hover {
+    background-color: km-var($colors, project-selector-hover);
+    border-radius: variables.$border-radius;
+    cursor: pointer;
   }
 }

--- a/modules/web/src/app/core/components/navigation/style.scss
+++ b/modules/web/src/app/core/components/navigation/style.scss
@@ -50,12 +50,10 @@ header {
     font-weight: normal;
     margin-left: 20px;
   }
-}
 
-.km-icon-arrow-up {
-  @include mixins.size(14px);
-
-  margin: 0 8px 0 24px;
+  .project-selector-component {
+    margin-left: 20px;
+  }
 }
 
 @include mixins.breakpoint('small') {

--- a/modules/web/src/app/core/components/navigation/template.html
+++ b/modules/web/src/app/core/components/navigation/template.html
@@ -35,7 +35,7 @@ limitations under the License.
     <div class="km-text view-name">{{currentView}}</div>
     @if (isAuthenticated() && showMenuSwitchAndProjectSelector) {
     <km-project-selector [showSidenav]="showSidenav"
-                         class="project-selector" />
+                         class="project-selector-component" />
     }
     @if (isAuthenticated()) {
     <km-help-panel />

--- a/modules/web/src/assets/css/auth.css
+++ b/modules/web/src/assets/css/auth.css
@@ -1,4 +1,5 @@
-/* Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+/*
+Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -10,7 +11,8 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License. */
+limitations under the License.
+*/
 
 * {
   box-sizing: border-box;

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -476,10 +476,6 @@ mat-error {
     min-width: 2ch;
   }
 
-  .mat-mdc-select-arrow {
-    display: none;
-  }
-
   .mat-mdc-select-value-text {
     font-size: variables.$font-size-subhead;
     line-height: 20px;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the project selector dropdown in the top navbar getting stuck open — the mat-list-item wrapper's unconditional open() call fought the panel's own close behavior.
Removes the wrapper so mat-select handles its own open/close natively, and moves layout/hover/arrow styling onto it directly.

Fixes: #8192 

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed the project selector dropdown in the top navigation bar not closing after being opened.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
