### PR TITLE
Hide KubeVirt instance type tabs that have no options

### DIFF
--- a/modules/web/src/app/node-data/basic/provider/kubevirt/machine-type-selector/component.ts
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/machine-type-selector/component.ts
@@ -168,6 +168,7 @@ export class KubeVirtMachineTypeSelectorComponent implements OnInit, OnChanges, 
     this.customGpuOptions = [];
     this.hasKubermaticGpuTypes = false;
     this.hasCustomGpuTypes = false;
+    this._updateVisibleTabs();
     this._updateDisplayedColumns();
     this._applySearchFilter();
   }
@@ -256,13 +257,19 @@ export class KubeVirtMachineTypeSelectorComponent implements OnInit, OnChanges, 
   }
 
   private _updateVisibleTabs(): void {
-    this.visibleTabs = [TabIndex.KubermaticCPU];
+    this.visibleTabs = [];
+
+    if (this.kubermaticCpuOptions.length > 0) {
+      this.visibleTabs.push(TabIndex.KubermaticCPU);
+    }
 
     if (this.hasKubermaticGpuTypes && this.showGpuFilter) {
       this.visibleTabs.push(TabIndex.KubermaticGPU);
     }
 
-    this.visibleTabs.push(TabIndex.CustomCPU);
+    if (this.customCpuOptions.length > 0) {
+      this.visibleTabs.push(TabIndex.CustomCPU);
+    }
 
     if (this.hasCustomGpuTypes && this.showGpuFilter) {
       this.visibleTabs.push(TabIndex.CustomGPU);
@@ -273,7 +280,7 @@ export class KubeVirtMachineTypeSelectorComponent implements OnInit, OnChanges, 
 
   private _syncTabIndices(): void {
     if (!this.visibleTabs.includes(this.selectedTabIndex)) {
-      this.selectedTabIndex = TabIndex.KubermaticCPU;
+      this.selectedTabIndex = this.visibleTabs[0];
       this.activeTabIndex = 0;
     } else {
       this.activeTabIndex = this.visibleTabs.indexOf(this.selectedTabIndex);

--- a/modules/web/src/app/node-data/basic/provider/kubevirt/machine-type-selector/template.html
+++ b/modules/web/src/app/node-data/basic/provider/kubevirt/machine-type-selector/template.html
@@ -41,12 +41,26 @@ limitations under the License.
       </mat-form-field>
     </div>
 
+    @if (isLoading) {
+    <div class="km-row"
+         fxLayoutAlign="center center">
+      <mat-spinner color="accent"
+                   class="km-spinner"
+                   [diameter]="25" />
+    </div>
+    } @else if (visibleTabs.length === 0) {
+    <div class="km-row km-empty-list-msg"
+         fxLayoutAlign="center center">
+      No instance types found
+    </div>
+    } @else {
     <mat-tab-group class="km-machine-type-selector-tabs"
                    mat-stretch-tabs="false"
                    animationDuration="0ms"
                    [selectedIndex]="activeTabIndex"
                    (selectedIndexChange)="onTabChange($event)">
       <!-- Kubermatic CPU Tab -->
+      @if (kubermaticCpuOptions.length > 0) {
       <mat-tab>
         <ng-template mat-tab-label>
           <span>Kubermatic CPU</span>
@@ -54,6 +68,7 @@ limitations under the License.
         </ng-template>
         <ng-container *ngTemplateOutlet="machineTypeTable" />
       </mat-tab>
+      }
 
       <!-- Kubermatic GPU Tab -->
       @if (showGpuFilter && hasKubermaticGpu) {
@@ -67,6 +82,7 @@ limitations under the License.
       }
 
       <!-- Custom CPU Tab -->
+      @if (customCpuOptions.length > 0) {
       <mat-tab>
         <ng-template mat-tab-label>
           <span>Custom CPU</span>
@@ -74,6 +90,7 @@ limitations under the License.
         </ng-template>
         <ng-container *ngTemplateOutlet="machineTypeTable" />
       </mat-tab>
+      }
 
       <!-- Custom GPU Tab -->
       @if (showGpuFilter && hasCustomGpu) {
@@ -86,19 +103,13 @@ limitations under the License.
       </mat-tab>
       }
     </mat-tab-group>
+    }
   </div>
 </div>
 
 <ng-template #machineTypeTable>
   <div class="km-machine-type-selector-table-container">
-    @if (isLoading) {
-    <div class="km-row"
-         fxLayoutAlign="center center">
-      <mat-spinner color="accent"
-                   class="km-spinner"
-                   [diameter]="25" />
-    </div>
-    } @else if (filteredOptions.length === 0) {
+    @if (filteredOptions.length === 0) {
     <div class="km-row km-empty-list-msg"
          fxLayoutAlign="center center">
       No instance types found


### PR DESCRIPTION
**What this PR does / why we need it**:
hide instance type tabs when their category has no options, and show a "No instance types found" message when all categories are empty.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #8191

**What type of PR is this?**
/kind design

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Hide KubeVirt instance type tabs that have no options.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
https://github.com/kubermatic/dashboard/issues/8197
```
