### PR TITLE
Fix unwanted redirect to login on invalid AWS credentials

### DIFF
--- a/modules/api/pkg/provider/cloud/aws/api.go
+++ b/modules/api/pkg/provider/cloud/aws/api.go
@@ -23,12 +23,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/aws/smithy-go"
 
 	"k8c.io/dashboard/v2/pkg/provider"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 )
 
 // The functions in this file are used throughout KKP, mostly in our REST API.
@@ -52,16 +50,6 @@ func GetSubnets(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN
 	return out.Subnets, nil
 }
 
-func isAuthFailure(err error) (bool, string) {
-	var awsErr smithy.APIError
-
-	if errors.As(err, &awsErr) && awsErr.ErrorCode() == authFailure {
-		return true, awsErr.ErrorMessage()
-	}
-
-	return false, ""
-}
-
 // GetVPCS returns the list of AWS VPCs.
 func GetVPCS(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region string) ([]ec2types.Vpc, error) {
 	client, err := GetClientSet(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region)
@@ -72,10 +60,6 @@ func GetVPCS(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN, a
 	vpcOut, err := client.EC2.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{})
 
 	if err != nil {
-		if ok, msg := isAuthFailure(err); ok {
-			return nil, utilerrors.New(401, fmt.Sprintf("failed to list VPCs: %s", msg))
-		}
-
 		return nil, fmt.Errorf("failed to list VPCs: %w", err)
 	}
 
@@ -91,10 +75,6 @@ func GetSecurityGroupsByVPC(ctx context.Context, accessKeyID, secretAccessKey, a
 	sgOut, err := client.EC2.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{Filters: []ec2types.Filter{ec2VPCFilter(vpcID)}})
 
 	if err != nil {
-		if ok, msg := isAuthFailure(err); ok {
-			return nil, utilerrors.New(401, fmt.Sprintf("failed to list security groups: %s", msg))
-		}
-
 		return nil, fmt.Errorf("failed to list security groups: %w", err)
 	}
 
@@ -130,10 +110,6 @@ func getSecurityGroupsWithClient(ctx context.Context, client *ec2.Client) ([]ec2
 	sgOut, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{})
 
 	if err != nil {
-		if ok, msg := isAuthFailure(err); ok {
-			return nil, utilerrors.New(401, fmt.Sprintf("failed to list security groups: %s", msg))
-		}
-
 		return nil, fmt.Errorf("failed to list security groups: %w", err)
 	}
 

--- a/modules/api/pkg/provider/cloud/aws/provider.go
+++ b/modules/api/pkg/provider/cloud/aws/provider.go
@@ -23,10 +23,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 )
 
-const (
-	authFailure = "AuthFailure"
-)
-
 type AmazonEC2 struct {
 	dc                *kubermaticv1.DatacenterSpecAWS
 	secretKeySelector provider.SecretKeySelectorValueFunc

--- a/modules/web/src/app/core/interceptors/auth.ts
+++ b/modules/web/src/app/core/interceptors/auth.ts
@@ -60,18 +60,18 @@ export class AuthInterceptor implements HttpInterceptor {
     this._refreshDone$.next(false);
 
     return this._http.post(this._refreshUrl, null).pipe(
-      switchMap(() => {
-        this._isRefreshing = false;
-        this._refreshDone$.next(true);
-        // Retry the original request — browser will send the new cookie.
-        return next.handle(req);
-      }),
       catchError(refreshError => {
         this._isRefreshing = false;
         this._refreshDone$.next(true);
         // Refresh failed — redirect to login page.
         window.location.href = '/';
         return throwError(() => refreshError);
+      }),
+      switchMap(() => {
+        this._isRefreshing = false;
+        this._refreshDone$.next(true);
+        // Retry the original request — browser will send the new cookie.
+        return next.handle(req);
       })
     );
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
AuthInterceptor's refresh-retry catchError also caught errors from the retried request itself, so any non-session failure (e.g. wrong AWS credentials) after a successful token refresh triggered a login redirect. Reorder the operators so only refresh failures redirect.
Also drop the AWS provider's 401 special-casing, which existed only to feed this bug and isn't needed for a plain listing error.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue in the create cluster wizard where entering invalid AWS credentials could incorrectly redirect the user to the login page
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
