### PR TITLE
List KubeVirt instancetypes/preferences via v1beta1

### DIFF
--- a/modules/api/hack/reconciling.yaml
+++ b/modules/api/hack/reconciling.yaml
@@ -18,6 +18,6 @@
 package: reconciling
 boilerplate: ../../hack/boilerplate/ce/boilerplate.go.txt
 resourceTypes:
-  # instancetype/v1alpha1
-  - { package: kubevirt.io/api/instancetype/v1alpha1, resourceName: VirtualMachineInstancetype }
-  - { package: kubevirt.io/api/instancetype/v1alpha1, resourceName: VirtualMachinePreference }
+  # instancetype/v1beta1
+  - { package: kubevirt.io/api/instancetype/v1beta1, resourceName: VirtualMachineInstancetype }
+  - { package: kubevirt.io/api/instancetype/v1beta1, resourceName: VirtualMachinePreference }

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	handlercommon "k8c.io/dashboard/v2/pkg/handler/common"
@@ -38,6 +39,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -237,16 +239,128 @@ func KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 	return KubeVirtVPCSubnets(ctx, kvKubeconfig, cluster.Spec.Cloud.Kubevirt.VPCName)
 }
 
-// kubeVirtInstancetypes returns the kvinstancetypev1alpha1.VirtualMachineInstanceType:
+// listClusterInstancetypes lists cluster-wide VirtualMachineClusterInstancetypes, trying
+// v1beta1 first and falling back to v1alpha1 only when the cluster does not serve v1beta1.
+// KubeVirt 1.6.0+ no longer serves v1alpha1, so listing it first would log a discovery
+// NoMatchError on every read; v1beta1 is served on every supported KubeVirt (>= v1.0.0).
+// A NoMatchError from the v1alpha1 fallback is swallowed (returns empty) so a cluster that
+// serves neither version produces no logged noise. Fallback items are round-tripped into
+// v1beta1 via JSON (the specs share field tags, v1beta1 is a superset) so the rest of the
+// pipeline stays version-agnostic.
+func listClusterInstancetypes(ctx context.Context, client ctrlruntimeclient.Client, opts ...ctrlruntimeclient.ListOption) ([]kvinstancetypev1beta1.VirtualMachineClusterInstancetype, error) {
+	betaList := &kvinstancetypev1beta1.VirtualMachineClusterInstancetypeList{}
+	err := client.List(ctx, betaList, opts...)
+	if err == nil {
+		return betaList.Items, nil
+	} else if !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+
+	alphaList := &kvinstancetypev1alpha1.VirtualMachineClusterInstancetypeList{}
+	if err := client.List(ctx, alphaList, opts...); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	items := make([]kvinstancetypev1beta1.VirtualMachineClusterInstancetype, 0, len(alphaList.Items))
+	for i := range alphaList.Items {
+		converted := &kvinstancetypev1beta1.VirtualMachineClusterInstancetype{}
+		if err := convertViaJSON(&alphaList.Items[i], converted); err != nil {
+			return nil, err
+		}
+		items = append(items, *converted)
+	}
+	return items, nil
+}
+
+// listNamespacedInstancetypes mirrors listClusterInstancetypes for namespaced
+// VirtualMachineInstancetypes.
+func listNamespacedInstancetypes(ctx context.Context, client ctrlruntimeclient.Client, opts ...ctrlruntimeclient.ListOption) ([]kvinstancetypev1beta1.VirtualMachineInstancetype, error) {
+	betaList := &kvinstancetypev1beta1.VirtualMachineInstancetypeList{}
+	if err := client.List(ctx, betaList, opts...); err == nil {
+		return betaList.Items, nil
+	} else if !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+
+	alphaList := &kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
+	if err := client.List(ctx, alphaList, opts...); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	items := make([]kvinstancetypev1beta1.VirtualMachineInstancetype, 0, len(alphaList.Items))
+	for i := range alphaList.Items {
+		converted := &kvinstancetypev1beta1.VirtualMachineInstancetype{}
+		if err := convertViaJSON(&alphaList.Items[i], converted); err != nil {
+			return nil, err
+		}
+
+		items = append(items, *converted)
+	}
+
+	return items, nil
+}
+
+// listClusterPreferences mirrors listClusterInstancetypes for cluster-wide
+// VirtualMachineClusterPreferences.
+func listClusterPreferences(ctx context.Context, client ctrlruntimeclient.Client, opts ...ctrlruntimeclient.ListOption) ([]kvinstancetypev1beta1.VirtualMachineClusterPreference, error) {
+	betaList := &kvinstancetypev1beta1.VirtualMachineClusterPreferenceList{}
+	if err := client.List(ctx, betaList, opts...); err == nil {
+		return betaList.Items, nil
+	} else if !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+
+	alphaList := &kvinstancetypev1alpha1.VirtualMachineClusterPreferenceList{}
+	if err := client.List(ctx, alphaList, opts...); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	items := make([]kvinstancetypev1beta1.VirtualMachineClusterPreference, 0, len(alphaList.Items))
+	for i := range alphaList.Items {
+		converted := &kvinstancetypev1beta1.VirtualMachineClusterPreference{}
+		if err := convertViaJSON(&alphaList.Items[i], converted); err != nil {
+			return nil, err
+		}
+
+		items = append(items, *converted)
+	}
+
+	return items, nil
+}
+
+// convertViaJSON copies src into dst by marshaling to JSON and back. Used to lift v1alpha1
+// instancetype/preference objects into their v1beta1 counterparts: the specs share JSON
+// field tags and v1beta1 is a superset, so the round-trip is lossless.
+func convertViaJSON(src, dst any) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, dst)
+}
+
+// kubeVirtInstancetypes returns the kvinstancetypev1beta1.VirtualMachineInstanceType:
 // - custom (cluster-wide)
 // - concatenated with kubermatic standard from yaml manifests.
 func kubeVirtInstancetypes(ctx context.Context, client ctrlruntimeclient.Client, datacenter *kubermaticv1.Datacenter) (instancetypeListWrapper, error) {
 	instancetypes := instancetypeListWrapper{}
-	clusterInstancetypes := kvinstancetypev1alpha1.VirtualMachineClusterInstancetypeList{}
-	standardInstancetypes := kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
-	namespaceInstancetypes := kvinstancetypev1alpha1.VirtualMachineInstancetypeList{}
+	standardInstancetypes := kvinstancetypev1beta1.VirtualMachineInstancetypeList{}
+	namespaceInstancetypes := kvinstancetypev1beta1.VirtualMachineInstancetypeList{}
 	// "custom" (cluster-wide)
-	if err := client.List(ctx, &clusterInstancetypes); err != nil {
+	clusterInstancetypeItems, err := listClusterInstancetypes(ctx, client)
+	if err != nil {
 		return instancetypes, err
 	}
 	// Always fetch the full set of kubermatic standard instancetypes once.
@@ -273,16 +387,19 @@ func kubeVirtInstancetypes(ctx context.Context, client ctrlruntimeclient.Client,
 		if namespace == "" {
 			return instancetypes, fmt.Errorf("namespaced mode enabled but no namespace configured")
 		}
-		if err := client.List(ctx, &namespaceInstancetypes, ctrlruntimeclient.InNamespace(namespace)); err != nil {
+		nsItems, err := listNamespacedInstancetypes(ctx, client, ctrlruntimeclient.InNamespace(namespace))
+		if err != nil {
 			return instancetypes, err
 		}
+
+		namespaceInstancetypes.Items = nsItems
 	}
 	// Wrap
-	if len(clusterInstancetypes.Items) > 0 || len(standardInstancetypes.Items) > 0 || len(namespaceInstancetypes.Items) > 0 {
+	if len(clusterInstancetypeItems) > 0 || len(standardInstancetypes.Items) > 0 || len(namespaceInstancetypes.Items) > 0 {
 		instancetypes.items = make([]instancetypeWrapper, 0)
 	}
-	for i := range clusterInstancetypes.Items {
-		w := customInstancetypeWrapper{&clusterInstancetypes.Items[i]}
+	for i := range clusterInstancetypeItems {
+		w := customInstancetypeWrapper{&clusterInstancetypeItems[i]}
 		instancetypes.items = append(instancetypes.items, &w)
 	}
 
@@ -394,15 +511,15 @@ func KubeVirtInstancetypes(ctx context.Context, projectID, kubeconfig, datacente
 	return filterInstancetypes(res, filter), nil
 }
 
-// kubeVirtPreferences returns the kvinstancetypev1alpha1.VirtualMachinePreference:
+// kubeVirtPreferences returns the kvinstancetypev1beta1.VirtualMachinePreference:
 // - custom (cluster-wide)
 // - concatenated with kubermatic standard from yaml manifests.
 func kubeVirtPreferences(ctx context.Context, client ctrlruntimeclient.Client, datacenter *kubermaticv1.Datacenter) (preferenceListWrapper, error) {
 	preferences := preferenceListWrapper{}
-	customPreferences := kvinstancetypev1alpha1.VirtualMachineClusterPreferenceList{}
-	standardPreferences := kvinstancetypev1alpha1.VirtualMachinePreferenceList{}
+	standardPreferences := kvinstancetypev1beta1.VirtualMachinePreferenceList{}
 	// "custom" (cluster-wide)
-	if err := client.List(ctx, &customPreferences); err != nil {
+	customPreferenceItems, err := listClusterPreferences(ctx, client)
+	if err != nil {
 		return preferences, err
 	}
 	// "standard" (namespaced)
@@ -411,11 +528,11 @@ func kubeVirtPreferences(ctx context.Context, client ctrlruntimeclient.Client, d
 	}
 
 	// Wrap
-	if len(customPreferences.Items) > 0 || len(standardPreferences.Items) > 0 {
+	if len(customPreferenceItems) > 0 || len(standardPreferences.Items) > 0 {
 		preferences.items = make([]preferenceWrapper, 0)
 	}
-	for i := range customPreferences.Items {
-		w := customPreferenceWrapper{&customPreferences.Items[i]}
+	for i := range customPreferenceItems {
+		w := customPreferenceWrapper{&customPreferenceItems[i]}
 		preferences.items = append(preferences.items, &w)
 	}
 	for i := range standardPreferences.Items {
@@ -513,7 +630,7 @@ func KubeVirtVPCSubnets(ctx context.Context, kubeconfig string, vpcName string) 
 
 func instancetypeReconciler(w instancetypeWrapper) reconciling.NamedVirtualMachineInstancetypeReconcilerFactory {
 	return func() (string, reconciling.VirtualMachineInstancetypeReconciler) {
-		return w.GetObjectMeta().GetName(), func(it *kvinstancetypev1alpha1.VirtualMachineInstancetype) (*kvinstancetypev1alpha1.VirtualMachineInstancetype, error) {
+		return w.GetObjectMeta().GetName(), func(it *kvinstancetypev1beta1.VirtualMachineInstancetype) (*kvinstancetypev1beta1.VirtualMachineInstancetype, error) {
 			it.Labels = w.GetObjectMeta().GetLabels()
 			it.Spec = w.Spec()
 			return it, nil
@@ -523,7 +640,7 @@ func instancetypeReconciler(w instancetypeWrapper) reconciling.NamedVirtualMachi
 
 func preferenceReconciler(w preferenceWrapper) reconciling.NamedVirtualMachinePreferenceReconcilerFactory {
 	return func() (string, reconciling.VirtualMachinePreferenceReconciler) {
-		return w.GetObjectMeta().GetName(), func(it *kvinstancetypev1alpha1.VirtualMachinePreference) (*kvinstancetypev1alpha1.VirtualMachinePreference, error) {
+		return w.GetObjectMeta().GetName(), func(it *kvinstancetypev1beta1.VirtualMachinePreference) (*kvinstancetypev1beta1.VirtualMachinePreference, error) {
 			it.Labels = w.GetObjectMeta().GetLabels()
 			it.Spec = w.Spec()
 			return it, nil
@@ -538,7 +655,7 @@ func filterInstancetypes(instancetypes *apiv2.VirtualMachineInstancetypeList, ma
 	// If the record passes all the filters, add it to the final slice.
 	for category, types := range instancetypes.Instancetypes {
 		for _, instancetype := range types {
-			spec := kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{}
+			spec := kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{}
 			if err := json.Unmarshal([]byte(instancetype.Spec), &spec); err != nil {
 				log.Logger.Errorf("skipping VirtualMachineInstancetype:%s, parsing instancetype.Spec failed:%v", instancetype.Name, err)
 				continue
@@ -568,16 +685,16 @@ func filterInstancetypes(instancetypes *apiv2.VirtualMachineInstancetypeList, ma
 }
 
 // instancetypeWrapper to wrap functions needed to convert to API type:
-//   - kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec, kvinstancetypev1alpha1.VirtualMachineClusterInstancetypeSpec
+//   - kvinstancetypev1beta1.VirtualMachineInstancetypeSpec, kvinstancetypev1beta1.VirtualMachineClusterInstancetypeSpec
 type instancetypeWrapper interface {
-	Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec
+	Spec() kvinstancetypev1beta1.VirtualMachineInstancetypeSpec
 	Category() apiv2.VirtualMachineInstancetypeCategory
 	Kind() string
 	GetObjectMeta() metav1.Object
 }
 
 type customInstancetypeWrapper struct {
-	*kvinstancetypev1alpha1.VirtualMachineClusterInstancetype
+	*kvinstancetypev1beta1.VirtualMachineClusterInstancetype
 }
 
 func (it *customInstancetypeWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
@@ -588,12 +705,12 @@ func (it *customInstancetypeWrapper) Kind() string {
 	return kindVirtualMachineClusterInstancetype
 }
 
-func (it *customInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
+func (it *customInstancetypeWrapper) Spec() kvinstancetypev1beta1.VirtualMachineInstancetypeSpec {
 	return it.VirtualMachineClusterInstancetype.Spec
 }
 
 type standardInstancetypeWrapper struct {
-	*kvinstancetypev1alpha1.VirtualMachineInstancetype
+	*kvinstancetypev1beta1.VirtualMachineInstancetype
 }
 
 func (it *standardInstancetypeWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
@@ -604,14 +721,14 @@ func (it *standardInstancetypeWrapper) Kind() string {
 	return kindVirtualMachineInstancetype
 }
 
-func (it *standardInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
+func (it *standardInstancetypeWrapper) Spec() kvinstancetypev1beta1.VirtualMachineInstancetypeSpec {
 	return it.VirtualMachineInstancetype.Spec
 }
 
 // customNamespacedInstancetypeWrapper wraps a namespaced VirtualMachineInstancetype
 // that was created by the user (not by the kubermatic reconciler).
 type customNamespacedInstancetypeWrapper struct {
-	*kvinstancetypev1alpha1.VirtualMachineInstancetype
+	*kvinstancetypev1beta1.VirtualMachineInstancetype
 }
 
 func (it *customNamespacedInstancetypeWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
@@ -622,7 +739,7 @@ func (it *customNamespacedInstancetypeWrapper) Kind() string {
 	return kindVirtualMachineInstancetype
 }
 
-func (it *customNamespacedInstancetypeWrapper) Spec() kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
+func (it *customNamespacedInstancetypeWrapper) Spec() kvinstancetypev1beta1.VirtualMachineInstancetypeSpec {
 	return it.VirtualMachineInstancetype.Spec
 }
 
@@ -647,34 +764,34 @@ func (l *instancetypeListWrapper) toApi() (*apiv2.VirtualMachineInstancetypeList
 }
 
 // preferenceWrapper to wrap functions needed to convert to API type:
-//   - kvinstancetypev1alpha1.VirtualMachinePreferenceSpec, kvinstancetypev1alpha1.VirtualMachineClusterPreferenceSpec
+//   - kvinstancetypev1beta1.VirtualMachinePreferenceSpec, kvinstancetypev1beta1.VirtualMachineClusterPreferenceSpec
 type preferenceWrapper interface {
-	Spec() kvinstancetypev1alpha1.VirtualMachinePreferenceSpec
+	Spec() kvinstancetypev1beta1.VirtualMachinePreferenceSpec
 	Category() apiv2.VirtualMachineInstancetypeCategory
 	GetObjectMeta() metav1.Object
 }
 
 type customPreferenceWrapper struct {
-	*kvinstancetypev1alpha1.VirtualMachineClusterPreference
+	*kvinstancetypev1beta1.VirtualMachineClusterPreference
 }
 
 func (p *customPreferenceWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
 	return apiv2.InstancetypeCustom
 }
 
-func (p *customPreferenceWrapper) Spec() kvinstancetypev1alpha1.VirtualMachinePreferenceSpec {
+func (p *customPreferenceWrapper) Spec() kvinstancetypev1beta1.VirtualMachinePreferenceSpec {
 	return p.VirtualMachineClusterPreference.Spec
 }
 
 type standardPreferenceWrapper struct {
-	*kvinstancetypev1alpha1.VirtualMachinePreference
+	*kvinstancetypev1beta1.VirtualMachinePreference
 }
 
 func (p *standardPreferenceWrapper) Category() apiv2.VirtualMachineInstancetypeCategory {
 	return apiv2.InstancetypeKubermatic
 }
 
-func (p *standardPreferenceWrapper) Spec() kvinstancetypev1alpha1.VirtualMachinePreferenceSpec {
+func (p *standardPreferenceWrapper) Spec() kvinstancetypev1beta1.VirtualMachinePreferenceSpec {
 	return p.VirtualMachinePreference.Spec
 }
 

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -26,15 +26,18 @@ import (
 
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	apiv2 "k8c.io/dashboard/v2/pkg/api/v2"
 	"k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt"
 	kvmanifests "k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt/manifests"
 	kubermaticv1 "k8c.io/kubermatic/sdk/v2/apis/kubermatic/v1"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -185,7 +188,7 @@ func (l *instancetypeListWrapper) addInstanceType(category apiv2.VirtualMachineI
 func newInstancetype(category apiv2.VirtualMachineInstancetypeCategory, cpu uint32, memory string) instancetypeWrapper {
 	switch category {
 	case apiv2.InstancetypeKubermatic:
-		instancetype := &kvinstancetypev1alpha1.VirtualMachineInstancetype{
+		instancetype := &kvinstancetypev1beta1.VirtualMachineInstancetype{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: instancetypeName(cpu, memory),
 			},
@@ -195,7 +198,7 @@ func newInstancetype(category apiv2.VirtualMachineInstancetypeCategory, cpu uint
 		return &standardInstancetypeWrapper{instancetype}
 
 	case apiv2.InstancetypeCustom:
-		instancetype := &kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+		instancetype := &kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: instancetypeName(cpu, memory),
 			},
@@ -212,23 +215,23 @@ func instancetypeName(cpu uint32, memory string) string {
 	return fmt.Sprintf("cpu-%d-memory-%s", cpu, memoryAsScaledString)
 }
 
-func getInstancetypeSpec(cpu uint32, memory string) kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
-	return kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-		CPU: kvinstancetypev1alpha1.CPUInstancetype{
+func getInstancetypeSpec(cpu uint32, memory string) kvinstancetypev1beta1.VirtualMachineInstancetypeSpec {
+	return kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+		CPU: kvinstancetypev1beta1.CPUInstancetype{
 			Guest: cpu,
 		},
-		Memory: kvinstancetypev1alpha1.MemoryInstancetype{
+		Memory: kvinstancetypev1beta1.MemoryInstancetype{
 			Guest: resource.MustParse(memory),
 		},
 	}
 }
 
-func getGPUInstancetypeSpec(cpu uint32, memory, gpuName, deviceName string) kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
-	return kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-		CPU: kvinstancetypev1alpha1.CPUInstancetype{
+func getGPUInstancetypeSpec(cpu uint32, memory, gpuName, deviceName string) kvinstancetypev1beta1.VirtualMachineInstancetypeSpec {
+	return kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+		CPU: kvinstancetypev1beta1.CPUInstancetype{
 			Guest: cpu,
 		},
-		Memory: kvinstancetypev1alpha1.MemoryInstancetype{
+		Memory: kvinstancetypev1beta1.MemoryInstancetype{
 			Guest: resource.MustParse(memory),
 		},
 		GPUs: []kubevirtcorev1.GPU{
@@ -241,7 +244,7 @@ func getGPUInstancetypeSpec(cpu uint32, memory, gpuName, deviceName string) kvin
 }
 
 // mustMarshalInstancetype builds an apiv2.VirtualMachineInstancetype with the spec JSON-marshalled.
-func mustMarshalInstancetype(name string, spec kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec) apiv2.VirtualMachineInstancetype {
+func mustMarshalInstancetype(name string, spec kvinstancetypev1beta1.VirtualMachineInstancetypeSpec) apiv2.VirtualMachineInstancetype {
 	b, err := json.Marshal(spec)
 	if err != nil {
 		panic(err)
@@ -251,7 +254,7 @@ func mustMarshalInstancetype(name string, spec kvinstancetypev1alpha1.VirtualMac
 
 // mustScaleMemory returns a copy of spec with Memory.Guest converted from BinarySI to
 // DecimalSI (Mega), matching what filterInstancetypes does before returning.
-func mustScaleMemory(spec kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec) kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
+func mustScaleMemory(spec kvinstancetypev1beta1.VirtualMachineInstancetypeSpec) kvinstancetypev1beta1.VirtualMachineInstancetypeSpec {
 	spec.Memory.Guest = *resource.NewScaledQuantity(spec.Memory.Guest.ScaledValue(resource.Mega), resource.Mega)
 	return spec
 }
@@ -261,8 +264,11 @@ func mustScaleMemory(spec kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec)
 func newFakeClient(t *testing.T, objs ...ctrlruntimeclient.Object) ctrlruntimeclient.Client {
 	t.Helper()
 	scheme := runtime.NewScheme()
+	if err := kvinstancetypev1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register KubeVirt instancetype v1beta1 scheme: %v", err)
+	}
 	if err := kvinstancetypev1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("failed to register KubeVirt instancetype scheme: %v", err)
+		t.Fatalf("failed to register KubeVirt instancetype v1alpha1 scheme: %v", err)
 	}
 	return fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -298,7 +304,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 	staleStandardInstanceTypes := func(namespace string) []ctrlruntimeclient.Object {
 		objs := make([]ctrlruntimeclient.Object, 0, len(standardNames))
 		for _, name := range standardNames {
-			objs = append(objs, &kvinstancetypev1alpha1.VirtualMachineInstancetype{
+			objs = append(objs, &kvinstancetypev1beta1.VirtualMachineInstancetype{
 				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 				Spec:       getInstancetypeSpec(2, "8Gi"),
 			})
@@ -321,7 +327,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 				},
 			},
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "cluster-custom-1"},
 					Spec:       getInstancetypeSpec(4, "8Gi"),
 				},
@@ -342,7 +348,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			},
 			objects: []ctrlruntimeclient.Object{
 				// Namespaced instancetype in some tenant namespace — must NOT appear.
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "tenant-it", Namespace: "tenant-ns-1"},
 					Spec:       getInstancetypeSpec(2, "4Gi"),
 				},
@@ -364,7 +370,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 				},
 			},
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "user-created", Namespace: "infra-ns"},
 					Spec:       getInstancetypeSpec(4, "16Gi"),
 				},
@@ -388,7 +394,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			},
 			objects: append(staleStandardInstanceTypes("infra-ns"),
 				// Plus a real user-created one.
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "my-flavor", Namespace: "infra-ns"},
 					Spec:       getInstancetypeSpec(8, "32Gi"),
 				},
@@ -415,7 +421,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 			},
 			objects: append(staleStandardInstanceTypes("infra-ns"),
 				// A real user-created instancetype.
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "my-custom", Namespace: "infra-ns"},
 					Spec:       getInstancetypeSpec(16, "64Gi"),
 				},
@@ -465,7 +471,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 				},
 			},
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "standard-gpu-2"},
 					Spec:       getGPUInstancetypeSpec(2, "8Gi", "A100", "nv-a100-standard"),
 				},
@@ -488,7 +494,7 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 				},
 			},
 			objects: []ctrlruntimeclient.Object{
-				&kvinstancetypev1alpha1.VirtualMachineInstancetype{
+				&kvinstancetypev1beta1.VirtualMachineInstancetype{
 					ObjectMeta: metav1.ObjectMeta{Name: "standard-gpu-2", Namespace: "infra-ns"},
 					Spec:       getGPUInstancetypeSpec(2, "8Gi", "A100", "nv-a100-standard"),
 				},
@@ -518,8 +524,8 @@ func Test_kubeVirtInstancetypes(t *testing.T) {
 func Test_instancetypeWrapperKind(t *testing.T) {
 	spec := getInstancetypeSpec(4, "8Gi")
 
-	namespaced := &kvinstancetypev1alpha1.VirtualMachineInstancetype{Spec: spec}
-	cluster := &kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{Spec: spec}
+	namespaced := &kvinstancetypev1beta1.VirtualMachineInstancetype{Spec: spec}
+	cluster := &kvinstancetypev1beta1.VirtualMachineClusterInstancetype{Spec: spec}
 
 	tests := []struct {
 		name         string
@@ -557,4 +563,235 @@ func sortedCategoryNames(items []instancetypeWrapper) map[apiv2.VirtualMachineIn
 		sort.Strings(m[cat])
 	}
 	return m
+}
+
+// noMatchListClient wraps a Client and makes List return a NoKindMatchError for the
+// object versions listed in unservedVersions, simulating a KubeVirt infra cluster that
+// does not serve those API versions. errorForVersion overrides that with a real error for
+// a given version (used to verify the v1alpha1 fallback propagates non-NoMatch errors).
+// Everything else delegates to the wrapped client.
+type noMatchListClient struct {
+	ctrlruntimeclient.Client
+	unservedVersions map[string]bool
+	errorForVersion  map[string]error
+}
+
+func (c *noMatchListClient) List(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+	gvks, _, err := c.Scheme().ObjectKinds(list)
+	if err != nil {
+		return err
+	}
+	for _, gvk := range gvks {
+		if c.errorForVersion != nil {
+			if e, ok := c.errorForVersion[gvk.Version]; ok {
+				return e
+			}
+		}
+		if c.unservedVersions[gvk.Version] {
+			return &meta.NoKindMatchError{
+				GroupKind:        gvk.GroupKind(),
+				SearchedVersions: []string{gvk.Version},
+			}
+		}
+	}
+	return c.Client.List(ctx, list, opts...)
+}
+
+func TestListClusterInstancetypes_fallback(t *testing.T) {
+	ctx := context.Background()
+
+	// Confirm NoKindMatchError is detected as such, guarding the fallback trigger.
+	nmErr := &meta.NoKindMatchError{GroupKind: schema.GroupKind{Group: "instancetype.kubevirt.io", Kind: "VirtualMachineClusterInstancetype"}, SearchedVersions: []string{"v1alpha1"}}
+	if !meta.IsNoMatchError(nmErr) {
+		t.Fatal("expected NoKindMatchError to satisfy meta.IsNoMatchError")
+	}
+
+	tests := []struct {
+		name             string
+		unservedVersions map[string]bool
+		objects          []ctrlruntimeclient.Object
+		wantNames        []string
+		// wantCPU maps item name -> expected CPU.Guest after conversion. Asserting it on the
+		// fallback case proves convertViaJSON copied the spec, not just the object name.
+		wantCPU map[string]uint32
+	}{
+		{
+			name:             "v1beta1 served: returns v1beta1 items, fallback not reached",
+			unservedVersions: map[string]bool{},
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "beta-1"},
+					Spec:       getInstancetypeSpec(4, "8Gi"),
+				},
+			},
+			wantNames: []string{"beta-1"},
+			wantCPU:   map[string]uint32{"beta-1": 4},
+		},
+		{
+			name:             "v1beta1 not served: falls back to v1alpha1 and converts items",
+			unservedVersions: map[string]bool{"v1beta1": true},
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "alpha-1"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+					},
+				},
+				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "alpha-2"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 8},
+						Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("16Gi")},
+					},
+				},
+			},
+			wantNames: []string{"alpha-1", "alpha-2"},
+			wantCPU:   map[string]uint32{"alpha-1": 2, "alpha-2": 8},
+		},
+		{
+			name:             "neither version served: returns empty, no error",
+			unservedVersions: map[string]bool{"v1beta1": true, "v1alpha1": true},
+			objects:          []ctrlruntimeclient.Object{},
+			wantNames:        []string{},
+		},
+		{
+			// v1beta1 is served but returns no objects. The fallback must NOT run: an empty
+			// v1beta1 result on a v1beta1-served cluster is a normal state, not a signal to
+			// try v1alpha1. Pins the documented no-empty-list-fallback semantics.
+			name:             "v1beta1 served but empty: does not fall back to v1alpha1",
+			unservedVersions: map[string]bool{},
+			objects: []ctrlruntimeclient.Object{
+				&kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+					ObjectMeta: metav1.ObjectMeta{Name: "alpha-stale"},
+					Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+						CPU: kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+					},
+				},
+			},
+			wantNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := newFakeClient(t, tt.objects...)
+			client := &noMatchListClient{Client: base, unservedVersions: tt.unservedVersions}
+
+			items, err := listClusterInstancetypes(ctx, client)
+			if err != nil {
+				t.Fatalf("listClusterInstancetypes() unexpected error: %v", err)
+			}
+
+			gotNames := make([]string, 0, len(items))
+			for _, it := range items {
+				gotNames = append(gotNames, it.Name)
+			}
+
+			sort.Strings(gotNames)
+			if !reflect.DeepEqual(gotNames, tt.wantNames) {
+				t.Errorf("listClusterInstancetypes() names = %v, want %v", gotNames, tt.wantNames)
+			}
+
+			for _, it := range items {
+				if tt.wantCPU != nil {
+					if want, ok := tt.wantCPU[it.Name]; !ok || it.Spec.CPU.Guest != want {
+						t.Errorf("item %q CPU.Guest = %d, want %d", it.Name, it.Spec.CPU.Guest, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Test_listClusterInstancetypes_realError verifies that a non-NoMatch error from the
+// v1beta1 List is propagated, never swallowed as an empty fallback result.
+func Test_listClusterInstancetypes_realError(t *testing.T) {
+	ctx := context.Background()
+	client := &errorListClient{Client: newFakeClient(t), err: fmt.Errorf("connection refused")}
+
+	if _, err := listClusterInstancetypes(ctx, client); err == nil {
+		t.Fatal("expected a real (non-NoMatch) error to propagate, got nil")
+	}
+}
+
+// errorListClient returns a fixed error from every List call.
+type errorListClient struct {
+	ctrlruntimeclient.Client
+	err error
+}
+
+func (c *errorListClient) List(_ context.Context, _ ctrlruntimeclient.ObjectList, _ ...ctrlruntimeclient.ListOption) error {
+	return c.err
+}
+
+// Test_listClusterInstancetypes_fallbackRealError verifies that a non-NoMatch error from
+// the v1alpha1 fallback List (after a v1beta1 NoMatch) is propagated, not swallowed as an
+// empty result. This is the inner branch errorListClient cannot reach, since it errors on
+// the v1beta1 List before the fallback runs.
+func Test_listClusterInstancetypes_fallbackRealError(t *testing.T) {
+	ctx := context.Background()
+	base := newFakeClient(t)
+	client := &noMatchListClient{
+		Client:           base,
+		unservedVersions: map[string]bool{"v1beta1": true},
+		errorForVersion:  map[string]error{"v1alpha1": fmt.Errorf("rpc error: timeout")},
+	}
+
+	if _, err := listClusterInstancetypes(ctx, client); err == nil {
+		t.Fatal("expected the v1alpha1 fallback's real error to propagate, got nil")
+	}
+}
+
+// Test_listNamespacedInstancetypes_fallback is a minimal parity check that the namespaced
+// helper shares the v1beta1-first / v1alpha1-fallback behavior of the cluster helper. The
+// three are near-copies; this guards against a copy-paste divergence (wrong list type or
+// convert target in one variant).
+func Test_listNamespacedInstancetypes_fallback(t *testing.T) {
+	ctx := context.Background()
+	base := newFakeClient(t, &kvinstancetypev1alpha1.VirtualMachineInstancetype{
+		ObjectMeta: metav1.ObjectMeta{Name: "ns-alpha-1", Namespace: "tenant"},
+		Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
+			CPU:    kvinstancetypev1alpha1.CPUInstancetype{Guest: 2},
+			Memory: kvinstancetypev1alpha1.MemoryInstancetype{Guest: resource.MustParse("4Gi")},
+		},
+	})
+	client := &noMatchListClient{Client: base, unservedVersions: map[string]bool{"v1beta1": true}}
+
+	items, err := listNamespacedInstancetypes(ctx, client, ctrlruntimeclient.InNamespace("tenant"))
+	if err != nil {
+		t.Fatalf("listNamespacedInstancetypes() unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "ns-alpha-1" {
+		t.Fatalf("got %+v, want one converted item named ns-alpha-1", items)
+	}
+	if items[0].Spec.CPU.Guest != 2 {
+		t.Errorf("converted CPU.Guest = %d, want 2", items[0].Spec.CPU.Guest)
+	}
+}
+
+// Test_listClusterPreferences_fallback is the preference-variant parity check. Confirms the
+// helper falls back to v1alpha1 preferences and converts them when v1beta1 is not served.
+func Test_listClusterPreferences_fallback(t *testing.T) {
+	ctx := context.Background()
+	base := newFakeClient(t, &kvinstancetypev1alpha1.VirtualMachineClusterPreference{
+		ObjectMeta: metav1.ObjectMeta{Name: "pref-alpha-1"},
+		Spec: kvinstancetypev1alpha1.VirtualMachinePreferenceSpec{
+			CPU: &kvinstancetypev1alpha1.CPUPreferences{
+				PreferredCPUTopology: kvinstancetypev1alpha1.PreferThreads,
+			},
+		},
+	})
+	client := &noMatchListClient{Client: base, unservedVersions: map[string]bool{"v1beta1": true}}
+
+	items, err := listClusterPreferences(ctx, client)
+	if err != nil {
+		t.Fatalf("listClusterPreferences() unexpected error: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "pref-alpha-1" {
+		t.Fatalf("got %+v, want one converted preference named pref-alpha-1", items)
+	}
+	if items[0].Spec.CPU == nil {
+		t.Errorf("converted preference CPU spec is nil; conversion did not copy the spec")
+	}
 }

--- a/modules/api/pkg/handler/v2/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/v2/provider/kubevirt_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	kvapiv1 "kubevirt.io/api/core/v1"
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	apiv1 "k8c.io/dashboard/v2/pkg/api/v1"
 	providercommon "k8c.io/dashboard/v2/pkg/handler/common/provider"
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -52,7 +53,7 @@ var testScheme = fake.NewScheme()
 
 func init() {
 	utilruntime.Must(kvapiv1.AddToScheme(testScheme))
-	utilruntime.Must(kvinstancetypev1alpha1.AddToScheme(testScheme))
+	utilruntime.Must(kvinstancetypev1beta1.AddToScheme(testScheme))
 }
 
 var (
@@ -121,8 +122,8 @@ var (
 		"{\"name\":\"standard-8\",\"kind\":\"VirtualMachineInstancetype\",\"spec\":\"{\\\"cpu\\\":{\\\"guest\\\":8},\\\"memory\\\":{\\\"guest\\\":\\\"34360M\\\"}}\"}]}}"
 )
 
-func newClusterInstancetype(cpu uint32, memory string) *kvinstancetypev1alpha1.VirtualMachineClusterInstancetype {
-	return &kvinstancetypev1alpha1.VirtualMachineClusterInstancetype{
+func newClusterInstancetype(cpu uint32, memory string) *kvinstancetypev1beta1.VirtualMachineClusterInstancetype {
+	return &kvinstancetypev1beta1.VirtualMachineClusterInstancetype{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: instancetypeName(cpu, memory),
 		},
@@ -139,12 +140,12 @@ func getQuantity(q string) *resource.Quantity {
 	return &res
 }
 
-func getInstancetypeSpec(cpu uint32, memory string) kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec {
-	return kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-		CPU: kvinstancetypev1alpha1.CPUInstancetype{
+func getInstancetypeSpec(cpu uint32, memory string) kvinstancetypev1beta1.VirtualMachineInstancetypeSpec {
+	return kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+		CPU: kvinstancetypev1beta1.CPUInstancetype{
 			Guest: cpu,
 		},
-		Memory: kvinstancetypev1alpha1.MemoryInstancetype{
+		Memory: kvinstancetypev1beta1.MemoryInstancetype{
 			Guest: *getQuantity(memory),
 		},
 	}
@@ -320,8 +321,8 @@ func TestListInstancetypeNoCredentialsEndpoint(t *testing.T) {
 }
 
 var (
-	preferenceCores        = newClusterPreference(kvinstancetypev1alpha1.PreferCores)
-	preferenceSockets      = newClusterPreference(kvinstancetypev1alpha1.PreferSockets)
+	preferenceCores        = newClusterPreference(kvinstancetypev1beta1.DeprecatedPreferCores)
+	preferenceSockets      = newClusterPreference(kvinstancetypev1beta1.DeprecatedPreferSockets)
 	preferenceListResponse = "{\"preferences\":" +
 		"{\"custom\":[" +
 		"{\"name\":\"preferCores\",\"spec\":\"{\\\"cpu\\\":{\\\"preferredCPUTopology\\\":\\\"preferCores\\\"}}\"}," +
@@ -330,14 +331,14 @@ var (
 		"{\"name\":\"sockets-advantage\",\"spec\":\"{\\\"cpu\\\":{\\\"preferredCPUTopology\\\":\\\"preferSockets\\\"}}\"}]}}"
 )
 
-func newClusterPreference(topology kvinstancetypev1alpha1.PreferredCPUTopology) *kvinstancetypev1alpha1.VirtualMachineClusterPreference {
-	return &kvinstancetypev1alpha1.VirtualMachineClusterPreference{
+func newClusterPreference(topology kvinstancetypev1beta1.PreferredCPUTopology) *kvinstancetypev1beta1.VirtualMachineClusterPreference {
+	return &kvinstancetypev1beta1.VirtualMachineClusterPreference{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: string(topology),
 		},
-		Spec: kvinstancetypev1alpha1.VirtualMachinePreferenceSpec{
-			CPU: &kvinstancetypev1alpha1.CPUPreferences{
-				PreferredCPUTopology: topology,
+		Spec: kvinstancetypev1beta1.VirtualMachinePreferenceSpec{
+			CPU: &kvinstancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: ptr.To(topology),
 			},
 		},
 	}

--- a/modules/api/pkg/provider/cloud/kubevirt/client.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/client.go
@@ -22,6 +22,7 @@ import (
 	kubeovnv1 "github.com/kubeovn/kube-ovn/pkg/apis/kubeovn/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	"k8c.io/kubermatic/v2/pkg/test/fake"
@@ -41,6 +42,7 @@ var (
 func init() {
 	utilruntime.Must(nativescheme.AddToScheme(scheme))
 	utilruntime.Must(kubevirtv1.AddToScheme(scheme))
+	utilruntime.Must(kvinstancetypev1beta1.AddToScheme(scheme))
 	utilruntime.Must(kvinstancetypev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(cdiv1beta1.AddToScheme(scheme))
 	utilruntime.Must(kubeovnv1.AddToScheme(scheme))

--- a/modules/api/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-2.yaml
+++ b/modules/api/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-2.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-2

--- a/modules/api/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-4.yaml
+++ b/modules/api/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-4.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-4

--- a/modules/api/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-8.yaml
+++ b/modules/api/pkg/provider/cloud/kubevirt/manifests/instancetypes/standard-8.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-8

--- a/modules/api/pkg/provider/cloud/kubevirt/manifests/manifests_test.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/manifests/manifests_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -50,7 +51,7 @@ var (
 
 func init() {
 	utilruntime.Must(kubevirtv1.AddToScheme(testScheme))
-	utilruntime.Must(kvinstancetypev1alpha1.AddToScheme(testScheme))
+	utilruntime.Must(kvinstancetypev1beta1.AddToScheme(testScheme))
 	fakeclient = fake.
 		NewClientBuilder().
 		WithScheme(testScheme).
@@ -118,19 +119,19 @@ func getInstancetype(cpu uint32, memory, name string) []runtime.Object {
 	if err != nil {
 		return nil
 	}
-	instancetype := &kvinstancetypev1alpha1.VirtualMachineInstancetype{
+	instancetype := &kvinstancetypev1beta1.VirtualMachineInstancetype{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: kvinstancetypev1alpha1.SchemeGroupVersion.String(),
+			APIVersion: kvinstancetypev1beta1.SchemeGroupVersion.String(),
 			Kind:       "VirtualMachineInstancetype",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: kvinstancetypev1alpha1.VirtualMachineInstancetypeSpec{
-			CPU: kvinstancetypev1alpha1.CPUInstancetype{
+		Spec: kvinstancetypev1beta1.VirtualMachineInstancetypeSpec{
+			CPU: kvinstancetypev1beta1.CPUInstancetype{
 				Guest: cpu,
 			},
-			Memory: kvinstancetypev1alpha1.MemoryInstancetype{
+			Memory: kvinstancetypev1beta1.MemoryInstancetype{
 				Guest: memoryQuantity,
 			},
 		},
@@ -139,17 +140,17 @@ func getInstancetype(cpu uint32, memory, name string) []runtime.Object {
 }
 
 func getPreference(name string) []runtime.Object {
-	preference := &kvinstancetypev1alpha1.VirtualMachinePreference{
+	preference := &kvinstancetypev1beta1.VirtualMachinePreference{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: kvinstancetypev1alpha1.SchemeGroupVersion.String(),
+			APIVersion: kvinstancetypev1beta1.SchemeGroupVersion.String(),
 			Kind:       "VirtualMachinePreference",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: kvinstancetypev1alpha1.VirtualMachinePreferenceSpec{
-			CPU: &kvinstancetypev1alpha1.CPUPreferences{
-				PreferredCPUTopology: kvinstancetypev1alpha1.PreferThreads,
+		Spec: kvinstancetypev1beta1.VirtualMachinePreferenceSpec{
+			CPU: &kvinstancetypev1beta1.CPUPreferences{
+				PreferredCPUTopology: ptr.To(kvinstancetypev1beta1.DeprecatedPreferThreads),
 			},
 		},
 	}

--- a/modules/api/pkg/provider/cloud/kubevirt/manifests/preferences/sockets-advantage.yaml
+++ b/modules/api/pkg/provider/cloud/kubevirt/manifests/preferences/sockets-advantage.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
 metadata:
   name: sockets-advantage

--- a/modules/api/pkg/provider/cloud/kubevirt/manifests/test/instancetypes/standard-1.yaml
+++ b/modules/api/pkg/provider/cloud/kubevirt/manifests/test/instancetypes/standard-1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: standard-1

--- a/modules/api/pkg/provider/cloud/kubevirt/manifests/test/preferences/standard-1.yaml
+++ b/modules/api/pkg/provider/cloud/kubevirt/manifests/test/preferences/standard-1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: instancetype.kubevirt.io/v1alpha1
+apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
 metadata:
   name: standard-1

--- a/modules/api/pkg/provider/cloud/kubevirt/vm_instancetype.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/vm_instancetype.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kubevirt
 
 import (
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	kvmanifests "k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt/manifests"
 
@@ -25,11 +25,11 @@ import (
 )
 
 // GetKubermaticStandardInstancetypes returns the Kubermatic standard VirtualMachineInstancetypes.
-func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1alpha1.VirtualMachineInstancetype {
+func GetKubermaticStandardInstancetypes(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1beta1.VirtualMachineInstancetype {
 	objs := kvmanifests.RuntimeFromYaml(client, getter)
-	instancetypes := make([]kvinstancetypev1alpha1.VirtualMachineInstancetype, 0, len(objs))
+	instancetypes := make([]kvinstancetypev1beta1.VirtualMachineInstancetype, 0, len(objs))
 	for _, obj := range objs {
-		instancetypes = append(instancetypes, *obj.(*kvinstancetypev1alpha1.VirtualMachineInstancetype))
+		instancetypes = append(instancetypes, *obj.(*kvinstancetypev1beta1.VirtualMachineInstancetype))
 	}
 	return instancetypes
 }

--- a/modules/api/pkg/provider/cloud/kubevirt/vm_preference.go
+++ b/modules/api/pkg/provider/cloud/kubevirt/vm_preference.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kubevirt
 
 import (
-	kvinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kvinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 
 	kvmanifests "k8c.io/dashboard/v2/pkg/provider/cloud/kubevirt/manifests"
 
@@ -25,11 +25,11 @@ import (
 )
 
 // GetKubermaticStandardPreferences returns the Kubermatic standard VirtualMachinePreferences.
-func GetKubermaticStandardPreferences(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1alpha1.VirtualMachinePreference {
+func GetKubermaticStandardPreferences(client ctrlruntimeclient.Client, getter kvmanifests.ManifestFSGetter) []kvinstancetypev1beta1.VirtualMachinePreference {
 	objs := kvmanifests.RuntimeFromYaml(client, getter)
-	preferences := make([]kvinstancetypev1alpha1.VirtualMachinePreference, 0, len(objs))
+	preferences := make([]kvinstancetypev1beta1.VirtualMachinePreference, 0, len(objs))
 	for _, obj := range objs {
-		preferences = append(preferences, *obj.(*kvinstancetypev1alpha1.VirtualMachinePreference))
+		preferences = append(preferences, *obj.(*kvinstancetypev1beta1.VirtualMachinePreference))
 	}
 	return preferences
 }

--- a/modules/api/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/modules/api/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	instancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 )
 
 // VirtualMachineInstancetypeReconciler defines an interface to create/update VirtualMachineInstancetypes.
-type VirtualMachineInstancetypeReconciler = func(existing *instancetypev1alpha1.VirtualMachineInstancetype) (*instancetypev1alpha1.VirtualMachineInstancetype, error)
+type VirtualMachineInstancetypeReconciler = func(existing *instancetypev1beta1.VirtualMachineInstancetype) (*instancetypev1beta1.VirtualMachineInstancetype, error)
 
 // NamedVirtualMachineInstancetypeReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
 type NamedVirtualMachineInstancetypeReconcilerFactory = func() (name string, reconciler VirtualMachineInstancetypeReconciler)
@@ -38,9 +38,9 @@ type NamedVirtualMachineInstancetypeReconcilerFactory = func() (name string, rec
 func VirtualMachineInstancetypeObjectWrapper(reconciler VirtualMachineInstancetypeReconciler) reconciling.ObjectReconciler {
 	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 		if existing != nil {
-			return reconciler(existing.(*instancetypev1alpha1.VirtualMachineInstancetype))
+			return reconciler(existing.(*instancetypev1beta1.VirtualMachineInstancetype))
 		}
-		return reconciler(&instancetypev1alpha1.VirtualMachineInstancetype{})
+		return reconciler(&instancetypev1beta1.VirtualMachineInstancetype{})
 	}
 }
 
@@ -56,7 +56,7 @@ func ReconcileVirtualMachineInstancetypes(ctx context.Context, namedFactories []
 			reconcileObject = objectModifier(reconcileObject)
 		}
 
-		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1alpha1.VirtualMachineInstancetype{}, false); err != nil {
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1beta1.VirtualMachineInstancetype{}, false); err != nil {
 			return fmt.Errorf("failed to ensure VirtualMachineInstancetype %s/%s: %w", namespace, name, err)
 		}
 	}
@@ -65,7 +65,7 @@ func ReconcileVirtualMachineInstancetypes(ctx context.Context, namedFactories []
 }
 
 // VirtualMachinePreferenceReconciler defines an interface to create/update VirtualMachinePreferences.
-type VirtualMachinePreferenceReconciler = func(existing *instancetypev1alpha1.VirtualMachinePreference) (*instancetypev1alpha1.VirtualMachinePreference, error)
+type VirtualMachinePreferenceReconciler = func(existing *instancetypev1beta1.VirtualMachinePreference) (*instancetypev1beta1.VirtualMachinePreference, error)
 
 // NamedVirtualMachinePreferenceReconcilerFactory returns the name of the resource and the corresponding Reconciler function.
 type NamedVirtualMachinePreferenceReconcilerFactory = func() (name string, reconciler VirtualMachinePreferenceReconciler)
@@ -75,9 +75,9 @@ type NamedVirtualMachinePreferenceReconcilerFactory = func() (name string, recon
 func VirtualMachinePreferenceObjectWrapper(reconciler VirtualMachinePreferenceReconciler) reconciling.ObjectReconciler {
 	return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
 		if existing != nil {
-			return reconciler(existing.(*instancetypev1alpha1.VirtualMachinePreference))
+			return reconciler(existing.(*instancetypev1beta1.VirtualMachinePreference))
 		}
-		return reconciler(&instancetypev1alpha1.VirtualMachinePreference{})
+		return reconciler(&instancetypev1beta1.VirtualMachinePreference{})
 	}
 }
 
@@ -93,7 +93,7 @@ func ReconcileVirtualMachinePreferences(ctx context.Context, namedFactories []Na
 			reconcileObject = objectModifier(reconcileObject)
 		}
 
-		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1alpha1.VirtualMachinePreference{}, false); err != nil {
+		if err := reconciling.EnsureNamedObject(ctx, types.NamespacedName{Namespace: namespace, Name: name}, reconcileObject, client, &instancetypev1beta1.VirtualMachinePreference{}, false); err != nil {
 			return fmt.Errorf("failed to ensure VirtualMachinePreference %s/%s: %w", namespace, name, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**

The dashboard API lists KubeVirt instancetypes/preferences using `instancetype.kubevirt.io/v1alpha1`, which KubeVirt 1.6.0 stopped serving. On a 1.6.x+ infra cluster every dropdown load fails API discovery (`no matches for instancetype.kubevirt.io/v1alpha1`) and the lists come back empty. This switches the dashboard API to list `v1beta1` first, falling back to `v1alpha1` only when v1beta1 is not served (older pre-v1.0.0 clusters). The fallback's own `NoMatchError` is swallowed so it never reintroduces the discovery noise on modern clusters.

**Which issue(s) this PR fixes:**
Fixes #7728

**What type of PR is this?**
/kind bug

**Special notes for your reviewer:**

This is a List-fallback pattern new to the Kubermatic KubeVirt code. KKP's listing is v1beta1-only (fixed in kubermatic/kubermatic#15958, backported kubermatic/kubermatic#16041), and machine-controller's version fallback is `client.Get`-based. The embedded standard manifests and the generated reconciling types move to v1beta1 in the same change (the decode path type-asserts v1beta1, so the manifest bump and getter-type swap are coupled).

**Does this PR introduce a user-facing change? Then add your Release Note here:**
```release-note
Fix KubeVirt instancetype/preference dropdowns failing on KubeVirt 1.6.x+ infra clusters by listing via the v1beta1 API (v1alpha1 fallback retained for older clusters).
```

**Documentation:**
```documentation
NONE
```

**Test issue:**
```test-issue
TBD
```

testing:

```
$ echo "current branch: $(git branch --show-current)" && KC=$(base64 -i cfg) && curl -s "http://127.0.0.1:8080/api/v2/providers/kubevirt/instancetypes" \
    -H "Authorization: Bearer <token>" -H "Kubeconfig: $KC" -H "DatacenterName: $DC" | jq .

current branch: main
{
  "error": {
    "code": 500,
    "message": "unable to retrieve the complete list of server APIs: instancetype.kubevirt.io/v1alpha1: no matches for instancetype.kubevirt.io/v1alpha1, Resource="
  }
}


$ echo "current branch: $(git branch --show-current)" && curl -s "http://127.0.0.1:8080/api/v2/providers/kubevirt/instancetypes" \
    -H "Authorization: Bearer <token>" -H "Kubeconfig: $KC" -H "DatacenterName: $DC" | jq ".instancetypes.custom | length"

current branch: fix/7728-kubevirt-instancetype-v1beta1
55
```
