### PR TITLE
Fix black focus outlines in dark theme after Angular v21 upgrade

### DIFF
--- a/modules/web/src/assets/css/theme/_main.scss
+++ b/modules/web/src/assets/css/theme/_main.scss
@@ -29,8 +29,17 @@ $my-typography: mat.m2-define-typography-config(
 @include mat.app-background;
 
 // Restores overflow:visible on chip cells (removed as a default in Angular Material v21 via
-// angular/components#31679 and now only re-applied through this mixin). 
-@include mat.strong-focus-indicators;
+// angular/components#31679). Inlined instead of including mat.strong-focus-indicators: that mixin
+// also emits --mat-focus-indicator-border-color: var(--mat-sys-secondary, black), and this app
+// still uses the M2 theming API, so --mat-sys-* is never defined and every focused control gets a
+// black outline.
+.mat-mdc-standard-chip {
+  .mdc-evolution-chip__cell--primary,
+  .mdc-evolution-chip__action--primary,
+  .mat-mdc-chip-action-label {
+    overflow: visible;
+  }
+}
 
 @mixin theme($theme, $colors) {
   $palette-background: map.get($theme, background);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the black outlines that appear around radio buttons and dropdown options in dark theme, regressed by 

Ref: #8084
Fixes: #8190 


**Before**
<img width="679" height="323" alt="Screenshot 2026-07-31 at 12 54 37 AM" src="https://github.com/user-attachments/assets/8a22f5b1-37d9-40f1-9d79-fd47d25daddf" />

<img width="601" height="253" alt="Screenshot 2026-07-31 at 12 55 01 AM" src="https://github.com/user-attachments/assets/5fa50ed7-4328-4b38-b76f-5939c6ebae22" />

**After**
<img width="631" height="262" alt="Screenshot 2026-07-31 at 12 54 50 AM" src="https://github.com/user-attachments/assets/54651afd-d8f0-4f57-bc41-db82b6b17886" />

<img width="608" height="215" alt="Screenshot 2026-07-31 at 12 55 10 AM" src="https://github.com/user-attachments/assets/51668e3d-6af5-43ea-9204-6472375f9876" />




**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref: #8084 

**What type of PR is this?**
/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
