### PR TITLE
Show info icons and tooltips consistently for cluster options

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -52,8 +52,11 @@ import {
   CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP,
   generateEncryptionKey,
 } from '@shared/utils/cluster';
-import {getEditionVersion} from '@shared/utils/common';
+import {getEditionVersion, tooltipWithAdminNote} from '@shared/utils/common';
 import {
+  ADMIN_ENFORCED_IN_DATACENTER_NOTE,
+  ADMIN_ENFORCED_NOTE,
+  CLUSTER_OPTION_TOOLTIPS,
   KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE,
   NODE_EGRESS_PROXY_TOOLTIP,
   OPA_DEPRECATED_MESSAGE,
@@ -148,6 +151,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   readonly KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE = KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE;
   readonly OPA_DEPRECATED_MESSAGE = OPA_DEPRECATED_MESSAGE;
   readonly NODE_EGRESS_PROXY_TOOLTIP = NODE_EGRESS_PROXY_TOOLTIP;
+  readonly Tooltips = CLUSTER_OPTION_TOOLTIPS;
+  readonly AdminEnforcedNote = ADMIN_ENFORCED_NOTE;
+  readonly AdminEnforcedInDatacenterNote = ADMIN_ENFORCED_IN_DATACENTER_NOTE;
+  readonly tooltipWithAdminNote = tooltipWithAdminNote;
   private readonly _nameMinLen = 3;
   private readonly ENCRYPTION_KEY_ANNOTATION = 'kubermatic.io/encryption-key';
   private _settings: AdminSettings;

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -50,7 +50,7 @@ limitations under the License.
                     class="km-select-ellipsis"
                     disableOptionCentering
                     disabled
-                    matTooltip="Containerd is the only supported container runtime"
+                    [matTooltip]="Tooltips.containerRuntime"
                     required
                     kmValueChangedIndicator>
           <mat-option [value]="containerRuntime.Containerd">containerd</mat-option>
@@ -72,7 +72,7 @@ limitations under the License.
               {{getPluginName(admissionPlugin)}}
               @if (admissionPlugin === admissionPlugin.PodSecurityPolicy) {
               <i class="km-icon-info km-pointer"
-                 matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
+                 [matTooltip]="Tooltips.podSecurityPolicy"></i>
               }
             </mat-option>
             }
@@ -164,7 +164,7 @@ limitations under the License.
         </mat-checkbox>
         @if (!!form.get(Controls.Konnectivity).value && form.get(Controls.Konnectivity).disabled) {
         <i class="km-icon-info km-pointer"
-           matTooltip="OpenVPN support is deprecated, hence Konnectivity can no longer be disabled."></i>
+           [matTooltip]="Tooltips.konnectivity"></i>
         }
       </div>
 
@@ -173,26 +173,26 @@ limitations under the License.
                       kmValueChangedIndicator>
           Audit Logging
           <i class="km-icon-info km-pointer"
-             [matTooltip]="!!datacenter.spec.enforceAuditLogging ? 'Audit Logging is enforced by your admin in the chosen datacenter.' : 'Enable audit logging to record requests received by the Kubernetes API of this cluster.'"></i>
+             [matTooltip]="tooltipWithAdminNote(Tooltips.auditLogging, AdminEnforcedInDatacenterNote, !!datacenter.spec.enforceAuditLogging)"></i>
         </mat-checkbox>
         @if (!!form.get(Controls.AuditLogging).value) {
         <mat-button-toggle-group [formControlName]="Controls.AuditPolicyPreset"
                                  group="auditLogging"
                                  kmValueChangedIndicator>
           <mat-button-toggle [value]="AuditPolicyPreset.Custom"
-                             matTooltip="Sets up cluster with a metadata audit policy that can be edited after the cluster has been created.">
+                             [matTooltip]="Tooltips.auditPolicyCustom">
             custom
           </mat-button-toggle>
           <mat-button-toggle [value]="AuditPolicyPreset.Metadata"
-                             matTooltip="Logs metadata for all requests received by the Kubernetes API.">
+                             [matTooltip]="Tooltips.auditPolicyMetadata">
             metadata
           </mat-button-toggle>
           <mat-button-toggle [value]="AuditPolicyPreset.Minimal"
-                             matTooltip="Logs extended information about key security concerns like workload modifications and access to sensitive information.">
+                             [matTooltip]="Tooltips.auditPolicyMinimal">
             minimal
           </mat-button-toggle>
           <mat-button-toggle [value]="AuditPolicyPreset.Recommended"
-                             matTooltip="Logs extended information about key security concerns and metadata for all other requests. Recommended for best security coverage.">
+                             [matTooltip]="Tooltips.auditPolicyRecommended">
             recommended
           </mat-button-toggle>
         </mat-button-toggle-group>
@@ -203,7 +203,7 @@ limitations under the License.
       <div fxLayoutAlign=" center">
         <mat-checkbox [formControlName]="Controls.AuditWebhookBackend"> Audit Webhook Backend </mat-checkbox>
         <i class="km-icon-info km-pointer"
-           matTooltip="Configure webhook backend for audit logging functionality."></i>
+           [matTooltip]="Tooltips.auditWebhookBackend"></i>
       </div>
       @if (!!form.get(Controls.AuditWebhookBackend).value) {
       <mat-form-field>
@@ -248,7 +248,7 @@ limitations under the License.
           <span>OPA Integration</span>
           @if (isEnforced(Controls.OPAIntegration)) {
           <i class="km-icon-info km-pointer"
-             matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
+             [matTooltip]="form.get(Controls.OPAIntegration).value ? Tooltips.opaEnforced : Tooltips.opaDisabled"></i>
           }
           <i class="km-icon-warning km-pointer"
              [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
@@ -260,7 +260,7 @@ limitations under the License.
                     kmValueChangedIndicator>
         Kyverno Policy Management
         <i class="km-icon-info km-pointer"
-           matTooltip="Enable to deploy Kyverno for this User Cluster"></i>
+           [matTooltip]="Tooltips.kyverno"></i>
       </mat-checkbox>
       }
 
@@ -269,7 +269,7 @@ limitations under the License.
                     kmValueChangedIndicator>
         User Cluster Logging
         <i class="km-icon-info km-pointer"
-           [matTooltip]="isEnforced(Controls.MLALogging) ? 'User Cluster Logging is enforced by your admin.' : 'Enable log collection for this user cluster.'"></i>
+           [matTooltip]="tooltipWithAdminNote(Tooltips.mlaLogging, AdminEnforcedNote, isEnforced(Controls.MLALogging))"></i>
       </mat-checkbox>
       }
 
@@ -278,7 +278,7 @@ limitations under the License.
                     kmValueChangedIndicator>
         User Cluster Monitoring
         <i class="km-icon-info km-pointer"
-           [matTooltip]="isEnforced(Controls.MLAMonitoring) ? 'User Cluster Monitoring is enforced by your admin.' : 'Enable metrics collection for this user cluster.'"></i>
+           [matTooltip]="tooltipWithAdminNote(Tooltips.mlaMonitoring, AdminEnforcedNote, isEnforced(Controls.MLAMonitoring))"></i>
       </mat-checkbox>
       }
 
@@ -299,7 +299,7 @@ limitations under the License.
       @if (isKubeLBEnabled || isKubeLBEnabledForCluster()) {
       <div fxLayout="row"
            fxLayoutAlign=" center"
-           [matTooltip]="isKubeLBEnforced ? 'Kubermatic KubeLB is enforced by your admin in the chosen datacenter and cannot be disabled.' : ''"
+           [matTooltip]="isKubeLBEnforced ? Tooltips.kubeLBEnforced : ''"
            [matTooltipDisabled]="!isKubeLBEnforced">
         <mat-checkbox [formControlName]="Controls.KubeLB"
                       [disabled]="isKubeLBEnforced"
@@ -308,7 +308,7 @@ limitations under the License.
         </mat-checkbox>
         @if (!isKubeLBEnforced) {
         <i class="km-icon-info km-pointer"
-           [matTooltip]="'Enable to use Kubermatic KubeLB for managing load balancers in your cluster. This allows automatic provisioning and management of load balancers for your services.'"></i>
+           [matTooltip]="Tooltips.kubeLB"></i>
         }
       </div>
       }
@@ -317,14 +317,14 @@ limitations under the License.
         <mat-checkbox [formControlName]="Controls.KubeLBUseLoadBalancerClass">
           Use LoadBalancer Class
           <i class="km-icon-info km-pointer"
-             matTooltip="Enable to limit KubeLB to only process services with Kubernetes LoadBalancer Class named `kubelb`. When disabled, KubeLB will manage all services of type `LoadBalancer`"></i>
+             [matTooltip]="Tooltips.kubeLBLoadBalancerClass"></i>
         </mat-checkbox>
       </div>
       <div class="km-suboption">
         <mat-checkbox [formControlName]="Controls.KubeLBEnableGatewayAPI">
           Enable Gateway API
           <i class="km-icon-info km-pointer"
-             matTooltip="Enable to use Gateway APIs. KKP will install the Gateway API CRDs in this cluster."></i>
+             [matTooltip]="Tooltips.gatewayAPI"></i>
         </mat-checkbox>
       </div>
       }
@@ -335,7 +335,7 @@ limitations under the License.
                     kmValueChangedIndicator>
         Disable CSI Driver
         <i class="km-icon-info km-pointer"
-           [matTooltip]="isCSIDriverDisabled ? 'CSI Driver is disabled by your admin in the chosen datacenter.' : 'Disable default CSI storage driver, if available.'"></i>
+           [matTooltip]="tooltipWithAdminNote(Tooltips.disableCSIDriver, Tooltips.csiDriverDisabledByAdmin, isCSIDriverDisabled)"></i>
       </mat-checkbox>
 
       <mat-checkbox [formControlName]="Controls.EncryptionAtRest"
@@ -345,7 +345,7 @@ limitations under the License.
              fxLayoutGap="8px">
           <span>Encryption at Rest</span>
           <i class="km-icon-info km-pointer"
-             [matTooltip]="isEncryptionActive() ? 'Enable or disable encryption at rest for cluster secrets.' : 'Enable encryption at rest for cluster secrets for this user cluster.'"></i>
+             [matTooltip]="Tooltips.encryptionAtRest"></i>
         </div>
       </mat-checkbox>
 
@@ -361,7 +361,7 @@ limitations under the License.
                 type="button"
                 matSuffix
                 class="km-randomize-btn"
-                matTooltip="Generate encryption key"
+                [matTooltip]="Tooltips.generateEncryptionKey"
                 (click)="generateEncryptionKey()">
           <i class="km-icon-randomize"></i>
         </button>
@@ -383,7 +383,7 @@ limitations under the License.
                     kmValueChangedIndicator>
         Cluster Backup
         <i class="km-icon-info km-pointer"
-           matTooltip="Enable create backups from this cluster"></i>
+           [matTooltip]="Tooltips.clusterBackup"></i>
       </mat-checkbox>
       }
 

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/template.html
@@ -170,7 +170,11 @@ limitations under the License.
 
       <div fxLayoutAlign=" center">
         <mat-checkbox [formControlName]="Controls.AuditLogging"
-                      kmValueChangedIndicator>Audit Logging</mat-checkbox>
+                      kmValueChangedIndicator>
+          Audit Logging
+          <i class="km-icon-info km-pointer"
+             [matTooltip]="!!datacenter.spec.enforceAuditLogging ? 'Audit Logging is enforced by your admin in the chosen datacenter.' : 'Enable audit logging to record requests received by the Kubernetes API of this cluster.'"></i>
+        </mat-checkbox>
         @if (!!form.get(Controls.AuditLogging).value) {
         <mat-button-toggle-group [formControlName]="Controls.AuditPolicyPreset"
                                  group="auditLogging"
@@ -192,10 +196,6 @@ limitations under the License.
             recommended
           </mat-button-toggle>
         </mat-button-toggle-group>
-        }
-        @if (!!datacenter.spec.enforceAuditLogging) {
-        <i class="km-icon-info km-pointer"
-           matTooltip="Audit Logging is enforced by your admin in the chosen datacenter."></i>
         }
       </div>
 
@@ -268,10 +268,8 @@ limitations under the License.
       <mat-checkbox [formControlName]="Controls.MLALogging"
                     kmValueChangedIndicator>
         User Cluster Logging
-        @if (isEnforced(Controls.MLALogging)) {
         <i class="km-icon-info km-pointer"
-           matTooltip="User Cluster Logging is enforced by your admin."></i>
-        }
+           [matTooltip]="isEnforced(Controls.MLALogging) ? 'User Cluster Logging is enforced by your admin.' : 'Enable log collection for this user cluster.'"></i>
       </mat-checkbox>
       }
 
@@ -279,10 +277,8 @@ limitations under the License.
       <mat-checkbox [formControlName]="Controls.MLAMonitoring"
                     kmValueChangedIndicator>
         User Cluster Monitoring
-        @if (isEnforced(Controls.MLAMonitoring)) {
         <i class="km-icon-info km-pointer"
-           matTooltip="User Cluster Monitoring is enforced by your admin."></i>
-        }
+           [matTooltip]="isEnforced(Controls.MLAMonitoring) ? 'User Cluster Monitoring is enforced by your admin.' : 'Enable metrics collection for this user cluster.'"></i>
       </mat-checkbox>
       }
 

--- a/modules/web/src/app/shared/constants/common.ts
+++ b/modules/web/src/app/shared/constants/common.ts
@@ -54,6 +54,65 @@ export const DELETE_SELECTED_TOOLTIP = 'Delete selected';
 export const CLOSE_PANEL_TOOLTIP = 'Close panel';
 export const GO_BACK_TO_CLUSTER_LIST_TOOLTIP = 'Go back to the cluster list';
 
+// Cluster option tooltips
+// Shared by the cluster wizard and the edit cluster dialog so both describe an option the same way.
+// Each entry says what the option actually does; when an admin locks the option, one of the notes
+// below is prefixed so the reason the control is disabled is the first thing the user reads.
+export const ADMIN_ENFORCED_NOTE = 'Enforced by your admin and cannot be changed.';
+export const ADMIN_ENFORCED_IN_DATACENTER_NOTE =
+  'Enforced by your admin in the chosen datacenter and cannot be changed.';
+export const ADMIN_DISABLED_IN_DATACENTER_NOTE =
+  'Disabled by your admin in the chosen datacenter and cannot be changed.';
+
+export const CLUSTER_OPTION_TOOLTIPS = {
+  containerRuntime: 'Containerd is the only supported container runtime',
+  dualStack:
+    'Dual Stack is a technology preview feature, some limitations may apply depending on the chosen provider. Please see the KKP documentation for more details.',
+  podSecurityPolicy: 'Pod Security Policies allow detailed authorization of pod creation and updates.',
+  konnectivity: 'OpenVPN support is deprecated, hence Konnectivity can no longer be disabled.',
+  ciliumIngress: 'Enable Cilium kubernetes ingress support',
+
+  auditLogging:
+    'Records requests received by the Kubernetes API of this cluster. Logs are collected by a fluent-bit sidecar in the control plane.',
+  auditPolicyCustom:
+    'Sets up cluster with a metadata audit policy that can be edited after the cluster has been created.',
+  auditPolicyMetadata: 'Logs metadata for all requests received by the Kubernetes API.',
+  auditPolicyMinimal:
+    'Logs extended information about key security concerns like workload modifications and access to sensitive information.',
+  auditPolicyRecommended:
+    'Logs extended information about key security concerns and metadata for all other requests. Recommended for best security coverage.',
+  auditWebhookBackend: 'Ships audit logs to an external webhook backend, configured from a secret in this cluster.',
+
+  opaEnforced: 'OPA Integration is enforced by your admin.',
+  opaDisabled: 'OPA Integration is disabled by your admin.',
+  kyverno:
+    'Deploys Kyverno for policy management. Its controllers run in the cluster control plane and register admission webhooks that validate and mutate resources in this user cluster.',
+
+  mlaLogging: 'Collects logs from all pods in this user cluster and ships them to the central Grafana Loki store.',
+  mlaMonitoring:
+    'Scrapes metrics from this user cluster and writes them to the central metrics store for viewing in Grafana.',
+
+  kubeLB:
+    'Enable to use Kubermatic KubeLB for managing load balancers in your cluster. This allows automatic provisioning and management of load balancers for your services.',
+  kubeLBEnforced: 'Kubermatic KubeLB is enforced by your admin in the chosen datacenter and cannot be disabled.',
+  kubeLBLoadBalancerClass:
+    'Enable to limit KubeLB to only process services with Kubernetes LoadBalancer Class named `kubelb`. When disabled, KubeLB will manage all services of type `LoadBalancer`',
+  gatewayAPI: 'Enable to use Gateway APIs. KKP will install the Gateway API CRDs in this cluster.',
+
+  disableCSIDriver:
+    "Skips installation of the provider's default CSI driver, leaving the cluster without dynamic volume provisioning or snapshots. It cannot be turned on while existing volumes still use the driver.",
+  csiDriverDisabledByAdmin: 'The CSI driver is disabled by your admin in the chosen datacenter and cannot be enabled.',
+
+  encryptionAtRest:
+    'Encrypts Kubernetes secrets at rest in etcd with a secretbox key. Enabling it or changing the key runs a job that re-encrypts all affected resources.',
+  generateEncryptionKey: 'Generate encryption key',
+
+  clusterBackup:
+    'Installs Velero in this cluster so cluster resources and volume data can be backed up to the selected backup storage location.',
+  userSSHKeyAgent:
+    'Enable to deploy User SSH Key Agent to the cluster. It cannot be changed once the cluster is created.',
+} as const;
+
 // Per-cluster proxy tooltips
 export const PROXY_MODE_HINT = 'kube-proxy mode for in-cluster service routing.';
 export const NODE_EGRESS_PROXY_TOOLTIP =

--- a/modules/web/src/app/shared/utils/common.ts
+++ b/modules/web/src/app/shared/utils/common.ts
@@ -100,6 +100,12 @@ export function getPercentage(total: number, used: number, maxUsage = maxUsageDe
   return Math.round(((used / total) * maxUsage + Number.EPSILON) * maxUsage) / maxUsage;
 }
 
+// Prefixes an option's description with the reason it is locked, so that a checkbox disabled by an
+// admin explains both why it cannot be changed and what it does.
+export function tooltipWithAdminNote(description: string, note: string, locked: boolean): string {
+  return locked ? `${note} ${description}` : description;
+}
+
 export function getEditionVersion(): string {
   return `v${version.semver?.major}.${version.semver?.minor}`;
 }

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -77,8 +77,11 @@ import {
   CLUSTER_DEFAULT_NODE_SELECTOR_TOOLTIP,
   generateEncryptionKey,
 } from '@shared/utils/cluster';
-import {getEditionVersion} from '@shared/utils/common';
+import {getEditionVersion, tooltipWithAdminNote} from '@shared/utils/common';
 import {
+  ADMIN_ENFORCED_IN_DATACENTER_NOTE,
+  ADMIN_ENFORCED_NOTE,
+  CLUSTER_OPTION_TOOLTIPS,
   GENERATE_NAME_TOOLTIP,
   KUBERNETES_DASHBOARD_DEPRECATED_MESSAGE,
   NODE_EGRESS_PROXY_TOOLTIP,
@@ -226,6 +229,10 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   readonly NODE_EGRESS_PROXY_TOOLTIP = NODE_EGRESS_PROXY_TOOLTIP;
   readonly PROXY_MODE_HINT = PROXY_MODE_HINT;
   readonly GENERATE_NAME_TOOLTIP = GENERATE_NAME_TOOLTIP;
+  readonly Tooltips = CLUSTER_OPTION_TOOLTIPS;
+  readonly AdminEnforcedNote = ADMIN_ENFORCED_NOTE;
+  readonly AdminEnforcedInDatacenterNote = ADMIN_ENFORCED_IN_DATACENTER_NOTE;
+  readonly tooltipWithAdminNote = tooltipWithAdminNote;
   private _datacenterSpec: Datacenter;
   private _seedSettings: SeedSettings;
   private _settings: AdminSettings;

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -456,7 +456,11 @@ limitations under the License.
                fxFlex="100"
                fxLayoutGap="10px">
             <div fxLayoutAlign=" center">
-              <mat-checkbox [formControlName]="Controls.AuditLogging">Audit Logging</mat-checkbox>
+              <mat-checkbox [formControlName]="Controls.AuditLogging">
+                Audit Logging
+                <i class="km-icon-info km-pointer"
+                   [matTooltip]="isEnforced(Controls.AuditLogging) ? 'Audit Logging is enforced by your admin in the chosen datacenter.' : 'Enable audit logging to record requests received by the Kubernetes API of this cluster.'"></i>
+              </mat-checkbox>
               @if (!!controlValue(Controls.AuditLogging)) {
               <mat-button-toggle-group [formControlName]="Controls.AuditPolicyPreset"
                                        group="auditLogging">
@@ -477,10 +481,6 @@ limitations under the License.
                   recommended
                 </mat-button-toggle>
               </mat-button-toggle-group>
-              }
-              @if (isEnforced(Controls.AuditLogging)) {
-              <i class="km-icon-info km-pointer"
-                 matTooltip="Audit Logging is enforced by your admin in the chosen datacenter."></i>
               }
             </div>
             @if (!!controlValue(Controls.AuditLogging) && !isAuditWebhookBackendHidden) {
@@ -661,17 +661,13 @@ limitations under the License.
             @if (isMLAEnabled()) {
             <mat-checkbox [formControlName]="Controls.MLALogging">
               User Cluster Logging
-              @if (isEnforced(Controls.MLALogging)) {
               <i class="km-icon-info km-pointer"
-                 matTooltip="User Cluster Logging is enforced by your admin."></i>
-              }
+                 [matTooltip]="isEnforced(Controls.MLALogging) ? 'User Cluster Logging is enforced by your admin.' : 'Enable log collection for this user cluster.'"></i>
             </mat-checkbox>
             <mat-checkbox [formControlName]="Controls.MLAMonitoring">
               User Cluster Monitoring
-              @if (isEnforced(Controls.MLAMonitoring)) {
               <i class="km-icon-info km-pointer"
-                 matTooltip="User Cluster Monitoring is enforced by your admin."></i>
-              }
+                 [matTooltip]="isEnforced(Controls.MLAMonitoring) ? 'User Cluster Monitoring is enforced by your admin.' : 'Enable metrics collection for this user cluster.'"></i>
             </mat-checkbox>
             }
             @if (isUserSshKeyEnabled) {

--- a/modules/web/src/app/wizard/step/cluster/template.html
+++ b/modules/web/src/app/wizard/step/cluster/template.html
@@ -107,7 +107,7 @@ limitations under the License.
                  fxLayoutAlign=" center">
               <span>IPv4 and IPv6 (Dual Stack)</span>
               <i class="km-icon-info km-pointer"
-                 matTooltip="Dual Stack is a technology preview feature, some limitations may apply depending on the chosen provider. Please see the KKP documentation for more details."></i>
+                 [matTooltip]="Tooltips.dualStack"></i>
             </div>
           </mat-radio-button>
         </mat-radio-group>
@@ -295,12 +295,12 @@ limitations under the License.
               </mat-checkbox>
               @if (!!control(Controls.Konnectivity).value && control(Controls.Konnectivity).disabled) {
               <i class="km-icon-info km-pointer"
-                 matTooltip="OpenVPN support is deprecated, hence Konnectivity can no longer be disabled."></i>
+                 [matTooltip]="Tooltips.konnectivity"></i>
               }
             </div>
             @if (isCiliumSelected()) {
             <mat-checkbox [formControlName]="Controls.CiliumIngress">Ingress <i class="km-icon-info km-pointer"
-                 matTooltip="Enable Cilium kubernetes ingress support"></i></mat-checkbox>
+                 [matTooltip]="Tooltips.ciliumIngress"></i></mat-checkbox>
             }
             <div fxLayoutAlign="flex-start">
               @if (canEditCNIValues) {
@@ -379,7 +379,7 @@ limitations under the License.
                         class="km-select-ellipsis"
                         disableOptionCentering
                         disabled
-                        matTooltip="Containerd is the only supported container runtime"
+                        [matTooltip]="Tooltips.containerRuntime"
                         required>
               <mat-option [value]="containerRuntime.Containerd">containerd</mat-option>
             </mat-select>
@@ -401,7 +401,7 @@ limitations under the License.
                   {{getPluginName(admissionPlugin)}}
                   @if (admissionPlugin === admissionPlugin.PodSecurityPolicy) {
                   <i class="km-icon-info km-pointer"
-                     matTooltip="Pod Security Policies allow detailed authorization of pod creation and updates."></i>
+                     [matTooltip]="Tooltips.podSecurityPolicy"></i>
                   }
                 </mat-option>
                 }
@@ -459,25 +459,25 @@ limitations under the License.
               <mat-checkbox [formControlName]="Controls.AuditLogging">
                 Audit Logging
                 <i class="km-icon-info km-pointer"
-                   [matTooltip]="isEnforced(Controls.AuditLogging) ? 'Audit Logging is enforced by your admin in the chosen datacenter.' : 'Enable audit logging to record requests received by the Kubernetes API of this cluster.'"></i>
+                   [matTooltip]="tooltipWithAdminNote(Tooltips.auditLogging, AdminEnforcedInDatacenterNote, isEnforced(Controls.AuditLogging))"></i>
               </mat-checkbox>
               @if (!!controlValue(Controls.AuditLogging)) {
               <mat-button-toggle-group [formControlName]="Controls.AuditPolicyPreset"
                                        group="auditLogging">
                 <mat-button-toggle [value]="AuditPolicyPreset.Custom"
-                                   matTooltip="Sets up cluster with a metadata audit policy that can be edited after the cluster has been created.">
+                                   [matTooltip]="Tooltips.auditPolicyCustom">
                   custom
                 </mat-button-toggle>
                 <mat-button-toggle [value]="AuditPolicyPreset.Metadata"
-                                   matTooltip="Logs metadata for all requests received by the Kubernetes API.">
+                                   [matTooltip]="Tooltips.auditPolicyMetadata">
                   metadata
                 </mat-button-toggle>
                 <mat-button-toggle [value]="AuditPolicyPreset.Minimal"
-                                   matTooltip="Logs extended information about key security concerns like workload modifications and access to sensitive information.">
+                                   [matTooltip]="Tooltips.auditPolicyMinimal">
                   minimal
                 </mat-button-toggle>
                 <mat-button-toggle [value]="AuditPolicyPreset.Recommended"
-                                   matTooltip="Logs extended information about key security concerns and metadata for all other requests. Recommended for best security coverage.">
+                                   [matTooltip]="Tooltips.auditPolicyRecommended">
                   recommended
                 </mat-button-toggle>
               </mat-button-toggle-group>
@@ -487,7 +487,7 @@ limitations under the License.
             <div fxLayoutAlign=" center">
               <mat-checkbox [formControlName]="Controls.AuditWebhookBackend"> Audit Webhook Backend </mat-checkbox>
               <i class="km-icon-info km-pointer"
-                 [matTooltip]="enforcedAuditWebhookSettings ? 'Audit Webhook Backend settings are enforced by your admin in the chosen datacenter.' : 'Configure webhook backend for audit logging functionality.'"></i>
+                 [matTooltip]="tooltipWithAdminNote(Tooltips.auditWebhookBackend, AdminEnforcedInDatacenterNote, !!enforcedAuditWebhookSettings)"></i>
             </div>
             @if (!!controlValue(Controls.AuditWebhookBackend)) {
             <mat-form-field>
@@ -528,7 +528,7 @@ limitations under the License.
             <mat-checkbox [formControlName]="Controls.ClusterBackup">
               Cluster Backup
               <i class="km-icon-info km-pointer"
-                 matTooltip="Enable create backups from this cluster"></i>
+                 [matTooltip]="Tooltips.clusterBackup"></i>
             </mat-checkbox>
             }
             @if (!!controlValue(Controls.ClusterBackup) && isclusterBackupEnabled) {
@@ -552,7 +552,7 @@ limitations under the License.
                           [disabled]="isCSIDriverDisabled">
               Disable CSI Driver
               <i class="km-icon-info km-pointer"
-                 [matTooltip]="isCSIDriverDisabled ? 'CSI Driver is disabled by your admin in the chosen datacenter.' : 'Disable default CSI storage driver, if available.'"></i>
+                 [matTooltip]="tooltipWithAdminNote(Tooltips.disableCSIDriver, Tooltips.csiDriverDisabledByAdmin, isCSIDriverDisabled)"></i>
             </mat-checkbox>
             @if (isEncryptionAtRestVisible()) {
             <mat-checkbox [formControlName]="Controls.EncryptionAtRest">
@@ -561,7 +561,7 @@ limitations under the License.
                    fxLayoutGap="8px">
                 <span>Encryption at Rest</span>
                 <i class="km-icon-info km-pointer"
-                   matTooltip="Enable encryption at rest for cluster secrets for this user cluster."></i>
+                   [matTooltip]="Tooltips.encryptionAtRest"></i>
               </div>
             </mat-checkbox>
             }
@@ -577,7 +577,7 @@ limitations under the License.
                       type="button"
                       matSuffix
                       class="km-randomize-btn"
-                      matTooltip="Generate encryption key"
+                      [matTooltip]="Tooltips.generateEncryptionKey"
                       (click)="generateEncryptionKey()">
                 <i class="km-icon-randomize"></i>
               </button>
@@ -598,7 +598,7 @@ limitations under the License.
             @if (isKubeLBEnabled) {
             <div fxLayout="row"
                  fxLayoutAlign=" center"
-                 [matTooltip]="isKubeLBEnforced ? 'Kubermatic KubeLB is enforced by your admin in the chosen datacenter and cannot be disabled.' : ''"
+                 [matTooltip]="isKubeLBEnforced ? Tooltips.kubeLBEnforced : ''"
                  [matTooltipDisabled]="!isKubeLBEnforced">
               <mat-checkbox [formControlName]="Controls.KubeLB"
                             [disabled]="isKubeLBEnforced">
@@ -606,7 +606,7 @@ limitations under the License.
               </mat-checkbox>
               @if (!isKubeLBEnforced) {
               <i class="km-icon-info km-pointer"
-                 [matTooltip]="'Enable to use Kubermatic KubeLB for managing load balancers in your cluster. This allows automatic provisioning and management of load balancers for your services.'"></i>
+                 [matTooltip]="Tooltips.kubeLB"></i>
               }
             </div>
             }
@@ -615,14 +615,14 @@ limitations under the License.
               <mat-checkbox [formControlName]="Controls.KubeLBUseLoadBalancerClass">
                 Use LoadBalancer Class
                 <i class="km-icon-info km-pointer"
-                   matTooltip="Enable to limit KubeLB to only process services with Kubernetes LoadBalancer Class named `kubelb`. When disabled, KubeLB will manage all services of type `LoadBalancer`"></i>
+                   [matTooltip]="Tooltips.kubeLBLoadBalancerClass"></i>
               </mat-checkbox>
             </div>
             <div class="km-suboption">
               <mat-checkbox [formControlName]="Controls.KubeLBEnableGatewayAPI">
                 Enable Gateway API
                 <i class="km-icon-info km-pointer"
-                   matTooltip="Enable to use Gateway APIs. KKP will install the Gateway API CRDs in this cluster."></i>
+                   [matTooltip]="Tooltips.gatewayAPI"></i>
               </mat-checkbox>
             </div>
             }
@@ -645,7 +645,7 @@ limitations under the License.
                 <span>OPA Integration</span>
                 @if (isEnforced(Controls.OPAIntegration)) {
                 <i class="km-icon-info km-pointer"
-                   matTooltip="OPA Integration is {{form.get(Controls.OPAIntegration).value ? 'enforced' : 'disabled'}} by your admin."></i>
+                   [matTooltip]="form.get(Controls.OPAIntegration).value ? Tooltips.opaEnforced : Tooltips.opaDisabled"></i>
                 }
                 <i class="km-icon-warning km-pointer"
                    [matTooltip]="OPA_DEPRECATED_MESSAGE"></i>
@@ -655,26 +655,26 @@ limitations under the License.
             <mat-checkbox [formControlName]="Controls.KyvernoIntegration">
               Kyverno Policy Management
               <i class="km-icon-info km-pointer"
-                 matTooltip="Enable to deploy Kyverno for this User Cluster"></i>
+                 [matTooltip]="Tooltips.kyverno"></i>
             </mat-checkbox>
             }
             @if (isMLAEnabled()) {
             <mat-checkbox [formControlName]="Controls.MLALogging">
               User Cluster Logging
               <i class="km-icon-info km-pointer"
-                 [matTooltip]="isEnforced(Controls.MLALogging) ? 'User Cluster Logging is enforced by your admin.' : 'Enable log collection for this user cluster.'"></i>
+                 [matTooltip]="tooltipWithAdminNote(Tooltips.mlaLogging, AdminEnforcedNote, isEnforced(Controls.MLALogging))"></i>
             </mat-checkbox>
             <mat-checkbox [formControlName]="Controls.MLAMonitoring">
               User Cluster Monitoring
               <i class="km-icon-info km-pointer"
-                 [matTooltip]="isEnforced(Controls.MLAMonitoring) ? 'User Cluster Monitoring is enforced by your admin.' : 'Enable metrics collection for this user cluster.'"></i>
+                 [matTooltip]="tooltipWithAdminNote(Tooltips.mlaMonitoring, AdminEnforcedNote, isEnforced(Controls.MLAMonitoring))"></i>
             </mat-checkbox>
             }
             @if (isUserSshKeyEnabled) {
             <mat-checkbox [formControlName]="Controls.UserSSHKeyAgent">
               User SSH Key Agent
               <i class="km-icon-info km-pointer"
-                 matTooltip="Enable to deploy User SSH Key Agent to the cluster. It cannot be changed once the cluster is created."></i>
+                 [matTooltip]="Tooltips.userSSHKeyAgent"></i>
             </mat-checkbox>
             }
             @if (form.get(Controls.RouterReconciliation)) {

--- a/modules/web/src/assets/css/material/_main.scss
+++ b/modules/web/src/assets/css/material/_main.scss
@@ -594,6 +594,13 @@ button {
   }
 }
 
+// Material puts `.mdc-checkbox--disabled { pointer-events: none; }` on the checkbox host, so a
+// disabled checkbox also swallows hover on its projected label content. Info icons there usually
+// explain *why* the option is disabled, so their tooltips must stay reachable.
+.mat-mdc-checkbox.mat-mdc-checkbox-disabled .mdc-label .km-icon-info {
+  pointer-events: auto;
+}
+
 .mat-button-toggle-group {
   &.mat-button-toggle-group-appearance-standard {
     border: none;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the missing info icons on the Audit Logging, User Cluster Logging and User Cluster Monitoring options and makes their tooltips readable when the option is disabled, so every cluster setting explains itself consistently.


**Before:**

- Missing info icons
- Missing tooltips

<img width="441" height="459" alt="Screenshot 2026-07-31 at 3 29 13 PM" src="https://github.com/user-attachments/assets/318e188c-4ec1-4a90-a6d2-9250d40bcae5" />


**After:**

<img width="427" height="489" alt="Screenshot 2026-08-05 at 6 01 54 PM" src="https://github.com/user-attachments/assets/e8eb159e-d7d2-4209-8f1f-4187dc912b5e" />

<img width="358" height="452" alt="Screenshot 2026-08-05 at 6 02 00 PM" src="https://github.com/user-attachments/assets/10003223-c8c0-4073-a600-e68ccf121366" />

<img width="279" height="482" alt="Screenshot 2026-08-05 at 6 02 10 PM" src="https://github.com/user-attachments/assets/54c19bdc-29c4-4a22-a845-08258c84ebd4" />

<img width="472" height="116" alt="Screenshot 2026-08-05 at 6 02 16 PM" src="https://github.com/user-attachments/assets/f3149953-5eee-45ad-839b-515c9df6d6ca" />




(On Disabled Info Icon)
<img width="380" height="143" alt="Screenshot 2026-08-05 at 6 02 32 PM" src="https://github.com/user-attachments/assets/6295ec5b-a189-4153-b727-823c5f1009b9" />



- Add ℹ️ icons
- Show tooltips in disabled
- Show tooltips on default/enforce in both cases (That is why "@if" syntax as been removed and instead ternary operator is used) to show tool for default scenario and enforced scenario

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
NONE

**What type of PR is this?**
/kind bug
/kind design
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

- Default/Enabled: Decided to show some valuable tooltips otherwise it was no purpose to show tooltip like "Enable this {feature"

Tooltip to show like:

- Enforced: Showing note (That feature is disabled by admin + tooltip also shows what the feature is like description of feature)

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Show info icons with tooltips for all cluster options, including disabled ones
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
