### PR TITLE
Make the KKP revision used by `make update-kkp` configurable

### DIFF
--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,10 +1,7 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
 KUBERMATIC_VERSION?=v2.30.0
-# Revision used by `make update-kkp`. Accepts a branch, tag or commit SHA,
-# e.g. `make update-kkp KKP_REF=a52d397b275f`.
-KKP_REF ?= main
-KKP_SDK_REF ?= $(KKP_REF)
+KKP_REVISION ?= main
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')
@@ -120,9 +117,9 @@ verify:
 	./hack/verify.sh
 
 .PHONY: update-kkp
-update-kkp: ## Update KKP + SDK deps. Override the revision with KKP_REF=<branch|tag|commit-sha>.
-	go get -v k8c.io/kubermatic/v2@$(KKP_REF)
-	go get -v k8c.io/kubermatic/sdk/v2@$(KKP_SDK_REF)
+update-kkp: ## Override the revision with KKP_REVISION=<branch|tag|commit-sha>.
+	go get -v k8c.io/kubermatic/v2@$(KKP_REVISION)
+	go get -v k8c.io/kubermatic/sdk/v2@$(KKP_REVISION)
 	$(MAKE) update-codegen
 
 .PHONY: fmt

--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -1,6 +1,10 @@
 SHELL = /bin/bash -eu -o pipefail
 export KUBERMATIC_EDITION ?= ee
 KUBERMATIC_VERSION?=v2.30.0
+# Revision used by `make update-kkp`. Accepts a branch, tag or commit SHA,
+# e.g. `make update-kkp KKP_REF=a52d397b275f`.
+KKP_REF ?= main
+KKP_SDK_REF ?= $(KKP_REF)
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/dashboard$(shell [[ "$(KUBERMATIC_EDITION)" != "ce" ]] && printf -- '-%s' ${KUBERMATIC_EDITION})
 IMAGE_TAG=$(shell echo $$(git rev-parse HEAD)|tr -d '\n')
@@ -116,9 +120,9 @@ verify:
 	./hack/verify.sh
 
 .PHONY: update-kkp
-update-kkp:
-	go get -v k8c.io/kubermatic/v2@main
-	go get -v k8c.io/kubermatic/sdk/v2@main
+update-kkp: ## Update KKP + SDK deps. Override the revision with KKP_REF=<branch|tag|commit-sha>.
+	go get -v k8c.io/kubermatic/v2@$(KKP_REF)
+	go get -v k8c.io/kubermatic/sdk/v2@$(KKP_SDK_REF)
 	$(MAKE) update-codegen
 
 .PHONY: fmt


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `KKP_REVISION` variable to the API Makefile so `make update-kkp` can pull KKP and its SDK from a branch, tag or commit SHA instead of always `main`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes: NONE

**What type of PR is this?**
/kind cleanup
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
