### PR TITLE
Add route guard for enterprise-only views in CE

### DIFF
--- a/modules/web/src/app/core/module.ts
+++ b/modules/web/src/app/core/module.ts
@@ -77,6 +77,7 @@ import {SidenavComponent} from './components/sidenav/component';
 import {UserPanelComponent} from './components/user-panel/component';
 import {AuthInterceptor, ErrorNotificationsInterceptor, LoaderInterceptor} from './interceptors';
 import {ClusterBackupService} from './services/cluster-backup';
+import {EnterpriseEditionGuard} from './services/enterprise-edition/guard';
 import {SSHKeyGuard} from './services/ssh-key/guard';
 import {KyvernoService} from './services/kyverno';
 
@@ -100,6 +101,7 @@ const services = [
   AuthzGuard,
   AdminGuard,
   SSHKeyGuard,
+  EnterpriseEditionGuard,
   DatacenterService,
   NameGeneratorService,
   ClusterService,

--- a/modules/web/src/app/core/services/enterprise-edition/guard.ts
+++ b/modules/web/src/app/core/services/enterprise-edition/guard.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Injectable} from '@angular/core';
+import {CanMatch, Route, UrlSegment} from '@angular/router';
+import {DynamicModule} from '@app/dynamic/module-registry';
+
+// Blocks enterprise-only routes in community edition builds so they fall through to the 404 page
+// instead of resolving to an empty stub module. CanMatch avoids fetching the stub chunk at all.
+@Injectable()
+export class EnterpriseEditionGuard implements CanMatch {
+  canMatch(_route: Route, _segments: UrlSegment[]): boolean {
+    return DynamicModule.isEnterpriseEdition;
+  }
+}

--- a/modules/web/src/app/routing.ts
+++ b/modules/web/src/app/routing.ts
@@ -20,6 +20,7 @@ import {DashboardComponent} from './dashboard/component';
 import {DynamicModule} from './dynamic/module-registry';
 import {View} from './shared/entity/common';
 import {SSHKeyGuard} from './core/services/ssh-key/guard';
+import {EnterpriseEditionGuard} from './core/services/enterprise-edition/guard';
 
 class SelectedPreloadingStrategy implements PreloadingStrategy {
   preload(route: Route, load: () => Observable<any>): Observable<any> {
@@ -101,22 +102,27 @@ function createRouting(): Routes {
         {
           path: `projects/:projectID/${View.ClusterBackup}`,
           loadChildren: () => DynamicModule.ClusterBackups,
+          canMatch: [EnterpriseEditionGuard],
         },
         {
           path: `projects/:projectID/${View.ClusterSchedule}`,
           loadChildren: () => DynamicModule.ClusterBackups,
+          canMatch: [EnterpriseEditionGuard],
         },
         {
           path: `projects/:projectID/${View.ClusterRestore}`,
           loadChildren: () => DynamicModule.ClusterBackups,
+          canMatch: [EnterpriseEditionGuard],
         },
         {
           path: `projects/:projectID/${View.BackupStorageLocation}`,
           loadChildren: () => DynamicModule.ClusterBackups,
+          canMatch: [EnterpriseEditionGuard],
         },
         {
           path: `projects/:projectID/${View.KyvernoPolicies}`,
           loadChildren: () => DynamicModule.KyvernoPolicies,
+          canMatch: [EnterpriseEditionGuard],
         },
         {
           path: 'account',

--- a/modules/web/src/app/routing.ts
+++ b/modules/web/src/app/routing.ts
@@ -66,6 +66,7 @@ function createRouting(): Routes {
         {
           path: 'projects/:projectID/groups',
           loadChildren: () => import('./member/module').then(m => m.MemberModule),
+          canMatch: [EnterpriseEditionGuard],
         },
         {
           path: 'projects/:projectID/serviceaccounts',

--- a/modules/web/src/app/settings/admin/routing.ts
+++ b/modules/web/src/app/settings/admin/routing.ts
@@ -16,6 +16,7 @@ import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {DynamicModule} from '@app/dynamic/module-registry';
 import {AuthGuard} from '@core/services/auth/guard';
+import {EnterpriseEditionGuard} from '@core/services/enterprise-edition/guard';
 import {AdminSettingsComponent} from './component';
 
 const routes: Routes = [
@@ -72,6 +73,7 @@ const routes: Routes = [
       {
         path: 'kyvernopolicies',
         loadChildren: () => DynamicModule.KyvernoPolicies,
+        canMatch: [EnterpriseEditionGuard],
       },
       {
         path: 'backupdestinations',
@@ -88,6 +90,7 @@ const routes: Routes = [
       {
         path: 'metering',
         loadChildren: () => DynamicModule.Metering,
+        canMatch: [EnterpriseEditionGuard],
         data: {preload: true},
       },
       {
@@ -97,6 +100,7 @@ const routes: Routes = [
       {
         path: 'quotas',
         loadChildren: () => DynamicModule.Quotas,
+        canMatch: [EnterpriseEditionGuard],
       },
     ],
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes enterprise-only routes (cluster backups, cluster schedules, cluster restores, backup storage locations, Kyverno policies, metering, quotas) being reachable in community edition builds, where they rendered an empty view instead of the 404 page.


Tested EE Routes: It now redirects to `404` route 

#### Project level routes
- projects/<project_id>/clusterbackups

#### Admin level routes
- settings/rulegroups/metering
- settings/quotas
- settings/kyvernopolicies

**Before:**

<img width="923" height="518" alt="Screenshot 2026-08-28 at 2 34 21 PM" src="https://github.com/user-attachments/assets/ca2a43d4-2452-48aa-8019-74eb4bc51d5d" />

<img width="1304" height="584" alt="Screenshot 2026-08-28 at 2 34 16 PM" src="https://github.com/user-attachments/assets/ee958d48-461e-41af-81ab-e3769aeddd09" />



**After**

Un-Authorized access to EE routes from CE edition is redirected to 404 Page

<img width="1920" height="926" alt="Screenshot 2026-08-28 at 12 46 43 PM" src="https://github.com/user-attachments/assets/f46ad718-ce7e-4134-9d22-33056c791ff3" />

**Which issue(s) this PR fixes**:
Fixes: NONE (Found while random testing)
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

You can test running CE edition locally:

```
KUBERMATIC_EDITION=ce npm run start
```


**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enterprise-only pages now return the 404 page in community edition instead of an empty view.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
