### PR TITLE
Add KubeVirt preset subnets field

### DIFF
--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -170,7 +171,7 @@ func KubeVirtVPCsWithClusterCredentialsEndpoint(ctx context.Context, userInfoGet
 }
 
 func KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfoGetter provider.UserInfoGetter, projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider,
-	seedsGetter provider.SeedsGetter, projectID, clusterID, storageClassName string) (interface{}, error) {
+	seedsGetter provider.SeedsGetter, presetsProvider provider.PresetProvider, projectID, clusterID, storageClassName string) (interface{}, error) {
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
 		return nil, common.KubernetesErrorToHTTPError(err)
@@ -179,6 +180,19 @@ func KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 	cluster, err := handlercommon.GetCluster(ctx, projectProvider, privilegedProjectProvider, userInfoGetter, projectID, clusterID, &provider.ClusterGetOptions{CheckInitStatus: true})
 	if err != nil {
 		return "", err
+	}
+
+	if presetName := cluster.Annotations[kubermaticv1.PresetNameAnnotation]; presetName != "" {
+		preset, err := presetsProvider.GetPreset(ctx, userInfo, ptr.To(projectID), presetName)
+		if err != nil {
+			log.Logger.Errorf("failed to get preset %s for user %s, falling back to seed/credentials subnet resolution: %v", presetName, userInfo.Email, err)
+		} else if credentials := preset.Spec.Kubevirt; credentials != nil && len(credentials.Subnets) > 0 {
+			kvSubnets := apiv2.KubeVirtSubnetList{}
+			for _, subnet := range credentials.Subnets {
+				kvSubnets = append(kvSubnets, apiv2.KubeVirtSubnet{Name: subnet})
+			}
+			return kvSubnets, nil
+		}
 	}
 
 	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)

--- a/modules/api/pkg/handler/common/provider/kubevirt.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt.go
@@ -182,22 +182,18 @@ func KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx context.Context, userInfo
 		return "", err
 	}
 
+	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting dc: %w", err)
+	}
+
 	if presetName := cluster.Annotations[kubermaticv1.PresetNameAnnotation]; presetName != "" {
 		preset, err := presetsProvider.GetPreset(ctx, userInfo, ptr.To(projectID), presetName)
 		if err != nil {
 			log.Logger.Errorf("failed to get preset %s for user %s, falling back to seed/credentials subnet resolution: %v", presetName, userInfo.Email, err)
 		} else if credentials := preset.Spec.Kubevirt; credentials != nil && len(credentials.Subnets) > 0 {
-			kvSubnets := apiv2.KubeVirtSubnetList{}
-			for _, subnet := range credentials.Subnets {
-				kvSubnets = append(kvSubnets, apiv2.KubeVirtSubnet{Name: subnet})
-			}
-			return kvSubnets, nil
+			return FilterKubeVirtPresetSubnets(datacenter.Spec.Kubevirt, credentials.Subnets, cluster.Spec.Cloud.Kubevirt.VPCName, storageClassName), nil
 		}
-	}
-
-	_, datacenter, err := provider.DatacenterFromSeedMap(userInfo, seedsGetter, cluster.Spec.Cloud.DatacenterName)
-	if err != nil {
-		return nil, fmt.Errorf("error getting dc: %w", err)
 	}
 
 	if datacenter.Spec.Kubevirt != nil &&
@@ -640,6 +636,46 @@ func KubeVirtVPCSubnets(ctx context.Context, kubeconfig string, vpcName string) 
 	}
 
 	return kubevirt.GetProviderNetworkSubnets(ctx, client, vpcName)
+}
+
+func FilterKubeVirtPresetSubnets(datacenter *kubermaticv1.DatacenterSpecKubevirt, presetSubnets []string, vpcName, storageClassName string) apiv2.KubeVirtSubnetList {
+	kvSubnets := apiv2.KubeVirtSubnetList{}
+
+	if datacenter == nil || datacenter.ProviderNetwork == nil ||
+		datacenter.MatchSubnetAndStorageLocation == nil || !*datacenter.MatchSubnetAndStorageLocation {
+		for _, subnet := range presetSubnets {
+			kvSubnets = append(kvSubnets, apiv2.KubeVirtSubnet{Name: subnet})
+		}
+		return kvSubnets
+	}
+
+	allowedSubnetNames := sets.New(presetSubnets...)
+
+	for _, vpc := range datacenter.ProviderNetwork.VPCs {
+		if vpc.Name != vpcName {
+			continue
+		}
+		for _, subnet := range vpc.Subnets {
+			if !allowedSubnetNames.Has(subnet.Name) {
+				continue
+			}
+			for _, sc := range datacenter.InfraStorageClasses {
+				if storageClassName == "" && sc.IsDefaultClass != nil && *sc.IsDefaultClass {
+					storageClassName = sc.Name
+				}
+				if sc.Name != storageClassName {
+					continue
+				}
+				scRegions := sets.New[string]().Insert(sc.Regions...)
+				scZones := sets.New[string]().Insert(sc.Zones...)
+				if scRegions.HasAll(subnet.Regions...) && scZones.HasAll(subnet.Zones...) {
+					kvSubnets = append(kvSubnets, apiv2.KubeVirtSubnet{Name: subnet.Name, CIDR: subnet.CIDR})
+				}
+			}
+		}
+	}
+
+	return kvSubnets
 }
 
 func instancetypeReconciler(w instancetypeWrapper) reconciling.NamedVirtualMachineInstancetypeReconcilerFactory {

--- a/modules/api/pkg/handler/common/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/common/provider/kubevirt_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -793,5 +794,118 @@ func Test_listClusterPreferences_fallback(t *testing.T) {
 	}
 	if items[0].Spec.CPU == nil {
 		t.Errorf("converted preference CPU spec is nil; conversion did not copy the spec")
+	}
+}
+
+func Test_FilterKubeVirtPresetSubnets(t *testing.T) {
+	dcWithoutMatching := &kubermaticv1.DatacenterSpecKubevirt{
+		ProviderNetwork: &kubermaticv1.ProviderNetwork{
+			VPCs: []kubermaticv1.VPC{
+				{
+					Name: "dev",
+					Subnets: []kubermaticv1.Subnet{
+						{Name: "subnet-a", CIDR: "10.0.0.0/24", Regions: []string{"region-a"}, Zones: []string{"zone-a"}},
+						{Name: "subnet-b", CIDR: "10.0.1.0/24", Regions: []string{"region-b"}, Zones: []string{"zone-b"}},
+					},
+				},
+			},
+		},
+	}
+
+	dcWithMatching := &kubermaticv1.DatacenterSpecKubevirt{
+		MatchSubnetAndStorageLocation: ptr.To(true),
+		InfraStorageClasses: []kubermaticv1.KubeVirtInfraStorageClass{
+			{Name: "storage-a", IsDefaultClass: ptr.To(true), Regions: []string{"region-a"}, Zones: []string{"zone-a"}},
+		},
+		ProviderNetwork: dcWithoutMatching.ProviderNetwork,
+	}
+
+	testcases := []struct {
+		name             string
+		datacenter       *kubermaticv1.DatacenterSpecKubevirt
+		presetSubnets    []string
+		vpcName          string
+		storageClassName string
+		want             apiv2.KubeVirtSubnetList
+	}{
+		{
+			name:          "matching disabled: preset subnets pass through unfiltered, no CIDR",
+			datacenter:    dcWithoutMatching,
+			presetSubnets: []string{"subnet-a", "subnet-b"},
+			vpcName:       "dev",
+			want: apiv2.KubeVirtSubnetList{
+				{Name: "subnet-a"},
+				{Name: "subnet-b"},
+			},
+		},
+		{
+			name:          "matching disabled: preset subnet unknown to the seed still passes through",
+			datacenter:    dcWithoutMatching,
+			presetSubnets: []string{"subnet-unknown"},
+			vpcName:       "dev",
+			want: apiv2.KubeVirtSubnetList{
+				{Name: "subnet-unknown"},
+			},
+		},
+		{
+			name:          "no declared subnet definitions to check against: preset subnets pass through unfiltered",
+			datacenter:    &kubermaticv1.DatacenterSpecKubevirt{MatchSubnetAndStorageLocation: ptr.To(true)},
+			presetSubnets: []string{"subnet-a"},
+			vpcName:       "dev",
+			want: apiv2.KubeVirtSubnetList{
+				{Name: "subnet-a"},
+			},
+		},
+		{
+			name:          "matching enabled: only the subnet compatible with the default storage class is kept",
+			datacenter:    dcWithMatching,
+			presetSubnets: []string{"subnet-a", "subnet-b"},
+			vpcName:       "dev",
+			want: apiv2.KubeVirtSubnetList{
+				{Name: "subnet-a", CIDR: "10.0.0.0/24"},
+			},
+		},
+		{
+			name:             "matching enabled: explicit storage class name is honored",
+			datacenter:       dcWithMatching,
+			presetSubnets:    []string{"subnet-a", "subnet-b"},
+			vpcName:          "dev",
+			storageClassName: "storage-a",
+			want: apiv2.KubeVirtSubnetList{
+				{Name: "subnet-a", CIDR: "10.0.0.0/24"},
+			},
+		},
+		{
+			name:          "matching enabled: preset subnet unknown to the seed cannot be verified and is dropped",
+			datacenter:    dcWithMatching,
+			presetSubnets: []string{"subnet-unknown"},
+			vpcName:       "dev",
+			want:          apiv2.KubeVirtSubnetList{},
+		},
+		{
+			name:          "matching enabled: no VPC matches the requested name",
+			datacenter:    dcWithMatching,
+			presetSubnets: []string{"subnet-a"},
+			vpcName:       "other-vpc",
+			want:          apiv2.KubeVirtSubnetList{},
+		},
+		{
+			name:          "nil datacenter: preset subnets pass through unfiltered",
+			datacenter:    nil,
+			presetSubnets: []string{"subnet-a"},
+			vpcName:       "dev",
+			want: apiv2.KubeVirtSubnetList{
+				{Name: "subnet-a"},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FilterKubeVirtPresetSubnets(tc.datacenter, tc.presetSubnets, tc.vpcName, tc.storageClassName)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
 	}
 }

--- a/modules/api/pkg/handler/v2/provider/kubevirt.go
+++ b/modules/api/pkg/handler/v2/provider/kubevirt.go
@@ -332,11 +332,7 @@ func KubeVirtSubnetsEndpoint(presetsProvider provider.PresetProvider, userInfoGe
 		}
 
 		if len(presetSubnets) > 0 {
-			kvSubnets := apiv2.KubeVirtSubnetList{}
-			for _, subnet := range presetSubnets {
-				kvSubnets = append(kvSubnets, apiv2.KubeVirtSubnet{Name: subnet})
-			}
-			return kvSubnets, nil
+			return providercommon.FilterKubeVirtPresetSubnets(datacenter.Spec.Kubevirt, presetSubnets, vpcName, storageClassName), nil
 		}
 
 		if datacenter.Spec.Kubevirt != nil &&

--- a/modules/api/pkg/handler/v2/provider/kubevirt.go
+++ b/modules/api/pkg/handler/v2/provider/kubevirt.go
@@ -108,22 +108,24 @@ func getKubeconfig(ctx context.Context, kubeconfig, credential, projectID string
 	return kubeconfig, nil
 }
 
-func getKubeconfigAndVPCName(ctx context.Context, kubeconfig, vpcName, credential, projectID string, presetsProvider provider.PresetProvider, userInfoGetter provider.UserInfoGetter) (string, string, error) {
+func getKubeconfigAndVPCName(ctx context.Context, kubeconfig, vpcName, credential, projectID string, presetsProvider provider.PresetProvider, userInfoGetter provider.UserInfoGetter) (string, string, []string, error) {
 	userInfo, err := userInfoGetter(ctx, projectID)
 	if err != nil {
-		return "", "", common.KubernetesErrorToHTTPError(err)
+		return "", "", nil, common.KubernetesErrorToHTTPError(err)
 	}
+	var presetSubnets []string
 	if len(credential) > 0 {
 		preset, err := presetsProvider.GetPreset(ctx, userInfo, ptr.To(projectID), credential)
 		if err != nil {
-			return "", "", utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", credential, userInfo.Email))
+			return "", "", nil, utilerrors.New(http.StatusInternalServerError, fmt.Sprintf("can not get preset %s for user %s", credential, userInfo.Email))
 		}
 		if credentials := preset.Spec.Kubevirt; credentials != nil {
 			kubeconfig = credentials.Kubeconfig
 			vpcName = credentials.VPCName
+			presetSubnets = credentials.Subnets
 		}
 	}
-	return kubeconfig, vpcName, nil
+	return kubeconfig, vpcName, presetSubnets, nil
 }
 
 // KubeVirtInstancetypesEndpoint handles the request to list available KubeVirtInstancetypes (provided credentials).
@@ -324,9 +326,17 @@ func KubeVirtSubnetsEndpoint(presetsProvider provider.PresetProvider, userInfoGe
 		}
 
 		// If preset was used, vpcName will be empty and returned by the function instead.
-		kubeconfig, vpcName, err := getKubeconfigAndVPCName(ctx, req.Kubeconfig, vpcName, req.Credential, projectID, presetsProvider, userInfoGetter)
+		kubeconfig, vpcName, presetSubnets, err := getKubeconfigAndVPCName(ctx, req.Kubeconfig, vpcName, req.Credential, projectID, presetsProvider, userInfoGetter)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(presetSubnets) > 0 {
+			kvSubnets := apiv2.KubeVirtSubnetList{}
+			for _, subnet := range presetSubnets {
+				kvSubnets = append(kvSubnets, apiv2.KubeVirtSubnet{Name: subnet})
+			}
+			return kvSubnets, nil
 		}
 
 		if datacenter.Spec.Kubevirt != nil &&
@@ -397,13 +407,13 @@ func KubeVirtVPCsWithClusterCredentialsEndpoint(projectProvider provider.Project
 }
 
 // KubeVirtSubnetsWithClusterCredentialsEndpoint handles the request to list Subnets for a VPC (cluster credentials).
-func KubeVirtSubnetsWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
+func KubeVirtSubnetsWithClusterCredentialsEndpoint(projectProvider provider.ProjectProvider, privilegedProjectProvider provider.PrivilegedProjectProvider, seedsGetter provider.SeedsGetter, presetsProvider provider.PresetProvider, userInfoGetter provider.UserInfoGetter) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req, ok := request.(KubeVirtSubnetsNoCredentialReq)
 		if !ok {
 			return nil, utilerrors.NewBadRequest("invalid request")
 		}
-		return providercommon.KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, seedsGetter, req.ProjectID, req.ClusterID, req.StorageClassName)
+		return providercommon.KubeVirtSubnetsWithClusterCredentialsEndpoint(ctx, userInfoGetter, projectProvider, privilegedProjectProvider, seedsGetter, presetsProvider, req.ProjectID, req.ClusterID, req.StorageClassName)
 	}
 }
 

--- a/modules/api/pkg/handler/v2/provider/kubevirt_test.go
+++ b/modules/api/pkg/handler/v2/provider/kubevirt_test.go
@@ -98,6 +98,51 @@ func GenKubeVirtKubermaticPreset() *kubermaticv1.Preset {
 	}
 }
 
+func GenKubeVirtKubermaticPresetWithSubnets(vpcName string, subnets []string) *kubermaticv1.Preset {
+	return &kubermaticv1.Preset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubermatic-preset-subnets",
+		},
+		Spec: kubermaticv1.PresetSpec{
+			Kubevirt: &kubermaticv1.Kubevirt{
+				Kubeconfig: fakeKvConfig,
+				VPCName:    vpcName,
+				Subnets:    subnets,
+			},
+			Fake: &kubermaticv1.Fake{Token: "dummy_pluton_token"},
+		},
+	}
+}
+
+// genKubevirtSeedWithProviderNetwork returns the default test seed with a "dev" VPC
+// declaring two subnets on the KubevirtDC datacenter, so preset subnets can be resolved
+// against real region/zone metadata. When matchSubnetAndStorageLocation is true, the DC
+// also requires subnet/storage-class region and zone compatibility, with only "subnet-a"
+// matching the declared default storage class.
+func genKubevirtSeedWithProviderNetwork(matchSubnetAndStorageLocation bool) *kubermaticv1.Seed {
+	return test.GenTestSeed(func(seed *kubermaticv1.Seed) {
+		dc := seed.Spec.Datacenters[kubevirtDatacenterName]
+		dc.Spec.Kubevirt.ProviderNetwork = &kubermaticv1.ProviderNetwork{
+			VPCs: []kubermaticv1.VPC{
+				{
+					Name: "dev",
+					Subnets: []kubermaticv1.Subnet{
+						{Name: "subnet-a", CIDR: "10.0.0.0/24", Regions: []string{"region-a"}, Zones: []string{"zone-a"}},
+						{Name: "subnet-b", CIDR: "10.0.1.0/24", Regions: []string{"region-b"}, Zones: []string{"zone-b"}},
+					},
+				},
+			},
+		}
+		if matchSubnetAndStorageLocation {
+			dc.Spec.Kubevirt.MatchSubnetAndStorageLocation = ptr.To(true)
+			dc.Spec.Kubevirt.InfraStorageClasses = []kubermaticv1.KubeVirtInfraStorageClass{
+				{Name: "storage-a", IsDefaultClass: ptr.To(true), Regions: []string{"region-a"}, Zones: []string{"zone-a"}},
+			}
+		}
+		seed.Spec.Datacenters[kubevirtDatacenterName] = dc
+	})
+}
+
 func setFakeNewKubeVirtClient(objects []ctrlruntimeclient.Object) {
 	providercommon.NewKubeVirtClient = func(kubeconfig string, options kubevirt.ClientOptions) (*kubevirt.Client, error) {
 		return &kubevirt.Client{
@@ -692,6 +737,138 @@ func TestListStorageClassNoCredentialsEndpoint(t *testing.T) {
 			ep.ServeHTTP(res, req)
 
 			// validate
+			if res.Code != tc.HTTPStatus {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
+			}
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
+		})
+	}
+}
+
+func TestListSubnetsEndpoint(t *testing.T) {
+	testcases := []struct {
+		Name                      string
+		HTTPRequestHeaders        []KeyValue
+		ExpectedResponse          string
+		HTTPStatus                int
+		ExistingKubermaticObjects []ctrlruntimeclient.Object
+	}{
+		{
+			Name: "scenario 1: preset-defined subnets take precedence over the seed's ProviderNetwork",
+			HTTPRequestHeaders: []KeyValue{
+				{Key: "Credential", Value: "kubermatic-preset-subnets"},
+				{Key: "DatacenterName", Value: kubevirtDatacenterName},
+			},
+			HTTPStatus: http.StatusOK,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				GenKubeVirtKubermaticPresetWithSubnets("dev", []string{"subnet-a", "subnet-b"}),
+				genKubevirtSeedWithProviderNetwork(false),
+			),
+			ExpectedResponse: `[{"name":"subnet-a","cidr":""},{"name":"subnet-b","cidr":""}]`,
+		},
+		{
+			Name: "scenario 2: preset subnets are filtered by storage-class region/zone match when the DC requires it",
+			HTTPRequestHeaders: []KeyValue{
+				{Key: "Credential", Value: "kubermatic-preset-subnets"},
+				{Key: "DatacenterName", Value: kubevirtDatacenterName},
+			},
+			HTTPStatus: http.StatusOK,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				GenKubeVirtKubermaticPresetWithSubnets("dev", []string{"subnet-a", "subnet-b"}),
+				genKubevirtSeedWithProviderNetwork(true),
+			),
+			ExpectedResponse: `[{"name":"subnet-a","cidr":"10.0.0.0/24"}]`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			setFakeNewKubeVirtClient(nil)
+
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/providers/kubevirt/subnets", test.GenDefaultProject().Name), strings.NewReader(""))
+			for _, h := range tc.HTTPRequestHeaders {
+				req.Header.Add(h.Key, h.Value)
+			}
+			res := httptest.NewRecorder()
+			ep, err := test.CreateTestEndpoint(*test.GenDefaultAPIUser(), nil, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint: %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
+			if res.Code != tc.HTTPStatus {
+				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
+			}
+			test.CompareWithResult(t, res, tc.ExpectedResponse)
+		})
+	}
+}
+
+func TestListSubnetsNoCredentialsEndpoint(t *testing.T) {
+	testcases := []struct {
+		Name                      string
+		ExpectedResponse          string
+		HTTPStatus                int
+		ExistingKubermaticObjects []ctrlruntimeclient.Object
+	}{
+		{
+			Name:       "scenario 1: preset-defined subnets take precedence, resolved from the cluster's preset annotation",
+			HTTPStatus: http.StatusOK,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				GenKubeVirtKubermaticPresetWithSubnets("dev", []string{"subnet-a", "subnet-b"}),
+				genKubevirtSeedWithProviderNetwork(false),
+				func() *kubermaticv1.Cluster {
+					cluster := test.GenCluster(clusterId, clusterName, test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster.Annotations = map[string]string{kubermaticv1.PresetNameAnnotation: "kubermatic-preset-subnets"}
+					cluster.Spec.Cloud = kubermaticv1.CloudSpec{
+						DatacenterName: kubevirtDatacenterName,
+						Kubevirt: &kubermaticv1.KubevirtCloudSpec{
+							Kubeconfig: fakeKvConfig,
+							VPCName:    "dev",
+						},
+					}
+					return cluster
+				}(),
+			),
+			ExpectedResponse: `[{"name":"subnet-a","cidr":""},{"name":"subnet-b","cidr":""}]`,
+		},
+		{
+			Name:       "scenario 2: preset subnets are filtered by storage-class region/zone match when the DC requires it",
+			HTTPStatus: http.StatusOK,
+			ExistingKubermaticObjects: test.GenDefaultKubermaticObjects(
+				GenKubeVirtKubermaticPresetWithSubnets("dev", []string{"subnet-a", "subnet-b"}),
+				genKubevirtSeedWithProviderNetwork(true),
+				func() *kubermaticv1.Cluster {
+					cluster := test.GenCluster(clusterId, clusterName, test.GenDefaultProject().Name, time.Date(2013, 02, 03, 19, 54, 0, 0, time.UTC))
+					cluster.Annotations = map[string]string{kubermaticv1.PresetNameAnnotation: "kubermatic-preset-subnets"}
+					cluster.Spec.Cloud = kubermaticv1.CloudSpec{
+						DatacenterName: kubevirtDatacenterName,
+						Kubevirt: &kubermaticv1.KubevirtCloudSpec{
+							Kubeconfig: fakeKvConfig,
+							VPCName:    "dev",
+						},
+					}
+					return cluster
+				}(),
+			),
+			ExpectedResponse: `[{"name":"subnet-a","cidr":"10.0.0.0/24"}]`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			setFakeNewKubeVirtClient(nil)
+
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v2/projects/%s/clusters/%s/providers/kubevirt/subnets", test.GenDefaultProject().Name, clusterId), strings.NewReader(""))
+			res := httptest.NewRecorder()
+			ep, err := test.CreateTestEndpoint(*test.GenDefaultAPIUser(), nil, tc.ExistingKubermaticObjects, nil, hack.NewTestRouting)
+			if err != nil {
+				t.Fatalf("failed to create test endpoint: %v", err)
+			}
+
+			ep.ServeHTTP(res, req)
+
 			if res.Code != tc.HTTPStatus {
 				t.Fatalf("Expected HTTP status code %d, got %d: %s", tc.HTTPStatus, res.Code, res.Body.String())
 			}

--- a/modules/api/pkg/handler/v2/routes_v2.go
+++ b/modules/api/pkg/handler/v2/routes_v2.go
@@ -5027,7 +5027,7 @@ func (r Routing) listKubeVirtSubnetsNoCredentials() http.Handler {
 			middleware.UserSaver(r.userProvider),
 			middleware.SetClusterProvider(r.clusterProviderGetter, r.seedsGetter),
 			middleware.SetPrivilegedClusterProvider(r.clusterProviderGetter, r.seedsGetter),
-		)(provider.KubeVirtSubnetsWithClusterCredentialsEndpoint(r.projectProvider, r.privilegedProjectProvider, r.seedsGetter, r.userInfoGetter)),
+		)(provider.KubeVirtSubnetsWithClusterCredentialsEndpoint(r.projectProvider, r.privilegedProjectProvider, r.seedsGetter, r.presetProvider, r.userInfoGetter)),
 		provider.DecodeKubeVirtSubnetsNoCredentialReq,
 		handler.EncodeJSON,
 		r.defaultServerOptions()...,

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/kubevirt/component.ts
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/kubevirt/component.ts
@@ -23,6 +23,7 @@ import {takeUntil} from 'rxjs/operators';
 export enum Controls {
   Kubeconfig = 'kubeconfig',
   VPC = 'vpc',
+  Subnets = 'subnets',
 }
 
 @Component({
@@ -56,9 +57,14 @@ export class KubevirtSettingsComponent extends BaseFormValidator implements OnIn
     this.form = this._builder.group({
       [Controls.Kubeconfig]: this._builder.control('', Validators.required),
       [Controls.VPC]: this._builder.control(''),
+      [Controls.Subnets]: this._builder.control([]),
     });
 
-    merge(this.form.get(Controls.Kubeconfig).valueChanges, this.form.get(Controls.VPC).valueChanges)
+    merge(
+      this.form.get(Controls.Kubeconfig).valueChanges,
+      this.form.get(Controls.VPC).valueChanges,
+      this.form.get(Controls.Subnets).valueChanges
+    )
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(_ => this._update());
 
@@ -77,6 +83,7 @@ export class KubevirtSettingsComponent extends BaseFormValidator implements OnIn
     this._presetDialogService.preset.spec.kubevirt = {
       kubeconfig: this.form.get(Controls.Kubeconfig).value,
       vpcName: this.form.get(Controls.VPC).value ? this.form.get(Controls.VPC).value : undefined,
+      subnets: this.form.get(Controls.Subnets).value?.length ? this.form.get(Controls.Subnets).value : undefined,
     } as KubevirtPresetSpec;
   }
 }

--- a/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/kubevirt/template.html
+++ b/modules/web/src/app/settings/admin/presets/dialog/steps/settings/provider/kubevirt/template.html
@@ -41,4 +41,9 @@ limitations under the License.
            autocomplete="off"
            kmValueChangedIndicator />
   </mat-form-field>
+
+  <km-chip-list label="Subnets"
+                placeholder="Subnets available to Machine Deployments using this preset..."
+                [formControlName]="Controls.Subnets"
+                fxFlex />
 </form>

--- a/modules/web/src/app/shared/entity/preset.ts
+++ b/modules/web/src/app/shared/entity/preset.ts
@@ -206,6 +206,9 @@ export class HetznerPresetSpec extends PresetProviderSpec {
 export class KubevirtPresetSpec extends PresetProviderSpec {
   kubeconfig: string;
   vpcName?: string;
+  /** @deprecated Use subnets instead. */
+  subnetName?: string;
+  subnets?: string[];
 }
 
 export class NutanixPresetSpec extends PresetProviderSpec {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a subnets field to the KubeVirt preset (admin UI + API), and resolves Machine Deployment subnets from the preset before falling back to the seed or live credentials.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #https://github.com/kubermatic/kubermatic/issues/16217

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt presets can now define subnets, used first when picking Machine Deployment subnets.
```

**Documentation**:
```documentation
TBD
```

**Test issue**:
```test-issue
TBD
```
