### PR TITLE
[release/v2.29] - Hide cluster backup features in CE builds (#8240)

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -143,7 +143,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
   }
 
   get isclusterBackupEnabled(): boolean {
-    return this._settings.enableClusterBackups;
+    return this.isEnterpriseEdition && !!this._settings?.enableClusterBackups;
   }
 
   constructor(
@@ -200,7 +200,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.Annotations]: new FormControl(null),
       [Controls.APIServerAllowedIPRanges]: new FormControl(this.cluster.spec.apiServerAllowedIPRanges?.cidrBlocks),
       [Controls.DisableCSIDriver]: new FormControl(this.cluster.spec.disableCsiDriver),
-      [Controls.ClusterBackup]: new FormControl(!!this.cluster.spec.backupConfig),
+      [Controls.ClusterBackup]: new FormControl(this.isEnterpriseEdition && !!this.cluster.spec.backupConfig),
       [Controls.RouterReconciliation]: new FormControl(
         this.cluster.annotations?.[InternalClusterSpecAnnotations.SkipRouterReconciliation] === 'true'
       ),
@@ -219,18 +219,20 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       this._initAuditWebhookBackendControls(this.cluster.spec?.auditLogging?.webhookBackend);
     }
 
-    this._getCBSL(this.projectID);
+    if (this.isEnterpriseEdition) {
+      this._getCBSL(this.projectID);
 
-    this.form
-      .get(Controls.ClusterBackup)
-      .valueChanges.pipe(takeUntil(this._unsubscribe))
-      .subscribe((value: boolean) => {
-        if (value) {
-          this.form.addControl(Controls.BackupStorageLocation, this._builder.control('', Validators.required));
-        } else {
-          this.form.removeControl(Controls.BackupStorageLocation);
-        }
-      });
+      this.form
+        .get(Controls.ClusterBackup)
+        .valueChanges.pipe(takeUntil(this._unsubscribe))
+        .subscribe((value: boolean) => {
+          if (value) {
+            this.form.addControl(Controls.BackupStorageLocation, this._builder.control('', Validators.required));
+          } else {
+            this.form.removeControl(Controls.BackupStorageLocation);
+          }
+        });
+    }
 
     this._settingsService.adminSettings.pipe(take(1)).subscribe(settings => {
       this._settings = settings;
@@ -571,14 +573,16 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       patch.spec.apiServerAllowedIPRanges = this.getAPIServerAllowedIPRange();
     }
 
-    if (this.form.get(Controls.ClusterBackup).value) {
-      patch.spec.backupConfig = {
-        backupStorageLocation: {
-          name: this.form.get(Controls.BackupStorageLocation).value,
-        },
-      };
-    } else {
-      patch.spec.backupConfig = null;
+    if (this.isEnterpriseEdition) {
+      if (this.form.get(Controls.ClusterBackup).value) {
+        patch.spec.backupConfig = {
+          backupStorageLocation: {
+            name: this.form.get(Controls.BackupStorageLocation).value,
+          },
+        };
+      } else {
+        patch.spec.backupConfig = null;
+      }
     }
 
     this._handleEncryptionConfigurationChanges(patch);

--- a/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/edit-cluster/component.ts
@@ -200,7 +200,7 @@ export class EditClusterComponent implements OnInit, OnDestroy {
       [Controls.Annotations]: new FormControl(null),
       [Controls.APIServerAllowedIPRanges]: new FormControl(this.cluster.spec.apiServerAllowedIPRanges?.cidrBlocks),
       [Controls.DisableCSIDriver]: new FormControl(this.cluster.spec.disableCsiDriver),
-      [Controls.ClusterBackup]: new FormControl(this.isEnterpriseEdition && !!this.cluster.spec.backupConfig),
+      [Controls.ClusterBackup]: new FormControl(this._isClusterBackupInitiallyEnabled()),
       [Controls.RouterReconciliation]: new FormControl(
         this.cluster.annotations?.[InternalClusterSpecAnnotations.SkipRouterReconciliation] === 'true'
       ),
@@ -367,6 +367,10 @@ export class EditClusterComponent implements OnInit, OnDestroy {
 
   isEncryptionActive(): boolean {
     return this.cluster.spec.encryptionConfiguration?.enabled || this.cluster.status?.encryption?.phase === 'Active';
+  }
+
+  private _isClusterBackupInitiallyEnabled(): boolean {
+    return this.isEnterpriseEdition && !!this.cluster.spec.backupConfig;
   }
 
   private _getAuditPolicyPresetInitialState(): AuditPolicyPreset | '' {

--- a/modules/web/src/app/settings/admin/defaults/component.ts
+++ b/modules/web/src/app/settings/admin/defaults/component.ts
@@ -14,6 +14,7 @@
 
 import {ChangeDetectorRef, Component, OnDestroy, OnInit} from '@angular/core';
 import {FeatureGateService} from '@app/core/services/feature-gate';
+import {DynamicModule} from '@app/dynamic/module-registry';
 import {VMwareCloudDirectorIPAllocationMode} from '@app/shared/entity/provider/vmware-cloud-director';
 import {OperatingSystem} from '@app/shared/model/NodeProviderConstants';
 import {NotificationService} from '@core/services/notification';
@@ -43,6 +44,7 @@ export class DefaultsComponent implements OnInit, OnDestroy {
   allowedOperatingSystems: string[] = Object.values(OperatingSystem);
   editionVersion: string = getEditionVersion();
 
+  readonly isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   readonly OperatingSystem = OperatingSystem;
   readonly ipAllocationModes = [VMwareCloudDirectorIPAllocationMode.POOL, VMwareCloudDirectorIPAllocationMode.DHCP];
   readonly veleroChecksumAlgorithms = Object.values(VeleroChecksumAlgorithm);

--- a/modules/web/src/app/settings/admin/defaults/template.html
+++ b/modules/web/src/app/settings/admin/defaults/template.html
@@ -302,6 +302,7 @@ limitations under the License.
           <km-spinner-with-confirmation [isSaved]="isEqual(settings.enableShareCluster, apiSettings.enableShareCluster)"></km-spinner-with-confirmation>
         </div>
 
+        <ng-container *ngIf="isEnterpriseEdition">
         <div fxLayout="row">
           <div fxFlex="16%"
                fxLayoutAlign=" center"
@@ -359,6 +360,7 @@ limitations under the License.
           </mat-form-field>
           <km-spinner-with-confirmation [isSaved]="isEqual(settings.clusterBackupOptions?.defaultChecksumAlgorithm, apiSettings.clusterBackupOptions?.defaultChecksumAlgorithm)"></km-spinner-with-confirmation>
         </div>
+        </ng-container>
 
         <div fxLayout="row">
           <div fxFlex="16%"

--- a/modules/web/src/app/shared/components/cluster-summary/component.ts
+++ b/modules/web/src/app/shared/components/cluster-summary/component.ts
@@ -16,6 +16,7 @@ import {Component, Input, OnInit} from '@angular/core';
 import {SettingsService} from '@app/core/services/settings';
 import {AdminSettings} from '@app/shared/entity/settings';
 import {getVisibleAnnotations} from '@app/shared/utils/annotations';
+import {DynamicModule} from '@app/dynamic/module-registry';
 import {ApplicationsListView} from '@shared/components/application-list/component';
 import {LabelFormComponent} from '@shared/components/label-form/component';
 import {Application} from '@shared/entity/application';
@@ -39,6 +40,7 @@ import {take} from 'rxjs/operators';
 })
 export class ClusterSummaryComponent implements OnInit {
   readonly ApplicationsListView = ApplicationsListView;
+  readonly isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
 
   @Input() cluster: Cluster;
   @Input() machineDeployment: MachineDeployment;

--- a/modules/web/src/app/shared/components/cluster-summary/template.html
+++ b/modules/web/src/app/shared/components/cluster-summary/template.html
@@ -66,7 +66,7 @@ limitations under the License.
               <div value>{{cluster.spec.containerRuntime}}</div>
             </km-property>
 
-            <km-property *ngIf="cluster.spec.backupConfig?.backupStorageLocation?.name">
+            <km-property *ngIf="isEnterpriseEdition && cluster.spec.backupConfig?.backupStorageLocation?.name">
               <div key>Cluster Backup</div>
               <div value>{{cluster.spec.backupConfig.backupStorageLocation.name}}</div>
             </km-property>
@@ -256,7 +256,7 @@ limitations under the License.
                                  label="CSI Storage Driver"
                                  [value]="!cluster.spec.disableCsiDriver">
             </km-property-boolean>
-            <km-property-boolean *ngIf="cluster.spec.backupConfig"
+            <km-property-boolean *ngIf="isEnterpriseEdition && cluster.spec.backupConfig"
                                  label="Cluster Backup"
                                  [value]="!!cluster.spec.backupConfig">
             </km-property-boolean>

--- a/modules/web/src/app/wizard/step/cluster/component.ts
+++ b/modules/web/src/app/wizard/step/cluster/component.ts
@@ -215,7 +215,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
   }
 
   get isclusterBackupEnabled(): boolean {
-    return this._settings.enableClusterBackups;
+    return this.isEnterpriseEdition && !!this._settings?.enableClusterBackups;
   }
 
   constructor(
@@ -272,9 +272,11 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       this.form.updateValueAndValidity();
     });
 
-    this._projectService.selectedProject
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(project => this._getCBSL(project.id));
+    if (this.isEnterpriseEdition) {
+      this._projectService.selectedProject
+        .pipe(takeUntil(this._unsubscribe))
+        .subscribe(project => this._getCBSL(project.id));
+    }
 
     this._fetchCNIPlugins();
 
@@ -400,16 +402,18 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
         }
       });
 
-    this.control(Controls.ClusterBackup)
-      .valueChanges.pipe(takeUntil(this._unsubscribe))
-      .subscribe((value: boolean) => {
-        if (value) {
-          this.form.addControl(Controls.BackupStorageLocation, this._builder.control('', Validators.required));
-          this._handleClusterBackupChange();
-        } else {
-          this.form.removeControl(Controls.BackupStorageLocation);
-        }
-      });
+    if (this.isEnterpriseEdition) {
+      this.control(Controls.ClusterBackup)
+        .valueChanges.pipe(takeUntil(this._unsubscribe))
+        .subscribe((value: boolean) => {
+          if (value) {
+            this.form.addControl(Controls.BackupStorageLocation, this._builder.control('', Validators.required));
+            this._handleClusterBackupChange();
+          } else {
+            this.form.removeControl(Controls.BackupStorageLocation);
+          }
+        });
+    }
 
     this.control(Controls.AuditLogging)
       .valueChanges.pipe(takeUntil(this._unsubscribe))
@@ -685,7 +689,9 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       [Controls.UserSSHKeyAgent]: this._builder.control(
         this.isUserSshKeyEnabled ? (clusterSpec?.enableUserSSHKeyAgent ?? true) : false
       ),
-      [Controls.ClusterBackup]: this._builder.control(clusterSpec?.backupConfig || false),
+      [Controls.ClusterBackup]: this._builder.control(
+        this.isEnterpriseEdition ? clusterSpec?.backupConfig || false : false
+      ),
       [Controls.OPAIntegration]: this._builder.control(clusterSpec?.opaIntegration?.enabled ?? false),
       [Controls.KyvernoIntegration]: this._builder.control(clusterSpec?.kyverno?.enabled ?? false),
       [Controls.Konnectivity]: this._builder.control(clusterSpec?.clusterNetwork?.konnectivityEnabled ?? true),
@@ -749,7 +755,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
 
     this.control(Controls.Konnectivity).disable();
 
-    if (this.control(Controls.ClusterBackup).value) {
+    if (this.isEnterpriseEdition && this.control(Controls.ClusterBackup).value) {
       this.form.addControl(
         Controls.BackupStorageLocation,
         this._builder.control(clusterSpec?.backupConfig?.backupStorageLocation?.name, Validators.required)
@@ -791,7 +797,7 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
             this.isUserSshKeyEnabled && clusterSpec?.enableUserSSHKeyAgent
               ? true
               : this.controlValue(Controls.UserSSHKeyAgent),
-          [Controls.ClusterBackup]: clusterSpec.backupConfig || false,
+          [Controls.ClusterBackup]: this.isEnterpriseEdition ? clusterSpec.backupConfig || false : false,
           [Controls.OPAIntegration]: clusterSpec?.opaIntegration?.enabled ?? this.controlValue(Controls.OPAIntegration),
           [Controls.KyvernoIntegration]:
             clusterSpec?.kyverno?.enabled ?? this.controlValue(Controls.KyvernoIntegration),
@@ -1211,14 +1217,16 @@ export class ClusterStepComponent extends StepBase implements OnInit, ControlVal
       } as ClusterSpec,
     } as Cluster;
 
-    if (this.controlValue(Controls.ClusterBackup)) {
-      clusterObject.spec.backupConfig = {
-        backupStorageLocation: {
-          name: this.controlValue(Controls.BackupStorageLocation),
-        },
-      };
-    } else {
-      clusterObject.spec.backupConfig = null;
+    if (this.isEnterpriseEdition) {
+      if (this.controlValue(Controls.ClusterBackup)) {
+        clusterObject.spec.backupConfig = {
+          backupStorageLocation: {
+            name: this.controlValue(Controls.BackupStorageLocation),
+          },
+        };
+      } else {
+        clusterObject.spec.backupConfig = null;
+      }
     }
     return clusterObject;
   }


### PR DESCRIPTION
This is a manual cherry-pick of #8240

FYI: Automated cherry-pick wasn't run for this branch. It predates the Angular control-flow syntax migration (#7675), so the cherry-pick had to be resolved manually.

```release-note
Hide cluster backup options in Community Edition, where the feature is not supported.
```