### PR TITLE
Show the Grafana metrics warning only when node-exporter or kube-state-metrics is missing

### DIFF
--- a/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.spec.ts
+++ b/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.spec.ts
@@ -26,6 +26,7 @@ import {MLAService} from '@core/services/mla';
 import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
+import {Application, KUBE_STATE_METRICS_APP_DEF_NAME, NODE_EXPORTER_APP_DEF_NAME} from '@shared/entity/application';
 import {SharedModule} from '@shared/module';
 import {NoopConfirmDialogComponent} from '@test/components/noop-confirmation-dialog.component';
 import {fakeDigitaloceanCluster} from '@test/data/cluster';
@@ -110,4 +111,41 @@ describe('AlertmanagerConfigComponent', () => {
     fixture.destroy();
     flush();
   }));
+
+  describe('Grafana monitoring components warning', () => {
+    const fakeApplication = (name: string): Application =>
+      ({name, spec: {applicationRef: {name, version: '1.0.0'}}}) as Application;
+
+    beforeEach(() => {
+      component.cluster.spec.mla = {monitoringEnabled: true};
+      jest.spyOn(component, 'shouldDisplayLink').mockReturnValue(true);
+    });
+
+    it('should not warn when both monitoring applications are deployed', () => {
+      component.applications = [
+        fakeApplication(NODE_EXPORTER_APP_DEF_NAME),
+        fakeApplication(KUBE_STATE_METRICS_APP_DEF_NAME),
+      ];
+      component.ngOnChanges();
+
+      expect(component.displayGrafanaWarning()).toBeFalsy();
+    });
+
+    it('should warn only about the application that is not deployed', () => {
+      component.applications = [fakeApplication(NODE_EXPORTER_APP_DEF_NAME)];
+      component.ngOnChanges();
+
+      expect(component.displayGrafanaWarning()).toBeTruthy();
+      expect(component.grafanaWarningText).toContain('kube-state-metrics application is deployed');
+      expect(component.grafanaWarningText).not.toContain('node-exporter');
+    });
+
+    it('should not warn when only MLA logging is enabled', () => {
+      component.cluster.spec.mla = {loggingEnabled: true, monitoringEnabled: false};
+      component.applications = [];
+      component.ngOnChanges();
+
+      expect(component.displayGrafanaWarning()).toBeFalsy();
+    });
+  });
 });

--- a/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
@@ -21,11 +21,7 @@ import {MLAService} from '@core/services/mla';
 import {SettingsService} from '@core/services/settings';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {Addon} from '@shared/entity/addon';
-import {
-  Application,
-  KUBE_STATE_METRICS_APP_DEF_NAME,
-  NODE_EXPORTER_APP_DEF_NAME,
-} from '@shared/entity/application';
+import {Application, KUBE_STATE_METRICS_APP_DEF_NAME, NODE_EXPORTER_APP_DEF_NAME} from '@shared/entity/application';
 import {Cluster} from '@shared/entity/cluster';
 import {SeedSettings} from '@shared/entity/datacenter';
 import {AlertmanagerConfig} from '@shared/entity/mla';
@@ -107,7 +103,6 @@ export class AlertmanagerConfigComponent implements OnInit, OnChanges, OnDestroy
   }
 
   shouldDisplayLink(type: string): boolean {
-    console.log('shouldDisplayLink', type, this._settings, this._seedSettings);
     switch (type) {
       case Type.Alertmanager:
         return !!this._settings && !!this._settings.mlaAlertmanagerPrefix;

--- a/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Component, Inject, Input, OnDestroy, OnInit} from '@angular/core';
+import {Component, Inject, Input, OnChanges, OnDestroy, OnInit} from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {DatacenterService} from '@core/services/datacenter';
@@ -21,6 +21,11 @@ import {MLAService} from '@core/services/mla';
 import {SettingsService} from '@core/services/settings';
 import {ConfirmationDialogComponent} from '@shared/components/confirmation-dialog/component';
 import {Addon} from '@shared/entity/addon';
+import {
+  Application,
+  KUBE_STATE_METRICS_APP_DEF_NAME,
+  NODE_EXPORTER_APP_DEF_NAME,
+} from '@shared/entity/application';
 import {Cluster} from '@shared/entity/cluster';
 import {SeedSettings} from '@shared/entity/datacenter';
 import {AlertmanagerConfig} from '@shared/entity/mla';
@@ -29,7 +34,6 @@ import _ from 'lodash';
 import {Subject} from 'rxjs';
 import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 import {AlertmanagerConfigDialog} from './alertmanager-config-dialog/component';
-import {AddonService} from '@core/services/addon';
 import {ProjectService} from '@app/core/services/project';
 import {ProjectAnnotation} from '@app/shared/entity/project';
 
@@ -38,10 +42,11 @@ export enum Type {
   Grafana = 'Grafana',
 }
 
-export enum AddonType {
-  NodeExporter = 'node-exporter',
-  KubeStateMetrics = 'kube-state-metrics',
-}
+// node-exporter and kube-state-metrics are deployed as Applications by KKP when user cluster monitoring is enabled.
+const MONITORING_COMPONENTS = [
+  {name: NODE_EXPORTER_APP_DEF_NAME, metrics: 'node-related metrics'},
+  {name: KUBE_STATE_METRICS_APP_DEF_NAME, metrics: 'Kubernetes workload metrics'},
+];
 
 @Component({
   selector: 'km-alertmanager-config',
@@ -49,15 +54,16 @@ export enum AddonType {
   styleUrls: ['./style.scss'],
   standalone: false,
 })
-export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
+export class AlertmanagerConfigComponent implements OnInit, OnChanges, OnDestroy {
   readonly Type = Type;
   @Input() cluster: Cluster;
   @Input() projectID: string;
   @Input() isClusterRunning: boolean;
   @Input() alertmanagerConfig: AlertmanagerConfig;
   @Input() addons: Addon[] = [];
+  @Input() applications: Application[] = [];
 
-  accessibleAddons: string[] = [];
+  grafanaWarningText = '';
   private _grafanaOrgId: string;
   private _settings: AdminSettings;
   private _seedSettings: SeedSettings;
@@ -70,7 +76,6 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
     private readonly _notificationService: NotificationService,
     private readonly _settingsService: SettingsService,
     private readonly _datacenterService: DatacenterService,
-    private readonly _addonService: AddonService,
     private readonly _projectService: ProjectService,
     @Inject(DOCUMENT) private readonly _document: Document
   ) {}
@@ -90,10 +95,10 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
       .pipe(switchMap(_ => this._datacenterService.seedSettings(this._seed)))
       .pipe(takeUntil(this._unsubscribe))
       .subscribe(seedSettings => (this._seedSettings = seedSettings));
+  }
 
-    this._addonService.accessibleAddons
-      .pipe(takeUntil(this._unsubscribe))
-      .subscribe(accessibleAddons => (this.accessibleAddons = accessibleAddons));
+  ngOnChanges(): void {
+    this.grafanaWarningText = this._getGrafanaWarningText();
   }
 
   ngOnDestroy(): void {
@@ -102,6 +107,7 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
   }
 
   shouldDisplayLink(type: string): boolean {
+    console.log('shouldDisplayLink', type, this._settings, this._seedSettings);
     switch (type) {
       case Type.Alertmanager:
         return !!this._settings && !!this._settings.mlaAlertmanagerPrefix;
@@ -128,55 +134,27 @@ export class AlertmanagerConfigComponent implements OnInit, OnDestroy {
 
   displayGrafanaWarning(): boolean {
     return (
-      this.shouldDisplayLink(Type.Grafana) &&
-      (!this._isAddonEnabled(AddonType.NodeExporter) || !this._isAddonEnabled(AddonType.KubeStateMetrics))
+      this.shouldDisplayLink(Type.Grafana) && !!this.cluster?.spec.mla?.monitoringEnabled && !!this.grafanaWarningText
     );
   }
 
-  private _isAddonEnabled(addon: AddonType): boolean {
-    return !!this.addons.find(a => a.id === addon);
+  private _isDeployed(name: string): boolean {
+    return (
+      !!this.applications?.some(application => application.spec?.applicationRef?.name === name) ||
+      !!this.addons?.some(addon => addon.id === name)
+    );
   }
 
-  private _isAddonAvailable(addon: AddonType): boolean {
-    return !!this.accessibleAddons.find(a => a === addon);
-  }
-
-  getAddonsEnabledWarningText(): string {
-    const nodeExporterEnabled = this._isAddonEnabled(AddonType.NodeExporter);
-    const kubeStateMetricsEnabled = this._isAddonEnabled(AddonType.KubeStateMetrics);
-
-    if (!nodeExporterEnabled && !kubeStateMetricsEnabled) {
-      return 'Please enable the node-exporter addon to see node-related stats and the kube-state-metrics addon to see all k8s workload stats in Grafana dashboards';
+  private _getGrafanaWarningText(): string {
+    const missing = MONITORING_COMPONENTS.filter(component => !this._isDeployed(component.name));
+    if (!missing.length) {
+      return '';
     }
 
-    if (!nodeExporterEnabled) {
-      return 'Please enable the node-exporter addon to see node-related stats in Grafana dashboards';
-    }
-
-    if (!kubeStateMetricsEnabled) {
-      return 'Please enable the kube-state-metrics addon to see all k8s workload stats in Grafana dashboards';
-    }
-
-    return '';
-  }
-
-  getAddonsAvailableWarningText(): string {
-    const nodeExporterAvailable = this._isAddonAvailable(AddonType.NodeExporter);
-    const kubeStateMetricsAvailable = this._isAddonAvailable(AddonType.KubeStateMetrics);
-
-    if (!nodeExporterAvailable && !kubeStateMetricsAvailable) {
-      return 'NOTE: The node-exporter and the kube-state-metrics addon are not available for installation in this cluster yet. Please contact your administrator for setting it up.';
-    }
-
-    if (!nodeExporterAvailable) {
-      return 'NOTE: The node-exporter addon is not available for installation in this cluster yet. Please contact your administrator for setting it up.';
-    }
-
-    if (!kubeStateMetricsAvailable) {
-      return 'NOTE: The kube-state-metrics addon is not available for installation in this cluster yet. Please contact your administrator for setting it up.';
-    }
-
-    return '';
+    const names = missing.map(component => component.name).join(' and ');
+    const metrics = missing.map(component => component.metrics).join(' and ');
+    const application = missing.length > 1 ? 'applications are' : 'application is';
+    return `To see ${metrics} in Grafana dashboards, make sure the ${names} ${application} deployed in this cluster.`;
   }
 
   edit(): void {

--- a/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/template.html
+++ b/modules/web/src/app/cluster/details/cluster/mla/alertmanager-config/template.html
@@ -60,7 +60,7 @@ limitations under the License.
     </a>
     }
     @if (displayGrafanaWarning()) {
-    <i matTooltip="{{getAddonsEnabledWarningText()}} {{getAddonsAvailableWarningText()}}"
+    <i [matTooltip]="grafanaWarningText"
        class="km-icon-warning addon-disabled-icon"></i>
     }
   </div>

--- a/modules/web/src/app/cluster/details/cluster/mla/component.ts
+++ b/modules/web/src/app/cluster/details/cluster/mla/component.ts
@@ -14,6 +14,7 @@
 
 import {Component, Input} from '@angular/core';
 import {Addon} from '@shared/entity/addon';
+import {Application} from '@shared/entity/application';
 import {Cluster} from '@shared/entity/cluster';
 import {AlertmanagerConfig, RuleGroup} from '@shared/entity/mla';
 import _ from 'lodash';
@@ -30,4 +31,5 @@ export class MLAComponent {
   @Input() alertmanagerConfig: AlertmanagerConfig;
   @Input() ruleGroups: RuleGroup[];
   @Input() addons: Addon[];
+  @Input() applications: Application[];
 }

--- a/modules/web/src/app/cluster/details/cluster/mla/template.html
+++ b/modules/web/src/app/cluster/details/cluster/mla/template.html
@@ -19,7 +19,8 @@ limitations under the License.
                         [cluster]="cluster"
                         [projectID]="projectID"
                         [isClusterRunning]="isClusterRunning"
-                        [addons]="addons" />
+                        [addons]="addons"
+                        [applications]="applications" />
 <km-rule-groups [ruleGroups]="ruleGroups"
                 [cluster]="cluster"
                 [projectID]="projectID"

--- a/modules/web/src/app/cluster/details/cluster/template.html
+++ b/modules/web/src/app/cluster/details/cluster/template.html
@@ -661,7 +661,8 @@ limitations under the License.
               [cluster]="cluster"
               [projectID]="projectID"
               [isClusterRunning]="isClusterRunning"
-              [addons]="addons" />
+              [addons]="addons"
+              [applications]="applications" />
     </km-tab>
     }
   </km-tab-card>

--- a/modules/web/src/app/shared/entity/application.ts
+++ b/modules/web/src/app/shared/entity/application.ts
@@ -18,6 +18,8 @@ import * as y from 'js-yaml';
 import semver from 'semver';
 
 export const CLUSTER_AUTOSCALING_APP_DEF_NAME = 'cluster-autoscaler';
+export const NODE_EXPORTER_APP_DEF_NAME = 'node-exporter';
+export const KUBE_STATE_METRICS_APP_DEF_NAME = 'kube-state-metrics';
 
 export class Application {
   creationTimestamp?: Date;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the misleading warning next to the "Open Grafana UI" button, which told users to enable node-exporter and kube-state-metrics addons even though those components are shipped as Applications and are already deployed on monitoring-enabled clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #8259

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
The warning is also skipped when user cluster monitoring is disabled but it is displayed in case enabled but applications not installed

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Grafana warning on the cluster MLA tab is now shown only when the node-exporter or kube-state-metrics application is missing.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
TBD
```
