### PR TITLE
Fix Gate admin groups behind enterprise edition

### DIFF
--- a/modules/web/src/app/settings/admin/admins/component.ts
+++ b/modules/web/src/app/settings/admin/admins/component.ts
@@ -17,6 +17,7 @@ import {MatDialog, MatDialogConfig} from '@angular/material/dialog';
 import {MatPaginator} from '@angular/material/paginator';
 import {MatSort} from '@angular/material/sort';
 import {MatTableDataSource} from '@angular/material/table';
+import {DynamicModule} from '@app/dynamic/module-registry';
 import {NotificationService} from '@core/services/notification';
 import {SettingsService} from '@core/services/settings';
 import {UserService} from '@core/services/user';
@@ -34,6 +35,7 @@ import {AddAdminDialogComponent} from './add-admin-dialog/component';
   standalone: false,
 })
 export class AdminsComponent implements OnInit, OnChanges {
+  readonly isEnterpriseEdition = DynamicModule.isEnterpriseEdition;
   user: Member;
   admins: Admin[] = [];
   dataSource = new MatTableDataSource<Admin>();
@@ -78,9 +80,13 @@ export class AdminsComponent implements OnInit, OnChanges {
     this._unsubscribe.complete();
   }
 
+  isGrantedByGroup(admin: Admin): boolean {
+    return this.isEnterpriseEdition && !!admin.grantedByGroup;
+  }
+
   isDeleteEnabled(admin: Admin): boolean {
     // Group-granted admins cannot be removed here; remove the group from admin settings instead.
-    return !!this.user && admin.email !== this.user.email && !admin.grantedByGroup;
+    return !!this.user && admin.email !== this.user.email && !this.isGrantedByGroup(admin);
   }
 
   delete(admin: Admin): void {

--- a/modules/web/src/app/settings/admin/admins/template.html
+++ b/modules/web/src/app/settings/admin/admins/template.html
@@ -44,7 +44,7 @@ limitations under the License.
         <td mat-cell
             *matCellDef="let element">
           {{element.name}}
-          @if (element.grantedByGroup) {
+          @if (isGrantedByGroup(element)) {
           <span class="km-admin-via-group"
                 title="Admin granted via OIDC group '{{element.grantedByGroup}}'. Remove the group from Admin Groups settings to revoke.">
             via {{element.grantedByGroup}}

--- a/modules/web/src/app/settings/admin/defaults/component.ts
+++ b/modules/web/src/app/settings/admin/defaults/component.ts
@@ -379,7 +379,6 @@ export class DefaultsComponent implements OnInit, OnDestroy {
       patch.disabledAuditWebhookBackendDCs = this.settings.disabledAuditWebhookBackendDCs;
     }
 
-    // Admin groups are reconciled by an enterprise-only controller, never patch them in community edition.
     if (!this.isEnterpriseEdition) {
       delete patch.adminGroups;
     } else if (patch.adminGroups) {

--- a/modules/web/src/app/settings/admin/defaults/component.ts
+++ b/modules/web/src/app/settings/admin/defaults/component.ts
@@ -379,8 +379,11 @@ export class DefaultsComponent implements OnInit, OnDestroy {
       patch.disabledAuditWebhookBackendDCs = this.settings.disabledAuditWebhookBackendDCs;
     }
 
-    // Send full adminGroups array to avoid merge-patch issues with removals.
-    if (patch.adminGroups) {
+    // Admin groups are reconciled by an enterprise-only controller, never patch them in community edition.
+    if (!this.isEnterpriseEdition) {
+      delete patch.adminGroups;
+    } else if (patch.adminGroups) {
+      // Send full adminGroups array to avoid merge-patch issues with removals.
       patch.adminGroups = this.settings.adminGroups;
     }
 

--- a/modules/web/src/app/settings/admin/defaults/template.html
+++ b/modules/web/src/app/settings/admin/defaults/template.html
@@ -529,6 +529,7 @@ limitations under the License.
                           fxFlex />
           </div>
         </div>
+        @if (isEnterpriseEdition) {
         <div fxLayout="row"
              fxLayoutAlign=" center">
           <div fxFlex="16%"
@@ -548,6 +549,7 @@ limitations under the License.
                           fxFlex="50%" />
           </div>
         </div>
+        }
         <div fxLayout="row"
              fxLayoutAlign=" center">
           <div fxFlex="16%"

--- a/modules/web/src/app/shared/entity/settings.ts
+++ b/modules/web/src/app/shared/entity/settings.ts
@@ -41,7 +41,7 @@ export interface AdminSettings {
   // disabledAuditWebhookBackendDCs is the list of datacenters for which the Audit Webhook Backend
   // option is hidden in the cluster wizard and edit-cluster dialog.
   disabledAuditWebhookBackendDCs?: string[];
-  adminGroups: string[];
+  adminGroups?: string[];
   userProjectsLimit: number;
   restrictProjectCreation: boolean;
   restrictProjectDeletion: boolean;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the Admin Groups setting and the group-granted admin indicator being shown in community edition builds, where the controller that reconciles them is enterprise-only.


**Before in CE Edition:**
<img width="1014" height="317" alt="image" src="https://github.com/user-attachments/assets/9e4d8061-3b0f-4cae-bca6-367b355ce8c5" />

**After** 
<img width="1143" height="257" alt="image" src="https://github.com/user-attachments/assets/28aa1cb4-34e7-4d24-a008-a2056313666c" />


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref: https://github.com/kubermatic/dashboard/pull/8205

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Follow-up to #8205. The admin-group controller added in kubermatic/kubermatic#16165 is built with the `ee` tag, so community edition rendered a setting that never takes effect.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
