### PR TITLE
Construct the Kubernetes Dashboard reverse proxy with Rewrite only

### DIFF
--- a/modules/api/pkg/handler/v2/kubernetes-dashboard/proxy.go
+++ b/modules/api/pkg/handler/v2/kubernetes-dashboard/proxy.go
@@ -199,8 +199,7 @@ func (h *proxyHandler) proxy(w http.ResponseWriter, request *http.Request) endpo
 		w.Header().Set("Content-Security-Policy", csp)
 
 		// Proxy the request
-		proxy := httputil.NewSingleHostReverseProxy(proxyURL)
-		proxy.Rewrite = newDashboardProxyDirector(proxyURL, token, request).rewrite()
+		proxy := &httputil.ReverseProxy{Rewrite: newDashboardProxyDirector(proxyURL, token, request).rewrite()}
 		proxy.ServeHTTP(w, request)
 
 		return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The Kubernetes Dashboard proxy constructed its `httputil.ReverseProxy` with `NewSingleHostReverseProxy`, which sets the `Director` field, and then also assigned the `Rewrite` field. `ReverseProxy` requires exactly one of `Director` or `Rewrite`; when both are set, every proxied request fails with `http: proxy error: ReverseProxy must have exactly one of Director or Rewrite set` and the user gets a 502 after logging in via Dex. This PR constructs the proxy with `Rewrite` only.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
Verified on a QA cluster: the `http: proxy error: ReverseProxy must have exactly one of Director or Rewrite set` error in the API logs matches this code path, and the login flow up to the proxy redirect works as expected.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
NONE
```
