### PR TITLE
[release/v2.30] Automate the web-terminal image build and update the k8s dependency

### DIFF
--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -31,3 +31,17 @@ presubmits:
           env:
             - name: KUBERMATIC_EDITION
               value: ee
+
+  - name: pre-dashboard-web-terminal-tag
+    run_if_changed: "^hack/images/web-terminal/"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-1
+          command:
+            - ./hack/verify-web-terminal-tag.sh
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m

--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -19,8 +19,8 @@ ARG TARGETARCH
 
 LABEL maintainer="support@kubermatic.com"
 
-# Source: https://dl.k8s.io/release/stable-1.34.txt
-ENV KUBECTL_VERSION=v1.34.3
+# Source: https://dl.k8s.io/release/stable-1.35.txt
+ENV KUBECTL_VERSION=v1.35.8
 
 # Source: https://github.com/helm/helm/releases
 ENV HELM_VERSION=v3.18.5

--- a/hack/images/web-terminal/metadata.yaml
+++ b/hack/images/web-terminal/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Source of truth for the web-terminal image release. Bump the tag to cut a new
+# release; a postsubmit job rebuilds and pushes when this file changes and the
+# tag does not yet exist in the registry.
+# After the release is published, bump WEBTerminalImage in
+# kubermatic/pkg/resources/resources.go so user clusters pick up the new image.
+tag: "0.12.1"

--- a/hack/images/web-terminal/release.sh
+++ b/hack/images/web-terminal/release.sh
@@ -20,11 +20,29 @@ cd $(dirname $0)/../../..
 source hack/lib.sh
 
 REPOSITORY=quay.io/kubermatic/web-terminal
-VERSION=0.12.0
+# read the tag from metadata.yaml so it has a single source of truth;
+# the path is relative to the repo root because of the cd above
+METADATA_FILE=hack/images/web-terminal/metadata.yaml
+# take the value after the first "tag:" and strip whitespace and quotes
+VERSION="$(grep -E '^tag:' "$METADATA_FILE" | head -n1 | cut -d: -f2- | tr -d ' \t"')"
+
+if [ -z "$VERSION" ]; then
+  echodate "No tag found in $METADATA_FILE"
+  exit 1
+fi
+
 SUFFIX=""
 ARCHITECTURES="${ARCHITECTURES:-linux/amd64,linux/arm64/v8}"
 IMAGE="$REPOSITORY:$VERSION$SUFFIX"
 MANIFEST="${MANIFEST:-$IMAGE}"
+
+# skip if the tag already exists in the registry; makes the postsubmit
+# idempotent so re-runs or re-merges of the same tag do not rebuild
+# retry so a transient registry error is not read as "tag missing"
+if retry 3 docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+  echodate "Image $IMAGE already exists in the registry, skipping build."
+  exit 0
+fi
 
 # build multi-arch images
 #  start_docker_daemon_ci

--- a/hack/verify-web-terminal-tag.sh
+++ b/hack/verify-web-terminal-tag.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Changes under hack/images/web-terminal/ only reach users through a new image
+# release, so any change there must come with an unpublished tag in
+# metadata.yaml. The presubmit runs this script only when files in that
+# directory change.
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+source hack/lib.sh
+
+METADATA_FILE=hack/images/web-terminal/metadata.yaml
+TAG="$(grep -E '^tag:' "$METADATA_FILE" | head -n1 | cut -d: -f2- | tr -d ' \t"')"
+
+if [ -z "$TAG" ]; then
+  echodate "No tag found in $METADATA_FILE"
+  exit 1
+fi
+
+# quay's public API needs no credentials for public repositories
+COUNT="$(retry 3 curl --fail --silent \
+  "https://quay.io/api/v1/repository/kubermatic/web-terminal/tag/?specificTag=${TAG}&onlyActiveTags=true" |
+  jq '.tags | length')"
+
+if [ "$COUNT" != "0" ]; then
+  echodate "Tag ${TAG} is already published at quay.io/kubermatic/web-terminal."
+  echodate "Files under hack/images/web-terminal/ changed; bump tag in $METADATA_FILE to release them."
+  exit 1
+fi
+
+echodate "Tag ${TAG} is not published yet; a merge will release it."


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherrypick of #8178 and updated k8s dependency to v1.35.8 to bump web-terminal to 1.12.1. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update web-terminal image version to v1.12.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
