### PR TITLE
Restrict web-terminal tag presubmit to main branch

### DIFF
--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -34,6 +34,10 @@ presubmits:
 
   - name: pre-dashboard-web-terminal-tag
     run_if_changed: "^hack/images/web-terminal/"
+    # The image is released from main only; cherry-picks to release branches
+    # reuse the already-published tag, so this gate does not apply there.
+    branches:
+      - ^main$
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:


### PR DESCRIPTION
This PR fixes the `pre-dashboard-web-terminal-tag` presubmit failing on release branches, where cherry-picked web-terminal changes reuse an already-published image tag that the gate rejects.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Ref PR: https://github.com/kubermatic/dashboard/pull/8178

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Same change as the one made in [#8282 ](https://github.com/kubermatic/dashboard/pull/8282)on `release/v2.31`, ported to `main` so both branches stay in sync. The web-terminal image is released from `main` only.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
