### PR TITLE
Add chrome-headless image release automation

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -33,7 +33,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
           command:
             - "./hack/ci/run-api-e2e.sh"
           env:
@@ -61,7 +61,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-14
           command:
             - make
           args:
@@ -82,7 +82,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-14
           command:
             - make
             - api-lint
@@ -102,7 +102,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-14
           command:
             - make
             - api-verify
@@ -122,7 +122,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-14
           command:
             - make
             - api-build

--- a/.prow/common.yaml
+++ b/.prow/common.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -42,9 +42,27 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
           command:
             - ./hack/verify-web-terminal-tag.sh
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+
+  - name: pre-dashboard-chrome-headless-tag
+    run_if_changed: "^modules/web/containers/chrome-headless/"
+    # The image is released from main only; cherry-picks to release branches
+    # reuse the already-published tag, so this gate does not apply there.
+    branches:
+      - ^main$
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/dashboard.git"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
+          command:
+            - ./hack/verify-chrome-headless-tag.sh
           resources:
             requests:
               memory: 256Mi

--- a/.prow/frontend.yaml
+++ b/.prow/frontend.yaml
@@ -103,7 +103,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
           command:
             - make
             - web-check-dependencies
@@ -119,7 +119,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-14
           command:
             - make
             - web-lint
@@ -139,7 +139,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-13
+        - image: quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
           command:
             - make
             - web-check

--- a/hack/verify-chrome-headless-tag.sh
+++ b/hack/verify-chrome-headless-tag.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Changes under modules/web/containers/chrome-headless/ only reach CI through a
+# new image release, so any change there must come with an unpublished tag in
+# metadata.yaml. The presubmit runs this script only when files in that
+# directory change.
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+source hack/lib.sh
+
+METADATA_FILE=modules/web/containers/chrome-headless/metadata.yaml
+TAG="$(grep -E '^tag:' "$METADATA_FILE" | head -n1 | cut -d: -f2- | tr -d ' \t"')"
+
+if [ -z "$TAG" ]; then
+  echodate "No tag found in $METADATA_FILE"
+  exit 1
+fi
+
+# quay's public API needs no credentials for public repositories
+COUNT="$(retry 3 curl --fail --silent \
+  "https://quay.io/api/v1/repository/kubermatic/chrome-headless/tag/?specificTag=${TAG}&onlyActiveTags=true" |
+  jq '.tags | length')"
+
+if [ "$COUNT" != "0" ]; then
+  echodate "Tag ${TAG} is already published at quay.io/kubermatic/chrome-headless."
+  echodate "Files under modules/web/containers/chrome-headless/ changed; bump tag in $METADATA_FILE to release them."
+  exit 1
+fi
+
+echodate "Tag ${TAG} is not published yet; a merge will release it."

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-13 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-24-14 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/modules/api/hack/gen-api-client.sh
+++ b/modules/api/hack/gen-api-client.sh
@@ -24,7 +24,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-13 containerize ./modules/api/hack/gen-api-client.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-24-14 containerize ./modules/api/hack/gen-api-client.sh
 
 cd $API/cmd/kubermatic-api/
 SWAGGER_FILE="swagger.json"

--- a/modules/api/hack/update-swagger.sh
+++ b/modules/api/hack/update-swagger.sh
@@ -21,7 +21,7 @@ source hack/lib.sh
 
 API=modules/api
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-22-13 containerize ./$API/hack/update-swagger.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-24-14 containerize ./$API/hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd $API/cmd/kubermatic-api/

--- a/modules/web/containers/chrome-headless/Dockerfile
+++ b/modules/web/containers/chrome-headless/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-13
+FROM quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
 
 LABEL maintainer="support@kubermatic.com"
 

--- a/modules/web/containers/chrome-headless/metadata.yaml
+++ b/modules/web/containers/chrome-headless/metadata.yaml
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-
-# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2026 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -euo pipefail
-
-cd $(dirname $0)/../../..
-source hack/lib.sh
-
-API=modules/api
-
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.26-node-24-14 containerize ./$API/hack/verify-licenses.sh
-
-cd $API
-go mod vendor
-
-echodate "Checking licenses..."
-wwhrd check -q
-echodate "Check successful."
+# Source of truth for the chrome-headless image release. Bump the tag to cut a
+# new release; a postsubmit job rebuilds and pushes when this file changes and
+# the tag does not yet exist in the registry.
+# After the release is published, bump the image references in a follow-up PR:
+# .prow/frontend.yaml in this repo and the coverage job in
+# kubermatic/infra prow/jobs/dashboard/dashboard-postsubmits-main.yaml.
+tag: "v1.10.0"

--- a/modules/web/containers/chrome-headless/release.sh
+++ b/modules/web/containers/chrome-headless/release.sh
@@ -14,16 +14,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG=v1.10.0
-
 set -euo pipefail
 
-cd $(dirname $0)
+cd $(dirname $0)/../../../..
+source hack/lib.sh
 
-# Ensure that you build for linux in apple silicon.
-if [[ $(uname -m) == 'arm64' ]]; then
-  export DOCKER_DEFAULT_PLATFORM=linux/amd64
+REPOSITORY=quay.io/kubermatic/chrome-headless
+# read the tag from metadata.yaml so it has a single source of truth;
+# the path is relative to the repo root because of the cd above
+METADATA_FILE=modules/web/containers/chrome-headless/metadata.yaml
+# take the value after the first "tag:" and strip whitespace and quotes
+VERSION="$(grep -E '^tag:' "$METADATA_FILE" | head -n1 | cut -d: -f2- | tr -d ' \t"')"
+
+if [ -z "$VERSION" ]; then
+  echodate "No tag found in $METADATA_FILE"
+  exit 1
 fi
 
-docker build --no-cache --pull -t quay.io/kubermatic/chrome-headless:${TAG} .
-docker push quay.io/kubermatic/chrome-headless:${TAG}
+SUFFIX=""
+ARCHITECTURES="${ARCHITECTURES:-linux/amd64}"
+IMAGE="$REPOSITORY:$VERSION$SUFFIX"
+MANIFEST="${MANIFEST:-$IMAGE}"
+
+# skip if the tag already exists in the registry; makes the postsubmit
+# idempotent so re-runs or re-merges of the same tag do not rebuild
+# retry so a transient registry error is not read as "tag missing"
+if retry 3 docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+  echodate "Image $IMAGE already exists in the registry, skipping build."
+  exit 0
+fi
+
+docker buildx create --use
+
+echodate "Building $IMAGE for $ARCHITECTURES…"
+docker buildx build ./modules/web/containers/chrome-headless \
+  --platform "$ARCHITECTURES" \
+  --push \
+  --tag "$IMAGE"
+
+echodate "Successfully built and pushed image."

--- a/modules/web/containers/custom-dashboard/Dockerfile
+++ b/modules/web/containers/custom-dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.26-node-22-kind-0.32-13
+FROM quay.io/kubermatic/build:go-1.26-node-24-kind-0.32-14
 LABEL maintainer="support@kubermatic.com"
 
 ENV NG_CLI_ANALYTICS=ci


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an automated release process for the chrome-headless e2e test image so new versions are published from main through CI instead of manual local builds.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes: NONE
Ref: https://github.com/kubermatic/infra/pull/3509

**What type of PR is this?**
/kind feature
/kind chore

**Special notes for your reviewer**:

The image version is defined in a single `metadata.yml` file.

* **Presubmit:** Ensures changes to the image directory include a new, unpublished tag. This catches missing version bumps before merge instead of failing or skipping during postsubmit.
* **Postsubmit:** Builds and pushes the image only if the tag does not already exist in the registry, making re-runs idempotent.
* **Release branches:** Publishing remains intentionally `main` only to avoid maintaining separate postsubmit jobs and version lines for each release branch.

If a release branch requires a new image, a small PR can bump `metadata.yml` on `main`. The postsubmit job publishes the image, and the resulting image version can then be referenced/cherry-picked into the required release branch.

This keeps the release flow simple while still supporting occasional release-branch updates.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

**Test issue**:
<!--
Please do one of the following options:
- Add a link to the GitHub issue for testing this change
- Add "TBD" if a test issue is needed, but will be created later
- Add "NONE" if a test issue is not needed
-->
```test-issue
NONE
```
