### PR TITLE
Run go mod tidy at the end of update-kkp

### DIFF
--- a/modules/api/Makefile
+++ b/modules/api/Makefile
@@ -121,6 +121,7 @@ update-kkp: ## Override the revision with KKP_REVISION=<branch|tag|commit-sha>.
 	go get -v k8c.io/kubermatic/v2@$(KKP_REVISION)
 	go get -v k8c.io/kubermatic/sdk/v2@$(KKP_REVISION)
 	$(MAKE) update-codegen
+	go mod tidy
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.


### PR DESCRIPTION
**What this PR does / why we need it**:

update-codegen can rewrite go.sum (its scripts run go commands that add entries) after the go get calls in update-kkp, so the target can leave the module in a state that `make check-dependencies` rejects in CI (`go mod tidy` + `git diff --exit-code`). Running tidy as the last step of update-kkp leaves the module consistent. Hit while preparing the v2.30.7 dependency bump in #8298.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

**test-issue**:
```test-issue
NONE
```